### PR TITLE
Better deprecated annotation and no extension methods for deprecated

### DIFF
--- a/src/main/scala/facade/amazonaws/services/ApplicationDiscovery.scala
+++ b/src/main/scala/facade/amazonaws/services/ApplicationDiscovery.scala
@@ -98,9 +98,6 @@ package object applicationdiscovery {
     def describeContinuousExportsFuture(
         params: DescribeContinuousExportsRequest
     ): Future[DescribeContinuousExportsResponse] = service.describeContinuousExports(params).promise.toFuture
-    def describeExportConfigurationsFuture(
-        params: DescribeExportConfigurationsRequest
-    ): Future[DescribeExportConfigurationsResponse] = service.describeExportConfigurations(params).promise.toFuture
     def describeExportTasksFuture(params: DescribeExportTasksRequest): Future[DescribeExportTasksResponse] =
       service.describeExportTasks(params).promise.toFuture
     def describeImportTasksFuture(params: DescribeImportTasksRequest): Future[DescribeImportTasksResponse] =
@@ -111,8 +108,6 @@ package object applicationdiscovery {
         params: DisassociateConfigurationItemsFromApplicationRequest
     ): Future[DisassociateConfigurationItemsFromApplicationResponse] =
       service.disassociateConfigurationItemsFromApplication(params).promise.toFuture
-    def exportConfigurationsFuture(): Future[ExportConfigurationsResponse] =
-      service.exportConfigurations().promise.toFuture
     def getDiscoverySummaryFuture(params: GetDiscoverySummaryRequest): Future[GetDiscoverySummaryResponse] =
       service.getDiscoverySummary(params).promise.toFuture
     def listConfigurationsFuture(params: ListConfigurationsRequest): Future[ListConfigurationsResponse] =

--- a/src/main/scala/facade/amazonaws/services/ApplicationDiscovery.scala
+++ b/src/main/scala/facade/amazonaws/services/ApplicationDiscovery.scala
@@ -157,17 +157,13 @@ package applicationdiscovery {
       js.native
     def describeContinuousExports(
         params: DescribeContinuousExportsRequest
-    ): Request[DescribeContinuousExportsResponse] = js.native
-    def describeExportConfigurations(
-        params: DescribeExportConfigurationsRequest
-    ): Request[DescribeExportConfigurationsResponse]                                                  = js.native
+    ): Request[DescribeContinuousExportsResponse]                                                     = js.native
     def describeExportTasks(params: DescribeExportTasksRequest): Request[DescribeExportTasksResponse] = js.native
     def describeImportTasks(params: DescribeImportTasksRequest): Request[DescribeImportTasksResponse] = js.native
     def describeTags(params: DescribeTagsRequest): Request[DescribeTagsResponse]                      = js.native
     def disassociateConfigurationItemsFromApplication(
         params: DisassociateConfigurationItemsFromApplicationRequest
     ): Request[DisassociateConfigurationItemsFromApplicationResponse]                                       = js.native
-    def exportConfigurations(): Request[ExportConfigurationsResponse]                                       = js.native
     def getDiscoverySummary(params: GetDiscoverySummaryRequest): Request[GetDiscoverySummaryResponse]       = js.native
     def listConfigurations(params: ListConfigurationsRequest): Request[ListConfigurationsResponse]          = js.native
     def listServerNeighbors(params: ListServerNeighborsRequest): Request[ListServerNeighborsResponse]       = js.native
@@ -182,6 +178,11 @@ package applicationdiscovery {
         params: StopDataCollectionByAgentIdsRequest
     ): Request[StopDataCollectionByAgentIdsResponse]                                            = js.native
     def updateApplication(params: UpdateApplicationRequest): Request[UpdateApplicationResponse] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def describeExportConfigurations(
+        params: DescribeExportConfigurationsRequest
+    ): Request[DescribeExportConfigurationsResponse] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def exportConfigurations(): Request[ExportConfigurationsResponse] =
+      js.native
   }
 
   /**

--- a/src/main/scala/facade/amazonaws/services/CodeDeploy.scala
+++ b/src/main/scala/facade/amazonaws/services/CodeDeploy.scala
@@ -151,9 +151,6 @@ package object codedeploy {
       service.batchGetApplications(params).promise.toFuture
     def batchGetDeploymentGroupsFuture(params: BatchGetDeploymentGroupsInput): Future[BatchGetDeploymentGroupsOutput] =
       service.batchGetDeploymentGroups(params).promise.toFuture
-    def batchGetDeploymentInstancesFuture(
-        params: BatchGetDeploymentInstancesInput
-    ): Future[BatchGetDeploymentInstancesOutput] = service.batchGetDeploymentInstances(params).promise.toFuture
     def batchGetDeploymentTargetsFuture(
         params: BatchGetDeploymentTargetsInput
     ): Future[BatchGetDeploymentTargetsOutput] = service.batchGetDeploymentTargets(params).promise.toFuture
@@ -192,8 +189,6 @@ package object codedeploy {
       service.getDeployment(params).promise.toFuture
     def getDeploymentGroupFuture(params: GetDeploymentGroupInput): Future[GetDeploymentGroupOutput] =
       service.getDeploymentGroup(params).promise.toFuture
-    def getDeploymentInstanceFuture(params: GetDeploymentInstanceInput): Future[GetDeploymentInstanceOutput] =
-      service.getDeploymentInstance(params).promise.toFuture
     def getDeploymentTargetFuture(params: GetDeploymentTargetInput): Future[GetDeploymentTargetOutput] =
       service.getDeploymentTarget(params).promise.toFuture
     def getOnPremisesInstanceFuture(params: GetOnPremisesInstanceInput): Future[GetOnPremisesInstanceOutput] =
@@ -206,8 +201,6 @@ package object codedeploy {
       service.listDeploymentConfigs(params).promise.toFuture
     def listDeploymentGroupsFuture(params: ListDeploymentGroupsInput): Future[ListDeploymentGroupsOutput] =
       service.listDeploymentGroups(params).promise.toFuture
-    def listDeploymentInstancesFuture(params: ListDeploymentInstancesInput): Future[ListDeploymentInstancesOutput] =
-      service.listDeploymentInstances(params).promise.toFuture
     def listDeploymentTargetsFuture(params: ListDeploymentTargetsInput): Future[ListDeploymentTargetsOutput] =
       service.listDeploymentTargets(params).promise.toFuture
     def listDeploymentsFuture(params: ListDeploymentsInput): Future[ListDeploymentsOutput] =
@@ -227,8 +220,6 @@ package object codedeploy {
       service.registerOnPremisesInstance(params).promise.toFuture
     def removeTagsFromOnPremisesInstancesFuture(params: RemoveTagsFromOnPremisesInstancesInput): Future[js.Object] =
       service.removeTagsFromOnPremisesInstances(params).promise.toFuture
-    def skipWaitTimeForInstanceTerminationFuture(params: SkipWaitTimeForInstanceTerminationInput): Future[js.Object] =
-      service.skipWaitTimeForInstanceTermination(params).promise.toFuture
     def stopDeploymentFuture(params: StopDeploymentInput): Future[StopDeploymentOutput] =
       service.stopDeployment(params).promise.toFuture
     def updateApplicationFuture(params: UpdateApplicationInput): Future[js.Object] =

--- a/src/main/scala/facade/amazonaws/services/CodeDeploy.scala
+++ b/src/main/scala/facade/amazonaws/services/CodeDeploy.scala
@@ -251,9 +251,6 @@ package codedeploy {
     def batchGetApplications(params: BatchGetApplicationsInput): Request[BatchGetApplicationsOutput] = js.native
     def batchGetDeploymentGroups(params: BatchGetDeploymentGroupsInput): Request[BatchGetDeploymentGroupsOutput] =
       js.native
-    def batchGetDeploymentInstances(
-        params: BatchGetDeploymentInstancesInput
-    ): Request[BatchGetDeploymentInstancesOutput] = js.native
     def batchGetDeploymentTargets(params: BatchGetDeploymentTargetsInput): Request[BatchGetDeploymentTargetsOutput] =
       js.native
     def batchGetDeployments(params: BatchGetDeploymentsInput): Request[BatchGetDeploymentsOutput] = js.native
@@ -276,7 +273,6 @@ package codedeploy {
     def getDeployment(params: GetDeploymentInput): Request[GetDeploymentOutput]                            = js.native
     def getDeploymentConfig(params: GetDeploymentConfigInput): Request[GetDeploymentConfigOutput]          = js.native
     def getDeploymentGroup(params: GetDeploymentGroupInput): Request[GetDeploymentGroupOutput]             = js.native
-    def getDeploymentInstance(params: GetDeploymentInstanceInput): Request[GetDeploymentInstanceOutput]    = js.native
     def getDeploymentTarget(params: GetDeploymentTargetInput): Request[GetDeploymentTargetOutput]          = js.native
     def getOnPremisesInstance(params: GetOnPremisesInstanceInput): Request[GetOnPremisesInstanceOutput]    = js.native
     def listApplicationRevisions(params: ListApplicationRevisionsInput): Request[ListApplicationRevisionsOutput] =
@@ -284,8 +280,6 @@ package codedeploy {
     def listApplications(params: ListApplicationsInput): Request[ListApplicationsOutput]                = js.native
     def listDeploymentConfigs(params: ListDeploymentConfigsInput): Request[ListDeploymentConfigsOutput] = js.native
     def listDeploymentGroups(params: ListDeploymentGroupsInput): Request[ListDeploymentGroupsOutput]    = js.native
-    def listDeploymentInstances(params: ListDeploymentInstancesInput): Request[ListDeploymentInstancesOutput] =
-      js.native
     def listDeploymentTargets(params: ListDeploymentTargetsInput): Request[ListDeploymentTargetsOutput] = js.native
     def listDeployments(params: ListDeploymentsInput): Request[ListDeploymentsOutput]                   = js.native
     def listGitHubAccountTokenNames(
@@ -300,11 +294,21 @@ package codedeploy {
     def registerOnPremisesInstance(params: RegisterOnPremisesInstanceInput): Request[js.Object]   = js.native
     def removeTagsFromOnPremisesInstances(params: RemoveTagsFromOnPremisesInstancesInput): Request[js.Object] =
       js.native
-    def skipWaitTimeForInstanceTermination(params: SkipWaitTimeForInstanceTerminationInput): Request[js.Object] =
-      js.native
     def stopDeployment(params: StopDeploymentInput): Request[StopDeploymentOutput]                      = js.native
     def updateApplication(params: UpdateApplicationInput): Request[js.Object]                           = js.native
     def updateDeploymentGroup(params: UpdateDeploymentGroupInput): Request[UpdateDeploymentGroupOutput] = js.native
+    @deprecated("This operation is deprecated, use BatchGetDeploymentTargets instead.", "forever") def batchGetDeploymentInstances(
+        params: BatchGetDeploymentInstancesInput
+    ): Request[BatchGetDeploymentInstancesOutput] = js.native
+    @deprecated("This operation is deprecated, use ContinueDeployment with DeploymentWaitType instead.", "forever") def skipWaitTimeForInstanceTermination(
+        params: SkipWaitTimeForInstanceTerminationInput
+    ): Request[js.Object] = js.native
+    @deprecated("This operation is deprecated, use GetDeploymentTarget instead.", "forever") def getDeploymentInstance(
+        params: GetDeploymentInstanceInput
+    ): Request[GetDeploymentInstanceOutput] = js.native
+    @deprecated("This operation is deprecated, use ListDeploymentTargets instead.", "forever") def listDeploymentInstances(
+        params: ListDeploymentInstancesInput
+    ): Request[ListDeploymentInstancesOutput] = js.native
   }
 
   /**
@@ -2792,7 +2796,7 @@ package codedeploy {
     }
   }
 
-  @deprecated
+  @deprecated("InstanceStatus is deprecated, use TargetStatus instead.", "forever")
   object InstanceStatusEnum {
     val Pending    = "Pending"
     val InProgress = "InProgress"
@@ -2808,7 +2812,7 @@ package codedeploy {
   /**
     * Information about an instance in a deployment.
     */
-  @deprecated
+  @deprecated("InstanceSummary is deprecated, use DeploymentTarget instead.", "forever")
   @js.native
   trait InstanceSummary extends js.Object {
     var deploymentId: js.UndefOr[DeploymentId]
@@ -3733,7 +3737,7 @@ package codedeploy {
   /**
     * A revision for an AWS Lambda deployment that is a YAML-formatted or JSON-formatted string. For AWS Lambda deployments, the revision is the same as the AppSpec file.
     */
-  @deprecated
+  @deprecated("RawString and String revision type are deprecated, use AppSpecContent type instead.", "forever")
   @js.native
   trait RawString extends js.Object {
     var content: js.UndefOr[RawStringContent]

--- a/src/main/scala/facade/amazonaws/services/DirectConnect.scala
+++ b/src/main/scala/facade/amazonaws/services/DirectConnect.scala
@@ -223,9 +223,7 @@ package directconnect {
 
     def acceptDirectConnectGatewayAssociationProposal(
         params: AcceptDirectConnectGatewayAssociationProposalRequest
-    ): Request[AcceptDirectConnectGatewayAssociationProposalResult] = js.native
-    def allocateConnectionOnInterconnect(params: AllocateConnectionOnInterconnectRequest): Request[Connection] =
-      js.native
+    ): Request[AcceptDirectConnectGatewayAssociationProposalResult]                            = js.native
     def allocateHostedConnection(params: AllocateHostedConnectionRequest): Request[Connection] = js.native
     def allocatePrivateVirtualInterface(params: AllocatePrivateVirtualInterfaceRequest): Request[VirtualInterface] =
       js.native
@@ -272,10 +270,7 @@ package directconnect {
     def deleteLag(params: DeleteLagRequest): Request[Lag]                                          = js.native
     def deleteVirtualInterface(params: DeleteVirtualInterfaceRequest): Request[DeleteVirtualInterfaceResponse] =
       js.native
-    def describeConnectionLoa(params: DescribeConnectionLoaRequest): Request[DescribeConnectionLoaResponse] = js.native
-    def describeConnections(params: DescribeConnectionsRequest): Request[Connections]                       = js.native
-    def describeConnectionsOnInterconnect(params: DescribeConnectionsOnInterconnectRequest): Request[Connections] =
-      js.native
+    def describeConnections(params: DescribeConnectionsRequest): Request[Connections] = js.native
     def describeDirectConnectGatewayAssociationProposals(
         params: DescribeDirectConnectGatewayAssociationProposalsRequest
     ): Request[DescribeDirectConnectGatewayAssociationProposalsResult] = js.native
@@ -287,10 +282,8 @@ package directconnect {
     ): Request[DescribeDirectConnectGatewayAttachmentsResult] = js.native
     def describeDirectConnectGateways(
         params: DescribeDirectConnectGatewaysRequest
-    ): Request[DescribeDirectConnectGatewaysResult]                                               = js.native
-    def describeHostedConnections(params: DescribeHostedConnectionsRequest): Request[Connections] = js.native
-    def describeInterconnectLoa(params: DescribeInterconnectLoaRequest): Request[DescribeInterconnectLoaResponse] =
-      js.native
+    ): Request[DescribeDirectConnectGatewaysResult]                                                      = js.native
+    def describeHostedConnections(params: DescribeHostedConnectionsRequest): Request[Connections]        = js.native
     def describeInterconnects(params: DescribeInterconnectsRequest): Request[Interconnects]              = js.native
     def describeLags(params: DescribeLagsRequest): Request[Lags]                                         = js.native
     def describeLoa(params: DescribeLoaRequest): Request[Loa]                                            = js.native
@@ -307,6 +300,18 @@ package directconnect {
     def updateLag(params: UpdateLagRequest): Request[Lag]   = js.native
     def updateVirtualInterfaceAttributes(params: UpdateVirtualInterfaceAttributesRequest): Request[VirtualInterface] =
       js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def allocateConnectionOnInterconnect(
+        params: AllocateConnectionOnInterconnectRequest
+    ): Request[Connection] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def describeConnectionLoa(
+        params: DescribeConnectionLoaRequest
+    ): Request[DescribeConnectionLoaResponse] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def describeConnectionsOnInterconnect(
+        params: DescribeConnectionsOnInterconnectRequest
+    ): Request[Connections] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def describeInterconnectLoa(
+        params: DescribeInterconnectLoaRequest
+    ): Request[DescribeInterconnectLoaResponse] = js.native
   }
 
   @js.native

--- a/src/main/scala/facade/amazonaws/services/DirectConnect.scala
+++ b/src/main/scala/facade/amazonaws/services/DirectConnect.scala
@@ -98,8 +98,6 @@ package object directconnect {
         params: AcceptDirectConnectGatewayAssociationProposalRequest
     ): Future[AcceptDirectConnectGatewayAssociationProposalResult] =
       service.acceptDirectConnectGatewayAssociationProposal(params).promise.toFuture
-    def allocateConnectionOnInterconnectFuture(params: AllocateConnectionOnInterconnectRequest): Future[Connection] =
-      service.allocateConnectionOnInterconnect(params).promise.toFuture
     def allocateHostedConnectionFuture(params: AllocateHostedConnectionRequest): Future[Connection] =
       service.allocateHostedConnection(params).promise.toFuture
     def allocatePrivateVirtualInterfaceFuture(
@@ -163,12 +161,8 @@ package object directconnect {
     def deleteLagFuture(params: DeleteLagRequest): Future[Lag] = service.deleteLag(params).promise.toFuture
     def deleteVirtualInterfaceFuture(params: DeleteVirtualInterfaceRequest): Future[DeleteVirtualInterfaceResponse] =
       service.deleteVirtualInterface(params).promise.toFuture
-    def describeConnectionLoaFuture(params: DescribeConnectionLoaRequest): Future[DescribeConnectionLoaResponse] =
-      service.describeConnectionLoa(params).promise.toFuture
     def describeConnectionsFuture(params: DescribeConnectionsRequest): Future[Connections] =
       service.describeConnections(params).promise.toFuture
-    def describeConnectionsOnInterconnectFuture(params: DescribeConnectionsOnInterconnectRequest): Future[Connections] =
-      service.describeConnectionsOnInterconnect(params).promise.toFuture
     def describeDirectConnectGatewayAssociationProposalsFuture(
         params: DescribeDirectConnectGatewayAssociationProposalsRequest
     ): Future[DescribeDirectConnectGatewayAssociationProposalsResult] =
@@ -186,8 +180,6 @@ package object directconnect {
     ): Future[DescribeDirectConnectGatewaysResult] = service.describeDirectConnectGateways(params).promise.toFuture
     def describeHostedConnectionsFuture(params: DescribeHostedConnectionsRequest): Future[Connections] =
       service.describeHostedConnections(params).promise.toFuture
-    def describeInterconnectLoaFuture(params: DescribeInterconnectLoaRequest): Future[DescribeInterconnectLoaResponse] =
-      service.describeInterconnectLoa(params).promise.toFuture
     def describeInterconnectsFuture(params: DescribeInterconnectsRequest): Future[Interconnects] =
       service.describeInterconnects(params).promise.toFuture
     def describeLagsFuture(params: DescribeLagsRequest): Future[Lags] = service.describeLags(params).promise.toFuture

--- a/src/main/scala/facade/amazonaws/services/EMR.scala
+++ b/src/main/scala/facade/amazonaws/services/EMR.scala
@@ -114,8 +114,6 @@ package object emr {
     ): Future[DeleteSecurityConfigurationOutput] = service.deleteSecurityConfiguration(params).promise.toFuture
     def describeClusterFuture(params: DescribeClusterInput): Future[DescribeClusterOutput] =
       service.describeCluster(params).promise.toFuture
-    def describeJobFlowsFuture(params: DescribeJobFlowsInput): Future[DescribeJobFlowsOutput] =
-      service.describeJobFlows(params).promise.toFuture
     def describeSecurityConfigurationFuture(
         params: DescribeSecurityConfigurationInput
     ): Future[DescribeSecurityConfigurationOutput] = service.describeSecurityConfiguration(params).promise.toFuture

--- a/src/main/scala/facade/amazonaws/services/EMR.scala
+++ b/src/main/scala/facade/amazonaws/services/EMR.scala
@@ -172,9 +172,8 @@ package emr {
     ): Request[CreateSecurityConfigurationOutput] = js.native
     def deleteSecurityConfiguration(
         params: DeleteSecurityConfigurationInput
-    ): Request[DeleteSecurityConfigurationOutput]                                        = js.native
-    def describeCluster(params: DescribeClusterInput): Request[DescribeClusterOutput]    = js.native
-    def describeJobFlows(params: DescribeJobFlowsInput): Request[DescribeJobFlowsOutput] = js.native
+    ): Request[DeleteSecurityConfigurationOutput]                                     = js.native
+    def describeCluster(params: DescribeClusterInput): Request[DescribeClusterOutput] = js.native
     def describeSecurityConfiguration(
         params: DescribeSecurityConfigurationInput
     ): Request[DescribeSecurityConfigurationOutput]                                                  = js.native
@@ -197,6 +196,9 @@ package emr {
     def setTerminationProtection(params: SetTerminationProtectionInput): Request[js.Object] = js.native
     def setVisibleToAllUsers(params: SetVisibleToAllUsersInput): Request[js.Object]         = js.native
     def terminateJobFlows(params: TerminateJobFlowsInput): Request[js.Object]               = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def describeJobFlows(
+        params: DescribeJobFlowsInput
+    ): Request[DescribeJobFlowsOutput] = js.native
   }
 
   object ActionOnFailureEnum {

--- a/src/main/scala/facade/amazonaws/services/ElasticTranscoder.scala
+++ b/src/main/scala/facade/amazonaws/services/ElasticTranscoder.scala
@@ -164,12 +164,13 @@ package elastictranscoder {
     def readJob(params: ReadJobRequest): Request[ReadJobResponse]                                  = js.native
     def readPipeline(params: ReadPipelineRequest): Request[ReadPipelineResponse]                   = js.native
     def readPreset(params: ReadPresetRequest): Request[ReadPresetResponse]                         = js.native
-    def testRole(params: TestRoleRequest): Request[TestRoleResponse]                               = js.native
     def updatePipeline(params: UpdatePipelineRequest): Request[UpdatePipelineResponse]             = js.native
     def updatePipelineNotifications(
         params: UpdatePipelineNotificationsRequest
     ): Request[UpdatePipelineNotificationsResponse]                                                      = js.native
     def updatePipelineStatus(params: UpdatePipelineStatusRequest): Request[UpdatePipelineStatusResponse] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def testRole(params: TestRoleRequest): Request[TestRoleResponse] =
+      js.native
   }
 
   /**
@@ -455,7 +456,7 @@ package elastictranscoder {
   /**
     * Settings for one clip in a composition. All jobs in a playlist must have the same clip settings.
     */
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait Clip extends js.Object {
     var TimeSpan: js.UndefOr[TimeSpan]
@@ -2128,7 +2129,7 @@ package elastictranscoder {
   /**
     * The <code>TestRoleRequest</code> structure.
     */
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait TestRoleRequest extends js.Object {
     var InputBucket: BucketName
@@ -2158,7 +2159,7 @@ package elastictranscoder {
   /**
     * The <code>TestRoleResponse</code> structure.
     */
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait TestRoleResponse extends js.Object {
     var Messages: js.UndefOr[ExceptionMessages]

--- a/src/main/scala/facade/amazonaws/services/ElasticTranscoder.scala
+++ b/src/main/scala/facade/amazonaws/services/ElasticTranscoder.scala
@@ -134,7 +134,6 @@ package object elastictranscoder {
       service.readPipeline(params).promise.toFuture
     def readPresetFuture(params: ReadPresetRequest): Future[ReadPresetResponse] =
       service.readPreset(params).promise.toFuture
-    def testRoleFuture(params: TestRoleRequest): Future[TestRoleResponse] = service.testRole(params).promise.toFuture
     def updatePipelineFuture(params: UpdatePipelineRequest): Future[UpdatePipelineResponse] =
       service.updatePipeline(params).promise.toFuture
     def updatePipelineNotificationsFuture(

--- a/src/main/scala/facade/amazonaws/services/Iot.scala
+++ b/src/main/scala/facade/amazonaws/services/Iot.scala
@@ -750,7 +750,6 @@ package iot {
     def associateTargetsWithJob(params: AssociateTargetsWithJobRequest): Request[AssociateTargetsWithJobResponse] =
       js.native
     def attachPolicy(params: AttachPolicyRequest): Request[js.Object]                                       = js.native
-    def attachPrincipalPolicy(params: AttachPrincipalPolicyRequest): Request[js.Object]                     = js.native
     def attachSecurityProfile(params: AttachSecurityProfileRequest): Request[AttachSecurityProfileResponse] = js.native
     def attachThingPrincipal(params: AttachThingPrincipalRequest): Request[AttachThingPrincipalResponse]    = js.native
     def cancelAuditTask(params: CancelAuditTaskRequest): Request[CancelAuditTaskResponse]                   = js.native
@@ -836,7 +835,6 @@ package iot {
     ): Request[DescribeThingRegistrationTaskResponse]                                                       = js.native
     def describeThingType(params: DescribeThingTypeRequest): Request[DescribeThingTypeResponse]             = js.native
     def detachPolicy(params: DetachPolicyRequest): Request[js.Object]                                       = js.native
-    def detachPrincipalPolicy(params: DetachPrincipalPolicyRequest): Request[js.Object]                     = js.native
     def detachSecurityProfile(params: DetachSecurityProfileRequest): Request[DetachSecurityProfileResponse] = js.native
     def detachThingPrincipal(params: DetachThingPrincipalRequest): Request[DetachThingPrincipalResponse]    = js.native
     def disableTopicRule(params: DisableTopicRuleRequest): Request[js.Object]                               = js.native
@@ -872,14 +870,12 @@ package iot {
     def listOTAUpdates(params: ListOTAUpdatesRequest): Request[ListOTAUpdatesResponse] = js.native
     def listOutgoingCertificates(params: ListOutgoingCertificatesRequest): Request[ListOutgoingCertificatesResponse] =
       js.native
-    def listPolicies(params: ListPoliciesRequest): Request[ListPoliciesResponse]                            = js.native
-    def listPolicyPrincipals(params: ListPolicyPrincipalsRequest): Request[ListPolicyPrincipalsResponse]    = js.native
-    def listPolicyVersions(params: ListPolicyVersionsRequest): Request[ListPolicyVersionsResponse]          = js.native
-    def listPrincipalPolicies(params: ListPrincipalPoliciesRequest): Request[ListPrincipalPoliciesResponse] = js.native
-    def listPrincipalThings(params: ListPrincipalThingsRequest): Request[ListPrincipalThingsResponse]       = js.native
-    def listRoleAliases(params: ListRoleAliasesRequest): Request[ListRoleAliasesResponse]                   = js.native
-    def listScheduledAudits(params: ListScheduledAuditsRequest): Request[ListScheduledAuditsResponse]       = js.native
-    def listSecurityProfiles(params: ListSecurityProfilesRequest): Request[ListSecurityProfilesResponse]    = js.native
+    def listPolicies(params: ListPoliciesRequest): Request[ListPoliciesResponse]                         = js.native
+    def listPolicyVersions(params: ListPolicyVersionsRequest): Request[ListPolicyVersionsResponse]       = js.native
+    def listPrincipalThings(params: ListPrincipalThingsRequest): Request[ListPrincipalThingsResponse]    = js.native
+    def listRoleAliases(params: ListRoleAliasesRequest): Request[ListRoleAliasesResponse]                = js.native
+    def listScheduledAudits(params: ListScheduledAuditsRequest): Request[ListScheduledAuditsResponse]    = js.native
+    def listSecurityProfiles(params: ListSecurityProfilesRequest): Request[ListSecurityProfilesResponse] = js.native
     def listSecurityProfilesForTarget(
         params: ListSecurityProfilesForTargetRequest
     ): Request[ListSecurityProfilesForTargetResponse]                                                    = js.native
@@ -966,6 +962,18 @@ package iot {
     def validateSecurityProfileBehaviors(
         params: ValidateSecurityProfileBehaviorsRequest
     ): Request[ValidateSecurityProfileBehaviorsResponse] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def attachPrincipalPolicy(
+        params: AttachPrincipalPolicyRequest
+    ): Request[js.Object] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def detachPrincipalPolicy(
+        params: DetachPrincipalPolicyRequest
+    ): Request[js.Object] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def listPolicyPrincipals(
+        params: ListPolicyPrincipalsRequest
+    ): Request[ListPolicyPrincipalsResponse] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def listPrincipalPolicies(
+        params: ListPrincipalPoliciesRequest
+    ): Request[ListPrincipalPoliciesResponse] = js.native
   }
 
   object AbortActionEnum {

--- a/src/main/scala/facade/amazonaws/services/Iot.scala
+++ b/src/main/scala/facade/amazonaws/services/Iot.scala
@@ -384,8 +384,6 @@ package object iot {
       service.associateTargetsWithJob(params).promise.toFuture
     def attachPolicyFuture(params: AttachPolicyRequest): Future[js.Object] =
       service.attachPolicy(params).promise.toFuture
-    def attachPrincipalPolicyFuture(params: AttachPrincipalPolicyRequest): Future[js.Object] =
-      service.attachPrincipalPolicy(params).promise.toFuture
     def attachSecurityProfileFuture(params: AttachSecurityProfileRequest): Future[AttachSecurityProfileResponse] =
       service.attachSecurityProfile(params).promise.toFuture
     def attachThingPrincipalFuture(params: AttachThingPrincipalRequest): Future[AttachThingPrincipalResponse] =
@@ -528,8 +526,6 @@ package object iot {
       service.describeThingType(params).promise.toFuture
     def detachPolicyFuture(params: DetachPolicyRequest): Future[js.Object] =
       service.detachPolicy(params).promise.toFuture
-    def detachPrincipalPolicyFuture(params: DetachPrincipalPolicyRequest): Future[js.Object] =
-      service.detachPrincipalPolicy(params).promise.toFuture
     def detachSecurityProfileFuture(params: DetachSecurityProfileRequest): Future[DetachSecurityProfileResponse] =
       service.detachSecurityProfile(params).promise.toFuture
     def detachThingPrincipalFuture(params: DetachThingPrincipalRequest): Future[DetachThingPrincipalResponse] =
@@ -594,12 +590,8 @@ package object iot {
     ): Future[ListOutgoingCertificatesResponse] = service.listOutgoingCertificates(params).promise.toFuture
     def listPoliciesFuture(params: ListPoliciesRequest): Future[ListPoliciesResponse] =
       service.listPolicies(params).promise.toFuture
-    def listPolicyPrincipalsFuture(params: ListPolicyPrincipalsRequest): Future[ListPolicyPrincipalsResponse] =
-      service.listPolicyPrincipals(params).promise.toFuture
     def listPolicyVersionsFuture(params: ListPolicyVersionsRequest): Future[ListPolicyVersionsResponse] =
       service.listPolicyVersions(params).promise.toFuture
-    def listPrincipalPoliciesFuture(params: ListPrincipalPoliciesRequest): Future[ListPrincipalPoliciesResponse] =
-      service.listPrincipalPolicies(params).promise.toFuture
     def listPrincipalThingsFuture(params: ListPrincipalThingsRequest): Future[ListPrincipalThingsResponse] =
       service.listPrincipalThings(params).promise.toFuture
     def listRoleAliasesFuture(params: ListRoleAliasesRequest): Future[ListRoleAliasesResponse] =

--- a/src/main/scala/facade/amazonaws/services/Lambda.scala
+++ b/src/main/scala/facade/amazonaws/services/Lambda.scala
@@ -194,7 +194,6 @@ package lambda {
     def getLayerVersionPolicy(params: GetLayerVersionPolicyRequest): Request[GetLayerVersionPolicyResponse] = js.native
     def getPolicy(params: GetPolicyRequest): Request[GetPolicyResponse]                                     = js.native
     def invoke(params: InvocationRequest): Request[InvocationResponse]                                      = js.native
-    def invokeAsync(params: InvokeAsyncRequest): Request[InvokeAsyncResponse]                               = js.native
     def listAliases(params: ListAliasesRequest): Request[ListAliasesResponse]                               = js.native
     def listEventSourceMappings(params: ListEventSourceMappingsRequest): Request[ListEventSourceMappingsResponse] =
       js.native
@@ -217,6 +216,9 @@ package lambda {
     def updateFunctionCode(params: UpdateFunctionCodeRequest): Request[FunctionConfiguration] = js.native
     def updateFunctionConfiguration(params: UpdateFunctionConfigurationRequest): Request[FunctionConfiguration] =
       js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def invokeAsync(
+        params: InvokeAsyncRequest
+    ): Request[InvokeAsyncResponse] = js.native
   }
 
   /**
@@ -1517,7 +1519,7 @@ package lambda {
     val values = IndexedSeq(Event, RequestResponse, DryRun)
   }
 
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait InvokeAsyncRequest extends js.Object {
     var FunctionName: NamespacedFunctionName
@@ -1541,7 +1543,7 @@ package lambda {
   /**
     * A success response (<code>202 Accepted</code>) indicates that the request is queued for invocation.
     */
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait InvokeAsyncResponse extends js.Object {
     var Status: js.UndefOr[HttpStatus]

--- a/src/main/scala/facade/amazonaws/services/Lambda.scala
+++ b/src/main/scala/facade/amazonaws/services/Lambda.scala
@@ -123,8 +123,6 @@ package object lambda {
       service.getLayerVersionPolicy(params).promise.toFuture
     def getPolicyFuture(params: GetPolicyRequest): Future[GetPolicyResponse] =
       service.getPolicy(params).promise.toFuture
-    def invokeAsyncFuture(params: InvokeAsyncRequest): Future[InvokeAsyncResponse] =
-      service.invokeAsync(params).promise.toFuture
     def invokeFuture(params: InvocationRequest): Future[InvocationResponse] = service.invoke(params).promise.toFuture
     def listAliasesFuture(params: ListAliasesRequest): Future[ListAliasesResponse] =
       service.listAliases(params).promise.toFuture

--- a/src/main/scala/facade/amazonaws/services/MediaPackage.scala
+++ b/src/main/scala/facade/amazonaws/services/MediaPackage.scala
@@ -83,8 +83,6 @@ package mediapackage {
     def listChannels(params: ListChannelsRequest): Request[ListChannelsResponse]                      = js.native
     def listOriginEndpoints(params: ListOriginEndpointsRequest): Request[ListOriginEndpointsResponse] = js.native
     def listTagsForResource(params: ListTagsForResourceRequest): Request[ListTagsForResourceResponse] = js.native
-    def rotateChannelCredentials(params: RotateChannelCredentialsRequest): Request[RotateChannelCredentialsResponse] =
-      js.native
     def rotateIngestEndpointCredentials(
         params: RotateIngestEndpointCredentialsRequest
     ): Request[RotateIngestEndpointCredentialsResponse]                                                  = js.native
@@ -92,6 +90,9 @@ package mediapackage {
     def untagResource(params: UntagResourceRequest): Request[js.Object]                                  = js.native
     def updateChannel(params: UpdateChannelRequest): Request[UpdateChannelResponse]                      = js.native
     def updateOriginEndpoint(params: UpdateOriginEndpointRequest): Request[UpdateOriginEndpointResponse] = js.native
+    @deprecated("This API is deprecated. Please use RotateIngestEndpointCredentials instead", "forever") def rotateChannelCredentials(
+        params: RotateChannelCredentialsRequest
+    ): Request[RotateChannelCredentialsResponse] = js.native
   }
 
   object AdMarkersEnum {
@@ -1369,7 +1370,7 @@ package mediapackage {
     val values = IndexedSeq(NONE, HBBTV_1_5)
   }
 
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait RotateChannelCredentialsRequest extends js.Object {
     var Id: __string
@@ -1387,7 +1388,7 @@ package mediapackage {
     }
   }
 
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait RotateChannelCredentialsResponse extends js.Object {
     var Arn: js.UndefOr[__string]

--- a/src/main/scala/facade/amazonaws/services/MediaPackage.scala
+++ b/src/main/scala/facade/amazonaws/services/MediaPackage.scala
@@ -50,9 +50,6 @@ package object mediapackage {
       service.listOriginEndpoints(params).promise.toFuture
     def listTagsForResourceFuture(params: ListTagsForResourceRequest): Future[ListTagsForResourceResponse] =
       service.listTagsForResource(params).promise.toFuture
-    def rotateChannelCredentialsFuture(
-        params: RotateChannelCredentialsRequest
-    ): Future[RotateChannelCredentialsResponse] = service.rotateChannelCredentials(params).promise.toFuture
     def rotateIngestEndpointCredentialsFuture(
         params: RotateIngestEndpointCredentialsRequest
     ): Future[RotateIngestEndpointCredentialsResponse] =

--- a/src/main/scala/facade/amazonaws/services/S3.scala
+++ b/src/main/scala/facade/amazonaws/services/S3.scala
@@ -309,8 +309,6 @@ package object s3 {
     def getBucketLifecycleConfigurationFuture(
         params: GetBucketLifecycleConfigurationRequest
     ): Future[GetBucketLifecycleConfigurationOutput] = service.getBucketLifecycleConfiguration(params).promise.toFuture
-    def getBucketLifecycleFuture(params: GetBucketLifecycleRequest): Future[GetBucketLifecycleOutput] =
-      service.getBucketLifecycle(params).promise.toFuture
     def getBucketLocationFuture(params: GetBucketLocationRequest): Future[GetBucketLocationOutput] =
       service.getBucketLocation(params).promise.toFuture
     def getBucketLoggingFuture(params: GetBucketLoggingRequest): Future[GetBucketLoggingOutput] =
@@ -321,9 +319,6 @@ package object s3 {
     def getBucketNotificationConfigurationFuture(
         params: GetBucketNotificationConfigurationRequest
     ): Future[NotificationConfiguration] = service.getBucketNotificationConfiguration(params).promise.toFuture
-    def getBucketNotificationFuture(
-        params: GetBucketNotificationConfigurationRequest
-    ): Future[NotificationConfigurationDeprecated] = service.getBucketNotification(params).promise.toFuture
     def getBucketPolicyFuture(params: GetBucketPolicyRequest): Future[GetBucketPolicyOutput] =
       service.getBucketPolicy(params).promise.toFuture
     def getBucketPolicyStatusFuture(params: GetBucketPolicyStatusRequest): Future[GetBucketPolicyStatusOutput] =
@@ -392,16 +387,12 @@ package object s3 {
       service.putBucketInventoryConfiguration(params).promise.toFuture
     def putBucketLifecycleConfigurationFuture(params: PutBucketLifecycleConfigurationRequest): Future[js.Object] =
       service.putBucketLifecycleConfiguration(params).promise.toFuture
-    def putBucketLifecycleFuture(params: PutBucketLifecycleRequest): Future[js.Object] =
-      service.putBucketLifecycle(params).promise.toFuture
     def putBucketLoggingFuture(params: PutBucketLoggingRequest): Future[js.Object] =
       service.putBucketLogging(params).promise.toFuture
     def putBucketMetricsConfigurationFuture(params: PutBucketMetricsConfigurationRequest): Future[js.Object] =
       service.putBucketMetricsConfiguration(params).promise.toFuture
     def putBucketNotificationConfigurationFuture(params: PutBucketNotificationConfigurationRequest): Future[js.Object] =
       service.putBucketNotificationConfiguration(params).promise.toFuture
-    def putBucketNotificationFuture(params: PutBucketNotificationRequest): Future[js.Object] =
-      service.putBucketNotification(params).promise.toFuture
     def putBucketPolicyFuture(params: PutBucketPolicyRequest): Future[js.Object] =
       service.putBucketPolicy(params).promise.toFuture
     def putBucketReplicationFuture(params: PutBucketReplicationRequest): Future[js.Object] =

--- a/src/main/scala/facade/amazonaws/services/S3.scala
+++ b/src/main/scala/facade/amazonaws/services/S3.scala
@@ -480,8 +480,7 @@ package s3 {
     def getBucketEncryption(params: GetBucketEncryptionRequest): Request[GetBucketEncryptionOutput] = js.native
     def getBucketInventoryConfiguration(
         params: GetBucketInventoryConfigurationRequest
-    ): Request[GetBucketInventoryConfigurationOutput]                                            = js.native
-    def getBucketLifecycle(params: GetBucketLifecycleRequest): Request[GetBucketLifecycleOutput] = js.native
+    ): Request[GetBucketInventoryConfigurationOutput] = js.native
     def getBucketLifecycleConfiguration(
         params: GetBucketLifecycleConfigurationRequest
     ): Request[GetBucketLifecycleConfigurationOutput]                                         = js.native
@@ -490,9 +489,6 @@ package s3 {
     def getBucketMetricsConfiguration(
         params: GetBucketMetricsConfigurationRequest
     ): Request[GetBucketMetricsConfigurationOutput] = js.native
-    def getBucketNotification(
-        params: GetBucketNotificationConfigurationRequest
-    ): Request[NotificationConfigurationDeprecated] = js.native
     def getBucketNotificationConfiguration(
         params: GetBucketNotificationConfigurationRequest
     ): Request[NotificationConfiguration]                                                                 = js.native
@@ -538,11 +534,9 @@ package s3 {
     def putBucketCors(params: PutBucketCorsRequest): Request[js.Object]                                     = js.native
     def putBucketEncryption(params: PutBucketEncryptionRequest): Request[js.Object]                         = js.native
     def putBucketInventoryConfiguration(params: PutBucketInventoryConfigurationRequest): Request[js.Object] = js.native
-    def putBucketLifecycle(params: PutBucketLifecycleRequest): Request[js.Object]                           = js.native
     def putBucketLifecycleConfiguration(params: PutBucketLifecycleConfigurationRequest): Request[js.Object] = js.native
     def putBucketLogging(params: PutBucketLoggingRequest): Request[js.Object]                               = js.native
     def putBucketMetricsConfiguration(params: PutBucketMetricsConfigurationRequest): Request[js.Object]     = js.native
-    def putBucketNotification(params: PutBucketNotificationRequest): Request[js.Object]                     = js.native
     def putBucketNotificationConfiguration(params: PutBucketNotificationConfigurationRequest): Request[js.Object] =
       js.native
     def putBucketPolicy(params: PutBucketPolicyRequest): Request[js.Object]                      = js.native
@@ -564,6 +558,18 @@ package s3 {
     def selectObjectContent(params: SelectObjectContentRequest): Request[SelectObjectContentOutput] = js.native
     def uploadPart(params: UploadPartRequest): Request[UploadPartOutput]                            = js.native
     def uploadPartCopy(params: UploadPartCopyRequest): Request[UploadPartCopyOutput]                = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def getBucketLifecycle(
+        params: GetBucketLifecycleRequest
+    ): Request[GetBucketLifecycleOutput] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def getBucketNotification(
+        params: GetBucketNotificationConfigurationRequest
+    ): Request[NotificationConfigurationDeprecated] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def putBucketLifecycle(
+        params: PutBucketLifecycleRequest
+    ): Request[js.Object] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def putBucketNotification(
+        params: PutBucketNotificationRequest
+    ): Request[js.Object] = js.native
   }
 
   /**

--- a/src/main/scala/facade/amazonaws/services/Shield.scala
+++ b/src/main/scala/facade/amazonaws/services/Shield.scala
@@ -52,8 +52,6 @@ package object shield {
       service.createSubscription(params).promise.toFuture
     def deleteProtectionFuture(params: DeleteProtectionRequest): Future[DeleteProtectionResponse] =
       service.deleteProtection(params).promise.toFuture
-    def deleteSubscriptionFuture(params: DeleteSubscriptionRequest): Future[DeleteSubscriptionResponse] =
-      service.deleteSubscription(params).promise.toFuture
     def describeAttackFuture(params: DescribeAttackRequest): Future[DescribeAttackResponse] =
       service.describeAttack(params).promise.toFuture
     def describeDRTAccessFuture(params: DescribeDRTAccessRequest): Future[DescribeDRTAccessResponse] =

--- a/src/main/scala/facade/amazonaws/services/Shield.scala
+++ b/src/main/scala/facade/amazonaws/services/Shield.scala
@@ -96,7 +96,6 @@ package shield {
     def createProtection(params: CreateProtectionRequest): Request[CreateProtectionResponse]                = js.native
     def createSubscription(params: CreateSubscriptionRequest): Request[CreateSubscriptionResponse]          = js.native
     def deleteProtection(params: DeleteProtectionRequest): Request[DeleteProtectionResponse]                = js.native
-    def deleteSubscription(params: DeleteSubscriptionRequest): Request[DeleteSubscriptionResponse]          = js.native
     def describeAttack(params: DescribeAttackRequest): Request[DescribeAttackResponse]                      = js.native
     def describeDRTAccess(params: DescribeDRTAccessRequest): Request[DescribeDRTAccessResponse]             = js.native
     def describeEmergencyContactSettings(
@@ -114,6 +113,9 @@ package shield {
         params: UpdateEmergencyContactSettingsRequest
     ): Request[UpdateEmergencyContactSettingsResponse]                                             = js.native
     def updateSubscription(params: UpdateSubscriptionRequest): Request[UpdateSubscriptionResponse] = js.native
+    @deprecated("Deprecated in AWS SDK", "forever") def deleteSubscription(
+        params: DeleteSubscriptionRequest
+    ): Request[DeleteSubscriptionResponse] = js.native
   }
 
   @js.native
@@ -484,7 +486,7 @@ package shield {
     }
   }
 
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait DeleteSubscriptionRequest extends js.Object {}
 
@@ -498,7 +500,7 @@ package shield {
     }
   }
 
-  @deprecated
+  @deprecated("Deprecated in AWS SDK", "forever")
   @js.native
   trait DeleteSubscriptionResponse extends js.Object {}
 


### PR DESCRIPTION
Closes #35 
Corresponds to https://github.com/exoego/aws-sdk-scalajs-facade-generator/pull/16

* Use `@deprecated("message", "version")`
* Do not generate extension methods for deprecated APIs, to discourage usage.
