### PR TITLE
Add cloudfront.Signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Now with AWS introduced in re:Invent 2018.
 libraryDependencies += "net.exoego" %%% "aws-sdk-scalajs-facade" % "0.22.0-v2-473"
 ```
 
+Note) Starting from `0.22.0`, version number includes the version of AWS SDK, as qualifier like `-v2-473`,
+which the facade is built for.
+
 ## Support matrix
 
 |            |   ScalaJS 0.6.28+              |   ScalaJS 1.x  |

--- a/src/main/scala/facade/amazonaws/services/cloudfront/Signer.scala
+++ b/src/main/scala/facade/amazonaws/services/cloudfront/Signer.scala
@@ -5,7 +5,7 @@ import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("aws-sdk", "CloudFront.Signer")
-class Signer protected () extends js.Object {
+class CloudFrontSigner protected () extends js.Object {
   def this(keyPairId: String, privateKey: String) = this()
 
   def getSignedCookie(options: SignerOptionsWithPolicy): CustomPolicy = js.native
@@ -26,6 +26,7 @@ class Signer protected () extends js.Object {
 
   def getSignedUrl(options: SignerOptionsWithoutPolicy, callback: js.Function2[Error, String, Unit]): Unit = js.native
 }
+
 @js.native
 trait SignerOptionsWithPolicy extends js.Object {
   var policy: String = js.native

--- a/src/main/scala/facade/amazonaws/services/cloudfront/Signer.scala
+++ b/src/main/scala/facade/amazonaws/services/cloudfront/Signer.scala
@@ -1,0 +1,110 @@
+package facade.amazonaws.services.cloudfront
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk", "CloudFront.Signer")
+class Signer protected () extends js.Object {
+  def this(keyPairId: String, privateKey: String) = this()
+
+  def getSignedCookie(options: SignerOptionsWithPolicy): CustomPolicy = js.native
+
+  def getSignedCookie(options: SignerOptionsWithoutPolicy): CannedPolicy = js.native
+
+  def getSignedCookie(options: SignerOptionsWithPolicy, callback: js.Function2[Error, CustomPolicy, Unit]): Unit =
+    js.native
+
+  def getSignedCookie(options: SignerOptionsWithoutPolicy, callback: js.Function2[Error, CannedPolicy, Unit]): Unit =
+    js.native
+
+  def getSignedUrl(options: SignerOptionsWithPolicy): String = js.native
+
+  def getSignedUrl(options: SignerOptionsWithoutPolicy): String = js.native
+
+  def getSignedUrl(options: SignerOptionsWithPolicy, callback: js.Function2[Error, String, Unit]): Unit = js.native
+
+  def getSignedUrl(options: SignerOptionsWithoutPolicy, callback: js.Function2[Error, String, Unit]): Unit = js.native
+}
+@js.native
+trait SignerOptionsWithPolicy extends js.Object {
+  var policy: String = js.native
+}
+
+object SignerOptionsWithPolicy {
+  def apply(
+      policy: String
+  ): SignerOptionsWithPolicy = {
+    val _fields = IndexedSeq[(String, js.Any)](
+      "policy" -> policy.asInstanceOf[js.Any]
+    ).filter(_._2 != (js.undefined: js.Any))
+
+    js.Dynamic.literal.applyDynamicNamed("apply")(_fields: _*).asInstanceOf[SignerOptionsWithPolicy]
+  }
+}
+
+@js.native
+trait SignerOptionsWithoutPolicy extends js.Object {
+  var url: String  = js.native
+  var expires: Int = js.native
+}
+
+object SignerOptionsWithoutPolicy {
+  def apply(
+      url: String,
+      expires: Int
+  ): SignerOptionsWithoutPolicy = {
+    val _fields = IndexedSeq[(String, js.Any)](
+      "url"     -> url.asInstanceOf[js.Any],
+      "expires" -> expires.asInstanceOf[js.Any]
+    ).filter(_._2 != (js.undefined: js.Any))
+
+    js.Dynamic.literal.applyDynamicNamed("apply")(_fields: _*).asInstanceOf[SignerOptionsWithoutPolicy]
+  }
+}
+
+@js.native
+trait CustomPolicy extends js.Object {
+  var `CloudFront-Policy`: String      = js.native
+  var `CloudFront-Key-Pair-Id`: String = js.native
+  var `CloudFront-Signature`: String   = js.native
+}
+
+object CustomPolicy {
+  def apply(
+      policy: String,
+      keyPairId: String,
+      signature: String
+  ): CustomPolicy = {
+    val _fields = IndexedSeq[(String, js.Any)](
+      "CloudFront-Policy"      -> policy.asInstanceOf[js.Any],
+      "CloudFront-Key-Pair-Id" -> keyPairId.asInstanceOf[js.Any],
+      "CloudFront-Signature"   -> signature.asInstanceOf[js.Any]
+    ).filter(_._2 != (js.undefined: js.Any))
+
+    js.Dynamic.literal.applyDynamicNamed("apply")(_fields: _*).asInstanceOf[CustomPolicy]
+  }
+}
+
+@js.native
+trait CannedPolicy extends js.Object {
+  var `CloudFront-Expires`: Int        = js.native
+  var `CloudFront-Key-Pair-Id`: String = js.native
+  var `CloudFront-Signature`: String   = js.native
+}
+
+object CannedPolicy {
+  def apply(
+      expires: Int,
+      keyPairId: String,
+      signature: String
+  ): CannedPolicy = {
+    val _fields = IndexedSeq[(String, js.Any)](
+      "CloudFront-Expires"     -> expires.asInstanceOf[js.Any],
+      "CloudFront-Key-Pair-Id" -> keyPairId.asInstanceOf[js.Any],
+      "CloudFront-Signature"   -> signature.asInstanceOf[js.Any]
+    ).filter(_._2 != (js.undefined: js.Any))
+
+    js.Dynamic.literal.applyDynamicNamed("apply")(_fields: _*).asInstanceOf[CannedPolicy]
+  }
+}


### PR DESCRIPTION
Closes https://github.com/exoego/aws-sdk-scalajs-facade/issues/21

`cloudfront.Signer` is manually added since it does not appear in [API definitions](https://github.com/aws/aws-sdk-js/tree/cc29728c1c4178969ebabe3bbe6b6f3159436394/apis) for unknown reason).

Types are based on https://github.com/aws/aws-sdk-js/blob/cc29728c1c4178969ebabe3bbe6b6f3159436394/lib/cloudfront/signer.d.ts