### PR TITLE
Address Map.mapValues deprecation in Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val awsDirectoryService                = defineAwsProject("DirectoryService
 lazy val awsDLM                             = defineAwsProject("DLM")
 lazy val awsDMS                             = defineAwsProject("DMS")
 lazy val awsDocDb                           = defineAwsProject("DocDB")
-lazy val awsDynamoDB                        = defineAwsProject("DynamoDB")
+lazy val awsDynamoDB                        = defineAwsProject("DynamoDB").settings(libraryDependencies += Dependencies.shared.compat.value)
 lazy val awsDynamoDBStreams                 = defineAwsProject("DynamoDBStreams")
 lazy val awsEC2                             = defineAwsProject("EC2")
 lazy val awsEC2InstanceConnect              = defineAwsProject("EC2InstanceConnect")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,8 @@ import autoImport._
 
 object Dependencies {
   object shared {
-    val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.0.8" % Test)
+    val scalatest = Def.setting("org.scalatest"          %%% "scalatest"               % "3.0.8" % Test)
+    val compat    = Def.setting("org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.2")
   }
   object scalajs {
     val nodejs = Def.setting("net.exoego" %%% "scala-js-nodejs-v8" % "0.8.0")

--- a/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDBExtension.scala
+++ b/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDBExtension.scala
@@ -16,11 +16,13 @@ object AttributeValueMapper {
   implicit val AttributeValueTypeList: AttributeValueMapper[ListAttributeValue] =
     AttributeValueMapper("L", identity[ListAttributeValue])
 
-  implicit def AttributeValueTypeMapT[T: AttributeValueMapper]: AttributeValueMapper[Map[String, T]] =
+  implicit def AttributeValueTypeMapT[T: AttributeValueMapper]: AttributeValueMapper[Map[String, T]] = {
+    import scala.collection.compat._
     AttributeValueMapper(
       "M",
       (seq: Map[String, T]) => js.Dictionary(seq.view.mapValues(implicitly[AttributeValueMapper[T]]).toSeq: _*)
     )
+  }
 
   implicit def AttributeValueTypeSeqT[T: AttributeValueMapper]: AttributeValueMapper[Seq[T]] =
     AttributeValueMapper("L", (seq: Seq[T]) => js.Array(seq.map(implicitly[AttributeValueMapper[T]]): _*))

--- a/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDBExtension.scala
+++ b/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDBExtension.scala
@@ -19,7 +19,7 @@ object AttributeValueMapper {
   implicit def AttributeValueTypeMapT[T: AttributeValueMapper]: AttributeValueMapper[Map[String, T]] =
     AttributeValueMapper(
       "M",
-      (seq: Map[String, T]) => js.Dictionary(seq.mapValues(implicitly[AttributeValueMapper[T]]).toSeq: _*)
+      (seq: Map[String, T]) => js.Dictionary(seq.view.mapValues(implicitly[AttributeValueMapper[T]]).toSeq: _*)
     )
 
   implicit def AttributeValueTypeSeqT[T: AttributeValueMapper]: AttributeValueMapper[Seq[T]] =


### PR DESCRIPTION
Closes #81 