### PR TITLE
Logger should extends js.Object

### DIFF
--- a/core/src/main/scala/facade/amazonaws/AWSConfig.scala
+++ b/core/src/main/scala/facade/amazonaws/AWSConfig.scala
@@ -124,7 +124,7 @@ object HttpOptions {
     new HttpOptions(proxy, agent, connectTimeout, timeout, xhrAsync, xhrWithCredentials)
 }
 
-trait Logger {
+trait Logger extends js.Object {
   def write(chunk: js.Any, encoding: js.UndefOr[String], callback: js.UndefOr[js.Function0[Unit]]): Unit
 
   def log(messages: js.Any*): Unit


### PR DESCRIPTION
Otherwise it is considered Scala trait, which is not compatible JavaScript object.