### PR TITLE
💥 Use typesafe enum string hack

### DIFF
--- a/services/accessanalyzer/src/main/scala/facade/amazonaws/services/AccessAnalyzer.scala
+++ b/services/accessanalyzer/src/main/scala/facade/amazonaws/services/AccessAnalyzer.scala
@@ -16,21 +16,16 @@ package object accessanalyzer {
   type FilterCriteriaMap      = js.Dictionary[Criterion]
   type FindingId              = String
   type FindingIdList          = js.Array[FindingId]
-  type FindingStatus          = String
-  type FindingStatusUpdate    = String
   type FindingsList           = js.Array[FindingSummary]
   type InlineArchiveRulesList = js.Array[InlineArchiveRule]
   type Name                   = String
-  type OrderBy                = String
   type PrincipalMap           = js.Dictionary[String]
   type ResourceArn            = String
-  type ResourceType           = String
   type SharedViaList          = js.Array[String]
   type TagKeys                = js.Array[String]
   type TagsMap                = js.Dictionary[String]
   type Timestamp              = js.Date
   type Token                  = String
-  type Type                   = String
   type ValueList              = js.Array[String]
 
   implicit final class AccessAnalyzerOps(private val service: AccessAnalyzer) extends AnyVal {
@@ -456,18 +451,20 @@ package accessanalyzer {
       __obj.asInstanceOf[Finding]
     }
   }
-
-  object FindingStatusEnum {
-    val ACTIVE   = "ACTIVE"
-    val ARCHIVED = "ARCHIVED"
-    val RESOLVED = "RESOLVED"
+  @js.native
+  sealed trait FindingStatus extends js.Any
+  object FindingStatus extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[FindingStatus]
+    val ARCHIVED = "ARCHIVED".asInstanceOf[FindingStatus]
+    val RESOLVED = "RESOLVED".asInstanceOf[FindingStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, ARCHIVED, RESOLVED))
   }
-
-  object FindingStatusUpdateEnum {
-    val ACTIVE   = "ACTIVE"
-    val ARCHIVED = "ARCHIVED"
+  @js.native
+  sealed trait FindingStatusUpdate extends js.Any
+  object FindingStatusUpdate extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[FindingStatusUpdate]
+    val ARCHIVED = "ARCHIVED".asInstanceOf[FindingStatusUpdate]
 
     val values = js.Object.freeze(js.Array(ACTIVE, ARCHIVED))
   }
@@ -973,21 +970,23 @@ package accessanalyzer {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object OrderByEnum {
-    val ASC  = "ASC"
-    val DESC = "DESC"
+  @js.native
+  sealed trait OrderBy extends js.Any
+  object OrderBy extends js.Object {
+    val ASC  = "ASC".asInstanceOf[OrderBy]
+    val DESC = "DESC".asInstanceOf[OrderBy]
 
     val values = js.Object.freeze(js.Array(ASC, DESC))
   }
-
-  object ResourceTypeEnum {
-    val `AWS::IAM::Role`            = "AWS::IAM::Role"
-    val `AWS::KMS::Key`             = "AWS::KMS::Key"
-    val `AWS::Lambda::Function`     = "AWS::Lambda::Function"
-    val `AWS::Lambda::LayerVersion` = "AWS::Lambda::LayerVersion"
-    val `AWS::S3::Bucket`           = "AWS::S3::Bucket"
-    val `AWS::SQS::Queue`           = "AWS::SQS::Queue"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val `AWS::IAM::Role`            = "AWS::IAM::Role".asInstanceOf[ResourceType]
+    val `AWS::KMS::Key`             = "AWS::KMS::Key".asInstanceOf[ResourceType]
+    val `AWS::Lambda::Function`     = "AWS::Lambda::Function".asInstanceOf[ResourceType]
+    val `AWS::Lambda::LayerVersion` = "AWS::Lambda::LayerVersion".asInstanceOf[ResourceType]
+    val `AWS::S3::Bucket`           = "AWS::S3::Bucket".asInstanceOf[ResourceType]
+    val `AWS::SQS::Queue`           = "AWS::SQS::Queue".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1086,9 +1085,10 @@ package accessanalyzer {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TypeEnum {
-    val ACCOUNT = "ACCOUNT"
+  @js.native
+  sealed trait Type extends js.Any
+  object Type extends js.Object {
+    val ACCOUNT = "ACCOUNT".asInstanceOf[Type]
 
     val values = js.Object.freeze(js.Array(ACCOUNT))
   }

--- a/services/acm/src/main/scala/facade/amazonaws/services/ACM.scala
+++ b/services/acm/src/main/scala/facade/amazonaws/services/ACM.scala
@@ -7,47 +7,34 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object acm {
-  type Arn                                      = String
-  type CertificateBody                          = String
-  type CertificateBodyBlob                      = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type CertificateChain                         = String
-  type CertificateChainBlob                     = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type CertificateStatus                        = String
-  type CertificateStatuses                      = js.Array[CertificateStatus]
-  type CertificateSummaryList                   = js.Array[CertificateSummary]
-  type CertificateTransparencyLoggingPreference = String
-  type CertificateType                          = String
-  type DomainList                               = js.Array[DomainNameString]
-  type DomainNameString                         = String
-  type DomainStatus                             = String
-  type DomainValidationList                     = js.Array[DomainValidation]
-  type DomainValidationOptionList               = js.Array[DomainValidationOption]
-  type ExtendedKeyUsageFilterList               = js.Array[ExtendedKeyUsageName]
-  type ExtendedKeyUsageList                     = js.Array[ExtendedKeyUsage]
-  type ExtendedKeyUsageName                     = String
-  type FailureReason                            = String
-  type IdempotencyToken                         = String
-  type InUseList                                = js.Array[String]
-  type KeyAlgorithm                             = String
-  type KeyAlgorithmList                         = js.Array[KeyAlgorithm]
-  type KeyUsageFilterList                       = js.Array[KeyUsageName]
-  type KeyUsageList                             = js.Array[KeyUsage]
-  type KeyUsageName                             = String
-  type MaxItems                                 = Int
-  type NextToken                                = String
-  type PassphraseBlob                           = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type PrivateKey                               = String
-  type PrivateKeyBlob                           = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type RecordType                               = String
-  type RenewalEligibility                       = String
-  type RenewalStatus                            = String
-  type RevocationReason                         = String
-  type TStamp                                   = js.Date
-  type TagKey                                   = String
-  type TagList                                  = js.Array[Tag]
-  type TagValue                                 = String
-  type ValidationEmailList                      = js.Array[String]
-  type ValidationMethod                         = String
+  type Arn                        = String
+  type CertificateBody            = String
+  type CertificateBodyBlob        = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type CertificateChain           = String
+  type CertificateChainBlob       = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type CertificateStatuses        = js.Array[CertificateStatus]
+  type CertificateSummaryList     = js.Array[CertificateSummary]
+  type DomainList                 = js.Array[DomainNameString]
+  type DomainNameString           = String
+  type DomainValidationList       = js.Array[DomainValidation]
+  type DomainValidationOptionList = js.Array[DomainValidationOption]
+  type ExtendedKeyUsageFilterList = js.Array[ExtendedKeyUsageName]
+  type ExtendedKeyUsageList       = js.Array[ExtendedKeyUsage]
+  type IdempotencyToken           = String
+  type InUseList                  = js.Array[String]
+  type KeyAlgorithmList           = js.Array[KeyAlgorithm]
+  type KeyUsageFilterList         = js.Array[KeyUsageName]
+  type KeyUsageList               = js.Array[KeyUsage]
+  type MaxItems                   = Int
+  type NextToken                  = String
+  type PassphraseBlob             = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type PrivateKey                 = String
+  type PrivateKeyBlob             = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type TStamp                     = js.Date
+  type TagKey                     = String
+  type TagList                    = js.Array[Tag]
+  type TagValue                   = String
+  type ValidationEmailList        = js.Array[String]
 
   implicit final class ACMOps(private val service: ACM) extends AnyVal {
 
@@ -238,15 +225,16 @@ package acm {
       __obj.asInstanceOf[CertificateOptions]
     }
   }
-
-  object CertificateStatusEnum {
-    val PENDING_VALIDATION   = "PENDING_VALIDATION"
-    val ISSUED               = "ISSUED"
-    val INACTIVE             = "INACTIVE"
-    val EXPIRED              = "EXPIRED"
-    val VALIDATION_TIMED_OUT = "VALIDATION_TIMED_OUT"
-    val REVOKED              = "REVOKED"
-    val FAILED               = "FAILED"
+  @js.native
+  sealed trait CertificateStatus extends js.Any
+  object CertificateStatus extends js.Object {
+    val PENDING_VALIDATION   = "PENDING_VALIDATION".asInstanceOf[CertificateStatus]
+    val ISSUED               = "ISSUED".asInstanceOf[CertificateStatus]
+    val INACTIVE             = "INACTIVE".asInstanceOf[CertificateStatus]
+    val EXPIRED              = "EXPIRED".asInstanceOf[CertificateStatus]
+    val VALIDATION_TIMED_OUT = "VALIDATION_TIMED_OUT".asInstanceOf[CertificateStatus]
+    val REVOKED              = "REVOKED".asInstanceOf[CertificateStatus]
+    val FAILED               = "FAILED".asInstanceOf[CertificateStatus]
 
     val values =
       js.Object.freeze(js.Array(PENDING_VALIDATION, ISSUED, INACTIVE, EXPIRED, VALIDATION_TIMED_OUT, REVOKED, FAILED))
@@ -273,18 +261,20 @@ package acm {
       __obj.asInstanceOf[CertificateSummary]
     }
   }
-
-  object CertificateTransparencyLoggingPreferenceEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait CertificateTransparencyLoggingPreference extends js.Any
+  object CertificateTransparencyLoggingPreference extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[CertificateTransparencyLoggingPreference]
+    val DISABLED = "DISABLED".asInstanceOf[CertificateTransparencyLoggingPreference]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
-
-  object CertificateTypeEnum {
-    val IMPORTED      = "IMPORTED"
-    val AMAZON_ISSUED = "AMAZON_ISSUED"
-    val PRIVATE       = "PRIVATE"
+  @js.native
+  sealed trait CertificateType extends js.Any
+  object CertificateType extends js.Object {
+    val IMPORTED      = "IMPORTED".asInstanceOf[CertificateType]
+    val AMAZON_ISSUED = "AMAZON_ISSUED".asInstanceOf[CertificateType]
+    val PRIVATE       = "PRIVATE".asInstanceOf[CertificateType]
 
     val values = js.Object.freeze(js.Array(IMPORTED, AMAZON_ISSUED, PRIVATE))
   }
@@ -340,11 +330,12 @@ package acm {
       __obj.asInstanceOf[DescribeCertificateResponse]
     }
   }
-
-  object DomainStatusEnum {
-    val PENDING_VALIDATION = "PENDING_VALIDATION"
-    val SUCCESS            = "SUCCESS"
-    val FAILED             = "FAILED"
+  @js.native
+  sealed trait DomainStatus extends js.Any
+  object DomainStatus extends js.Object {
+    val PENDING_VALIDATION = "PENDING_VALIDATION".asInstanceOf[DomainStatus]
+    val SUCCESS            = "SUCCESS".asInstanceOf[DomainStatus]
+    val FAILED             = "FAILED".asInstanceOf[DomainStatus]
 
     val values = js.Object.freeze(js.Array(PENDING_VALIDATION, SUCCESS, FAILED))
   }
@@ -473,20 +464,21 @@ package acm {
       __obj.asInstanceOf[ExtendedKeyUsage]
     }
   }
-
-  object ExtendedKeyUsageNameEnum {
-    val TLS_WEB_SERVER_AUTHENTICATION = "TLS_WEB_SERVER_AUTHENTICATION"
-    val TLS_WEB_CLIENT_AUTHENTICATION = "TLS_WEB_CLIENT_AUTHENTICATION"
-    val CODE_SIGNING                  = "CODE_SIGNING"
-    val EMAIL_PROTECTION              = "EMAIL_PROTECTION"
-    val TIME_STAMPING                 = "TIME_STAMPING"
-    val OCSP_SIGNING                  = "OCSP_SIGNING"
-    val IPSEC_END_SYSTEM              = "IPSEC_END_SYSTEM"
-    val IPSEC_TUNNEL                  = "IPSEC_TUNNEL"
-    val IPSEC_USER                    = "IPSEC_USER"
-    val ANY                           = "ANY"
-    val NONE                          = "NONE"
-    val CUSTOM                        = "CUSTOM"
+  @js.native
+  sealed trait ExtendedKeyUsageName extends js.Any
+  object ExtendedKeyUsageName extends js.Object {
+    val TLS_WEB_SERVER_AUTHENTICATION = "TLS_WEB_SERVER_AUTHENTICATION".asInstanceOf[ExtendedKeyUsageName]
+    val TLS_WEB_CLIENT_AUTHENTICATION = "TLS_WEB_CLIENT_AUTHENTICATION".asInstanceOf[ExtendedKeyUsageName]
+    val CODE_SIGNING                  = "CODE_SIGNING".asInstanceOf[ExtendedKeyUsageName]
+    val EMAIL_PROTECTION              = "EMAIL_PROTECTION".asInstanceOf[ExtendedKeyUsageName]
+    val TIME_STAMPING                 = "TIME_STAMPING".asInstanceOf[ExtendedKeyUsageName]
+    val OCSP_SIGNING                  = "OCSP_SIGNING".asInstanceOf[ExtendedKeyUsageName]
+    val IPSEC_END_SYSTEM              = "IPSEC_END_SYSTEM".asInstanceOf[ExtendedKeyUsageName]
+    val IPSEC_TUNNEL                  = "IPSEC_TUNNEL".asInstanceOf[ExtendedKeyUsageName]
+    val IPSEC_USER                    = "IPSEC_USER".asInstanceOf[ExtendedKeyUsageName]
+    val ANY                           = "ANY".asInstanceOf[ExtendedKeyUsageName]
+    val NONE                          = "NONE".asInstanceOf[ExtendedKeyUsageName]
+    val CUSTOM                        = "CUSTOM".asInstanceOf[ExtendedKeyUsageName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -505,24 +497,25 @@ package acm {
       )
     )
   }
-
-  object FailureReasonEnum {
-    val NO_AVAILABLE_CONTACTS            = "NO_AVAILABLE_CONTACTS"
-    val ADDITIONAL_VERIFICATION_REQUIRED = "ADDITIONAL_VERIFICATION_REQUIRED"
-    val DOMAIN_NOT_ALLOWED               = "DOMAIN_NOT_ALLOWED"
-    val INVALID_PUBLIC_DOMAIN            = "INVALID_PUBLIC_DOMAIN"
-    val DOMAIN_VALIDATION_DENIED         = "DOMAIN_VALIDATION_DENIED"
-    val CAA_ERROR                        = "CAA_ERROR"
-    val PCA_LIMIT_EXCEEDED               = "PCA_LIMIT_EXCEEDED"
-    val PCA_INVALID_ARN                  = "PCA_INVALID_ARN"
-    val PCA_INVALID_STATE                = "PCA_INVALID_STATE"
-    val PCA_REQUEST_FAILED               = "PCA_REQUEST_FAILED"
-    val PCA_NAME_CONSTRAINTS_VALIDATION  = "PCA_NAME_CONSTRAINTS_VALIDATION"
-    val PCA_RESOURCE_NOT_FOUND           = "PCA_RESOURCE_NOT_FOUND"
-    val PCA_INVALID_ARGS                 = "PCA_INVALID_ARGS"
-    val PCA_INVALID_DURATION             = "PCA_INVALID_DURATION"
-    val PCA_ACCESS_DENIED                = "PCA_ACCESS_DENIED"
-    val OTHER                            = "OTHER"
+  @js.native
+  sealed trait FailureReason extends js.Any
+  object FailureReason extends js.Object {
+    val NO_AVAILABLE_CONTACTS            = "NO_AVAILABLE_CONTACTS".asInstanceOf[FailureReason]
+    val ADDITIONAL_VERIFICATION_REQUIRED = "ADDITIONAL_VERIFICATION_REQUIRED".asInstanceOf[FailureReason]
+    val DOMAIN_NOT_ALLOWED               = "DOMAIN_NOT_ALLOWED".asInstanceOf[FailureReason]
+    val INVALID_PUBLIC_DOMAIN            = "INVALID_PUBLIC_DOMAIN".asInstanceOf[FailureReason]
+    val DOMAIN_VALIDATION_DENIED         = "DOMAIN_VALIDATION_DENIED".asInstanceOf[FailureReason]
+    val CAA_ERROR                        = "CAA_ERROR".asInstanceOf[FailureReason]
+    val PCA_LIMIT_EXCEEDED               = "PCA_LIMIT_EXCEEDED".asInstanceOf[FailureReason]
+    val PCA_INVALID_ARN                  = "PCA_INVALID_ARN".asInstanceOf[FailureReason]
+    val PCA_INVALID_STATE                = "PCA_INVALID_STATE".asInstanceOf[FailureReason]
+    val PCA_REQUEST_FAILED               = "PCA_REQUEST_FAILED".asInstanceOf[FailureReason]
+    val PCA_NAME_CONSTRAINTS_VALIDATION  = "PCA_NAME_CONSTRAINTS_VALIDATION".asInstanceOf[FailureReason]
+    val PCA_RESOURCE_NOT_FOUND           = "PCA_RESOURCE_NOT_FOUND".asInstanceOf[FailureReason]
+    val PCA_INVALID_ARGS                 = "PCA_INVALID_ARGS".asInstanceOf[FailureReason]
+    val PCA_INVALID_DURATION             = "PCA_INVALID_DURATION".asInstanceOf[FailureReason]
+    val PCA_ACCESS_DENIED                = "PCA_ACCESS_DENIED".asInstanceOf[FailureReason]
+    val OTHER                            = "OTHER".asInstanceOf[FailureReason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -653,14 +646,15 @@ package acm {
       __obj.asInstanceOf[ImportCertificateResponse]
     }
   }
-
-  object KeyAlgorithmEnum {
-    val RSA_2048      = "RSA_2048"
-    val RSA_1024      = "RSA_1024"
-    val RSA_4096      = "RSA_4096"
-    val EC_prime256v1 = "EC_prime256v1"
-    val EC_secp384r1  = "EC_secp384r1"
-    val EC_secp521r1  = "EC_secp521r1"
+  @js.native
+  sealed trait KeyAlgorithm extends js.Any
+  object KeyAlgorithm extends js.Object {
+    val RSA_2048      = "RSA_2048".asInstanceOf[KeyAlgorithm]
+    val RSA_1024      = "RSA_1024".asInstanceOf[KeyAlgorithm]
+    val RSA_4096      = "RSA_4096".asInstanceOf[KeyAlgorithm]
+    val EC_prime256v1 = "EC_prime256v1".asInstanceOf[KeyAlgorithm]
+    val EC_secp384r1  = "EC_secp384r1".asInstanceOf[KeyAlgorithm]
+    val EC_secp521r1  = "EC_secp521r1".asInstanceOf[KeyAlgorithm]
 
     val values = js.Object.freeze(js.Array(RSA_2048, RSA_1024, RSA_4096, EC_prime256v1, EC_secp384r1, EC_secp521r1))
   }
@@ -683,19 +677,20 @@ package acm {
       __obj.asInstanceOf[KeyUsage]
     }
   }
-
-  object KeyUsageNameEnum {
-    val DIGITAL_SIGNATURE   = "DIGITAL_SIGNATURE"
-    val NON_REPUDIATION     = "NON_REPUDIATION"
-    val KEY_ENCIPHERMENT    = "KEY_ENCIPHERMENT"
-    val DATA_ENCIPHERMENT   = "DATA_ENCIPHERMENT"
-    val KEY_AGREEMENT       = "KEY_AGREEMENT"
-    val CERTIFICATE_SIGNING = "CERTIFICATE_SIGNING"
-    val CRL_SIGNING         = "CRL_SIGNING"
-    val ENCIPHER_ONLY       = "ENCIPHER_ONLY"
-    val DECIPHER_ONLY       = "DECIPHER_ONLY"
-    val ANY                 = "ANY"
-    val CUSTOM              = "CUSTOM"
+  @js.native
+  sealed trait KeyUsageName extends js.Any
+  object KeyUsageName extends js.Object {
+    val DIGITAL_SIGNATURE   = "DIGITAL_SIGNATURE".asInstanceOf[KeyUsageName]
+    val NON_REPUDIATION     = "NON_REPUDIATION".asInstanceOf[KeyUsageName]
+    val KEY_ENCIPHERMENT    = "KEY_ENCIPHERMENT".asInstanceOf[KeyUsageName]
+    val DATA_ENCIPHERMENT   = "DATA_ENCIPHERMENT".asInstanceOf[KeyUsageName]
+    val KEY_AGREEMENT       = "KEY_AGREEMENT".asInstanceOf[KeyUsageName]
+    val CERTIFICATE_SIGNING = "CERTIFICATE_SIGNING".asInstanceOf[KeyUsageName]
+    val CRL_SIGNING         = "CRL_SIGNING".asInstanceOf[KeyUsageName]
+    val ENCIPHER_ONLY       = "ENCIPHER_ONLY".asInstanceOf[KeyUsageName]
+    val DECIPHER_ONLY       = "DECIPHER_ONLY".asInstanceOf[KeyUsageName]
+    val ANY                 = "ANY".asInstanceOf[KeyUsageName]
+    val CUSTOM              = "CUSTOM".asInstanceOf[KeyUsageName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -791,9 +786,10 @@ package acm {
       __obj.asInstanceOf[ListTagsForCertificateResponse]
     }
   }
-
-  object RecordTypeEnum {
-    val CNAME = "CNAME"
+  @js.native
+  sealed trait RecordType extends js.Any
+  object RecordType extends js.Object {
+    val CNAME = "CNAME".asInstanceOf[RecordType]
 
     val values = js.Object.freeze(js.Array(CNAME))
   }
@@ -836,19 +832,21 @@ package acm {
       __obj.asInstanceOf[RenewCertificateRequest]
     }
   }
-
-  object RenewalEligibilityEnum {
-    val ELIGIBLE   = "ELIGIBLE"
-    val INELIGIBLE = "INELIGIBLE"
+  @js.native
+  sealed trait RenewalEligibility extends js.Any
+  object RenewalEligibility extends js.Object {
+    val ELIGIBLE   = "ELIGIBLE".asInstanceOf[RenewalEligibility]
+    val INELIGIBLE = "INELIGIBLE".asInstanceOf[RenewalEligibility]
 
     val values = js.Object.freeze(js.Array(ELIGIBLE, INELIGIBLE))
   }
-
-  object RenewalStatusEnum {
-    val PENDING_AUTO_RENEWAL = "PENDING_AUTO_RENEWAL"
-    val PENDING_VALIDATION   = "PENDING_VALIDATION"
-    val SUCCESS              = "SUCCESS"
-    val FAILED               = "FAILED"
+  @js.native
+  sealed trait RenewalStatus extends js.Any
+  object RenewalStatus extends js.Object {
+    val PENDING_AUTO_RENEWAL = "PENDING_AUTO_RENEWAL".asInstanceOf[RenewalStatus]
+    val PENDING_VALIDATION   = "PENDING_VALIDATION".asInstanceOf[RenewalStatus]
+    val SUCCESS              = "SUCCESS".asInstanceOf[RenewalStatus]
+    val FAILED               = "FAILED".asInstanceOf[RenewalStatus]
 
     val values = js.Object.freeze(js.Array(PENDING_AUTO_RENEWAL, PENDING_VALIDATION, SUCCESS, FAILED))
   }
@@ -988,18 +986,19 @@ package acm {
       __obj.asInstanceOf[ResourceRecord]
     }
   }
-
-  object RevocationReasonEnum {
-    val UNSPECIFIED            = "UNSPECIFIED"
-    val KEY_COMPROMISE         = "KEY_COMPROMISE"
-    val CA_COMPROMISE          = "CA_COMPROMISE"
-    val AFFILIATION_CHANGED    = "AFFILIATION_CHANGED"
-    val SUPERCEDED             = "SUPERCEDED"
-    val CESSATION_OF_OPERATION = "CESSATION_OF_OPERATION"
-    val CERTIFICATE_HOLD       = "CERTIFICATE_HOLD"
-    val REMOVE_FROM_CRL        = "REMOVE_FROM_CRL"
-    val PRIVILEGE_WITHDRAWN    = "PRIVILEGE_WITHDRAWN"
-    val A_A_COMPROMISE         = "A_A_COMPROMISE"
+  @js.native
+  sealed trait RevocationReason extends js.Any
+  object RevocationReason extends js.Object {
+    val UNSPECIFIED            = "UNSPECIFIED".asInstanceOf[RevocationReason]
+    val KEY_COMPROMISE         = "KEY_COMPROMISE".asInstanceOf[RevocationReason]
+    val CA_COMPROMISE          = "CA_COMPROMISE".asInstanceOf[RevocationReason]
+    val AFFILIATION_CHANGED    = "AFFILIATION_CHANGED".asInstanceOf[RevocationReason]
+    val SUPERCEDED             = "SUPERCEDED".asInstanceOf[RevocationReason]
+    val CESSATION_OF_OPERATION = "CESSATION_OF_OPERATION".asInstanceOf[RevocationReason]
+    val CERTIFICATE_HOLD       = "CERTIFICATE_HOLD".asInstanceOf[RevocationReason]
+    val REMOVE_FROM_CRL        = "REMOVE_FROM_CRL".asInstanceOf[RevocationReason]
+    val PRIVILEGE_WITHDRAWN    = "PRIVILEGE_WITHDRAWN".asInstanceOf[RevocationReason]
+    val A_A_COMPROMISE         = "A_A_COMPROMISE".asInstanceOf[RevocationReason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1061,10 +1060,11 @@ package acm {
       __obj.asInstanceOf[UpdateCertificateOptionsRequest]
     }
   }
-
-  object ValidationMethodEnum {
-    val EMAIL = "EMAIL"
-    val DNS   = "DNS"
+  @js.native
+  sealed trait ValidationMethod extends js.Any
+  object ValidationMethod extends js.Object {
+    val EMAIL = "EMAIL".asInstanceOf[ValidationMethod]
+    val DNS   = "DNS".asInstanceOf[ValidationMethod]
 
     val values = js.Object.freeze(js.Array(EMAIL, DNS))
   }

--- a/services/acmpca/src/main/scala/facade/amazonaws/services/ACMPCA.scala
+++ b/services/acmpca/src/main/scala/facade/amazonaws/services/ACMPCA.scala
@@ -9,14 +9,9 @@ import facade.amazonaws._
 package object acmpca {
   type AccountId                        = String
   type ActionList                       = js.Array[ActionType]
-  type ActionType                       = String
   type Arn                              = String
   type AuditReportId                    = String
-  type AuditReportResponseFormat        = String
-  type AuditReportStatus                = String
   type CertificateAuthorities           = js.Array[CertificateAuthority]
-  type CertificateAuthorityStatus       = String
-  type CertificateAuthorityType         = String
   type CertificateBody                  = String
   type CertificateBodyBlob              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type CertificateChain                 = String
@@ -25,18 +20,14 @@ package object acmpca {
   type CsrBlob                          = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type CsrBody                          = String
   type DistinguishedNameQualifierString = String
-  type FailureReason                    = String
   type IdempotencyToken                 = String
   type Integer1To5000                   = Int
-  type KeyAlgorithm                     = String
   type MaxResults                       = Int
   type NextToken                        = String
   type PermanentDeletionTimeInDays      = Int
   type PermissionList                   = js.Array[Permission]
   type PositiveLong                     = Double
   type Principal                        = String
-  type RevocationReason                 = String
-  type SigningAlgorithm                 = String
   type String128                        = String
   type String16                         = String
   type String253                        = String
@@ -49,7 +40,6 @@ package object acmpca {
   type TagKey                           = String
   type TagList                          = js.Array[Tag]
   type TagValue                         = String
-  type ValidityPeriodType               = String
 
   implicit final class ACMPCAOps(private val service: ACMPCA) extends AnyVal {
 
@@ -210,26 +200,29 @@ package acmpca {
       __obj.asInstanceOf[ASN1Subject]
     }
   }
-
-  object ActionTypeEnum {
-    val IssueCertificate = "IssueCertificate"
-    val GetCertificate   = "GetCertificate"
-    val ListPermissions  = "ListPermissions"
+  @js.native
+  sealed trait ActionType extends js.Any
+  object ActionType extends js.Object {
+    val IssueCertificate = "IssueCertificate".asInstanceOf[ActionType]
+    val GetCertificate   = "GetCertificate".asInstanceOf[ActionType]
+    val ListPermissions  = "ListPermissions".asInstanceOf[ActionType]
 
     val values = js.Object.freeze(js.Array(IssueCertificate, GetCertificate, ListPermissions))
   }
-
-  object AuditReportResponseFormatEnum {
-    val JSON = "JSON"
-    val CSV  = "CSV"
+  @js.native
+  sealed trait AuditReportResponseFormat extends js.Any
+  object AuditReportResponseFormat extends js.Object {
+    val JSON = "JSON".asInstanceOf[AuditReportResponseFormat]
+    val CSV  = "CSV".asInstanceOf[AuditReportResponseFormat]
 
     val values = js.Object.freeze(js.Array(JSON, CSV))
   }
-
-  object AuditReportStatusEnum {
-    val CREATING = "CREATING"
-    val SUCCESS  = "SUCCESS"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait AuditReportStatus extends js.Any
+  object AuditReportStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[AuditReportStatus]
+    val SUCCESS  = "SUCCESS".asInstanceOf[AuditReportStatus]
+    val FAILED   = "FAILED".asInstanceOf[AuditReportStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, SUCCESS, FAILED))
   }
@@ -314,22 +307,24 @@ package acmpca {
       __obj.asInstanceOf[CertificateAuthorityConfiguration]
     }
   }
-
-  object CertificateAuthorityStatusEnum {
-    val CREATING            = "CREATING"
-    val PENDING_CERTIFICATE = "PENDING_CERTIFICATE"
-    val ACTIVE              = "ACTIVE"
-    val DELETED             = "DELETED"
-    val DISABLED            = "DISABLED"
-    val EXPIRED             = "EXPIRED"
-    val FAILED              = "FAILED"
+  @js.native
+  sealed trait CertificateAuthorityStatus extends js.Any
+  object CertificateAuthorityStatus extends js.Object {
+    val CREATING            = "CREATING".asInstanceOf[CertificateAuthorityStatus]
+    val PENDING_CERTIFICATE = "PENDING_CERTIFICATE".asInstanceOf[CertificateAuthorityStatus]
+    val ACTIVE              = "ACTIVE".asInstanceOf[CertificateAuthorityStatus]
+    val DELETED             = "DELETED".asInstanceOf[CertificateAuthorityStatus]
+    val DISABLED            = "DISABLED".asInstanceOf[CertificateAuthorityStatus]
+    val EXPIRED             = "EXPIRED".asInstanceOf[CertificateAuthorityStatus]
+    val FAILED              = "FAILED".asInstanceOf[CertificateAuthorityStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, PENDING_CERTIFICATE, ACTIVE, DELETED, DISABLED, EXPIRED, FAILED))
   }
-
-  object CertificateAuthorityTypeEnum {
-    val ROOT        = "ROOT"
-    val SUBORDINATE = "SUBORDINATE"
+  @js.native
+  sealed trait CertificateAuthorityType extends js.Any
+  object CertificateAuthorityType extends js.Object {
+    val ROOT        = "ROOT".asInstanceOf[CertificateAuthorityType]
+    val SUBORDINATE = "SUBORDINATE".asInstanceOf[CertificateAuthorityType]
 
     val values = js.Object.freeze(js.Array(ROOT, SUBORDINATE))
   }
@@ -625,11 +620,12 @@ package acmpca {
       __obj.asInstanceOf[DescribeCertificateAuthorityResponse]
     }
   }
-
-  object FailureReasonEnum {
-    val REQUEST_TIMED_OUT     = "REQUEST_TIMED_OUT"
-    val UNSUPPORTED_ALGORITHM = "UNSUPPORTED_ALGORITHM"
-    val OTHER                 = "OTHER"
+  @js.native
+  sealed trait FailureReason extends js.Any
+  object FailureReason extends js.Object {
+    val REQUEST_TIMED_OUT     = "REQUEST_TIMED_OUT".asInstanceOf[FailureReason]
+    val UNSUPPORTED_ALGORITHM = "UNSUPPORTED_ALGORITHM".asInstanceOf[FailureReason]
+    val OTHER                 = "OTHER".asInstanceOf[FailureReason]
 
     val values = js.Object.freeze(js.Array(REQUEST_TIMED_OUT, UNSUPPORTED_ALGORITHM, OTHER))
   }
@@ -817,12 +813,13 @@ package acmpca {
       __obj.asInstanceOf[IssueCertificateResponse]
     }
   }
-
-  object KeyAlgorithmEnum {
-    val RSA_2048      = "RSA_2048"
-    val RSA_4096      = "RSA_4096"
-    val EC_prime256v1 = "EC_prime256v1"
-    val EC_secp384r1  = "EC_secp384r1"
+  @js.native
+  sealed trait KeyAlgorithm extends js.Any
+  object KeyAlgorithm extends js.Object {
+    val RSA_2048      = "RSA_2048".asInstanceOf[KeyAlgorithm]
+    val RSA_4096      = "RSA_4096".asInstanceOf[KeyAlgorithm]
+    val EC_prime256v1 = "EC_prime256v1".asInstanceOf[KeyAlgorithm]
+    val EC_secp384r1  = "EC_secp384r1".asInstanceOf[KeyAlgorithm]
 
     val values = js.Object.freeze(js.Array(RSA_2048, RSA_4096, EC_prime256v1, EC_secp384r1))
   }
@@ -1021,16 +1018,17 @@ package acmpca {
       __obj.asInstanceOf[RevocationConfiguration]
     }
   }
-
-  object RevocationReasonEnum {
-    val UNSPECIFIED                      = "UNSPECIFIED"
-    val KEY_COMPROMISE                   = "KEY_COMPROMISE"
-    val CERTIFICATE_AUTHORITY_COMPROMISE = "CERTIFICATE_AUTHORITY_COMPROMISE"
-    val AFFILIATION_CHANGED              = "AFFILIATION_CHANGED"
-    val SUPERSEDED                       = "SUPERSEDED"
-    val CESSATION_OF_OPERATION           = "CESSATION_OF_OPERATION"
-    val PRIVILEGE_WITHDRAWN              = "PRIVILEGE_WITHDRAWN"
-    val A_A_COMPROMISE                   = "A_A_COMPROMISE"
+  @js.native
+  sealed trait RevocationReason extends js.Any
+  object RevocationReason extends js.Object {
+    val UNSPECIFIED                      = "UNSPECIFIED".asInstanceOf[RevocationReason]
+    val KEY_COMPROMISE                   = "KEY_COMPROMISE".asInstanceOf[RevocationReason]
+    val CERTIFICATE_AUTHORITY_COMPROMISE = "CERTIFICATE_AUTHORITY_COMPROMISE".asInstanceOf[RevocationReason]
+    val AFFILIATION_CHANGED              = "AFFILIATION_CHANGED".asInstanceOf[RevocationReason]
+    val SUPERSEDED                       = "SUPERSEDED".asInstanceOf[RevocationReason]
+    val CESSATION_OF_OPERATION           = "CESSATION_OF_OPERATION".asInstanceOf[RevocationReason]
+    val PRIVILEGE_WITHDRAWN              = "PRIVILEGE_WITHDRAWN".asInstanceOf[RevocationReason]
+    val A_A_COMPROMISE                   = "A_A_COMPROMISE".asInstanceOf[RevocationReason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1069,14 +1067,15 @@ package acmpca {
       __obj.asInstanceOf[RevokeCertificateRequest]
     }
   }
-
-  object SigningAlgorithmEnum {
-    val SHA256WITHECDSA = "SHA256WITHECDSA"
-    val SHA384WITHECDSA = "SHA384WITHECDSA"
-    val SHA512WITHECDSA = "SHA512WITHECDSA"
-    val SHA256WITHRSA   = "SHA256WITHRSA"
-    val SHA384WITHRSA   = "SHA384WITHRSA"
-    val SHA512WITHRSA   = "SHA512WITHRSA"
+  @js.native
+  sealed trait SigningAlgorithm extends js.Any
+  object SigningAlgorithm extends js.Object {
+    val SHA256WITHECDSA = "SHA256WITHECDSA".asInstanceOf[SigningAlgorithm]
+    val SHA384WITHECDSA = "SHA384WITHECDSA".asInstanceOf[SigningAlgorithm]
+    val SHA512WITHECDSA = "SHA512WITHECDSA".asInstanceOf[SigningAlgorithm]
+    val SHA256WITHRSA   = "SHA256WITHRSA".asInstanceOf[SigningAlgorithm]
+    val SHA384WITHRSA   = "SHA384WITHRSA".asInstanceOf[SigningAlgorithm]
+    val SHA512WITHRSA   = "SHA512WITHRSA".asInstanceOf[SigningAlgorithm]
 
     val values = js.Object.freeze(
       js.Array(SHA256WITHECDSA, SHA384WITHECDSA, SHA512WITHECDSA, SHA256WITHRSA, SHA384WITHRSA, SHA512WITHRSA)
@@ -1196,13 +1195,14 @@ package acmpca {
       __obj.asInstanceOf[Validity]
     }
   }
-
-  object ValidityPeriodTypeEnum {
-    val END_DATE = "END_DATE"
-    val ABSOLUTE = "ABSOLUTE"
-    val DAYS     = "DAYS"
-    val MONTHS   = "MONTHS"
-    val YEARS    = "YEARS"
+  @js.native
+  sealed trait ValidityPeriodType extends js.Any
+  object ValidityPeriodType extends js.Object {
+    val END_DATE = "END_DATE".asInstanceOf[ValidityPeriodType]
+    val ABSOLUTE = "ABSOLUTE".asInstanceOf[ValidityPeriodType]
+    val DAYS     = "DAYS".asInstanceOf[ValidityPeriodType]
+    val MONTHS   = "MONTHS".asInstanceOf[ValidityPeriodType]
+    val YEARS    = "YEARS".asInstanceOf[ValidityPeriodType]
 
     val values = js.Object.freeze(js.Array(END_DATE, ABSOLUTE, DAYS, MONTHS, YEARS))
   }

--- a/services/alexaforbusiness/src/main/scala/facade/amazonaws/services/AlexaForBusiness.scala
+++ b/services/alexaforbusiness/src/main/scala/facade/amazonaws/services/AlexaForBusiness.scala
@@ -23,24 +23,17 @@ package object alexaforbusiness {
   type BulletPoints                    = js.Array[BulletPoint]
   type BusinessReportDeliveryTime      = js.Date
   type BusinessReportDownloadUrl       = String
-  type BusinessReportFailureCode       = String
-  type BusinessReportFormat            = String
-  type BusinessReportInterval          = String
   type BusinessReportS3Path            = String
   type BusinessReportScheduleList      = js.Array[BusinessReportSchedule]
   type BusinessReportScheduleName      = String
-  type BusinessReportStatus            = String
   type CategoryId                      = Double
   type CategoryList                    = js.Array[Category]
   type CategoryName                    = String
   type CertificateTime                 = js.Date
   type ClientId                        = String
   type ClientRequestToken              = String
-  type CommsProtocol                   = String
   type ConferenceProviderName          = String
-  type ConferenceProviderType          = String
   type ConferenceProvidersList         = js.Array[ConferenceProvider]
-  type ConnectionStatus                = String
   type ConnectionStatusUpdatedTime     = js.Date
   type ContactDataList                 = js.Array[ContactData]
   type ContactName                     = String
@@ -53,28 +46,18 @@ package object alexaforbusiness {
   type DeviceDataList                  = js.Array[DeviceData]
   type DeviceEventList                 = js.Array[DeviceEvent]
   type DeviceEventTime                 = js.Date
-  type DeviceEventType                 = String
   type DeviceEventValue                = String
   type DeviceLocale                    = String
   type DeviceName                      = String
   type DeviceSerialNumber              = String
   type DeviceSerialNumberForAVS        = String
-  type DeviceStatus                    = String
-  type DeviceStatusDetailCode          = String
   type DeviceStatusDetails             = js.Array[DeviceStatusDetail]
   type DeviceType                      = String
-  type DeviceUsageType                 = String
-  type DistanceUnit                    = String
   type Email                           = String
-  type EnablementType                  = String
-  type EnablementTypeFilter            = String
   type EndOfMeetingReminderMinutesList = js.Array[Minutes]
-  type EndOfMeetingReminderType        = String
   type EndUserLicenseAgreement         = String
   type Endpoint                        = String
   type EnrollmentId                    = String
-  type EnrollmentStatus                = String
-  type Feature                         = String
   type Features                        = js.Array[Feature]
   type FilterKey                       = String
   type FilterList                      = js.Array[Filter]
@@ -92,16 +75,13 @@ package object alexaforbusiness {
   type IconUrl                         = String
   type InvocationPhrase                = String
   type Key                             = String
-  type Locale                          = String
   type MacAddress                      = String
   type MaxResults                      = Int
   type MaxVolumeLimit                  = Int
   type Minutes                         = Int
-  type NetworkEapMethod                = String
   type NetworkProfileDataList          = js.Array[NetworkProfileData]
   type NetworkProfileDescription       = String
   type NetworkProfileName              = String
-  type NetworkSecurityType             = String
   type NetworkSsid                     = String
   type NewInThisVersionBulletPoints    = js.Array[BulletPoint]
   type NextToken                       = String
@@ -111,7 +91,6 @@ package object alexaforbusiness {
   type OrganizationName                = String
   type OutboundPhoneNumber             = String
   type PhoneNumberList                 = js.Array[PhoneNumber]
-  type PhoneNumberType                 = String
   type PrivacyPolicy                   = String
   type ProductDescription              = String
   type ProductId                       = String
@@ -120,7 +99,6 @@ package object alexaforbusiness {
   type ProviderCalendarId              = String
   type RawPhoneNumber                  = String
   type ReleaseDate                     = String
-  type RequirePin                      = String
   type ReviewKey                       = String
   type ReviewValue                     = String
   type Reviews                         = js.Dictionary[ReviewValue]
@@ -135,7 +113,6 @@ package object alexaforbusiness {
   type ShortDescription                = String
   type ShortSkillIdList                = js.Array[SkillId]
   type SipAddressList                  = js.Array[SipAddress]
-  type SipType                         = String
   type SipUri                          = String
   type SkillGroupDataList              = js.Array[SkillGroupData]
   type SkillGroupDescription           = String
@@ -145,22 +122,18 @@ package object alexaforbusiness {
   type SkillName                       = String
   type SkillStoreType                  = String
   type SkillSummaryList                = js.Array[SkillSummary]
-  type SkillType                       = String
-  type SkillTypeFilter                 = String
   type SkillTypes                      = js.Array[SkillStoreType]
   type SkillsStoreSkillList            = js.Array[SkillsStoreSkill]
   type SmartHomeApplianceList          = js.Array[SmartHomeAppliance]
   type SoftwareVersion                 = String
   type SortKey                         = String
   type SortList                        = js.Array[Sort]
-  type SortValue                       = String
   type SsmlList                        = js.Array[Ssml]
   type SsmlValue                       = String
   type TagKey                          = String
   type TagKeyList                      = js.Array[TagKey]
   type TagList                         = js.Array[Tag]
   type TagValue                        = String
-  type TemperatureUnit                 = String
   type TextList                        = js.Array[Text]
   type TextValue                       = String
   type TimeToLiveInSeconds             = Int
@@ -174,7 +147,6 @@ package object alexaforbusiness {
   type UserId                          = String
   type Utterance                       = String
   type Value                           = String
-  type WakeWord                        = String
   type user_FirstName                  = String
   type user_LastName                   = String
   type user_UserId                     = String
@@ -915,26 +887,29 @@ package alexaforbusiness {
       __obj.asInstanceOf[BusinessReportContentRange]
     }
   }
-
-  object BusinessReportFailureCodeEnum {
-    val ACCESS_DENIED    = "ACCESS_DENIED"
-    val NO_SUCH_BUCKET   = "NO_SUCH_BUCKET"
-    val INTERNAL_FAILURE = "INTERNAL_FAILURE"
+  @js.native
+  sealed trait BusinessReportFailureCode extends js.Any
+  object BusinessReportFailureCode extends js.Object {
+    val ACCESS_DENIED    = "ACCESS_DENIED".asInstanceOf[BusinessReportFailureCode]
+    val NO_SUCH_BUCKET   = "NO_SUCH_BUCKET".asInstanceOf[BusinessReportFailureCode]
+    val INTERNAL_FAILURE = "INTERNAL_FAILURE".asInstanceOf[BusinessReportFailureCode]
 
     val values = js.Object.freeze(js.Array(ACCESS_DENIED, NO_SUCH_BUCKET, INTERNAL_FAILURE))
   }
-
-  object BusinessReportFormatEnum {
-    val CSV     = "CSV"
-    val CSV_ZIP = "CSV_ZIP"
+  @js.native
+  sealed trait BusinessReportFormat extends js.Any
+  object BusinessReportFormat extends js.Object {
+    val CSV     = "CSV".asInstanceOf[BusinessReportFormat]
+    val CSV_ZIP = "CSV_ZIP".asInstanceOf[BusinessReportFormat]
 
     val values = js.Object.freeze(js.Array(CSV, CSV_ZIP))
   }
-
-  object BusinessReportIntervalEnum {
-    val ONE_DAY     = "ONE_DAY"
-    val ONE_WEEK    = "ONE_WEEK"
-    val THIRTY_DAYS = "THIRTY_DAYS"
+  @js.native
+  sealed trait BusinessReportInterval extends js.Any
+  object BusinessReportInterval extends js.Object {
+    val ONE_DAY     = "ONE_DAY".asInstanceOf[BusinessReportInterval]
+    val ONE_WEEK    = "ONE_WEEK".asInstanceOf[BusinessReportInterval]
+    val THIRTY_DAYS = "THIRTY_DAYS".asInstanceOf[BusinessReportInterval]
 
     val values = js.Object.freeze(js.Array(ONE_DAY, ONE_WEEK, THIRTY_DAYS))
   }
@@ -1019,11 +994,12 @@ package alexaforbusiness {
       __obj.asInstanceOf[BusinessReportSchedule]
     }
   }
-
-  object BusinessReportStatusEnum {
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait BusinessReportStatus extends js.Any
+  object BusinessReportStatus extends js.Object {
+    val RUNNING   = "RUNNING".asInstanceOf[BusinessReportStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[BusinessReportStatus]
+    val FAILED    = "FAILED".asInstanceOf[BusinessReportStatus]
 
     val values = js.Object.freeze(js.Array(RUNNING, SUCCEEDED, FAILED))
   }
@@ -1049,11 +1025,12 @@ package alexaforbusiness {
       __obj.asInstanceOf[Category]
     }
   }
-
-  object CommsProtocolEnum {
-    val SIP  = "SIP"
-    val SIPS = "SIPS"
-    val H323 = "H323"
+  @js.native
+  sealed trait CommsProtocol extends js.Any
+  object CommsProtocol extends js.Object {
+    val SIP  = "SIP".asInstanceOf[CommsProtocol]
+    val SIPS = "SIPS".asInstanceOf[CommsProtocol]
+    val H323 = "H323".asInstanceOf[CommsProtocol]
 
     val values = js.Object.freeze(js.Array(SIP, SIPS, H323))
   }
@@ -1112,27 +1089,29 @@ package alexaforbusiness {
       __obj.asInstanceOf[ConferenceProvider]
     }
   }
-
-  object ConferenceProviderTypeEnum {
-    val CHIME              = "CHIME"
-    val BLUEJEANS          = "BLUEJEANS"
-    val FUZE               = "FUZE"
-    val GOOGLE_HANGOUTS    = "GOOGLE_HANGOUTS"
-    val POLYCOM            = "POLYCOM"
-    val RINGCENTRAL        = "RINGCENTRAL"
-    val SKYPE_FOR_BUSINESS = "SKYPE_FOR_BUSINESS"
-    val WEBEX              = "WEBEX"
-    val ZOOM               = "ZOOM"
-    val CUSTOM             = "CUSTOM"
+  @js.native
+  sealed trait ConferenceProviderType extends js.Any
+  object ConferenceProviderType extends js.Object {
+    val CHIME              = "CHIME".asInstanceOf[ConferenceProviderType]
+    val BLUEJEANS          = "BLUEJEANS".asInstanceOf[ConferenceProviderType]
+    val FUZE               = "FUZE".asInstanceOf[ConferenceProviderType]
+    val GOOGLE_HANGOUTS    = "GOOGLE_HANGOUTS".asInstanceOf[ConferenceProviderType]
+    val POLYCOM            = "POLYCOM".asInstanceOf[ConferenceProviderType]
+    val RINGCENTRAL        = "RINGCENTRAL".asInstanceOf[ConferenceProviderType]
+    val SKYPE_FOR_BUSINESS = "SKYPE_FOR_BUSINESS".asInstanceOf[ConferenceProviderType]
+    val WEBEX              = "WEBEX".asInstanceOf[ConferenceProviderType]
+    val ZOOM               = "ZOOM".asInstanceOf[ConferenceProviderType]
+    val CUSTOM             = "CUSTOM".asInstanceOf[ConferenceProviderType]
 
     val values = js.Object.freeze(
       js.Array(CHIME, BLUEJEANS, FUZE, GOOGLE_HANGOUTS, POLYCOM, RINGCENTRAL, SKYPE_FOR_BUSINESS, WEBEX, ZOOM, CUSTOM)
     )
   }
-
-  object ConnectionStatusEnum {
-    val ONLINE  = "ONLINE"
-    val OFFLINE = "OFFLINE"
+  @js.native
+  sealed trait ConnectionStatus extends js.Any
+  object ConnectionStatus extends js.Object {
+    val ONLINE  = "ONLINE".asInstanceOf[ConnectionStatus]
+    val OFFLINE = "OFFLINE".asInstanceOf[ConnectionStatus]
 
     val values = js.Object.freeze(js.Array(ONLINE, OFFLINE))
   }
@@ -2436,10 +2415,11 @@ package alexaforbusiness {
       __obj.asInstanceOf[DeviceEvent]
     }
   }
-
-  object DeviceEventTypeEnum {
-    val CONNECTION_STATUS = "CONNECTION_STATUS"
-    val DEVICE_STATUS     = "DEVICE_STATUS"
+  @js.native
+  sealed trait DeviceEventType extends js.Any
+  object DeviceEventType extends js.Object {
+    val CONNECTION_STATUS = "CONNECTION_STATUS".asInstanceOf[DeviceEventType]
+    val DEVICE_STATUS     = "DEVICE_STATUS".asInstanceOf[DeviceEventType]
 
     val values = js.Object.freeze(js.Array(CONNECTION_STATUS, DEVICE_STATUS))
   }
@@ -2470,13 +2450,14 @@ package alexaforbusiness {
       __obj.asInstanceOf[DeviceNetworkProfileInfo]
     }
   }
-
-  object DeviceStatusEnum {
-    val READY        = "READY"
-    val PENDING      = "PENDING"
-    val WAS_OFFLINE  = "WAS_OFFLINE"
-    val DEREGISTERED = "DEREGISTERED"
-    val FAILED       = "FAILED"
+  @js.native
+  sealed trait DeviceStatus extends js.Any
+  object DeviceStatus extends js.Object {
+    val READY        = "READY".asInstanceOf[DeviceStatus]
+    val PENDING      = "PENDING".asInstanceOf[DeviceStatus]
+    val WAS_OFFLINE  = "WAS_OFFLINE".asInstanceOf[DeviceStatus]
+    val DEREGISTERED = "DEREGISTERED".asInstanceOf[DeviceStatus]
+    val FAILED       = "FAILED".asInstanceOf[DeviceStatus]
 
     val values = js.Object.freeze(js.Array(READY, PENDING, WAS_OFFLINE, DEREGISTERED, FAILED))
   }
@@ -2502,23 +2483,24 @@ package alexaforbusiness {
       __obj.asInstanceOf[DeviceStatusDetail]
     }
   }
-
-  object DeviceStatusDetailCodeEnum {
-    val DEVICE_SOFTWARE_UPDATE_NEEDED      = "DEVICE_SOFTWARE_UPDATE_NEEDED"
-    val DEVICE_WAS_OFFLINE                 = "DEVICE_WAS_OFFLINE"
-    val CREDENTIALS_ACCESS_FAILURE         = "CREDENTIALS_ACCESS_FAILURE"
-    val TLS_VERSION_MISMATCH               = "TLS_VERSION_MISMATCH"
-    val ASSOCIATION_REJECTION              = "ASSOCIATION_REJECTION"
-    val AUTHENTICATION_FAILURE             = "AUTHENTICATION_FAILURE"
-    val DHCP_FAILURE                       = "DHCP_FAILURE"
-    val INTERNET_UNAVAILABLE               = "INTERNET_UNAVAILABLE"
-    val DNS_FAILURE                        = "DNS_FAILURE"
-    val UNKNOWN_FAILURE                    = "UNKNOWN_FAILURE"
-    val CERTIFICATE_ISSUING_LIMIT_EXCEEDED = "CERTIFICATE_ISSUING_LIMIT_EXCEEDED"
-    val INVALID_CERTIFICATE_AUTHORITY      = "INVALID_CERTIFICATE_AUTHORITY"
-    val NETWORK_PROFILE_NOT_FOUND          = "NETWORK_PROFILE_NOT_FOUND"
-    val INVALID_PASSWORD_STATE             = "INVALID_PASSWORD_STATE"
-    val PASSWORD_NOT_FOUND                 = "PASSWORD_NOT_FOUND"
+  @js.native
+  sealed trait DeviceStatusDetailCode extends js.Any
+  object DeviceStatusDetailCode extends js.Object {
+    val DEVICE_SOFTWARE_UPDATE_NEEDED      = "DEVICE_SOFTWARE_UPDATE_NEEDED".asInstanceOf[DeviceStatusDetailCode]
+    val DEVICE_WAS_OFFLINE                 = "DEVICE_WAS_OFFLINE".asInstanceOf[DeviceStatusDetailCode]
+    val CREDENTIALS_ACCESS_FAILURE         = "CREDENTIALS_ACCESS_FAILURE".asInstanceOf[DeviceStatusDetailCode]
+    val TLS_VERSION_MISMATCH               = "TLS_VERSION_MISMATCH".asInstanceOf[DeviceStatusDetailCode]
+    val ASSOCIATION_REJECTION              = "ASSOCIATION_REJECTION".asInstanceOf[DeviceStatusDetailCode]
+    val AUTHENTICATION_FAILURE             = "AUTHENTICATION_FAILURE".asInstanceOf[DeviceStatusDetailCode]
+    val DHCP_FAILURE                       = "DHCP_FAILURE".asInstanceOf[DeviceStatusDetailCode]
+    val INTERNET_UNAVAILABLE               = "INTERNET_UNAVAILABLE".asInstanceOf[DeviceStatusDetailCode]
+    val DNS_FAILURE                        = "DNS_FAILURE".asInstanceOf[DeviceStatusDetailCode]
+    val UNKNOWN_FAILURE                    = "UNKNOWN_FAILURE".asInstanceOf[DeviceStatusDetailCode]
+    val CERTIFICATE_ISSUING_LIMIT_EXCEEDED = "CERTIFICATE_ISSUING_LIMIT_EXCEEDED".asInstanceOf[DeviceStatusDetailCode]
+    val INVALID_CERTIFICATE_AUTHORITY      = "INVALID_CERTIFICATE_AUTHORITY".asInstanceOf[DeviceStatusDetailCode]
+    val NETWORK_PROFILE_NOT_FOUND          = "NETWORK_PROFILE_NOT_FOUND".asInstanceOf[DeviceStatusDetailCode]
+    val INVALID_PASSWORD_STATE             = "INVALID_PASSWORD_STATE".asInstanceOf[DeviceStatusDetailCode]
+    val PASSWORD_NOT_FOUND                 = "PASSWORD_NOT_FOUND".asInstanceOf[DeviceStatusDetailCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2567,9 +2549,10 @@ package alexaforbusiness {
       __obj.asInstanceOf[DeviceStatusInfo]
     }
   }
-
-  object DeviceUsageTypeEnum {
-    val VOICE = "VOICE"
+  @js.native
+  sealed trait DeviceUsageType extends js.Any
+  object DeviceUsageType extends js.Object {
+    val VOICE = "VOICE".asInstanceOf[DeviceUsageType]
 
     val values = js.Object.freeze(js.Array(VOICE))
   }
@@ -2733,24 +2716,27 @@ package alexaforbusiness {
       __obj.asInstanceOf[DisassociateSkillGroupFromRoomResponse]
     }
   }
-
-  object DistanceUnitEnum {
-    val METRIC   = "METRIC"
-    val IMPERIAL = "IMPERIAL"
+  @js.native
+  sealed trait DistanceUnit extends js.Any
+  object DistanceUnit extends js.Object {
+    val METRIC   = "METRIC".asInstanceOf[DistanceUnit]
+    val IMPERIAL = "IMPERIAL".asInstanceOf[DistanceUnit]
 
     val values = js.Object.freeze(js.Array(METRIC, IMPERIAL))
   }
-
-  object EnablementTypeEnum {
-    val ENABLED = "ENABLED"
-    val PENDING = "PENDING"
+  @js.native
+  sealed trait EnablementType extends js.Any
+  object EnablementType extends js.Object {
+    val ENABLED = "ENABLED".asInstanceOf[EnablementType]
+    val PENDING = "PENDING".asInstanceOf[EnablementType]
 
     val values = js.Object.freeze(js.Array(ENABLED, PENDING))
   }
-
-  object EnablementTypeFilterEnum {
-    val ENABLED = "ENABLED"
-    val PENDING = "PENDING"
+  @js.native
+  sealed trait EnablementTypeFilter extends js.Any
+  object EnablementTypeFilter extends js.Object {
+    val ENABLED = "ENABLED".asInstanceOf[EnablementTypeFilter]
+    val PENDING = "PENDING".asInstanceOf[EnablementTypeFilter]
 
     val values = js.Object.freeze(js.Array(ENABLED, PENDING))
   }
@@ -2779,35 +2765,38 @@ package alexaforbusiness {
       __obj.asInstanceOf[EndOfMeetingReminder]
     }
   }
-
-  object EndOfMeetingReminderTypeEnum {
-    val ANNOUNCEMENT_TIME_CHECK         = "ANNOUNCEMENT_TIME_CHECK"
-    val ANNOUNCEMENT_VARIABLE_TIME_LEFT = "ANNOUNCEMENT_VARIABLE_TIME_LEFT"
-    val CHIME                           = "CHIME"
-    val KNOCK                           = "KNOCK"
+  @js.native
+  sealed trait EndOfMeetingReminderType extends js.Any
+  object EndOfMeetingReminderType extends js.Object {
+    val ANNOUNCEMENT_TIME_CHECK         = "ANNOUNCEMENT_TIME_CHECK".asInstanceOf[EndOfMeetingReminderType]
+    val ANNOUNCEMENT_VARIABLE_TIME_LEFT = "ANNOUNCEMENT_VARIABLE_TIME_LEFT".asInstanceOf[EndOfMeetingReminderType]
+    val CHIME                           = "CHIME".asInstanceOf[EndOfMeetingReminderType]
+    val KNOCK                           = "KNOCK".asInstanceOf[EndOfMeetingReminderType]
 
     val values = js.Object.freeze(js.Array(ANNOUNCEMENT_TIME_CHECK, ANNOUNCEMENT_VARIABLE_TIME_LEFT, CHIME, KNOCK))
   }
-
-  object EnrollmentStatusEnum {
-    val INITIALIZED    = "INITIALIZED"
-    val PENDING        = "PENDING"
-    val REGISTERED     = "REGISTERED"
-    val DISASSOCIATING = "DISASSOCIATING"
-    val DEREGISTERING  = "DEREGISTERING"
+  @js.native
+  sealed trait EnrollmentStatus extends js.Any
+  object EnrollmentStatus extends js.Object {
+    val INITIALIZED    = "INITIALIZED".asInstanceOf[EnrollmentStatus]
+    val PENDING        = "PENDING".asInstanceOf[EnrollmentStatus]
+    val REGISTERED     = "REGISTERED".asInstanceOf[EnrollmentStatus]
+    val DISASSOCIATING = "DISASSOCIATING".asInstanceOf[EnrollmentStatus]
+    val DEREGISTERING  = "DEREGISTERING".asInstanceOf[EnrollmentStatus]
 
     val values = js.Object.freeze(js.Array(INITIALIZED, PENDING, REGISTERED, DISASSOCIATING, DEREGISTERING))
   }
-
-  object FeatureEnum {
-    val BLUETOOTH       = "BLUETOOTH"
-    val VOLUME          = "VOLUME"
-    val NOTIFICATIONS   = "NOTIFICATIONS"
-    val LISTS           = "LISTS"
-    val SKILLS          = "SKILLS"
-    val NETWORK_PROFILE = "NETWORK_PROFILE"
-    val SETTINGS        = "SETTINGS"
-    val ALL             = "ALL"
+  @js.native
+  sealed trait Feature extends js.Any
+  object Feature extends js.Object {
+    val BLUETOOTH       = "BLUETOOTH".asInstanceOf[Feature]
+    val VOLUME          = "VOLUME".asInstanceOf[Feature]
+    val NOTIFICATIONS   = "NOTIFICATIONS".asInstanceOf[Feature]
+    val LISTS           = "LISTS".asInstanceOf[Feature]
+    val SKILLS          = "SKILLS".asInstanceOf[Feature]
+    val NETWORK_PROFILE = "NETWORK_PROFILE".asInstanceOf[Feature]
+    val SETTINGS        = "SETTINGS".asInstanceOf[Feature]
+    val ALL             = "ALL".asInstanceOf[Feature]
 
     val values =
       js.Object.freeze(js.Array(BLUETOOTH, VOLUME, NOTIFICATIONS, LISTS, SKILLS, NETWORK_PROFILE, SETTINGS, ALL))
@@ -3876,9 +3865,10 @@ package alexaforbusiness {
       __obj.asInstanceOf[ListTagsResponse]
     }
   }
-
-  object LocaleEnum {
-    val `en-US` = "en-US"
+  @js.native
+  sealed trait Locale extends js.Any
+  object Locale extends js.Object {
+    val `en-US` = "en-US".asInstanceOf[Locale]
 
     val values = js.Object.freeze(js.Array(`en-US`))
   }
@@ -3936,9 +3926,10 @@ package alexaforbusiness {
       __obj.asInstanceOf[MeetingSetting]
     }
   }
-
-  object NetworkEapMethodEnum {
-    val EAP_TLS = "EAP_TLS"
+  @js.native
+  sealed trait NetworkEapMethod extends js.Any
+  object NetworkEapMethod extends js.Object {
+    val EAP_TLS = "EAP_TLS".asInstanceOf[NetworkEapMethod]
 
     val values = js.Object.freeze(js.Array(EAP_TLS))
   }
@@ -4025,13 +4016,14 @@ package alexaforbusiness {
       __obj.asInstanceOf[NetworkProfileData]
     }
   }
-
-  object NetworkSecurityTypeEnum {
-    val OPEN            = "OPEN"
-    val WEP             = "WEP"
-    val WPA_PSK         = "WPA_PSK"
-    val WPA2_PSK        = "WPA2_PSK"
-    val WPA2_ENTERPRISE = "WPA2_ENTERPRISE"
+  @js.native
+  sealed trait NetworkSecurityType extends js.Any
+  object NetworkSecurityType extends js.Object {
+    val OPEN            = "OPEN".asInstanceOf[NetworkSecurityType]
+    val WEP             = "WEP".asInstanceOf[NetworkSecurityType]
+    val WPA_PSK         = "WPA_PSK".asInstanceOf[NetworkSecurityType]
+    val WPA2_PSK        = "WPA2_PSK".asInstanceOf[NetworkSecurityType]
+    val WPA2_ENTERPRISE = "WPA2_ENTERPRISE".asInstanceOf[NetworkSecurityType]
 
     val values = js.Object.freeze(js.Array(OPEN, WEP, WPA_PSK, WPA2_PSK, WPA2_ENTERPRISE))
   }
@@ -4089,11 +4081,12 @@ package alexaforbusiness {
       __obj.asInstanceOf[PhoneNumber]
     }
   }
-
-  object PhoneNumberTypeEnum {
-    val MOBILE = "MOBILE"
-    val WORK   = "WORK"
-    val HOME   = "HOME"
+  @js.native
+  sealed trait PhoneNumberType extends js.Any
+  object PhoneNumberType extends js.Object {
+    val MOBILE = "MOBILE".asInstanceOf[PhoneNumberType]
+    val WORK   = "WORK".asInstanceOf[PhoneNumberType]
+    val HOME   = "HOME".asInstanceOf[PhoneNumberType]
 
     val values = js.Object.freeze(js.Array(MOBILE, WORK, HOME))
   }
@@ -4439,11 +4432,12 @@ package alexaforbusiness {
       __obj.asInstanceOf[RequireCheckIn]
     }
   }
-
-  object RequirePinEnum {
-    val YES      = "YES"
-    val NO       = "NO"
-    val OPTIONAL = "OPTIONAL"
+  @js.native
+  sealed trait RequirePin extends js.Any
+  object RequirePin extends js.Object {
+    val YES      = "YES".asInstanceOf[RequirePin]
+    val NO       = "NO".asInstanceOf[RequirePin]
+    val OPTIONAL = "OPTIONAL".asInstanceOf[RequirePin]
 
     val values = js.Object.freeze(js.Array(YES, NO, OPTIONAL))
   }
@@ -5083,9 +5077,10 @@ package alexaforbusiness {
       __obj.asInstanceOf[SipAddress]
     }
   }
-
-  object SipTypeEnum {
-    val WORK = "WORK"
+  @js.native
+  sealed trait SipType extends js.Any
+  object SipType extends js.Object {
+    val WORK = "WORK".asInstanceOf[SipType]
 
     val values = js.Object.freeze(js.Array(WORK))
   }
@@ -5218,18 +5213,20 @@ package alexaforbusiness {
       __obj.asInstanceOf[SkillSummary]
     }
   }
-
-  object SkillTypeEnum {
-    val PUBLIC  = "PUBLIC"
-    val PRIVATE = "PRIVATE"
+  @js.native
+  sealed trait SkillType extends js.Any
+  object SkillType extends js.Object {
+    val PUBLIC  = "PUBLIC".asInstanceOf[SkillType]
+    val PRIVATE = "PRIVATE".asInstanceOf[SkillType]
 
     val values = js.Object.freeze(js.Array(PUBLIC, PRIVATE))
   }
-
-  object SkillTypeFilterEnum {
-    val PUBLIC  = "PUBLIC"
-    val PRIVATE = "PRIVATE"
-    val ALL     = "ALL"
+  @js.native
+  sealed trait SkillTypeFilter extends js.Any
+  object SkillTypeFilter extends js.Object {
+    val PUBLIC  = "PUBLIC".asInstanceOf[SkillTypeFilter]
+    val PRIVATE = "PRIVATE".asInstanceOf[SkillTypeFilter]
+    val ALL     = "ALL".asInstanceOf[SkillTypeFilter]
 
     val values = js.Object.freeze(js.Array(PUBLIC, PRIVATE, ALL))
   }
@@ -5319,10 +5316,11 @@ package alexaforbusiness {
       __obj.asInstanceOf[Sort]
     }
   }
-
-  object SortValueEnum {
-    val ASC  = "ASC"
-    val DESC = "DESC"
+  @js.native
+  sealed trait SortValue extends js.Any
+  object SortValue extends js.Object {
+    val ASC  = "ASC".asInstanceOf[SortValue]
+    val DESC = "DESC".asInstanceOf[SortValue]
 
     val values = js.Object.freeze(js.Array(ASC, DESC))
   }
@@ -5476,10 +5474,11 @@ package alexaforbusiness {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TemperatureUnitEnum {
-    val FAHRENHEIT = "FAHRENHEIT"
-    val CELSIUS    = "CELSIUS"
+  @js.native
+  sealed trait TemperatureUnit extends js.Any
+  object TemperatureUnit extends js.Object {
+    val FAHRENHEIT = "FAHRENHEIT".asInstanceOf[TemperatureUnit]
+    val CELSIUS    = "CELSIUS".asInstanceOf[TemperatureUnit]
 
     val values = js.Object.freeze(js.Array(FAHRENHEIT, CELSIUS))
   }
@@ -6148,12 +6147,13 @@ package alexaforbusiness {
       __obj.asInstanceOf[UserData]
     }
   }
-
-  object WakeWordEnum {
-    val ALEXA    = "ALEXA"
-    val AMAZON   = "AMAZON"
-    val ECHO     = "ECHO"
-    val COMPUTER = "COMPUTER"
+  @js.native
+  sealed trait WakeWord extends js.Any
+  object WakeWord extends js.Object {
+    val ALEXA    = "ALEXA".asInstanceOf[WakeWord]
+    val AMAZON   = "AMAZON".asInstanceOf[WakeWord]
+    val ECHO     = "ECHO".asInstanceOf[WakeWord]
+    val COMPUTER = "COMPUTER".asInstanceOf[WakeWord]
 
     val values = js.Object.freeze(js.Array(ALEXA, AMAZON, ECHO, COMPUTER))
   }

--- a/services/amplify/src/main/scala/facade/amazonaws/services/Amplify.scala
+++ b/services/amplify/src/main/scala/facade/amazonaws/services/Amplify.scala
@@ -47,7 +47,6 @@ package object amplify {
   type DomainAssociations               = js.Array[DomainAssociation]
   type DomainName                       = String
   type DomainPrefix                     = String
-  type DomainStatus                     = String
   type EnableAutoBranchCreation         = Boolean
   type EnableAutoBuild                  = Boolean
   type EnableAutoSubDomain              = Boolean
@@ -67,9 +66,7 @@ package object amplify {
   type JobArn                           = String
   type JobId                            = String
   type JobReason                        = String
-  type JobStatus                        = String
   type JobSummaries                     = js.Array[JobSummary]
-  type JobType                          = String
   type LastDeployTime                   = js.Date
   type LogUrl                           = String
   type MD5Hash                          = String
@@ -77,7 +74,6 @@ package object amplify {
   type Name                             = String
   type NextToken                        = String
   type OauthToken                       = String
-  type Platform                         = String
   type PullRequestEnvironmentName       = String
   type Repository                       = String
   type ResourceArn                      = String
@@ -86,7 +82,6 @@ package object amplify {
   type Source                           = String
   type SourceUrl                        = String
   type StackName                        = String
-  type Stage                            = String
   type StartTime                        = js.Date
   type Status                           = String
   type StatusReason                     = String
@@ -1252,16 +1247,17 @@ package amplify {
       __obj.asInstanceOf[DomainAssociation]
     }
   }
-
-  object DomainStatusEnum {
-    val PENDING_VERIFICATION   = "PENDING_VERIFICATION"
-    val IN_PROGRESS            = "IN_PROGRESS"
-    val AVAILABLE              = "AVAILABLE"
-    val PENDING_DEPLOYMENT     = "PENDING_DEPLOYMENT"
-    val FAILED                 = "FAILED"
-    val CREATING               = "CREATING"
-    val REQUESTING_CERTIFICATE = "REQUESTING_CERTIFICATE"
-    val UPDATING               = "UPDATING"
+  @js.native
+  sealed trait DomainStatus extends js.Any
+  object DomainStatus extends js.Object {
+    val PENDING_VERIFICATION   = "PENDING_VERIFICATION".asInstanceOf[DomainStatus]
+    val IN_PROGRESS            = "IN_PROGRESS".asInstanceOf[DomainStatus]
+    val AVAILABLE              = "AVAILABLE".asInstanceOf[DomainStatus]
+    val PENDING_DEPLOYMENT     = "PENDING_DEPLOYMENT".asInstanceOf[DomainStatus]
+    val FAILED                 = "FAILED".asInstanceOf[DomainStatus]
+    val CREATING               = "CREATING".asInstanceOf[DomainStatus]
+    val REQUESTING_CERTIFICATE = "REQUESTING_CERTIFICATE".asInstanceOf[DomainStatus]
+    val UPDATING               = "UPDATING".asInstanceOf[DomainStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1652,15 +1648,16 @@ package amplify {
       __obj.asInstanceOf[Job]
     }
   }
-
-  object JobStatusEnum {
-    val PENDING      = "PENDING"
-    val PROVISIONING = "PROVISIONING"
-    val RUNNING      = "RUNNING"
-    val FAILED       = "FAILED"
-    val SUCCEED      = "SUCCEED"
-    val CANCELLING   = "CANCELLING"
-    val CANCELLED    = "CANCELLED"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val PENDING      = "PENDING".asInstanceOf[JobStatus]
+    val PROVISIONING = "PROVISIONING".asInstanceOf[JobStatus]
+    val RUNNING      = "RUNNING".asInstanceOf[JobStatus]
+    val FAILED       = "FAILED".asInstanceOf[JobStatus]
+    val SUCCEED      = "SUCCEED".asInstanceOf[JobStatus]
+    val CANCELLING   = "CANCELLING".asInstanceOf[JobStatus]
+    val CANCELLED    = "CANCELLED".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, PROVISIONING, RUNNING, FAILED, SUCCEED, CANCELLING, CANCELLED))
   }
@@ -1709,12 +1706,13 @@ package amplify {
       __obj.asInstanceOf[JobSummary]
     }
   }
-
-  object JobTypeEnum {
-    val RELEASE  = "RELEASE"
-    val RETRY    = "RETRY"
-    val MANUAL   = "MANUAL"
-    val WEB_HOOK = "WEB_HOOK"
+  @js.native
+  sealed trait JobType extends js.Any
+  object JobType extends js.Object {
+    val RELEASE  = "RELEASE".asInstanceOf[JobType]
+    val RETRY    = "RETRY".asInstanceOf[JobType]
+    val MANUAL   = "MANUAL".asInstanceOf[JobType]
+    val WEB_HOOK = "WEB_HOOK".asInstanceOf[JobType]
 
     val values = js.Object.freeze(js.Array(RELEASE, RETRY, MANUAL, WEB_HOOK))
   }
@@ -2122,9 +2120,10 @@ package amplify {
       __obj.asInstanceOf[ListWebhooksResult]
     }
   }
-
-  object PlatformEnum {
-    val WEB = "WEB"
+  @js.native
+  sealed trait Platform extends js.Any
+  object Platform extends js.Object {
+    val WEB = "WEB".asInstanceOf[Platform]
 
     val values = js.Object.freeze(js.Array(WEB))
   }
@@ -2156,13 +2155,14 @@ package amplify {
       __obj.asInstanceOf[ProductionBranch]
     }
   }
-
-  object StageEnum {
-    val PRODUCTION   = "PRODUCTION"
-    val BETA         = "BETA"
-    val DEVELOPMENT  = "DEVELOPMENT"
-    val EXPERIMENTAL = "EXPERIMENTAL"
-    val PULL_REQUEST = "PULL_REQUEST"
+  @js.native
+  sealed trait Stage extends js.Any
+  object Stage extends js.Object {
+    val PRODUCTION   = "PRODUCTION".asInstanceOf[Stage]
+    val BETA         = "BETA".asInstanceOf[Stage]
+    val DEVELOPMENT  = "DEVELOPMENT".asInstanceOf[Stage]
+    val EXPERIMENTAL = "EXPERIMENTAL".asInstanceOf[Stage]
+    val PULL_REQUEST = "PULL_REQUEST".asInstanceOf[Stage]
 
     val values = js.Object.freeze(js.Array(PRODUCTION, BETA, DEVELOPMENT, EXPERIMENTAL, PULL_REQUEST))
   }

--- a/services/apigateway/src/main/scala/facade/amazonaws/services/APIGateway.scala
+++ b/services/apigateway/src/main/scala/facade/amazonaws/services/APIGateway.scala
@@ -7,70 +7,51 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object apigateway {
-  type ApiKeySourceType                       = String
-  type ApiKeysFormat                          = String
-  type AuthorizerType                         = String
-  type Blob                                   = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type CacheClusterSize                       = String
-  type CacheClusterStatus                     = String
-  type ConnectionType                         = String
-  type ContentHandlingStrategy                = String
-  type DocumentationPartLocationStatusCode    = String
-  type DocumentationPartType                  = String
-  type DomainNameStatus                       = String
-  type EndpointType                           = String
-  type GatewayResponseType                    = String
-  type IntegrationType                        = String
-  type ListOfARNs                             = js.Array[ProviderARN]
-  type ListOfApiKey                           = js.Array[ApiKey]
-  type ListOfApiStage                         = js.Array[ApiStage]
-  type ListOfAuthorizer                       = js.Array[Authorizer]
-  type ListOfBasePathMapping                  = js.Array[BasePathMapping]
-  type ListOfClientCertificate                = js.Array[ClientCertificate]
-  type ListOfDeployment                       = js.Array[Deployment]
-  type ListOfDocumentationPart                = js.Array[DocumentationPart]
-  type ListOfDocumentationVersion             = js.Array[DocumentationVersion]
-  type ListOfDomainName                       = js.Array[DomainName]
-  type ListOfEndpointType                     = js.Array[EndpointType]
-  type ListOfGatewayResponse                  = js.Array[GatewayResponse]
-  type ListOfLong                             = js.Array[Double]
-  type ListOfModel                            = js.Array[Model]
-  type ListOfPatchOperation                   = js.Array[PatchOperation]
-  type ListOfRequestValidator                 = js.Array[RequestValidator]
-  type ListOfResource                         = js.Array[Resource]
-  type ListOfRestApi                          = js.Array[RestApi]
-  type ListOfSdkConfigurationProperty         = js.Array[SdkConfigurationProperty]
-  type ListOfSdkType                          = js.Array[SdkType]
-  type ListOfStage                            = js.Array[Stage]
-  type ListOfStageKeys                        = js.Array[StageKey]
-  type ListOfString                           = js.Array[String]
-  type ListOfUsage                            = js.Array[ListOfLong]
-  type ListOfUsagePlan                        = js.Array[UsagePlan]
-  type ListOfUsagePlanKey                     = js.Array[UsagePlanKey]
-  type ListOfVpcLink                          = js.Array[VpcLink]
-  type LocationStatusType                     = String
-  type MapOfApiStageThrottleSettings          = js.Dictionary[ThrottleSettings]
-  type MapOfIntegrationResponse               = js.Dictionary[IntegrationResponse]
-  type MapOfKeyUsages                         = js.Dictionary[ListOfUsage]
-  type MapOfMethod                            = js.Dictionary[Method]
-  type MapOfMethodResponse                    = js.Dictionary[MethodResponse]
-  type MapOfMethodSettings                    = js.Dictionary[MethodSetting]
-  type MapOfMethodSnapshot                    = js.Dictionary[MethodSnapshot]
-  type MapOfStringToBoolean                   = js.Dictionary[NullableBoolean]
-  type MapOfStringToList                      = js.Dictionary[ListOfString]
-  type MapOfStringToString                    = js.Dictionary[String]
-  type NullableBoolean                        = Boolean
-  type NullableInteger                        = Int
-  type Op                                     = String
-  type PathToMapOfMethodSnapshot              = js.Dictionary[MapOfMethodSnapshot]
-  type ProviderARN                            = String
-  type PutMode                                = String
-  type QuotaPeriodType                        = String
-  type SecurityPolicy                         = String
-  type StatusCode                             = String
-  type Timestamp                              = js.Date
-  type UnauthorizedCacheControlHeaderStrategy = String
-  type VpcLinkStatus                          = String
+  type Blob                                = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type DocumentationPartLocationStatusCode = String
+  type ListOfARNs                          = js.Array[ProviderARN]
+  type ListOfApiKey                        = js.Array[ApiKey]
+  type ListOfApiStage                      = js.Array[ApiStage]
+  type ListOfAuthorizer                    = js.Array[Authorizer]
+  type ListOfBasePathMapping               = js.Array[BasePathMapping]
+  type ListOfClientCertificate             = js.Array[ClientCertificate]
+  type ListOfDeployment                    = js.Array[Deployment]
+  type ListOfDocumentationPart             = js.Array[DocumentationPart]
+  type ListOfDocumentationVersion          = js.Array[DocumentationVersion]
+  type ListOfDomainName                    = js.Array[DomainName]
+  type ListOfEndpointType                  = js.Array[EndpointType]
+  type ListOfGatewayResponse               = js.Array[GatewayResponse]
+  type ListOfLong                          = js.Array[Double]
+  type ListOfModel                         = js.Array[Model]
+  type ListOfPatchOperation                = js.Array[PatchOperation]
+  type ListOfRequestValidator              = js.Array[RequestValidator]
+  type ListOfResource                      = js.Array[Resource]
+  type ListOfRestApi                       = js.Array[RestApi]
+  type ListOfSdkConfigurationProperty      = js.Array[SdkConfigurationProperty]
+  type ListOfSdkType                       = js.Array[SdkType]
+  type ListOfStage                         = js.Array[Stage]
+  type ListOfStageKeys                     = js.Array[StageKey]
+  type ListOfString                        = js.Array[String]
+  type ListOfUsage                         = js.Array[ListOfLong]
+  type ListOfUsagePlan                     = js.Array[UsagePlan]
+  type ListOfUsagePlanKey                  = js.Array[UsagePlanKey]
+  type ListOfVpcLink                       = js.Array[VpcLink]
+  type MapOfApiStageThrottleSettings       = js.Dictionary[ThrottleSettings]
+  type MapOfIntegrationResponse            = js.Dictionary[IntegrationResponse]
+  type MapOfKeyUsages                      = js.Dictionary[ListOfUsage]
+  type MapOfMethod                         = js.Dictionary[Method]
+  type MapOfMethodResponse                 = js.Dictionary[MethodResponse]
+  type MapOfMethodSettings                 = js.Dictionary[MethodSetting]
+  type MapOfMethodSnapshot                 = js.Dictionary[MethodSnapshot]
+  type MapOfStringToBoolean                = js.Dictionary[NullableBoolean]
+  type MapOfStringToList                   = js.Dictionary[ListOfString]
+  type MapOfStringToString                 = js.Dictionary[String]
+  type NullableBoolean                     = Boolean
+  type NullableInteger                     = Int
+  type PathToMapOfMethodSnapshot           = js.Dictionary[MapOfMethodSnapshot]
+  type ProviderARN                         = String
+  type StatusCode                          = String
+  type Timestamp                           = js.Date
 
   implicit final class APIGatewayOps(private val service: APIGateway) extends AnyVal {
 
@@ -574,10 +555,11 @@ package apigateway {
       __obj.asInstanceOf[ApiKeyIds]
     }
   }
-
-  object ApiKeySourceTypeEnum {
-    val HEADER     = "HEADER"
-    val AUTHORIZER = "AUTHORIZER"
+  @js.native
+  sealed trait ApiKeySourceType extends js.Any
+  object ApiKeySourceType extends js.Object {
+    val HEADER     = "HEADER".asInstanceOf[ApiKeySourceType]
+    val AUTHORIZER = "AUTHORIZER".asInstanceOf[ApiKeySourceType]
 
     val values = js.Object.freeze(js.Array(HEADER, AUTHORIZER))
   }
@@ -608,9 +590,10 @@ package apigateway {
       __obj.asInstanceOf[ApiKeys]
     }
   }
-
-  object ApiKeysFormatEnum {
-    val csv = "csv"
+  @js.native
+  sealed trait ApiKeysFormat extends js.Any
+  object ApiKeysFormat extends js.Object {
+    val csv = "csv".asInstanceOf[ApiKeysFormat]
 
     val values = js.Object.freeze(js.Array(csv))
   }
@@ -695,10 +678,12 @@ package apigateway {
   /**
     * The authorizer type. Valid values are <code>TOKEN</code> for a Lambda function using a single authorization token submitted in a custom header, <code>REQUEST</code> for a Lambda function using incoming request parameters, and <code>COGNITO_USER_POOLS</code> for using an Amazon Cognito user pool.
     */
-  object AuthorizerTypeEnum {
-    val TOKEN              = "TOKEN"
-    val REQUEST            = "REQUEST"
-    val COGNITO_USER_POOLS = "COGNITO_USER_POOLS"
+  @js.native
+  sealed trait AuthorizerType extends js.Any
+  object AuthorizerType extends js.Object {
+    val TOKEN              = "TOKEN".asInstanceOf[AuthorizerType]
+    val REQUEST            = "REQUEST".asInstanceOf[AuthorizerType]
+    val COGNITO_USER_POOLS = "COGNITO_USER_POOLS".asInstanceOf[AuthorizerType]
 
     val values = js.Object.freeze(js.Array(TOKEN, REQUEST, COGNITO_USER_POOLS))
   }
@@ -781,15 +766,17 @@ package apigateway {
   /**
     * Returns the size of the ```CacheCluster```.
     */
-  object CacheClusterSizeEnum {
-    val `0.5`  = "0.5"
-    val `1.6`  = "1.6"
-    val `6.1`  = "6.1"
-    val `13.5` = "13.5"
-    val `28.4` = "28.4"
-    val `58.2` = "58.2"
-    val `118`  = "118"
-    val `237`  = "237"
+  @js.native
+  sealed trait CacheClusterSize extends js.Any
+  object CacheClusterSize extends js.Object {
+    val `0.5`  = "0.5".asInstanceOf[CacheClusterSize]
+    val `1.6`  = "1.6".asInstanceOf[CacheClusterSize]
+    val `6.1`  = "6.1".asInstanceOf[CacheClusterSize]
+    val `13.5` = "13.5".asInstanceOf[CacheClusterSize]
+    val `28.4` = "28.4".asInstanceOf[CacheClusterSize]
+    val `58.2` = "58.2".asInstanceOf[CacheClusterSize]
+    val `118`  = "118".asInstanceOf[CacheClusterSize]
+    val `237`  = "237".asInstanceOf[CacheClusterSize]
 
     val values = js.Object.freeze(js.Array(`0.5`, `1.6`, `6.1`, `13.5`, `28.4`, `58.2`, `118`, `237`))
   }
@@ -797,12 +784,14 @@ package apigateway {
   /**
     * Returns the status of the ```CacheCluster```.
     */
-  object CacheClusterStatusEnum {
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val AVAILABLE          = "AVAILABLE"
-    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
-    val NOT_AVAILABLE      = "NOT_AVAILABLE"
-    val FLUSH_IN_PROGRESS  = "FLUSH_IN_PROGRESS"
+  @js.native
+  sealed trait CacheClusterStatus extends js.Any
+  object CacheClusterStatus extends js.Object {
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[CacheClusterStatus]
+    val AVAILABLE          = "AVAILABLE".asInstanceOf[CacheClusterStatus]
+    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS".asInstanceOf[CacheClusterStatus]
+    val NOT_AVAILABLE      = "NOT_AVAILABLE".asInstanceOf[CacheClusterStatus]
+    val FLUSH_IN_PROGRESS  = "FLUSH_IN_PROGRESS".asInstanceOf[CacheClusterStatus]
 
     val values =
       js.Object.freeze(js.Array(CREATE_IN_PROGRESS, AVAILABLE, DELETE_IN_PROGRESS, NOT_AVAILABLE, FLUSH_IN_PROGRESS))
@@ -895,17 +884,19 @@ package apigateway {
       __obj.asInstanceOf[ClientCertificates]
     }
   }
-
-  object ConnectionTypeEnum {
-    val INTERNET = "INTERNET"
-    val VPC_LINK = "VPC_LINK"
+  @js.native
+  sealed trait ConnectionType extends js.Any
+  object ConnectionType extends js.Object {
+    val INTERNET = "INTERNET".asInstanceOf[ConnectionType]
+    val VPC_LINK = "VPC_LINK".asInstanceOf[ConnectionType]
 
     val values = js.Object.freeze(js.Array(INTERNET, VPC_LINK))
   }
-
-  object ContentHandlingStrategyEnum {
-    val CONVERT_TO_BINARY = "CONVERT_TO_BINARY"
-    val CONVERT_TO_TEXT   = "CONVERT_TO_TEXT"
+  @js.native
+  sealed trait ContentHandlingStrategy extends js.Any
+  object ContentHandlingStrategy extends js.Object {
+    val CONVERT_TO_BINARY = "CONVERT_TO_BINARY".asInstanceOf[ContentHandlingStrategy]
+    val CONVERT_TO_TEXT   = "CONVERT_TO_TEXT".asInstanceOf[ContentHandlingStrategy]
 
     val values = js.Object.freeze(js.Array(CONVERT_TO_BINARY, CONVERT_TO_TEXT))
   }
@@ -2137,20 +2128,21 @@ package apigateway {
       __obj.asInstanceOf[DocumentationPartLocation]
     }
   }
-
-  object DocumentationPartTypeEnum {
-    val API             = "API"
-    val AUTHORIZER      = "AUTHORIZER"
-    val MODEL           = "MODEL"
-    val RESOURCE        = "RESOURCE"
-    val METHOD          = "METHOD"
-    val PATH_PARAMETER  = "PATH_PARAMETER"
-    val QUERY_PARAMETER = "QUERY_PARAMETER"
-    val REQUEST_HEADER  = "REQUEST_HEADER"
-    val REQUEST_BODY    = "REQUEST_BODY"
-    val RESPONSE        = "RESPONSE"
-    val RESPONSE_HEADER = "RESPONSE_HEADER"
-    val RESPONSE_BODY   = "RESPONSE_BODY"
+  @js.native
+  sealed trait DocumentationPartType extends js.Any
+  object DocumentationPartType extends js.Object {
+    val API             = "API".asInstanceOf[DocumentationPartType]
+    val AUTHORIZER      = "AUTHORIZER".asInstanceOf[DocumentationPartType]
+    val MODEL           = "MODEL".asInstanceOf[DocumentationPartType]
+    val RESOURCE        = "RESOURCE".asInstanceOf[DocumentationPartType]
+    val METHOD          = "METHOD".asInstanceOf[DocumentationPartType]
+    val PATH_PARAMETER  = "PATH_PARAMETER".asInstanceOf[DocumentationPartType]
+    val QUERY_PARAMETER = "QUERY_PARAMETER".asInstanceOf[DocumentationPartType]
+    val REQUEST_HEADER  = "REQUEST_HEADER".asInstanceOf[DocumentationPartType]
+    val REQUEST_BODY    = "REQUEST_BODY".asInstanceOf[DocumentationPartType]
+    val RESPONSE        = "RESPONSE".asInstanceOf[DocumentationPartType]
+    val RESPONSE_HEADER = "RESPONSE_HEADER".asInstanceOf[DocumentationPartType]
+    val RESPONSE_BODY   = "RESPONSE_BODY".asInstanceOf[DocumentationPartType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2310,11 +2302,12 @@ package apigateway {
       __obj.asInstanceOf[DomainName]
     }
   }
-
-  object DomainNameStatusEnum {
-    val AVAILABLE = "AVAILABLE"
-    val UPDATING  = "UPDATING"
-    val PENDING   = "PENDING"
+  @js.native
+  sealed trait DomainNameStatus extends js.Any
+  object DomainNameStatus extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[DomainNameStatus]
+    val UPDATING  = "UPDATING".asInstanceOf[DomainNameStatus]
+    val PENDING   = "PENDING".asInstanceOf[DomainNameStatus]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, UPDATING, PENDING))
   }
@@ -2368,10 +2361,12 @@ package apigateway {
   /**
     * The endpoint type. The valid values are <code>EDGE</code> for edge-optimized API setup, most suitable for mobile applications; <code>REGIONAL</code> for regional API endpoint setup, most suitable for calling from AWS Region; and <code>PRIVATE</code> for private APIs.
     */
-  object EndpointTypeEnum {
-    val REGIONAL = "REGIONAL"
-    val EDGE     = "EDGE"
-    val PRIVATE  = "PRIVATE"
+  @js.native
+  sealed trait EndpointType extends js.Any
+  object EndpointType extends js.Object {
+    val REGIONAL = "REGIONAL".asInstanceOf[EndpointType]
+    val EDGE     = "EDGE".asInstanceOf[EndpointType]
+    val PRIVATE  = "PRIVATE".asInstanceOf[EndpointType]
 
     val values = js.Object.freeze(js.Array(REGIONAL, EDGE, PRIVATE))
   }
@@ -2491,28 +2486,29 @@ package apigateway {
       __obj.asInstanceOf[GatewayResponse]
     }
   }
-
-  object GatewayResponseTypeEnum {
-    val DEFAULT_4XX                    = "DEFAULT_4XX"
-    val DEFAULT_5XX                    = "DEFAULT_5XX"
-    val RESOURCE_NOT_FOUND             = "RESOURCE_NOT_FOUND"
-    val UNAUTHORIZED                   = "UNAUTHORIZED"
-    val INVALID_API_KEY                = "INVALID_API_KEY"
-    val ACCESS_DENIED                  = "ACCESS_DENIED"
-    val AUTHORIZER_FAILURE             = "AUTHORIZER_FAILURE"
-    val AUTHORIZER_CONFIGURATION_ERROR = "AUTHORIZER_CONFIGURATION_ERROR"
-    val INVALID_SIGNATURE              = "INVALID_SIGNATURE"
-    val EXPIRED_TOKEN                  = "EXPIRED_TOKEN"
-    val MISSING_AUTHENTICATION_TOKEN   = "MISSING_AUTHENTICATION_TOKEN"
-    val INTEGRATION_FAILURE            = "INTEGRATION_FAILURE"
-    val INTEGRATION_TIMEOUT            = "INTEGRATION_TIMEOUT"
-    val API_CONFIGURATION_ERROR        = "API_CONFIGURATION_ERROR"
-    val UNSUPPORTED_MEDIA_TYPE         = "UNSUPPORTED_MEDIA_TYPE"
-    val BAD_REQUEST_PARAMETERS         = "BAD_REQUEST_PARAMETERS"
-    val BAD_REQUEST_BODY               = "BAD_REQUEST_BODY"
-    val REQUEST_TOO_LARGE              = "REQUEST_TOO_LARGE"
-    val THROTTLED                      = "THROTTLED"
-    val QUOTA_EXCEEDED                 = "QUOTA_EXCEEDED"
+  @js.native
+  sealed trait GatewayResponseType extends js.Any
+  object GatewayResponseType extends js.Object {
+    val DEFAULT_4XX                    = "DEFAULT_4XX".asInstanceOf[GatewayResponseType]
+    val DEFAULT_5XX                    = "DEFAULT_5XX".asInstanceOf[GatewayResponseType]
+    val RESOURCE_NOT_FOUND             = "RESOURCE_NOT_FOUND".asInstanceOf[GatewayResponseType]
+    val UNAUTHORIZED                   = "UNAUTHORIZED".asInstanceOf[GatewayResponseType]
+    val INVALID_API_KEY                = "INVALID_API_KEY".asInstanceOf[GatewayResponseType]
+    val ACCESS_DENIED                  = "ACCESS_DENIED".asInstanceOf[GatewayResponseType]
+    val AUTHORIZER_FAILURE             = "AUTHORIZER_FAILURE".asInstanceOf[GatewayResponseType]
+    val AUTHORIZER_CONFIGURATION_ERROR = "AUTHORIZER_CONFIGURATION_ERROR".asInstanceOf[GatewayResponseType]
+    val INVALID_SIGNATURE              = "INVALID_SIGNATURE".asInstanceOf[GatewayResponseType]
+    val EXPIRED_TOKEN                  = "EXPIRED_TOKEN".asInstanceOf[GatewayResponseType]
+    val MISSING_AUTHENTICATION_TOKEN   = "MISSING_AUTHENTICATION_TOKEN".asInstanceOf[GatewayResponseType]
+    val INTEGRATION_FAILURE            = "INTEGRATION_FAILURE".asInstanceOf[GatewayResponseType]
+    val INTEGRATION_TIMEOUT            = "INTEGRATION_TIMEOUT".asInstanceOf[GatewayResponseType]
+    val API_CONFIGURATION_ERROR        = "API_CONFIGURATION_ERROR".asInstanceOf[GatewayResponseType]
+    val UNSUPPORTED_MEDIA_TYPE         = "UNSUPPORTED_MEDIA_TYPE".asInstanceOf[GatewayResponseType]
+    val BAD_REQUEST_PARAMETERS         = "BAD_REQUEST_PARAMETERS".asInstanceOf[GatewayResponseType]
+    val BAD_REQUEST_BODY               = "BAD_REQUEST_BODY".asInstanceOf[GatewayResponseType]
+    val REQUEST_TOO_LARGE              = "REQUEST_TOO_LARGE".asInstanceOf[GatewayResponseType]
+    val THROTTLED                      = "THROTTLED".asInstanceOf[GatewayResponseType]
+    val QUOTA_EXCEEDED                 = "QUOTA_EXCEEDED".asInstanceOf[GatewayResponseType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3957,19 +3953,22 @@ package apigateway {
   /**
     * The integration type. The valid value is <code>HTTP</code> for integrating an API method with an HTTP backend; <code>AWS</code> with any AWS service endpoints; <code>MOCK</code> for testing without actually invoking the backend; <code>HTTP_PROXY</code> for integrating with the HTTP proxy integration; <code>AWS_PROXY</code> for integrating with the Lambda proxy integration.
     */
-  object IntegrationTypeEnum {
-    val HTTP       = "HTTP"
-    val AWS        = "AWS"
-    val MOCK       = "MOCK"
-    val HTTP_PROXY = "HTTP_PROXY"
-    val AWS_PROXY  = "AWS_PROXY"
+  @js.native
+  sealed trait IntegrationType extends js.Any
+  object IntegrationType extends js.Object {
+    val HTTP       = "HTTP".asInstanceOf[IntegrationType]
+    val AWS        = "AWS".asInstanceOf[IntegrationType]
+    val MOCK       = "MOCK".asInstanceOf[IntegrationType]
+    val HTTP_PROXY = "HTTP_PROXY".asInstanceOf[IntegrationType]
+    val AWS_PROXY  = "AWS_PROXY".asInstanceOf[IntegrationType]
 
     val values = js.Object.freeze(js.Array(HTTP, AWS, MOCK, HTTP_PROXY, AWS_PROXY))
   }
-
-  object LocationStatusTypeEnum {
-    val DOCUMENTED   = "DOCUMENTED"
-    val UNDOCUMENTED = "UNDOCUMENTED"
+  @js.native
+  sealed trait LocationStatusType extends js.Any
+  object LocationStatusType extends js.Object {
+    val DOCUMENTED   = "DOCUMENTED".asInstanceOf[LocationStatusType]
+    val UNDOCUMENTED = "UNDOCUMENTED".asInstanceOf[LocationStatusType]
 
     val values = js.Object.freeze(js.Array(DOCUMENTED, UNDOCUMENTED))
   }
@@ -4199,14 +4198,15 @@ package apigateway {
       __obj.asInstanceOf[Models]
     }
   }
-
-  object OpEnum {
-    val add     = "add"
-    val remove  = "remove"
-    val replace = "replace"
-    val move    = "move"
-    val copy    = "copy"
-    val test    = "test"
+  @js.native
+  sealed trait Op extends js.Any
+  object Op extends js.Object {
+    val add     = "add".asInstanceOf[Op]
+    val remove  = "remove".asInstanceOf[Op]
+    val replace = "replace".asInstanceOf[Op]
+    val move    = "move".asInstanceOf[Op]
+    val copy    = "copy".asInstanceOf[Op]
+    val test    = "test".asInstanceOf[Op]
 
     val values = js.Object.freeze(js.Array(add, remove, replace, move, copy, test))
   }
@@ -4466,10 +4466,11 @@ package apigateway {
       __obj.asInstanceOf[PutMethodResponseRequest]
     }
   }
-
-  object PutModeEnum {
-    val merge     = "merge"
-    val overwrite = "overwrite"
+  @js.native
+  sealed trait PutMode extends js.Any
+  object PutMode extends js.Object {
+    val merge     = "merge".asInstanceOf[PutMode]
+    val overwrite = "overwrite".asInstanceOf[PutMode]
 
     val values = js.Object.freeze(js.Array(merge, overwrite))
   }
@@ -4506,11 +4507,12 @@ package apigateway {
       __obj.asInstanceOf[PutRestApiRequest]
     }
   }
-
-  object QuotaPeriodTypeEnum {
-    val DAY   = "DAY"
-    val WEEK  = "WEEK"
-    val MONTH = "MONTH"
+  @js.native
+  sealed trait QuotaPeriodType extends js.Any
+  object QuotaPeriodType extends js.Object {
+    val DAY   = "DAY".asInstanceOf[QuotaPeriodType]
+    val WEEK  = "WEEK".asInstanceOf[QuotaPeriodType]
+    val MONTH = "MONTH".asInstanceOf[QuotaPeriodType]
 
     val values = js.Object.freeze(js.Array(DAY, WEEK, MONTH))
   }
@@ -4838,10 +4840,11 @@ package apigateway {
       __obj.asInstanceOf[SdkTypes]
     }
   }
-
-  object SecurityPolicyEnum {
-    val TLS_1_0 = "TLS_1_0"
-    val TLS_1_2 = "TLS_1_2"
+  @js.native
+  sealed trait SecurityPolicy extends js.Any
+  object SecurityPolicy extends js.Object {
+    val TLS_1_0 = "TLS_1_0".asInstanceOf[SecurityPolicy]
+    val TLS_1_2 = "TLS_1_2".asInstanceOf[SecurityPolicy]
 
     val values = js.Object.freeze(js.Array(TLS_1_0, TLS_1_2))
   }
@@ -5203,11 +5206,14 @@ package apigateway {
       __obj.asInstanceOf[ThrottleSettings]
     }
   }
-
-  object UnauthorizedCacheControlHeaderStrategyEnum {
-    val FAIL_WITH_403                   = "FAIL_WITH_403"
-    val SUCCEED_WITH_RESPONSE_HEADER    = "SUCCEED_WITH_RESPONSE_HEADER"
-    val SUCCEED_WITHOUT_RESPONSE_HEADER = "SUCCEED_WITHOUT_RESPONSE_HEADER"
+  @js.native
+  sealed trait UnauthorizedCacheControlHeaderStrategy extends js.Any
+  object UnauthorizedCacheControlHeaderStrategy extends js.Object {
+    val FAIL_WITH_403 = "FAIL_WITH_403".asInstanceOf[UnauthorizedCacheControlHeaderStrategy]
+    val SUCCEED_WITH_RESPONSE_HEADER =
+      "SUCCEED_WITH_RESPONSE_HEADER".asInstanceOf[UnauthorizedCacheControlHeaderStrategy]
+    val SUCCEED_WITHOUT_RESPONSE_HEADER =
+      "SUCCEED_WITHOUT_RESPONSE_HEADER".asInstanceOf[UnauthorizedCacheControlHeaderStrategy]
 
     val values =
       js.Object.freeze(js.Array(FAIL_WITH_403, SUCCEED_WITH_RESPONSE_HEADER, SUCCEED_WITHOUT_RESPONSE_HEADER))
@@ -6016,12 +6022,13 @@ package apigateway {
       __obj.asInstanceOf[VpcLink]
     }
   }
-
-  object VpcLinkStatusEnum {
-    val AVAILABLE = "AVAILABLE"
-    val PENDING   = "PENDING"
-    val DELETING  = "DELETING"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait VpcLinkStatus extends js.Any
+  object VpcLinkStatus extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[VpcLinkStatus]
+    val PENDING   = "PENDING".asInstanceOf[VpcLinkStatus]
+    val DELETING  = "DELETING".asInstanceOf[VpcLinkStatus]
+    val FAILED    = "FAILED".asInstanceOf[VpcLinkStatus]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, PENDING, DELETING, FAILED))
   }

--- a/services/apigatewayv2/src/main/scala/facade/amazonaws/services/ApiGatewayV2.scala
+++ b/services/apigatewayv2/src/main/scala/facade/amazonaws/services/ApiGatewayV2.scala
@@ -9,32 +9,20 @@ import facade.amazonaws._
 package object apigatewayv2 {
   type Arn                                    = String
   type AuthorizationScopes                    = js.Array[StringWithLengthBetween1And64]
-  type AuthorizationType                      = String
-  type AuthorizerType                         = String
-  type ConnectionType                         = String
-  type ContentHandlingStrategy                = String
   type CorsHeaderList                         = js.Array[__string]
   type CorsMethodList                         = js.Array[StringWithLengthBetween1And64]
   type CorsOriginList                         = js.Array[__string]
-  type DeploymentStatus                       = String
   type DomainNameConfigurations               = js.Array[DomainNameConfiguration]
-  type DomainNameStatus                       = String
-  type EndpointType                           = String
   type Id                                     = String
   type IdentitySourceList                     = js.Array[__string]
   type IntegerWithLengthBetween0And3600       = Int
   type IntegerWithLengthBetween50And29000     = Int
   type IntegerWithLengthBetweenMinus1And86400 = Int
   type IntegrationParameters                  = js.Dictionary[StringWithLengthBetween1And512]
-  type IntegrationType                        = String
-  type LoggingLevel                           = String
   type NextToken                              = String
-  type PassthroughBehavior                    = String
-  type ProtocolType                           = String
   type RouteModels                            = js.Dictionary[StringWithLengthBetween1And128]
   type RouteParameters                        = js.Dictionary[ParameterConstraints]
   type RouteSettingsMap                       = js.Dictionary[RouteSettings]
-  type SecurityPolicy                         = String
   type SelectionExpression                    = String
   type SelectionKey                           = String
   type StageVariablesMap                      = js.Dictionary[StringWithLengthBetween0And2048]
@@ -396,11 +384,13 @@ package apigatewayv2 {
   /**
     * The authorization type. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer. For HTTP APIs, valid values are NONE for open access, or JWT for using JSON Web Tokens.
     */
-  object AuthorizationTypeEnum {
-    val NONE    = "NONE"
-    val AWS_IAM = "AWS_IAM"
-    val CUSTOM  = "CUSTOM"
-    val JWT     = "JWT"
+  @js.native
+  sealed trait AuthorizationType extends js.Any
+  object AuthorizationType extends js.Object {
+    val NONE    = "NONE".asInstanceOf[AuthorizationType]
+    val AWS_IAM = "AWS_IAM".asInstanceOf[AuthorizationType]
+    val CUSTOM  = "CUSTOM".asInstanceOf[AuthorizationType]
+    val JWT     = "JWT".asInstanceOf[AuthorizationType]
 
     val values = js.Object.freeze(js.Array(NONE, AWS_IAM, CUSTOM, JWT))
   }
@@ -457,9 +447,11 @@ package apigatewayv2 {
   /**
     * The authorizer type. For WebSocket APIs, specify REQUEST for a Lambda function using incoming request parameters. For HTTP APIs, specify JWT to use JSON Web Tokens.
     */
-  object AuthorizerTypeEnum {
-    val REQUEST = "REQUEST"
-    val JWT     = "JWT"
+  @js.native
+  sealed trait AuthorizerType extends js.Any
+  object AuthorizerType extends js.Object {
+    val REQUEST = "REQUEST".asInstanceOf[AuthorizerType]
+    val JWT     = "JWT".asInstanceOf[AuthorizerType]
 
     val values = js.Object.freeze(js.Array(REQUEST, JWT))
   }
@@ -467,9 +459,11 @@ package apigatewayv2 {
   /**
     * Represents a connection type.
     */
-  object ConnectionTypeEnum {
-    val INTERNET = "INTERNET"
-    val VPC_LINK = "VPC_LINK"
+  @js.native
+  sealed trait ConnectionType extends js.Any
+  object ConnectionType extends js.Object {
+    val INTERNET = "INTERNET".asInstanceOf[ConnectionType]
+    val VPC_LINK = "VPC_LINK".asInstanceOf[ConnectionType]
 
     val values = js.Object.freeze(js.Array(INTERNET, VPC_LINK))
   }
@@ -477,9 +471,11 @@ package apigatewayv2 {
   /**
     * Specifies how to handle response payload content type conversions. Supported only for WebSocket APIs.
     */
-  object ContentHandlingStrategyEnum {
-    val CONVERT_TO_BINARY = "CONVERT_TO_BINARY"
-    val CONVERT_TO_TEXT   = "CONVERT_TO_TEXT"
+  @js.native
+  sealed trait ContentHandlingStrategy extends js.Any
+  object ContentHandlingStrategy extends js.Object {
+    val CONVERT_TO_BINARY = "CONVERT_TO_BINARY".asInstanceOf[ContentHandlingStrategy]
+    val CONVERT_TO_TEXT   = "CONVERT_TO_TEXT".asInstanceOf[ContentHandlingStrategy]
 
     val values = js.Object.freeze(js.Array(CONVERT_TO_BINARY, CONVERT_TO_TEXT))
   }
@@ -1751,10 +1747,12 @@ package apigatewayv2 {
   /**
     * Represents a deployment status.
     */
-  object DeploymentStatusEnum {
-    val PENDING  = "PENDING"
-    val FAILED   = "FAILED"
-    val DEPLOYED = "DEPLOYED"
+  @js.native
+  sealed trait DeploymentStatus extends js.Any
+  object DeploymentStatus extends js.Object {
+    val PENDING  = "PENDING".asInstanceOf[DeploymentStatus]
+    val FAILED   = "FAILED".asInstanceOf[DeploymentStatus]
+    val DEPLOYED = "DEPLOYED".asInstanceOf[DeploymentStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, FAILED, DEPLOYED))
   }
@@ -1837,9 +1835,11 @@ package apigatewayv2 {
   /**
     * The status of the domain name migration. The valid values are AVAILABLE and UPDATING. If the status is UPDATING, the domain cannot be modified further until the existing operation is complete. If it is AVAILABLE, the domain can be updated.
     */
-  object DomainNameStatusEnum {
-    val AVAILABLE = "AVAILABLE"
-    val UPDATING  = "UPDATING"
+  @js.native
+  sealed trait DomainNameStatus extends js.Any
+  object DomainNameStatus extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[DomainNameStatus]
+    val UPDATING  = "UPDATING".asInstanceOf[DomainNameStatus]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, UPDATING))
   }
@@ -1847,9 +1847,11 @@ package apigatewayv2 {
   /**
     * Represents an endpoint type.
     */
-  object EndpointTypeEnum {
-    val REGIONAL = "REGIONAL"
-    val EDGE     = "EDGE"
+  @js.native
+  sealed trait EndpointType extends js.Any
+  object EndpointType extends js.Object {
+    val REGIONAL = "REGIONAL".asInstanceOf[EndpointType]
+    val EDGE     = "EDGE".asInstanceOf[EndpointType]
 
     val values = js.Object.freeze(js.Array(REGIONAL, EDGE))
   }
@@ -3275,12 +3277,14 @@ package apigatewayv2 {
   /**
     * Represents an API method integration type.
     */
-  object IntegrationTypeEnum {
-    val AWS        = "AWS"
-    val HTTP       = "HTTP"
-    val MOCK       = "MOCK"
-    val HTTP_PROXY = "HTTP_PROXY"
-    val AWS_PROXY  = "AWS_PROXY"
+  @js.native
+  sealed trait IntegrationType extends js.Any
+  object IntegrationType extends js.Object {
+    val AWS        = "AWS".asInstanceOf[IntegrationType]
+    val HTTP       = "HTTP".asInstanceOf[IntegrationType]
+    val MOCK       = "MOCK".asInstanceOf[IntegrationType]
+    val HTTP_PROXY = "HTTP_PROXY".asInstanceOf[IntegrationType]
+    val AWS_PROXY  = "AWS_PROXY".asInstanceOf[IntegrationType]
 
     val values = js.Object.freeze(js.Array(AWS, HTTP, MOCK, HTTP_PROXY, AWS_PROXY))
   }
@@ -3310,10 +3314,12 @@ package apigatewayv2 {
   /**
     * The logging level.
     */
-  object LoggingLevelEnum {
-    val ERROR   = "ERROR"
-    val INFO    = "INFO"
-    val `false` = "false"
+  @js.native
+  sealed trait LoggingLevel extends js.Any
+  object LoggingLevel extends js.Object {
+    val ERROR   = "ERROR".asInstanceOf[LoggingLevel]
+    val INFO    = "INFO".asInstanceOf[LoggingLevel]
+    val `false` = "false".asInstanceOf[LoggingLevel]
 
     val values = js.Object.freeze(js.Array(ERROR, INFO, `false`))
   }
@@ -3373,10 +3379,12 @@ package apigatewayv2 {
   /**
     * Represents passthrough behavior for an integration response. Supported only for WebSocket APIs.
     */
-  object PassthroughBehaviorEnum {
-    val WHEN_NO_MATCH     = "WHEN_NO_MATCH"
-    val NEVER             = "NEVER"
-    val WHEN_NO_TEMPLATES = "WHEN_NO_TEMPLATES"
+  @js.native
+  sealed trait PassthroughBehavior extends js.Any
+  object PassthroughBehavior extends js.Object {
+    val WHEN_NO_MATCH     = "WHEN_NO_MATCH".asInstanceOf[PassthroughBehavior]
+    val NEVER             = "NEVER".asInstanceOf[PassthroughBehavior]
+    val WHEN_NO_TEMPLATES = "WHEN_NO_TEMPLATES".asInstanceOf[PassthroughBehavior]
 
     val values = js.Object.freeze(js.Array(WHEN_NO_MATCH, NEVER, WHEN_NO_TEMPLATES))
   }
@@ -3384,9 +3392,11 @@ package apigatewayv2 {
   /**
     * Represents a protocol type.
     */
-  object ProtocolTypeEnum {
-    val WEBSOCKET = "WEBSOCKET"
-    val HTTP      = "HTTP"
+  @js.native
+  sealed trait ProtocolType extends js.Any
+  object ProtocolType extends js.Object {
+    val WEBSOCKET = "WEBSOCKET".asInstanceOf[ProtocolType]
+    val HTTP      = "HTTP".asInstanceOf[ProtocolType]
 
     val values = js.Object.freeze(js.Array(WEBSOCKET, HTTP))
   }
@@ -3604,9 +3614,11 @@ package apigatewayv2 {
   /**
     * The Transport Layer Security (TLS) version of the security policy for this domain name. The valid values are TLS_1_0 and TLS_1_2.
     */
-  object SecurityPolicyEnum {
-    val TLS_1_0 = "TLS_1_0"
-    val TLS_1_2 = "TLS_1_2"
+  @js.native
+  sealed trait SecurityPolicy extends js.Any
+  object SecurityPolicy extends js.Object {
+    val TLS_1_0 = "TLS_1_0".asInstanceOf[SecurityPolicy]
+    val TLS_1_2 = "TLS_1_2".asInstanceOf[SecurityPolicy]
 
     val values = js.Object.freeze(js.Array(TLS_1_0, TLS_1_2))
   }

--- a/services/appconfig/src/main/scala/facade/amazonaws/services/AppConfig.scala
+++ b/services/appconfig/src/main/scala/facade/amazonaws/services/AppConfig.scala
@@ -12,14 +12,11 @@ package object appconfig {
   type Blob                             = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type ConfigurationProfileSummaryList  = js.Array[ConfigurationProfileSummary]
   type DeploymentList                   = js.Array[DeploymentSummary]
-  type DeploymentState                  = String
   type DeploymentStrategyId             = String
   type DeploymentStrategyList           = js.Array[DeploymentStrategy]
   type Description                      = String
   type EnvironmentList                  = js.Array[Environment]
-  type EnvironmentState                 = String
   type GrowthFactor                     = Float
-  type GrowthType                       = String
   type Id                               = String
   type Iso8601DateTime                  = js.Date
   type MaxResults                       = Int
@@ -28,7 +25,6 @@ package object appconfig {
   type Name                             = String
   type NextToken                        = String
   type Percentage                       = Float
-  type ReplicateTo                      = String
   type StringWithLengthBetween0And32768 = String
   type StringWithLengthBetween1And64    = String
   type TagKey                           = String
@@ -37,7 +33,6 @@ package object appconfig {
   type TagValue                         = String
   type Uri                              = String
   type ValidatorList                    = js.Array[Validator]
-  type ValidatorType                    = String
   type ValidatorTypeList                = js.Array[ValidatorType]
   type Version                          = String
 
@@ -563,14 +558,15 @@ package appconfig {
       __obj.asInstanceOf[Deployment]
     }
   }
-
-  object DeploymentStateEnum {
-    val BAKING       = "BAKING"
-    val VALIDATING   = "VALIDATING"
-    val DEPLOYING    = "DEPLOYING"
-    val COMPLETE     = "COMPLETE"
-    val ROLLING_BACK = "ROLLING_BACK"
-    val ROLLED_BACK  = "ROLLED_BACK"
+  @js.native
+  sealed trait DeploymentState extends js.Any
+  object DeploymentState extends js.Object {
+    val BAKING       = "BAKING".asInstanceOf[DeploymentState]
+    val VALIDATING   = "VALIDATING".asInstanceOf[DeploymentState]
+    val DEPLOYING    = "DEPLOYING".asInstanceOf[DeploymentState]
+    val COMPLETE     = "COMPLETE".asInstanceOf[DeploymentState]
+    val ROLLING_BACK = "ROLLING_BACK".asInstanceOf[DeploymentState]
+    val ROLLED_BACK  = "ROLLED_BACK".asInstanceOf[DeploymentState]
 
     val values = js.Object.freeze(js.Array(BAKING, VALIDATING, DEPLOYING, COMPLETE, ROLLING_BACK, ROLLED_BACK))
   }
@@ -733,12 +729,13 @@ package appconfig {
       __obj.asInstanceOf[Environment]
     }
   }
-
-  object EnvironmentStateEnum {
-    val READY_FOR_DEPLOYMENT = "READY_FOR_DEPLOYMENT"
-    val DEPLOYING            = "DEPLOYING"
-    val ROLLING_BACK         = "ROLLING_BACK"
-    val ROLLED_BACK          = "ROLLED_BACK"
+  @js.native
+  sealed trait EnvironmentState extends js.Any
+  object EnvironmentState extends js.Object {
+    val READY_FOR_DEPLOYMENT = "READY_FOR_DEPLOYMENT".asInstanceOf[EnvironmentState]
+    val DEPLOYING            = "DEPLOYING".asInstanceOf[EnvironmentState]
+    val ROLLING_BACK         = "ROLLING_BACK".asInstanceOf[EnvironmentState]
+    val ROLLED_BACK          = "ROLLED_BACK".asInstanceOf[EnvironmentState]
 
     val values = js.Object.freeze(js.Array(READY_FOR_DEPLOYMENT, DEPLOYING, ROLLING_BACK, ROLLED_BACK))
   }
@@ -895,10 +892,11 @@ package appconfig {
       __obj.asInstanceOf[GetEnvironmentRequest]
     }
   }
-
-  object GrowthTypeEnum {
-    val LINEAR      = "LINEAR"
-    val EXPONENTIAL = "EXPONENTIAL"
+  @js.native
+  sealed trait GrowthType extends js.Any
+  object GrowthType extends js.Object {
+    val LINEAR      = "LINEAR".asInstanceOf[GrowthType]
+    val EXPONENTIAL = "EXPONENTIAL".asInstanceOf[GrowthType]
 
     val values = js.Object.freeze(js.Array(LINEAR, EXPONENTIAL))
   }
@@ -1055,10 +1053,11 @@ package appconfig {
       __obj.asInstanceOf[Monitor]
     }
   }
-
-  object ReplicateToEnum {
-    val NONE         = "NONE"
-    val SSM_DOCUMENT = "SSM_DOCUMENT"
+  @js.native
+  sealed trait ReplicateTo extends js.Any
+  object ReplicateTo extends js.Object {
+    val NONE         = "NONE".asInstanceOf[ReplicateTo]
+    val SSM_DOCUMENT = "SSM_DOCUMENT".asInstanceOf[ReplicateTo]
 
     val values = js.Object.freeze(js.Array(NONE, SSM_DOCUMENT))
   }
@@ -1350,10 +1349,11 @@ package appconfig {
       __obj.asInstanceOf[Validator]
     }
   }
-
-  object ValidatorTypeEnum {
-    val JSON_SCHEMA = "JSON_SCHEMA"
-    val LAMBDA      = "LAMBDA"
+  @js.native
+  sealed trait ValidatorType extends js.Any
+  object ValidatorType extends js.Object {
+    val JSON_SCHEMA = "JSON_SCHEMA".asInstanceOf[ValidatorType]
+    val LAMBDA      = "LAMBDA".asInstanceOf[ValidatorType]
 
     val values = js.Object.freeze(js.Array(JSON_SCHEMA, LAMBDA))
   }

--- a/services/applicationautoscaling/src/main/scala/facade/amazonaws/services/ApplicationAutoScaling.scala
+++ b/services/applicationautoscaling/src/main/scala/facade/amazonaws/services/ApplicationAutoScaling.scala
@@ -7,42 +7,34 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object applicationautoscaling {
-  type AdjustmentType            = String
-  type Alarms                    = js.Array[Alarm]
-  type Cooldown                  = Int
-  type DisableScaleIn            = Boolean
-  type MaxResults                = Int
-  type MetricAggregationType     = String
-  type MetricDimensionName       = String
-  type MetricDimensionValue      = String
-  type MetricDimensions          = js.Array[MetricDimension]
-  type MetricName                = String
-  type MetricNamespace           = String
-  type MetricScale               = Double
-  type MetricStatistic           = String
-  type MetricType                = String
-  type MetricUnit                = String
-  type MinAdjustmentMagnitude    = Int
-  type PolicyName                = String
-  type PolicyType                = String
-  type ResourceCapacity          = Int
-  type ResourceId                = String
-  type ResourceIdMaxLen1600      = String
-  type ResourceIdsMaxLen1600     = js.Array[ResourceIdMaxLen1600]
-  type ResourceLabel             = String
-  type ScalableDimension         = String
-  type ScalableTargets           = js.Array[ScalableTarget]
-  type ScalingActivities         = js.Array[ScalingActivity]
-  type ScalingActivityStatusCode = String
-  type ScalingAdjustment         = Int
-  type ScalingPolicies           = js.Array[ScalingPolicy]
-  type ScalingSuspended          = Boolean
-  type ScheduledActionName       = String
-  type ScheduledActions          = js.Array[ScheduledAction]
-  type ServiceNamespace          = String
-  type StepAdjustments           = js.Array[StepAdjustment]
-  type TimestampType             = js.Date
-  type XmlString                 = String
+  type Alarms                 = js.Array[Alarm]
+  type Cooldown               = Int
+  type DisableScaleIn         = Boolean
+  type MaxResults             = Int
+  type MetricDimensionName    = String
+  type MetricDimensionValue   = String
+  type MetricDimensions       = js.Array[MetricDimension]
+  type MetricName             = String
+  type MetricNamespace        = String
+  type MetricScale            = Double
+  type MetricUnit             = String
+  type MinAdjustmentMagnitude = Int
+  type PolicyName             = String
+  type ResourceCapacity       = Int
+  type ResourceId             = String
+  type ResourceIdMaxLen1600   = String
+  type ResourceIdsMaxLen1600  = js.Array[ResourceIdMaxLen1600]
+  type ResourceLabel          = String
+  type ScalableTargets        = js.Array[ScalableTarget]
+  type ScalingActivities      = js.Array[ScalingActivity]
+  type ScalingAdjustment      = Int
+  type ScalingPolicies        = js.Array[ScalingPolicy]
+  type ScalingSuspended       = Boolean
+  type ScheduledActionName    = String
+  type ScheduledActions       = js.Array[ScheduledAction]
+  type StepAdjustments        = js.Array[StepAdjustment]
+  type TimestampType          = js.Date
+  type XmlString              = String
 
   implicit final class ApplicationAutoScalingOps(private val service: ApplicationAutoScaling) extends AnyVal {
 
@@ -100,11 +92,12 @@ package applicationautoscaling {
     def registerScalableTarget(params: RegisterScalableTargetRequest): Request[RegisterScalableTargetResponse] =
       js.native
   }
-
-  object AdjustmentTypeEnum {
-    val ChangeInCapacity        = "ChangeInCapacity"
-    val PercentChangeInCapacity = "PercentChangeInCapacity"
-    val ExactCapacity           = "ExactCapacity"
+  @js.native
+  sealed trait AdjustmentType extends js.Any
+  object AdjustmentType extends js.Object {
+    val ChangeInCapacity        = "ChangeInCapacity".asInstanceOf[AdjustmentType]
+    val PercentChangeInCapacity = "PercentChangeInCapacity".asInstanceOf[AdjustmentType]
+    val ExactCapacity           = "ExactCapacity".asInstanceOf[AdjustmentType]
 
     val values = js.Object.freeze(js.Array(ChangeInCapacity, PercentChangeInCapacity, ExactCapacity))
   }
@@ -488,11 +481,12 @@ package applicationautoscaling {
       __obj.asInstanceOf[DescribeScheduledActionsResponse]
     }
   }
-
-  object MetricAggregationTypeEnum {
-    val Average = "Average"
-    val Minimum = "Minimum"
-    val Maximum = "Maximum"
+  @js.native
+  sealed trait MetricAggregationType extends js.Any
+  object MetricAggregationType extends js.Object {
+    val Average = "Average".asInstanceOf[MetricAggregationType]
+    val Minimum = "Minimum".asInstanceOf[MetricAggregationType]
+    val Maximum = "Maximum".asInstanceOf[MetricAggregationType]
 
     val values = js.Object.freeze(js.Array(Average, Minimum, Maximum))
   }
@@ -520,32 +514,34 @@ package applicationautoscaling {
       __obj.asInstanceOf[MetricDimension]
     }
   }
-
-  object MetricStatisticEnum {
-    val Average     = "Average"
-    val Minimum     = "Minimum"
-    val Maximum     = "Maximum"
-    val SampleCount = "SampleCount"
-    val Sum         = "Sum"
+  @js.native
+  sealed trait MetricStatistic extends js.Any
+  object MetricStatistic extends js.Object {
+    val Average     = "Average".asInstanceOf[MetricStatistic]
+    val Minimum     = "Minimum".asInstanceOf[MetricStatistic]
+    val Maximum     = "Maximum".asInstanceOf[MetricStatistic]
+    val SampleCount = "SampleCount".asInstanceOf[MetricStatistic]
+    val Sum         = "Sum".asInstanceOf[MetricStatistic]
 
     val values = js.Object.freeze(js.Array(Average, Minimum, Maximum, SampleCount, Sum))
   }
-
-  object MetricTypeEnum {
-    val DynamoDBReadCapacityUtilization          = "DynamoDBReadCapacityUtilization"
-    val DynamoDBWriteCapacityUtilization         = "DynamoDBWriteCapacityUtilization"
-    val ALBRequestCountPerTarget                 = "ALBRequestCountPerTarget"
-    val RDSReaderAverageCPUUtilization           = "RDSReaderAverageCPUUtilization"
-    val RDSReaderAverageDatabaseConnections      = "RDSReaderAverageDatabaseConnections"
-    val EC2SpotFleetRequestAverageCPUUtilization = "EC2SpotFleetRequestAverageCPUUtilization"
-    val EC2SpotFleetRequestAverageNetworkIn      = "EC2SpotFleetRequestAverageNetworkIn"
-    val EC2SpotFleetRequestAverageNetworkOut     = "EC2SpotFleetRequestAverageNetworkOut"
-    val SageMakerVariantInvocationsPerInstance   = "SageMakerVariantInvocationsPerInstance"
-    val ECSServiceAverageCPUUtilization          = "ECSServiceAverageCPUUtilization"
-    val ECSServiceAverageMemoryUtilization       = "ECSServiceAverageMemoryUtilization"
-    val AppStreamAverageCapacityUtilization      = "AppStreamAverageCapacityUtilization"
-    val ComprehendInferenceUtilization           = "ComprehendInferenceUtilization"
-    val LambdaProvisionedConcurrencyUtilization  = "LambdaProvisionedConcurrencyUtilization"
+  @js.native
+  sealed trait MetricType extends js.Any
+  object MetricType extends js.Object {
+    val DynamoDBReadCapacityUtilization          = "DynamoDBReadCapacityUtilization".asInstanceOf[MetricType]
+    val DynamoDBWriteCapacityUtilization         = "DynamoDBWriteCapacityUtilization".asInstanceOf[MetricType]
+    val ALBRequestCountPerTarget                 = "ALBRequestCountPerTarget".asInstanceOf[MetricType]
+    val RDSReaderAverageCPUUtilization           = "RDSReaderAverageCPUUtilization".asInstanceOf[MetricType]
+    val RDSReaderAverageDatabaseConnections      = "RDSReaderAverageDatabaseConnections".asInstanceOf[MetricType]
+    val EC2SpotFleetRequestAverageCPUUtilization = "EC2SpotFleetRequestAverageCPUUtilization".asInstanceOf[MetricType]
+    val EC2SpotFleetRequestAverageNetworkIn      = "EC2SpotFleetRequestAverageNetworkIn".asInstanceOf[MetricType]
+    val EC2SpotFleetRequestAverageNetworkOut     = "EC2SpotFleetRequestAverageNetworkOut".asInstanceOf[MetricType]
+    val SageMakerVariantInvocationsPerInstance   = "SageMakerVariantInvocationsPerInstance".asInstanceOf[MetricType]
+    val ECSServiceAverageCPUUtilization          = "ECSServiceAverageCPUUtilization".asInstanceOf[MetricType]
+    val ECSServiceAverageMemoryUtilization       = "ECSServiceAverageMemoryUtilization".asInstanceOf[MetricType]
+    val AppStreamAverageCapacityUtilization      = "AppStreamAverageCapacityUtilization".asInstanceOf[MetricType]
+    val ComprehendInferenceUtilization           = "ComprehendInferenceUtilization".asInstanceOf[MetricType]
+    val LambdaProvisionedConcurrencyUtilization  = "LambdaProvisionedConcurrencyUtilization".asInstanceOf[MetricType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -566,10 +562,11 @@ package applicationautoscaling {
       )
     )
   }
-
-  object PolicyTypeEnum {
-    val StepScaling           = "StepScaling"
-    val TargetTrackingScaling = "TargetTrackingScaling"
+  @js.native
+  sealed trait PolicyType extends js.Any
+  object PolicyType extends js.Object {
+    val StepScaling           = "StepScaling".asInstanceOf[PolicyType]
+    val TargetTrackingScaling = "TargetTrackingScaling".asInstanceOf[PolicyType]
 
     val values = js.Object.freeze(js.Array(StepScaling, TargetTrackingScaling))
   }
@@ -759,22 +756,28 @@ package applicationautoscaling {
       __obj.asInstanceOf[RegisterScalableTargetResponse]
     }
   }
-
-  object ScalableDimensionEnum {
-    val `ecs:service:DesiredCount`                     = "ecs:service:DesiredCount"
-    val `ec2:spot-fleet-request:TargetCapacity`        = "ec2:spot-fleet-request:TargetCapacity"
-    val `elasticmapreduce:instancegroup:InstanceCount` = "elasticmapreduce:instancegroup:InstanceCount"
-    val `appstream:fleet:DesiredCapacity`              = "appstream:fleet:DesiredCapacity"
-    val `dynamodb:table:ReadCapacityUnits`             = "dynamodb:table:ReadCapacityUnits"
-    val `dynamodb:table:WriteCapacityUnits`            = "dynamodb:table:WriteCapacityUnits"
-    val `dynamodb:index:ReadCapacityUnits`             = "dynamodb:index:ReadCapacityUnits"
-    val `dynamodb:index:WriteCapacityUnits`            = "dynamodb:index:WriteCapacityUnits"
-    val `rds:cluster:ReadReplicaCount`                 = "rds:cluster:ReadReplicaCount"
-    val `sagemaker:variant:DesiredInstanceCount`       = "sagemaker:variant:DesiredInstanceCount"
-    val `custom-resource:ResourceType:Property`        = "custom-resource:ResourceType:Property"
+  @js.native
+  sealed trait ScalableDimension extends js.Any
+  object ScalableDimension extends js.Object {
+    val `ecs:service:DesiredCount` = "ecs:service:DesiredCount".asInstanceOf[ScalableDimension]
+    val `ec2:spot-fleet-request:TargetCapacity` =
+      "ec2:spot-fleet-request:TargetCapacity".asInstanceOf[ScalableDimension]
+    val `elasticmapreduce:instancegroup:InstanceCount` =
+      "elasticmapreduce:instancegroup:InstanceCount".asInstanceOf[ScalableDimension]
+    val `appstream:fleet:DesiredCapacity`   = "appstream:fleet:DesiredCapacity".asInstanceOf[ScalableDimension]
+    val `dynamodb:table:ReadCapacityUnits`  = "dynamodb:table:ReadCapacityUnits".asInstanceOf[ScalableDimension]
+    val `dynamodb:table:WriteCapacityUnits` = "dynamodb:table:WriteCapacityUnits".asInstanceOf[ScalableDimension]
+    val `dynamodb:index:ReadCapacityUnits`  = "dynamodb:index:ReadCapacityUnits".asInstanceOf[ScalableDimension]
+    val `dynamodb:index:WriteCapacityUnits` = "dynamodb:index:WriteCapacityUnits".asInstanceOf[ScalableDimension]
+    val `rds:cluster:ReadReplicaCount`      = "rds:cluster:ReadReplicaCount".asInstanceOf[ScalableDimension]
+    val `sagemaker:variant:DesiredInstanceCount` =
+      "sagemaker:variant:DesiredInstanceCount".asInstanceOf[ScalableDimension]
+    val `custom-resource:ResourceType:Property` =
+      "custom-resource:ResourceType:Property".asInstanceOf[ScalableDimension]
     val `comprehend:document-classifier-endpoint:DesiredInferenceUnits` =
-      "comprehend:document-classifier-endpoint:DesiredInferenceUnits"
-    val `lambda:function:ProvisionedConcurrency` = "lambda:function:ProvisionedConcurrency"
+      "comprehend:document-classifier-endpoint:DesiredInferenceUnits".asInstanceOf[ScalableDimension]
+    val `lambda:function:ProvisionedConcurrency` =
+      "lambda:function:ProvisionedConcurrency".asInstanceOf[ScalableDimension]
 
     val values = js.Object.freeze(
       js.Array(
@@ -909,14 +912,15 @@ package applicationautoscaling {
       __obj.asInstanceOf[ScalingActivity]
     }
   }
-
-  object ScalingActivityStatusCodeEnum {
-    val Pending     = "Pending"
-    val InProgress  = "InProgress"
-    val Successful  = "Successful"
-    val Overridden  = "Overridden"
-    val Unfulfilled = "Unfulfilled"
-    val Failed      = "Failed"
+  @js.native
+  sealed trait ScalingActivityStatusCode extends js.Any
+  object ScalingActivityStatusCode extends js.Object {
+    val Pending     = "Pending".asInstanceOf[ScalingActivityStatusCode]
+    val InProgress  = "InProgress".asInstanceOf[ScalingActivityStatusCode]
+    val Successful  = "Successful".asInstanceOf[ScalingActivityStatusCode]
+    val Overridden  = "Overridden".asInstanceOf[ScalingActivityStatusCode]
+    val Unfulfilled = "Unfulfilled".asInstanceOf[ScalingActivityStatusCode]
+    val Failed      = "Failed".asInstanceOf[ScalingActivityStatusCode]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Successful, Overridden, Unfulfilled, Failed))
   }
@@ -1020,18 +1024,19 @@ package applicationautoscaling {
       __obj.asInstanceOf[ScheduledAction]
     }
   }
-
-  object ServiceNamespaceEnum {
-    val ecs               = "ecs"
-    val elasticmapreduce  = "elasticmapreduce"
-    val ec2               = "ec2"
-    val appstream         = "appstream"
-    val dynamodb          = "dynamodb"
-    val rds               = "rds"
-    val sagemaker         = "sagemaker"
-    val `custom-resource` = "custom-resource"
-    val comprehend        = "comprehend"
-    val lambda            = "lambda"
+  @js.native
+  sealed trait ServiceNamespace extends js.Any
+  object ServiceNamespace extends js.Object {
+    val ecs               = "ecs".asInstanceOf[ServiceNamespace]
+    val elasticmapreduce  = "elasticmapreduce".asInstanceOf[ServiceNamespace]
+    val ec2               = "ec2".asInstanceOf[ServiceNamespace]
+    val appstream         = "appstream".asInstanceOf[ServiceNamespace]
+    val dynamodb          = "dynamodb".asInstanceOf[ServiceNamespace]
+    val rds               = "rds".asInstanceOf[ServiceNamespace]
+    val sagemaker         = "sagemaker".asInstanceOf[ServiceNamespace]
+    val `custom-resource` = "custom-resource".asInstanceOf[ServiceNamespace]
+    val comprehend        = "comprehend".asInstanceOf[ServiceNamespace]
+    val lambda            = "lambda".asInstanceOf[ServiceNamespace]
 
     val values = js.Object.freeze(
       js.Array(ecs, elasticmapreduce, ec2, appstream, dynamodb, rds, sagemaker, `custom-resource`, comprehend, lambda)

--- a/services/applicationdiscovery/src/main/scala/facade/amazonaws/services/ApplicationDiscovery.scala
+++ b/services/applicationdiscovery/src/main/scala/facade/amazonaws/services/ApplicationDiscovery.scala
@@ -11,11 +11,9 @@ package object applicationdiscovery {
   type AgentId                               = String
   type AgentIds                              = js.Array[AgentId]
   type AgentNetworkInfoList                  = js.Array[AgentNetworkInfo]
-  type AgentStatus                           = String
   type AgentsInfo                            = js.Array[AgentInfo]
   type ApplicationId                         = String
   type ApplicationIdsList                    = js.Array[ApplicationId]
-  type BatchDeleteImportDataErrorCode        = String
   type BatchDeleteImportDataErrorDescription = String
   type BatchDeleteImportDataErrorList        = js.Array[BatchDeleteImportDataError]
   type BoxedInteger                          = Int
@@ -24,35 +22,28 @@ package object applicationdiscovery {
   type Configuration                         = js.Dictionary[String]
   type ConfigurationId                       = String
   type ConfigurationIdList                   = js.Array[ConfigurationId]
-  type ConfigurationItemType                 = String
   type ConfigurationTagSet                   = js.Array[ConfigurationTag]
   type Configurations                        = js.Array[Configuration]
   type ConfigurationsDownloadUrl             = String
   type ConfigurationsExportId                = String
   type ContinuousExportDescriptions          = js.Array[ContinuousExportDescription]
   type ContinuousExportIds                   = js.Array[ConfigurationsExportId]
-  type ContinuousExportStatus                = String
-  type DataSource                            = String
   type DatabaseName                          = String
   type DescribeConfigurationsAttribute       = js.Dictionary[String]
   type DescribeConfigurationsAttributes      = js.Array[DescribeConfigurationsAttribute]
   type DescribeContinuousExportsMaxResults   = Int
   type DescribeImportTasksFilterList         = js.Array[ImportTaskFilter]
   type DescribeImportTasksMaxResults         = Int
-  type ExportDataFormat                      = String
   type ExportDataFormats                     = js.Array[ExportDataFormat]
   type ExportFilters                         = js.Array[ExportFilter]
   type ExportIds                             = js.Array[ConfigurationsExportId]
   type ExportRequestTime                     = js.Date
-  type ExportStatus                          = String
   type ExportStatusMessage                   = String
   type ExportsInfo                           = js.Array[ExportInfo]
   type FilterName                            = String
   type FilterValue                           = String
   type FilterValues                          = js.Array[FilterValue]
   type Filters                               = js.Array[Filter]
-  type ImportStatus                          = String
-  type ImportTaskFilterName                  = String
   type ImportTaskFilterValue                 = String
   type ImportTaskFilterValueList             = js.Array[ImportTaskFilterValue]
   type ImportTaskIdentifier                  = String
@@ -72,7 +63,6 @@ package object applicationdiscovery {
   type TagValue                              = String
   type TimeStamp                             = js.Date
   type ToDeleteIdentifierList                = js.Array[ImportTaskIdentifier]
-  type orderString                           = String
 
   implicit final class ApplicationDiscoveryOps(private val service: ApplicationDiscovery) extends AnyVal {
 
@@ -274,14 +264,15 @@ package applicationdiscovery {
       __obj.asInstanceOf[AgentNetworkInfo]
     }
   }
-
-  object AgentStatusEnum {
-    val HEALTHY     = "HEALTHY"
-    val UNHEALTHY   = "UNHEALTHY"
-    val RUNNING     = "RUNNING"
-    val UNKNOWN     = "UNKNOWN"
-    val BLACKLISTED = "BLACKLISTED"
-    val SHUTDOWN    = "SHUTDOWN"
+  @js.native
+  sealed trait AgentStatus extends js.Any
+  object AgentStatus extends js.Object {
+    val HEALTHY     = "HEALTHY".asInstanceOf[AgentStatus]
+    val UNHEALTHY   = "UNHEALTHY".asInstanceOf[AgentStatus]
+    val RUNNING     = "RUNNING".asInstanceOf[AgentStatus]
+    val UNKNOWN     = "UNKNOWN".asInstanceOf[AgentStatus]
+    val BLACKLISTED = "BLACKLISTED".asInstanceOf[AgentStatus]
+    val SHUTDOWN    = "SHUTDOWN".asInstanceOf[AgentStatus]
 
     val values = js.Object.freeze(js.Array(HEALTHY, UNHEALTHY, RUNNING, UNKNOWN, BLACKLISTED, SHUTDOWN))
   }
@@ -344,11 +335,12 @@ package applicationdiscovery {
       __obj.asInstanceOf[BatchDeleteImportDataError]
     }
   }
-
-  object BatchDeleteImportDataErrorCodeEnum {
-    val NOT_FOUND             = "NOT_FOUND"
-    val INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
-    val OVER_LIMIT            = "OVER_LIMIT"
+  @js.native
+  sealed trait BatchDeleteImportDataErrorCode extends js.Any
+  object BatchDeleteImportDataErrorCode extends js.Object {
+    val NOT_FOUND             = "NOT_FOUND".asInstanceOf[BatchDeleteImportDataErrorCode]
+    val INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR".asInstanceOf[BatchDeleteImportDataErrorCode]
+    val OVER_LIMIT            = "OVER_LIMIT".asInstanceOf[BatchDeleteImportDataErrorCode]
 
     val values = js.Object.freeze(js.Array(NOT_FOUND, INTERNAL_SERVER_ERROR, OVER_LIMIT))
   }
@@ -386,12 +378,13 @@ package applicationdiscovery {
       __obj.asInstanceOf[BatchDeleteImportDataResponse]
     }
   }
-
-  object ConfigurationItemTypeEnum {
-    val SERVER      = "SERVER"
-    val PROCESS     = "PROCESS"
-    val CONNECTION  = "CONNECTION"
-    val APPLICATION = "APPLICATION"
+  @js.native
+  sealed trait ConfigurationItemType extends js.Any
+  object ConfigurationItemType extends js.Object {
+    val SERVER      = "SERVER".asInstanceOf[ConfigurationItemType]
+    val PROCESS     = "PROCESS".asInstanceOf[ConfigurationItemType]
+    val CONNECTION  = "CONNECTION".asInstanceOf[ConfigurationItemType]
+    val APPLICATION = "APPLICATION".asInstanceOf[ConfigurationItemType]
 
     val values = js.Object.freeze(js.Array(SERVER, PROCESS, CONNECTION, APPLICATION))
   }
@@ -466,15 +459,16 @@ package applicationdiscovery {
       __obj.asInstanceOf[ContinuousExportDescription]
     }
   }
-
-  object ContinuousExportStatusEnum {
-    val START_IN_PROGRESS = "START_IN_PROGRESS"
-    val START_FAILED      = "START_FAILED"
-    val ACTIVE            = "ACTIVE"
-    val ERROR             = "ERROR"
-    val STOP_IN_PROGRESS  = "STOP_IN_PROGRESS"
-    val STOP_FAILED       = "STOP_FAILED"
-    val INACTIVE          = "INACTIVE"
+  @js.native
+  sealed trait ContinuousExportStatus extends js.Any
+  object ContinuousExportStatus extends js.Object {
+    val START_IN_PROGRESS = "START_IN_PROGRESS".asInstanceOf[ContinuousExportStatus]
+    val START_FAILED      = "START_FAILED".asInstanceOf[ContinuousExportStatus]
+    val ACTIVE            = "ACTIVE".asInstanceOf[ContinuousExportStatus]
+    val ERROR             = "ERROR".asInstanceOf[ContinuousExportStatus]
+    val STOP_IN_PROGRESS  = "STOP_IN_PROGRESS".asInstanceOf[ContinuousExportStatus]
+    val STOP_FAILED       = "STOP_FAILED".asInstanceOf[ContinuousExportStatus]
+    val INACTIVE          = "INACTIVE".asInstanceOf[ContinuousExportStatus]
 
     val values = js.Object.freeze(
       js.Array(START_IN_PROGRESS, START_FAILED, ACTIVE, ERROR, STOP_IN_PROGRESS, STOP_FAILED, INACTIVE)
@@ -629,9 +623,10 @@ package applicationdiscovery {
       __obj.asInstanceOf[CustomerConnectorInfo]
     }
   }
-
-  object DataSourceEnum {
-    val AGENT = "AGENT"
+  @js.native
+  sealed trait DataSource extends js.Any
+  object DataSource extends js.Object {
+    val AGENT = "AGENT".asInstanceOf[DataSource]
 
     val values = js.Object.freeze(js.Array(AGENT))
   }
@@ -1036,10 +1031,11 @@ package applicationdiscovery {
       __obj.asInstanceOf[ExportConfigurationsResponse]
     }
   }
-
-  object ExportDataFormatEnum {
-    val CSV     = "CSV"
-    val GRAPHML = "GRAPHML"
+  @js.native
+  sealed trait ExportDataFormat extends js.Any
+  object ExportDataFormat extends js.Object {
+    val CSV     = "CSV".asInstanceOf[ExportDataFormat]
+    val GRAPHML = "GRAPHML".asInstanceOf[ExportDataFormat]
 
     val values = js.Object.freeze(js.Array(CSV, GRAPHML))
   }
@@ -1114,11 +1110,12 @@ package applicationdiscovery {
       __obj.asInstanceOf[ExportInfo]
     }
   }
-
-  object ExportStatusEnum {
-    val FAILED      = "FAILED"
-    val SUCCEEDED   = "SUCCEEDED"
-    val IN_PROGRESS = "IN_PROGRESS"
+  @js.native
+  sealed trait ExportStatus extends js.Any
+  object ExportStatus extends js.Object {
+    val FAILED      = "FAILED".asInstanceOf[ExportStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[ExportStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ExportStatus]
 
     val values = js.Object.freeze(js.Array(FAILED, SUCCEEDED, IN_PROGRESS))
   }
@@ -1196,19 +1193,20 @@ package applicationdiscovery {
       __obj.asInstanceOf[GetDiscoverySummaryResponse]
     }
   }
-
-  object ImportStatusEnum {
-    val IMPORT_IN_PROGRESS                  = "IMPORT_IN_PROGRESS"
-    val IMPORT_COMPLETE                     = "IMPORT_COMPLETE"
-    val IMPORT_COMPLETE_WITH_ERRORS         = "IMPORT_COMPLETE_WITH_ERRORS"
-    val IMPORT_FAILED                       = "IMPORT_FAILED"
-    val IMPORT_FAILED_SERVER_LIMIT_EXCEEDED = "IMPORT_FAILED_SERVER_LIMIT_EXCEEDED"
-    val IMPORT_FAILED_RECORD_LIMIT_EXCEEDED = "IMPORT_FAILED_RECORD_LIMIT_EXCEEDED"
-    val DELETE_IN_PROGRESS                  = "DELETE_IN_PROGRESS"
-    val DELETE_COMPLETE                     = "DELETE_COMPLETE"
-    val DELETE_FAILED                       = "DELETE_FAILED"
-    val DELETE_FAILED_LIMIT_EXCEEDED        = "DELETE_FAILED_LIMIT_EXCEEDED"
-    val INTERNAL_ERROR                      = "INTERNAL_ERROR"
+  @js.native
+  sealed trait ImportStatus extends js.Any
+  object ImportStatus extends js.Object {
+    val IMPORT_IN_PROGRESS                  = "IMPORT_IN_PROGRESS".asInstanceOf[ImportStatus]
+    val IMPORT_COMPLETE                     = "IMPORT_COMPLETE".asInstanceOf[ImportStatus]
+    val IMPORT_COMPLETE_WITH_ERRORS         = "IMPORT_COMPLETE_WITH_ERRORS".asInstanceOf[ImportStatus]
+    val IMPORT_FAILED                       = "IMPORT_FAILED".asInstanceOf[ImportStatus]
+    val IMPORT_FAILED_SERVER_LIMIT_EXCEEDED = "IMPORT_FAILED_SERVER_LIMIT_EXCEEDED".asInstanceOf[ImportStatus]
+    val IMPORT_FAILED_RECORD_LIMIT_EXCEEDED = "IMPORT_FAILED_RECORD_LIMIT_EXCEEDED".asInstanceOf[ImportStatus]
+    val DELETE_IN_PROGRESS                  = "DELETE_IN_PROGRESS".asInstanceOf[ImportStatus]
+    val DELETE_COMPLETE                     = "DELETE_COMPLETE".asInstanceOf[ImportStatus]
+    val DELETE_FAILED                       = "DELETE_FAILED".asInstanceOf[ImportStatus]
+    val DELETE_FAILED_LIMIT_EXCEEDED        = "DELETE_FAILED_LIMIT_EXCEEDED".asInstanceOf[ImportStatus]
+    val INTERNAL_ERROR                      = "INTERNAL_ERROR".asInstanceOf[ImportStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1307,11 +1305,12 @@ package applicationdiscovery {
       __obj.asInstanceOf[ImportTaskFilter]
     }
   }
-
-  object ImportTaskFilterNameEnum {
-    val IMPORT_TASK_ID = "IMPORT_TASK_ID"
-    val STATUS         = "STATUS"
-    val NAME           = "NAME"
+  @js.native
+  sealed trait ImportTaskFilterName extends js.Any
+  object ImportTaskFilterName extends js.Object {
+    val IMPORT_TASK_ID = "IMPORT_TASK_ID".asInstanceOf[ImportTaskFilterName]
+    val STATUS         = "STATUS".asInstanceOf[ImportTaskFilterName]
+    val NAME           = "NAME".asInstanceOf[ImportTaskFilterName]
 
     val values = js.Object.freeze(js.Array(IMPORT_TASK_ID, STATUS, NAME))
   }
@@ -1791,10 +1790,11 @@ package applicationdiscovery {
       __obj.asInstanceOf[UpdateApplicationResponse]
     }
   }
-
-  object orderStringEnum {
-    val ASC  = "ASC"
-    val DESC = "DESC"
+  @js.native
+  sealed trait orderString extends js.Any
+  object orderString extends js.Object {
+    val ASC  = "ASC".asInstanceOf[orderString]
+    val DESC = "DESC".asInstanceOf[orderString]
 
     val values = js.Object.freeze(js.Array(ASC, DESC))
   }

--- a/services/applicationinsights/src/main/scala/facade/amazonaws/services/ApplicationInsights.scala
+++ b/services/applicationinsights/src/main/scala/facade/amazonaws/services/ApplicationInsights.scala
@@ -17,17 +17,12 @@ package object applicationinsights {
   type ConfigurationEventList                 = js.Array[ConfigurationEvent]
   type ConfigurationEventMonitoredResourceARN = String
   type ConfigurationEventResourceName         = String
-  type ConfigurationEventResourceType         = String
-  type ConfigurationEventStatus               = String
   type ConfigurationEventTime                 = js.Date
   type EndTime                                = js.Date
   type Feedback                               = js.Dictionary[FeedbackValue]
-  type FeedbackKey                            = String
-  type FeedbackValue                          = String
   type Insights                               = String
   type LifeCycle                              = String
   type LineTime                               = js.Date
-  type LogFilter                              = String
   type LogGroup                               = String
   type LogPatternList                         = js.Array[LogPattern]
   type LogPatternName                         = String
@@ -54,16 +49,13 @@ package object applicationinsights {
   type ResourceGroupName                      = String
   type ResourceList                           = js.Array[ResourceARN]
   type ResourceType                           = String
-  type SeverityLevel                          = String
   type SourceARN                              = String
   type SourceType                             = String
   type StartTime                              = js.Date
-  type Status                                 = String
   type TagKey                                 = String
   type TagKeyList                             = js.Array[TagKey]
   type TagList                                = js.Array[Tag]
   type TagValue                               = String
-  type Tier                                   = String
   type Title                                  = String
   type Unit                                   = String
   type Value                                  = Double
@@ -269,19 +261,21 @@ package applicationinsights {
       __obj.asInstanceOf[ConfigurationEvent]
     }
   }
-
-  object ConfigurationEventResourceTypeEnum {
-    val CLOUDWATCH_ALARM = "CLOUDWATCH_ALARM"
-    val CLOUDFORMATION   = "CLOUDFORMATION"
-    val SSM_ASSOCIATION  = "SSM_ASSOCIATION"
+  @js.native
+  sealed trait ConfigurationEventResourceType extends js.Any
+  object ConfigurationEventResourceType extends js.Object {
+    val CLOUDWATCH_ALARM = "CLOUDWATCH_ALARM".asInstanceOf[ConfigurationEventResourceType]
+    val CLOUDFORMATION   = "CLOUDFORMATION".asInstanceOf[ConfigurationEventResourceType]
+    val SSM_ASSOCIATION  = "SSM_ASSOCIATION".asInstanceOf[ConfigurationEventResourceType]
 
     val values = js.Object.freeze(js.Array(CLOUDWATCH_ALARM, CLOUDFORMATION, SSM_ASSOCIATION))
   }
-
-  object ConfigurationEventStatusEnum {
-    val INFO  = "INFO"
-    val WARN  = "WARN"
-    val ERROR = "ERROR"
+  @js.native
+  sealed trait ConfigurationEventStatus extends js.Any
+  object ConfigurationEventStatus extends js.Object {
+    val INFO  = "INFO".asInstanceOf[ConfigurationEventStatus]
+    val WARN  = "WARN".asInstanceOf[ConfigurationEventStatus]
+    val ERROR = "ERROR".asInstanceOf[ConfigurationEventStatus]
 
     val values = js.Object.freeze(js.Array(INFO, WARN, ERROR))
   }
@@ -818,17 +812,19 @@ package applicationinsights {
       __obj.asInstanceOf[DescribeProblemResponse]
     }
   }
-
-  object FeedbackKeyEnum {
-    val INSIGHTS_FEEDBACK = "INSIGHTS_FEEDBACK"
+  @js.native
+  sealed trait FeedbackKey extends js.Any
+  object FeedbackKey extends js.Object {
+    val INSIGHTS_FEEDBACK = "INSIGHTS_FEEDBACK".asInstanceOf[FeedbackKey]
 
     val values = js.Object.freeze(js.Array(INSIGHTS_FEEDBACK))
   }
-
-  object FeedbackValueEnum {
-    val NOT_SPECIFIED = "NOT_SPECIFIED"
-    val USEFUL        = "USEFUL"
-    val NOT_USEFUL    = "NOT_USEFUL"
+  @js.native
+  sealed trait FeedbackValue extends js.Any
+  object FeedbackValue extends js.Object {
+    val NOT_SPECIFIED = "NOT_SPECIFIED".asInstanceOf[FeedbackValue]
+    val USEFUL        = "USEFUL".asInstanceOf[FeedbackValue]
+    val NOT_USEFUL    = "NOT_USEFUL".asInstanceOf[FeedbackValue]
 
     val values = js.Object.freeze(js.Array(NOT_SPECIFIED, USEFUL, NOT_USEFUL))
   }
@@ -1139,11 +1135,12 @@ package applicationinsights {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object LogFilterEnum {
-    val ERROR = "ERROR"
-    val WARN  = "WARN"
-    val INFO  = "INFO"
+  @js.native
+  sealed trait LogFilter extends js.Any
+  object LogFilter extends js.Object {
+    val ERROR = "ERROR".asInstanceOf[LogFilter]
+    val WARN  = "WARN".asInstanceOf[LogFilter]
+    val INFO  = "INFO".asInstanceOf[LogFilter]
 
     val values = js.Object.freeze(js.Array(ERROR, WARN, INFO))
   }
@@ -1295,19 +1292,21 @@ package applicationinsights {
       __obj.asInstanceOf[RelatedObservations]
     }
   }
-
-  object SeverityLevelEnum {
-    val Low    = "Low"
-    val Medium = "Medium"
-    val High   = "High"
+  @js.native
+  sealed trait SeverityLevel extends js.Any
+  object SeverityLevel extends js.Object {
+    val Low    = "Low".asInstanceOf[SeverityLevel]
+    val Medium = "Medium".asInstanceOf[SeverityLevel]
+    val High   = "High".asInstanceOf[SeverityLevel]
 
     val values = js.Object.freeze(js.Array(Low, Medium, High))
   }
-
-  object StatusEnum {
-    val IGNORE   = "IGNORE"
-    val RESOLVED = "RESOLVED"
-    val PENDING  = "PENDING"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val IGNORE   = "IGNORE".asInstanceOf[Status]
+    val RESOLVED = "RESOLVED".asInstanceOf[Status]
+    val PENDING  = "PENDING".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(IGNORE, RESOLVED, PENDING))
   }
@@ -1373,13 +1372,14 @@ package applicationinsights {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TierEnum {
-    val DEFAULT        = "DEFAULT"
-    val DOT_NET_CORE   = "DOT_NET_CORE"
-    val DOT_NET_WORKER = "DOT_NET_WORKER"
-    val DOT_NET_WEB    = "DOT_NET_WEB"
-    val SQL_SERVER     = "SQL_SERVER"
+  @js.native
+  sealed trait Tier extends js.Any
+  object Tier extends js.Object {
+    val DEFAULT        = "DEFAULT".asInstanceOf[Tier]
+    val DOT_NET_CORE   = "DOT_NET_CORE".asInstanceOf[Tier]
+    val DOT_NET_WORKER = "DOT_NET_WORKER".asInstanceOf[Tier]
+    val DOT_NET_WEB    = "DOT_NET_WEB".asInstanceOf[Tier]
+    val SQL_SERVER     = "SQL_SERVER".asInstanceOf[Tier]
 
     val values = js.Object.freeze(js.Array(DEFAULT, DOT_NET_CORE, DOT_NET_WORKER, DOT_NET_WEB, SQL_SERVER))
   }

--- a/services/appmesh/src/main/scala/facade/amazonaws/services/AppMesh.scala
+++ b/services/appmesh/src/main/scala/facade/amazonaws/services/AppMesh.scala
@@ -13,11 +13,8 @@ package object appmesh {
   type AwsCloudMapInstanceAttributes     = js.Array[AwsCloudMapInstanceAttribute]
   type AwsCloudMapName                   = String
   type Backends                          = js.Array[Backend]
-  type DurationUnit                      = String
   type DurationValue                     = Double
-  type EgressFilterType                  = String
   type FilePath                          = String
-  type GrpcRetryPolicyEvent              = String
   type GrpcRetryPolicyEvents             = js.Array[GrpcRetryPolicyEvent]
   type GrpcRouteMetadataList             = js.Array[GrpcRouteMetadata]
   type HeaderMatch                       = String
@@ -26,11 +23,9 @@ package object appmesh {
   type HealthCheckThreshold              = Int
   type HealthCheckTimeoutMillis          = Double
   type Hostname                          = String
-  type HttpMethod                        = String
   type HttpRetryPolicyEvent              = String
   type HttpRetryPolicyEvents             = js.Array[HttpRetryPolicyEvent]
   type HttpRouteHeaders                  = js.Array[HttpRouteHeader]
-  type HttpScheme                        = String
   type ListMeshesLimit                   = Int
   type ListRoutesLimit                   = Int
   type ListVirtualNodesLimit             = Int
@@ -39,31 +34,24 @@ package object appmesh {
   type Listeners                         = js.Array[Listener]
   type MaxRetries                        = Double
   type MeshList                          = js.Array[MeshRef]
-  type MeshStatusCode                    = String
   type MethodName                        = String
   type PercentInt                        = Int
   type PortNumber                        = Int
-  type PortProtocol                      = String
   type ResourceName                      = String
   type RouteList                         = js.Array[RouteRef]
   type RoutePriority                     = Int
-  type RouteStatusCode                   = String
   type ServiceName                       = String
   type TagKey                            = String
   type TagKeyList                        = js.Array[TagKey]
   type TagList                           = js.Array[TagRef]
   type TagValue                          = String
   type TagsLimit                         = Int
-  type TcpRetryPolicyEvent               = String
   type TcpRetryPolicyEvents              = js.Array[TcpRetryPolicyEvent]
   type Timestamp                         = js.Date
   type VirtualNodeList                   = js.Array[VirtualNodeRef]
-  type VirtualNodeStatusCode             = String
   type VirtualRouterList                 = js.Array[VirtualRouterRef]
   type VirtualRouterListeners            = js.Array[VirtualRouterListener]
-  type VirtualRouterStatusCode           = String
   type VirtualServiceList                = js.Array[VirtualServiceRef]
-  type VirtualServiceStatusCode          = String
   type WeightedTargets                   = js.Array[WeightedTarget]
 
   implicit final class AppMeshOps(private val service: AppMesh) extends AnyVal {
@@ -1019,10 +1007,11 @@ package appmesh {
       __obj.asInstanceOf[Duration]
     }
   }
-
-  object DurationUnitEnum {
-    val ms = "ms"
-    val s  = "s"
+  @js.native
+  sealed trait DurationUnit extends js.Any
+  object DurationUnit extends js.Object {
+    val ms = "ms".asInstanceOf[DurationUnit]
+    val s  = "s".asInstanceOf[DurationUnit]
 
     val values = js.Object.freeze(js.Array(ms, s))
   }
@@ -1047,10 +1036,11 @@ package appmesh {
       __obj.asInstanceOf[EgressFilter]
     }
   }
-
-  object EgressFilterTypeEnum {
-    val ALLOW_ALL = "ALLOW_ALL"
-    val DROP_ALL  = "DROP_ALL"
+  @js.native
+  sealed trait EgressFilterType extends js.Any
+  object EgressFilterType extends js.Object {
+    val ALLOW_ALL = "ALLOW_ALL".asInstanceOf[EgressFilterType]
+    val DROP_ALL  = "DROP_ALL".asInstanceOf[EgressFilterType]
 
     val values = js.Object.freeze(js.Array(ALLOW_ALL, DROP_ALL))
   }
@@ -1108,13 +1098,14 @@ package appmesh {
       __obj.asInstanceOf[GrpcRetryPolicy]
     }
   }
-
-  object GrpcRetryPolicyEventEnum {
-    val cancelled            = "cancelled"
-    val `deadline-exceeded`  = "deadline-exceeded"
-    val internal             = "internal"
-    val `resource-exhausted` = "resource-exhausted"
-    val unavailable          = "unavailable"
+  @js.native
+  sealed trait GrpcRetryPolicyEvent extends js.Any
+  object GrpcRetryPolicyEvent extends js.Object {
+    val cancelled            = "cancelled".asInstanceOf[GrpcRetryPolicyEvent]
+    val `deadline-exceeded`  = "deadline-exceeded".asInstanceOf[GrpcRetryPolicyEvent]
+    val internal             = "internal".asInstanceOf[GrpcRetryPolicyEvent]
+    val `resource-exhausted` = "resource-exhausted".asInstanceOf[GrpcRetryPolicyEvent]
+    val unavailable          = "unavailable".asInstanceOf[GrpcRetryPolicyEvent]
 
     val values = js.Object.freeze(js.Array(cancelled, `deadline-exceeded`, internal, `resource-exhausted`, unavailable))
   }
@@ -1320,17 +1311,18 @@ package appmesh {
       __obj.asInstanceOf[HealthCheckPolicy]
     }
   }
-
-  object HttpMethodEnum {
-    val CONNECT = "CONNECT"
-    val DELETE  = "DELETE"
-    val GET     = "GET"
-    val HEAD    = "HEAD"
-    val OPTIONS = "OPTIONS"
-    val PATCH   = "PATCH"
-    val POST    = "POST"
-    val PUT     = "PUT"
-    val TRACE   = "TRACE"
+  @js.native
+  sealed trait HttpMethod extends js.Any
+  object HttpMethod extends js.Object {
+    val CONNECT = "CONNECT".asInstanceOf[HttpMethod]
+    val DELETE  = "DELETE".asInstanceOf[HttpMethod]
+    val GET     = "GET".asInstanceOf[HttpMethod]
+    val HEAD    = "HEAD".asInstanceOf[HttpMethod]
+    val OPTIONS = "OPTIONS".asInstanceOf[HttpMethod]
+    val PATCH   = "PATCH".asInstanceOf[HttpMethod]
+    val POST    = "POST".asInstanceOf[HttpMethod]
+    val PUT     = "PUT".asInstanceOf[HttpMethod]
+    val TRACE   = "TRACE".asInstanceOf[HttpMethod]
 
     val values = js.Object.freeze(js.Array(CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE))
   }
@@ -1470,10 +1462,11 @@ package appmesh {
       __obj.asInstanceOf[HttpRouteMatch]
     }
   }
-
-  object HttpSchemeEnum {
-    val http  = "http"
-    val https = "https"
+  @js.native
+  sealed trait HttpScheme extends js.Any
+  object HttpScheme extends js.Object {
+    val http  = "http".asInstanceOf[HttpScheme]
+    val https = "https".asInstanceOf[HttpScheme]
 
     val values = js.Object.freeze(js.Array(http, https))
   }
@@ -1940,11 +1933,12 @@ package appmesh {
       __obj.asInstanceOf[MeshStatus]
     }
   }
-
-  object MeshStatusCodeEnum {
-    val ACTIVE   = "ACTIVE"
-    val DELETED  = "DELETED"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait MeshStatusCode extends js.Any
+  object MeshStatusCode extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[MeshStatusCode]
+    val DELETED  = "DELETED".asInstanceOf[MeshStatusCode]
+    val INACTIVE = "INACTIVE".asInstanceOf[MeshStatusCode]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETED, INACTIVE))
   }
@@ -1972,12 +1966,13 @@ package appmesh {
       __obj.asInstanceOf[PortMapping]
     }
   }
-
-  object PortProtocolEnum {
-    val grpc  = "grpc"
-    val http  = "http"
-    val http2 = "http2"
-    val tcp   = "tcp"
+  @js.native
+  sealed trait PortProtocol extends js.Any
+  object PortProtocol extends js.Object {
+    val grpc  = "grpc".asInstanceOf[PortProtocol]
+    val http  = "http".asInstanceOf[PortProtocol]
+    val http2 = "http2".asInstanceOf[PortProtocol]
+    val tcp   = "tcp".asInstanceOf[PortProtocol]
 
     val values = js.Object.freeze(js.Array(grpc, http, http2, tcp))
   }
@@ -2132,11 +2127,12 @@ package appmesh {
       __obj.asInstanceOf[RouteStatus]
     }
   }
-
-  object RouteStatusCodeEnum {
-    val ACTIVE   = "ACTIVE"
-    val DELETED  = "DELETED"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait RouteStatusCode extends js.Any
+  object RouteStatusCode extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[RouteStatusCode]
+    val DELETED  = "DELETED".asInstanceOf[RouteStatusCode]
+    val INACTIVE = "INACTIVE".asInstanceOf[RouteStatusCode]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETED, INACTIVE))
   }
@@ -2229,9 +2225,10 @@ package appmesh {
       __obj.asInstanceOf[TagResourceOutput]
     }
   }
-
-  object TcpRetryPolicyEventEnum {
-    val `connection-error` = "connection-error"
+  @js.native
+  sealed trait TcpRetryPolicyEvent extends js.Any
+  object TcpRetryPolicyEvent extends js.Object {
+    val `connection-error` = "connection-error".asInstanceOf[TcpRetryPolicyEvent]
 
     val values = js.Object.freeze(js.Array(`connection-error`))
   }
@@ -2702,11 +2699,12 @@ package appmesh {
       __obj.asInstanceOf[VirtualNodeStatus]
     }
   }
-
-  object VirtualNodeStatusCodeEnum {
-    val ACTIVE   = "ACTIVE"
-    val DELETED  = "DELETED"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait VirtualNodeStatusCode extends js.Any
+  object VirtualNodeStatusCode extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[VirtualNodeStatusCode]
+    val DELETED  = "DELETED".asInstanceOf[VirtualNodeStatusCode]
+    val INACTIVE = "INACTIVE".asInstanceOf[VirtualNodeStatusCode]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETED, INACTIVE))
   }
@@ -2852,11 +2850,12 @@ package appmesh {
       __obj.asInstanceOf[VirtualRouterStatus]
     }
   }
-
-  object VirtualRouterStatusCodeEnum {
-    val ACTIVE   = "ACTIVE"
-    val DELETED  = "DELETED"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait VirtualRouterStatusCode extends js.Any
+  object VirtualRouterStatusCode extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[VirtualRouterStatusCode]
+    val DELETED  = "DELETED".asInstanceOf[VirtualRouterStatusCode]
+    val INACTIVE = "INACTIVE".asInstanceOf[VirtualRouterStatusCode]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETED, INACTIVE))
   }
@@ -3003,11 +3002,12 @@ package appmesh {
       __obj.asInstanceOf[VirtualServiceStatus]
     }
   }
-
-  object VirtualServiceStatusCodeEnum {
-    val ACTIVE   = "ACTIVE"
-    val DELETED  = "DELETED"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait VirtualServiceStatusCode extends js.Any
+  object VirtualServiceStatusCode extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[VirtualServiceStatusCode]
+    val DELETED  = "DELETED".asInstanceOf[VirtualServiceStatusCode]
+    val INACTIVE = "INACTIVE".asInstanceOf[VirtualServiceStatusCode]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETED, INACTIVE))
   }

--- a/services/appstream/src/main/scala/facade/amazonaws/services/AppStream.scala
+++ b/services/appstream/src/main/scala/facade/amazonaws/services/AppStream.scala
@@ -8,15 +8,12 @@ import facade.amazonaws._
 
 package object appstream {
   type AccessEndpointList                       = js.Array[AccessEndpoint]
-  type AccessEndpointType                       = String
   type AccountName                              = String
   type AccountPassword                          = String
-  type Action                                   = String
   type Applications                             = js.Array[Application]
   type AppstreamAgentVersion                    = String
   type Arn                                      = String
   type ArnList                                  = js.Array[Arn]
-  type AuthenticationType                       = String
   type AwsAccountId                             = String
   type AwsAccountIdList                         = js.Array[AwsAccountId]
   type BooleanObject                            = Boolean
@@ -31,45 +28,29 @@ package object appstream {
   type EmbedHostDomain                          = String
   type EmbedHostDomains                         = js.Array[EmbedHostDomain]
   type FeedbackURL                              = String
-  type FleetAttribute                           = String
   type FleetAttributes                          = js.Array[FleetAttribute]
-  type FleetErrorCode                           = String
   type FleetErrors                              = js.Array[FleetError]
   type FleetList                                = js.Array[Fleet]
-  type FleetState                               = String
-  type FleetType                                = String
   type ImageBuilderList                         = js.Array[ImageBuilder]
-  type ImageBuilderState                        = String
-  type ImageBuilderStateChangeReasonCode        = String
   type ImageList                                = js.Array[Image]
-  type ImageState                               = String
-  type ImageStateChangeReasonCode               = String
   type LastReportGenerationExecutionErrors      = js.Array[LastReportGenerationExecutionError]
   type MaxResults                               = Int
-  type MessageAction                            = String
   type Metadata                                 = js.Dictionary[String]
   type Name                                     = String
   type OrganizationalUnitDistinguishedName      = String
   type OrganizationalUnitDistinguishedNamesList = js.Array[OrganizationalUnitDistinguishedName]
-  type Permission                               = String
-  type PlatformType                             = String
   type RedirectURL                              = String
   type RegionName                               = String
   type ResourceErrors                           = js.Array[ResourceError]
   type ResourceIdentifier                       = String
   type SecurityGroupIdList                      = js.Array[String]
-  type SessionConnectionState                   = String
   type SessionList                              = js.Array[Session]
-  type SessionState                             = String
   type SettingsGroup                            = String
   type SharedImagePermissionsList               = js.Array[SharedImagePermissions]
-  type StackAttribute                           = String
   type StackAttributes                          = js.Array[StackAttribute]
-  type StackErrorCode                           = String
   type StackErrors                              = js.Array[StackError]
   type StackList                                = js.Array[Stack]
   type StorageConnectorList                     = js.Array[StorageConnector]
-  type StorageConnectorType                     = String
   type StreamingUrlUserId                       = String
   type StringList                               = js.Array[String]
   type SubnetIdList                             = js.Array[String]
@@ -78,18 +59,14 @@ package object appstream {
   type TagValue                                 = String
   type Tags                                     = js.Dictionary[TagValue]
   type Timestamp                                = js.Date
-  type UsageReportExecutionErrorCode            = String
-  type UsageReportSchedule                      = String
   type UsageReportSubscriptionList              = js.Array[UsageReportSubscription]
   type UserAttributeValue                       = String
   type UserId                                   = String
   type UserList                                 = js.Array[User]
   type UserSettingList                          = js.Array[UserSetting]
-  type UserStackAssociationErrorCode            = String
   type UserStackAssociationErrorList            = js.Array[UserStackAssociationError]
   type UserStackAssociationList                 = js.Array[UserStackAssociation]
   type Username                                 = String
-  type VisibilityType                           = String
 
   implicit final class AppStreamOps(private val service: AppStream) extends AnyVal {
 
@@ -295,19 +272,21 @@ package appstream {
       __obj.asInstanceOf[AccessEndpoint]
     }
   }
-
-  object AccessEndpointTypeEnum {
-    val STREAMING = "STREAMING"
+  @js.native
+  sealed trait AccessEndpointType extends js.Any
+  object AccessEndpointType extends js.Object {
+    val STREAMING = "STREAMING".asInstanceOf[AccessEndpointType]
 
     val values = js.Object.freeze(js.Array(STREAMING))
   }
-
-  object ActionEnum {
-    val CLIPBOARD_COPY_FROM_LOCAL_DEVICE = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
-    val CLIPBOARD_COPY_TO_LOCAL_DEVICE   = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
-    val FILE_UPLOAD                      = "FILE_UPLOAD"
-    val FILE_DOWNLOAD                    = "FILE_DOWNLOAD"
-    val PRINTING_TO_LOCAL_DEVICE         = "PRINTING_TO_LOCAL_DEVICE"
+  @js.native
+  sealed trait Action extends js.Any
+  object Action extends js.Object {
+    val CLIPBOARD_COPY_FROM_LOCAL_DEVICE = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE".asInstanceOf[Action]
+    val CLIPBOARD_COPY_TO_LOCAL_DEVICE   = "CLIPBOARD_COPY_TO_LOCAL_DEVICE".asInstanceOf[Action]
+    val FILE_UPLOAD                      = "FILE_UPLOAD".asInstanceOf[Action]
+    val FILE_DOWNLOAD                    = "FILE_DOWNLOAD".asInstanceOf[Action]
+    val PRINTING_TO_LOCAL_DEVICE         = "PRINTING_TO_LOCAL_DEVICE".asInstanceOf[Action]
 
     val values = js.Object.freeze(
       js.Array(
@@ -439,11 +418,12 @@ package appstream {
       __obj.asInstanceOf[AssociateFleetResult]
     }
   }
-
-  object AuthenticationTypeEnum {
-    val API      = "API"
-    val SAML     = "SAML"
-    val USERPOOL = "USERPOOL"
+  @js.native
+  sealed trait AuthenticationType extends js.Any
+  object AuthenticationType extends js.Object {
+    val API      = "API".asInstanceOf[AuthenticationType]
+    val SAML     = "SAML".asInstanceOf[AuthenticationType]
+    val USERPOOL = "USERPOOL".asInstanceOf[AuthenticationType]
 
     val values = js.Object.freeze(js.Array(API, SAML, USERPOOL))
   }
@@ -2006,11 +1986,13 @@ package appstream {
   /**
     * The fleet attribute.
     */
-  object FleetAttributeEnum {
-    val VPC_CONFIGURATION                    = "VPC_CONFIGURATION"
-    val VPC_CONFIGURATION_SECURITY_GROUP_IDS = "VPC_CONFIGURATION_SECURITY_GROUP_IDS"
-    val DOMAIN_JOIN_INFO                     = "DOMAIN_JOIN_INFO"
-    val IAM_ROLE_ARN                         = "IAM_ROLE_ARN"
+  @js.native
+  sealed trait FleetAttribute extends js.Any
+  object FleetAttribute extends js.Object {
+    val VPC_CONFIGURATION                    = "VPC_CONFIGURATION".asInstanceOf[FleetAttribute]
+    val VPC_CONFIGURATION_SECURITY_GROUP_IDS = "VPC_CONFIGURATION_SECURITY_GROUP_IDS".asInstanceOf[FleetAttribute]
+    val DOMAIN_JOIN_INFO                     = "DOMAIN_JOIN_INFO".asInstanceOf[FleetAttribute]
+    val IAM_ROLE_ARN                         = "IAM_ROLE_ARN".asInstanceOf[FleetAttribute]
 
     val values = js.Object.freeze(
       js.Array(VPC_CONFIGURATION, VPC_CONFIGURATION_SECURITY_GROUP_IDS, DOMAIN_JOIN_INFO, IAM_ROLE_ARN)
@@ -2038,37 +2020,44 @@ package appstream {
       __obj.asInstanceOf[FleetError]
     }
   }
-
-  object FleetErrorCodeEnum {
-    val IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION    = "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION"
-    val IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION      = "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION"
-    val IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION      = "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION"
-    val NETWORK_INTERFACE_LIMIT_EXCEEDED                = "NETWORK_INTERFACE_LIMIT_EXCEEDED"
-    val INTERNAL_SERVICE_ERROR                          = "INTERNAL_SERVICE_ERROR"
-    val IAM_SERVICE_ROLE_IS_MISSING                     = "IAM_SERVICE_ROLE_IS_MISSING"
-    val MACHINE_ROLE_IS_MISSING                         = "MACHINE_ROLE_IS_MISSING"
-    val STS_DISABLED_IN_REGION                          = "STS_DISABLED_IN_REGION"
-    val SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES            = "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES"
-    val IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION = "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION"
-    val SUBNET_NOT_FOUND                                = "SUBNET_NOT_FOUND"
-    val IMAGE_NOT_FOUND                                 = "IMAGE_NOT_FOUND"
-    val INVALID_SUBNET_CONFIGURATION                    = "INVALID_SUBNET_CONFIGURATION"
-    val SECURITY_GROUPS_NOT_FOUND                       = "SECURITY_GROUPS_NOT_FOUND"
-    val IGW_NOT_ATTACHED                                = "IGW_NOT_ATTACHED"
+  @js.native
+  sealed trait FleetErrorCode extends js.Any
+  object FleetErrorCode extends js.Object {
+    val IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION =
+      "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION".asInstanceOf[FleetErrorCode]
+    val IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION =
+      "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION".asInstanceOf[FleetErrorCode]
+    val IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION =
+      "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION".asInstanceOf[FleetErrorCode]
+    val NETWORK_INTERFACE_LIMIT_EXCEEDED     = "NETWORK_INTERFACE_LIMIT_EXCEEDED".asInstanceOf[FleetErrorCode]
+    val INTERNAL_SERVICE_ERROR               = "INTERNAL_SERVICE_ERROR".asInstanceOf[FleetErrorCode]
+    val IAM_SERVICE_ROLE_IS_MISSING          = "IAM_SERVICE_ROLE_IS_MISSING".asInstanceOf[FleetErrorCode]
+    val MACHINE_ROLE_IS_MISSING              = "MACHINE_ROLE_IS_MISSING".asInstanceOf[FleetErrorCode]
+    val STS_DISABLED_IN_REGION               = "STS_DISABLED_IN_REGION".asInstanceOf[FleetErrorCode]
+    val SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES = "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES".asInstanceOf[FleetErrorCode]
+    val IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION =
+      "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION".asInstanceOf[FleetErrorCode]
+    val SUBNET_NOT_FOUND             = "SUBNET_NOT_FOUND".asInstanceOf[FleetErrorCode]
+    val IMAGE_NOT_FOUND              = "IMAGE_NOT_FOUND".asInstanceOf[FleetErrorCode]
+    val INVALID_SUBNET_CONFIGURATION = "INVALID_SUBNET_CONFIGURATION".asInstanceOf[FleetErrorCode]
+    val SECURITY_GROUPS_NOT_FOUND    = "SECURITY_GROUPS_NOT_FOUND".asInstanceOf[FleetErrorCode]
+    val IGW_NOT_ATTACHED             = "IGW_NOT_ATTACHED".asInstanceOf[FleetErrorCode]
     val IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION =
-      "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION"
-    val DOMAIN_JOIN_ERROR_FILE_NOT_FOUND                    = "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND"
-    val DOMAIN_JOIN_ERROR_ACCESS_DENIED                     = "DOMAIN_JOIN_ERROR_ACCESS_DENIED"
-    val DOMAIN_JOIN_ERROR_LOGON_FAILURE                     = "DOMAIN_JOIN_ERROR_LOGON_FAILURE"
-    val DOMAIN_JOIN_ERROR_INVALID_PARAMETER                 = "DOMAIN_JOIN_ERROR_INVALID_PARAMETER"
-    val DOMAIN_JOIN_ERROR_MORE_DATA                         = "DOMAIN_JOIN_ERROR_MORE_DATA"
-    val DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN                    = "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN"
-    val DOMAIN_JOIN_ERROR_NOT_SUPPORTED                     = "DOMAIN_JOIN_ERROR_NOT_SUPPORTED"
-    val DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME             = "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME"
-    val DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED            = "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED"
-    val DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED = "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED"
-    val DOMAIN_JOIN_NERR_PASSWORD_EXPIRED                   = "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED"
-    val DOMAIN_JOIN_INTERNAL_SERVICE_ERROR                  = "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR"
+      "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_FILE_NOT_FOUND        = "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_ACCESS_DENIED         = "DOMAIN_JOIN_ERROR_ACCESS_DENIED".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_LOGON_FAILURE         = "DOMAIN_JOIN_ERROR_LOGON_FAILURE".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_INVALID_PARAMETER     = "DOMAIN_JOIN_ERROR_INVALID_PARAMETER".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_MORE_DATA             = "DOMAIN_JOIN_ERROR_MORE_DATA".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN        = "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_NOT_SUPPORTED         = "DOMAIN_JOIN_ERROR_NOT_SUPPORTED".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME = "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED =
+      "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED =
+      "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_NERR_PASSWORD_EXPIRED  = "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED".asInstanceOf[FleetErrorCode]
+    val DOMAIN_JOIN_INTERNAL_SERVICE_ERROR = "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR".asInstanceOf[FleetErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2103,19 +2092,21 @@ package appstream {
       )
     )
   }
-
-  object FleetStateEnum {
-    val STARTING = "STARTING"
-    val RUNNING  = "RUNNING"
-    val STOPPING = "STOPPING"
-    val STOPPED  = "STOPPED"
+  @js.native
+  sealed trait FleetState extends js.Any
+  object FleetState extends js.Object {
+    val STARTING = "STARTING".asInstanceOf[FleetState]
+    val RUNNING  = "RUNNING".asInstanceOf[FleetState]
+    val STOPPING = "STOPPING".asInstanceOf[FleetState]
+    val STOPPED  = "STOPPED".asInstanceOf[FleetState]
 
     val values = js.Object.freeze(js.Array(STARTING, RUNNING, STOPPING, STOPPED))
   }
-
-  object FleetTypeEnum {
-    val ALWAYS_ON = "ALWAYS_ON"
-    val ON_DEMAND = "ON_DEMAND"
+  @js.native
+  sealed trait FleetType extends js.Any
+  object FleetType extends js.Object {
+    val ALWAYS_ON = "ALWAYS_ON".asInstanceOf[FleetType]
+    val ON_DEMAND = "ON_DEMAND".asInstanceOf[FleetType]
 
     val values = js.Object.freeze(js.Array(ALWAYS_ON, ON_DEMAND))
   }
@@ -2263,17 +2254,18 @@ package appstream {
       __obj.asInstanceOf[ImageBuilder]
     }
   }
-
-  object ImageBuilderStateEnum {
-    val PENDING        = "PENDING"
-    val UPDATING_AGENT = "UPDATING_AGENT"
-    val RUNNING        = "RUNNING"
-    val STOPPING       = "STOPPING"
-    val STOPPED        = "STOPPED"
-    val REBOOTING      = "REBOOTING"
-    val SNAPSHOTTING   = "SNAPSHOTTING"
-    val DELETING       = "DELETING"
-    val FAILED         = "FAILED"
+  @js.native
+  sealed trait ImageBuilderState extends js.Any
+  object ImageBuilderState extends js.Object {
+    val PENDING        = "PENDING".asInstanceOf[ImageBuilderState]
+    val UPDATING_AGENT = "UPDATING_AGENT".asInstanceOf[ImageBuilderState]
+    val RUNNING        = "RUNNING".asInstanceOf[ImageBuilderState]
+    val STOPPING       = "STOPPING".asInstanceOf[ImageBuilderState]
+    val STOPPED        = "STOPPED".asInstanceOf[ImageBuilderState]
+    val REBOOTING      = "REBOOTING".asInstanceOf[ImageBuilderState]
+    val SNAPSHOTTING   = "SNAPSHOTTING".asInstanceOf[ImageBuilderState]
+    val DELETING       = "DELETING".asInstanceOf[ImageBuilderState]
+    val FAILED         = "FAILED".asInstanceOf[ImageBuilderState]
 
     val values = js.Object.freeze(
       js.Array(PENDING, UPDATING_AGENT, RUNNING, STOPPING, STOPPED, REBOOTING, SNAPSHOTTING, DELETING, FAILED)
@@ -2301,10 +2293,11 @@ package appstream {
       __obj.asInstanceOf[ImageBuilderStateChangeReason]
     }
   }
-
-  object ImageBuilderStateChangeReasonCodeEnum {
-    val INTERNAL_ERROR    = "INTERNAL_ERROR"
-    val IMAGE_UNAVAILABLE = "IMAGE_UNAVAILABLE"
+  @js.native
+  sealed trait ImageBuilderStateChangeReasonCode extends js.Any
+  object ImageBuilderStateChangeReasonCode extends js.Object {
+    val INTERNAL_ERROR    = "INTERNAL_ERROR".asInstanceOf[ImageBuilderStateChangeReasonCode]
+    val IMAGE_UNAVAILABLE = "IMAGE_UNAVAILABLE".asInstanceOf[ImageBuilderStateChangeReasonCode]
 
     val values = js.Object.freeze(js.Array(INTERNAL_ERROR, IMAGE_UNAVAILABLE))
   }
@@ -2330,13 +2323,14 @@ package appstream {
       __obj.asInstanceOf[ImagePermissions]
     }
   }
-
-  object ImageStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val FAILED    = "FAILED"
-    val COPYING   = "COPYING"
-    val DELETING  = "DELETING"
+  @js.native
+  sealed trait ImageState extends js.Any
+  object ImageState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[ImageState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[ImageState]
+    val FAILED    = "FAILED".asInstanceOf[ImageState]
+    val COPYING   = "COPYING".asInstanceOf[ImageState]
+    val DELETING  = "DELETING".asInstanceOf[ImageState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, FAILED, COPYING, DELETING))
   }
@@ -2362,11 +2356,12 @@ package appstream {
       __obj.asInstanceOf[ImageStateChangeReason]
     }
   }
-
-  object ImageStateChangeReasonCodeEnum {
-    val INTERNAL_ERROR              = "INTERNAL_ERROR"
-    val IMAGE_BUILDER_NOT_AVAILABLE = "IMAGE_BUILDER_NOT_AVAILABLE"
-    val IMAGE_COPY_FAILURE          = "IMAGE_COPY_FAILURE"
+  @js.native
+  sealed trait ImageStateChangeReasonCode extends js.Any
+  object ImageStateChangeReasonCode extends js.Object {
+    val INTERNAL_ERROR              = "INTERNAL_ERROR".asInstanceOf[ImageStateChangeReasonCode]
+    val IMAGE_BUILDER_NOT_AVAILABLE = "IMAGE_BUILDER_NOT_AVAILABLE".asInstanceOf[ImageStateChangeReasonCode]
+    val IMAGE_COPY_FAILURE          = "IMAGE_COPY_FAILURE".asInstanceOf[ImageStateChangeReasonCode]
 
     val values = js.Object.freeze(js.Array(INTERNAL_ERROR, IMAGE_BUILDER_NOT_AVAILABLE, IMAGE_COPY_FAILURE))
   }
@@ -2506,10 +2501,11 @@ package appstream {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object MessageActionEnum {
-    val SUPPRESS = "SUPPRESS"
-    val RESEND   = "RESEND"
+  @js.native
+  sealed trait MessageAction extends js.Any
+  object MessageAction extends js.Object {
+    val SUPPRESS = "SUPPRESS".asInstanceOf[MessageAction]
+    val RESEND   = "RESEND".asInstanceOf[MessageAction]
 
     val values = js.Object.freeze(js.Array(SUPPRESS, RESEND))
   }
@@ -2535,18 +2531,20 @@ package appstream {
       __obj.asInstanceOf[NetworkAccessConfiguration]
     }
   }
-
-  object PermissionEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait Permission extends js.Any
+  object Permission extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[Permission]
+    val DISABLED = "DISABLED".asInstanceOf[Permission]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
-
-  object PlatformTypeEnum {
-    val WINDOWS             = "WINDOWS"
-    val WINDOWS_SERVER_2016 = "WINDOWS_SERVER_2016"
-    val WINDOWS_SERVER_2019 = "WINDOWS_SERVER_2019"
+  @js.native
+  sealed trait PlatformType extends js.Any
+  object PlatformType extends js.Object {
+    val WINDOWS             = "WINDOWS".asInstanceOf[PlatformType]
+    val WINDOWS_SERVER_2016 = "WINDOWS_SERVER_2016".asInstanceOf[PlatformType]
+    val WINDOWS_SERVER_2019 = "WINDOWS_SERVER_2019".asInstanceOf[PlatformType]
 
     val values = js.Object.freeze(js.Array(WINDOWS, WINDOWS_SERVER_2016, WINDOWS_SERVER_2019))
   }
@@ -2649,10 +2647,11 @@ package appstream {
       __obj.asInstanceOf[Session]
     }
   }
-
-  object SessionConnectionStateEnum {
-    val CONNECTED     = "CONNECTED"
-    val NOT_CONNECTED = "NOT_CONNECTED"
+  @js.native
+  sealed trait SessionConnectionState extends js.Any
+  object SessionConnectionState extends js.Object {
+    val CONNECTED     = "CONNECTED".asInstanceOf[SessionConnectionState]
+    val NOT_CONNECTED = "NOT_CONNECTED".asInstanceOf[SessionConnectionState]
 
     val values = js.Object.freeze(js.Array(CONNECTED, NOT_CONNECTED))
   }
@@ -2660,10 +2659,12 @@ package appstream {
   /**
     * Possible values for the state of a streaming session.
     */
-  object SessionStateEnum {
-    val ACTIVE  = "ACTIVE"
-    val PENDING = "PENDING"
-    val EXPIRED = "EXPIRED"
+  @js.native
+  sealed trait SessionState extends js.Any
+  object SessionState extends js.Object {
+    val ACTIVE  = "ACTIVE".asInstanceOf[SessionState]
+    val PENDING = "PENDING".asInstanceOf[SessionState]
+    val EXPIRED = "EXPIRED".asInstanceOf[SessionState]
 
     val values = js.Object.freeze(js.Array(ACTIVE, PENDING, EXPIRED))
   }
@@ -2748,19 +2749,20 @@ package appstream {
       __obj.asInstanceOf[Stack]
     }
   }
-
-  object StackAttributeEnum {
-    val STORAGE_CONNECTORS             = "STORAGE_CONNECTORS"
-    val STORAGE_CONNECTOR_HOMEFOLDERS  = "STORAGE_CONNECTOR_HOMEFOLDERS"
-    val STORAGE_CONNECTOR_GOOGLE_DRIVE = "STORAGE_CONNECTOR_GOOGLE_DRIVE"
-    val STORAGE_CONNECTOR_ONE_DRIVE    = "STORAGE_CONNECTOR_ONE_DRIVE"
-    val REDIRECT_URL                   = "REDIRECT_URL"
-    val FEEDBACK_URL                   = "FEEDBACK_URL"
-    val THEME_NAME                     = "THEME_NAME"
-    val USER_SETTINGS                  = "USER_SETTINGS"
-    val EMBED_HOST_DOMAINS             = "EMBED_HOST_DOMAINS"
-    val IAM_ROLE_ARN                   = "IAM_ROLE_ARN"
-    val ACCESS_ENDPOINTS               = "ACCESS_ENDPOINTS"
+  @js.native
+  sealed trait StackAttribute extends js.Any
+  object StackAttribute extends js.Object {
+    val STORAGE_CONNECTORS             = "STORAGE_CONNECTORS".asInstanceOf[StackAttribute]
+    val STORAGE_CONNECTOR_HOMEFOLDERS  = "STORAGE_CONNECTOR_HOMEFOLDERS".asInstanceOf[StackAttribute]
+    val STORAGE_CONNECTOR_GOOGLE_DRIVE = "STORAGE_CONNECTOR_GOOGLE_DRIVE".asInstanceOf[StackAttribute]
+    val STORAGE_CONNECTOR_ONE_DRIVE    = "STORAGE_CONNECTOR_ONE_DRIVE".asInstanceOf[StackAttribute]
+    val REDIRECT_URL                   = "REDIRECT_URL".asInstanceOf[StackAttribute]
+    val FEEDBACK_URL                   = "FEEDBACK_URL".asInstanceOf[StackAttribute]
+    val THEME_NAME                     = "THEME_NAME".asInstanceOf[StackAttribute]
+    val USER_SETTINGS                  = "USER_SETTINGS".asInstanceOf[StackAttribute]
+    val EMBED_HOST_DOMAINS             = "EMBED_HOST_DOMAINS".asInstanceOf[StackAttribute]
+    val IAM_ROLE_ARN                   = "IAM_ROLE_ARN".asInstanceOf[StackAttribute]
+    val ACCESS_ENDPOINTS               = "ACCESS_ENDPOINTS".asInstanceOf[StackAttribute]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2800,10 +2802,11 @@ package appstream {
       __obj.asInstanceOf[StackError]
     }
   }
-
-  object StackErrorCodeEnum {
-    val STORAGE_CONNECTOR_ERROR = "STORAGE_CONNECTOR_ERROR"
-    val INTERNAL_SERVICE_ERROR  = "INTERNAL_SERVICE_ERROR"
+  @js.native
+  sealed trait StackErrorCode extends js.Any
+  object StackErrorCode extends js.Object {
+    val STORAGE_CONNECTOR_ERROR = "STORAGE_CONNECTOR_ERROR".asInstanceOf[StackErrorCode]
+    val INTERNAL_SERVICE_ERROR  = "INTERNAL_SERVICE_ERROR".asInstanceOf[StackErrorCode]
 
     val values = js.Object.freeze(js.Array(STORAGE_CONNECTOR_ERROR, INTERNAL_SERVICE_ERROR))
   }
@@ -2971,10 +2974,12 @@ package appstream {
   /**
     * The type of storage connector.
     */
-  object StorageConnectorTypeEnum {
-    val HOMEFOLDERS  = "HOMEFOLDERS"
-    val GOOGLE_DRIVE = "GOOGLE_DRIVE"
-    val ONE_DRIVE    = "ONE_DRIVE"
+  @js.native
+  sealed trait StorageConnectorType extends js.Any
+  object StorageConnectorType extends js.Object {
+    val HOMEFOLDERS  = "HOMEFOLDERS".asInstanceOf[StorageConnectorType]
+    val GOOGLE_DRIVE = "GOOGLE_DRIVE".asInstanceOf[StorageConnectorType]
+    val ONE_DRIVE    = "ONE_DRIVE".asInstanceOf[StorageConnectorType]
 
     val values = js.Object.freeze(js.Array(HOMEFOLDERS, GOOGLE_DRIVE, ONE_DRIVE))
   }
@@ -3277,17 +3282,19 @@ package appstream {
       __obj.asInstanceOf[UpdateStackResult]
     }
   }
-
-  object UsageReportExecutionErrorCodeEnum {
-    val RESOURCE_NOT_FOUND     = "RESOURCE_NOT_FOUND"
-    val ACCESS_DENIED          = "ACCESS_DENIED"
-    val INTERNAL_SERVICE_ERROR = "INTERNAL_SERVICE_ERROR"
+  @js.native
+  sealed trait UsageReportExecutionErrorCode extends js.Any
+  object UsageReportExecutionErrorCode extends js.Object {
+    val RESOURCE_NOT_FOUND     = "RESOURCE_NOT_FOUND".asInstanceOf[UsageReportExecutionErrorCode]
+    val ACCESS_DENIED          = "ACCESS_DENIED".asInstanceOf[UsageReportExecutionErrorCode]
+    val INTERNAL_SERVICE_ERROR = "INTERNAL_SERVICE_ERROR".asInstanceOf[UsageReportExecutionErrorCode]
 
     val values = js.Object.freeze(js.Array(RESOURCE_NOT_FOUND, ACCESS_DENIED, INTERNAL_SERVICE_ERROR))
   }
-
-  object UsageReportScheduleEnum {
-    val DAILY = "DAILY"
+  @js.native
+  sealed trait UsageReportSchedule extends js.Any
+  object UsageReportSchedule extends js.Object {
+    val DAILY = "DAILY".asInstanceOf[UsageReportSchedule]
 
     val values = js.Object.freeze(js.Array(DAILY))
   }
@@ -3440,19 +3447,21 @@ package appstream {
       __obj.asInstanceOf[UserStackAssociationError]
     }
   }
-
-  object UserStackAssociationErrorCodeEnum {
-    val STACK_NOT_FOUND     = "STACK_NOT_FOUND"
-    val USER_NAME_NOT_FOUND = "USER_NAME_NOT_FOUND"
-    val INTERNAL_ERROR      = "INTERNAL_ERROR"
+  @js.native
+  sealed trait UserStackAssociationErrorCode extends js.Any
+  object UserStackAssociationErrorCode extends js.Object {
+    val STACK_NOT_FOUND     = "STACK_NOT_FOUND".asInstanceOf[UserStackAssociationErrorCode]
+    val USER_NAME_NOT_FOUND = "USER_NAME_NOT_FOUND".asInstanceOf[UserStackAssociationErrorCode]
+    val INTERNAL_ERROR      = "INTERNAL_ERROR".asInstanceOf[UserStackAssociationErrorCode]
 
     val values = js.Object.freeze(js.Array(STACK_NOT_FOUND, USER_NAME_NOT_FOUND, INTERNAL_ERROR))
   }
-
-  object VisibilityTypeEnum {
-    val PUBLIC  = "PUBLIC"
-    val PRIVATE = "PRIVATE"
-    val SHARED  = "SHARED"
+  @js.native
+  sealed trait VisibilityType extends js.Any
+  object VisibilityType extends js.Object {
+    val PUBLIC  = "PUBLIC".asInstanceOf[VisibilityType]
+    val PRIVATE = "PRIVATE".asInstanceOf[VisibilityType]
+    val SHARED  = "SHARED".asInstanceOf[VisibilityType]
 
     val values = js.Object.freeze(js.Array(PUBLIC, PRIVATE, SHARED))
   }

--- a/services/appsync/src/main/scala/facade/amazonaws/services/AppSync.scala
+++ b/services/appsync/src/main/scala/facade/amazonaws/services/AppSync.scala
@@ -8,40 +8,25 @@ import facade.amazonaws._
 
 package object appsync {
   type AdditionalAuthenticationProviders = js.Array[AdditionalAuthenticationProvider]
-  type ApiCacheStatus                    = String
-  type ApiCacheType                      = String
-  type ApiCachingBehavior                = String
   type ApiKeys                           = js.Array[ApiKey]
-  type AuthenticationType                = String
-  type AuthorizationType                 = String
   type Blob                              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type BooleanValue                      = Boolean
   type CachingKeys                       = js.Array[String]
-  type ConflictDetectionType             = String
-  type ConflictHandlerType               = String
-  type DataSourceType                    = String
   type DataSources                       = js.Array[DataSource]
-  type DefaultAction                     = String
-  type FieldLogLevel                     = String
   type Functions                         = js.Array[FunctionConfiguration]
   type FunctionsIds                      = js.Array[String]
   type GraphqlApis                       = js.Array[GraphqlApi]
   type MapOfStringToString               = js.Dictionary[String]
   type MappingTemplate                   = String
   type MaxResults                        = Int
-  type OutputType                        = String
   type PaginationToken                   = String
-  type RelationalDatabaseSourceType      = String
-  type ResolverKind                      = String
   type Resolvers                         = js.Array[Resolver]
   type ResourceArn                       = String
   type ResourceName                      = String
-  type SchemaStatus                      = String
   type TagKey                            = String
   type TagKeyList                        = js.Array[TagKey]
   type TagMap                            = js.Dictionary[TagValue]
   type TagValue                          = String
-  type TypeDefinitionFormat              = String
   type TypeList                          = js.Array[Type]
 
   implicit final class AppSyncOps(private val service: AppSync) extends AnyVal {
@@ -244,33 +229,36 @@ package appsync {
       __obj.asInstanceOf[ApiCache]
     }
   }
-
-  object ApiCacheStatusEnum {
-    val AVAILABLE = "AVAILABLE"
-    val CREATING  = "CREATING"
-    val DELETING  = "DELETING"
-    val MODIFYING = "MODIFYING"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait ApiCacheStatus extends js.Any
+  object ApiCacheStatus extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[ApiCacheStatus]
+    val CREATING  = "CREATING".asInstanceOf[ApiCacheStatus]
+    val DELETING  = "DELETING".asInstanceOf[ApiCacheStatus]
+    val MODIFYING = "MODIFYING".asInstanceOf[ApiCacheStatus]
+    val FAILED    = "FAILED".asInstanceOf[ApiCacheStatus]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, CREATING, DELETING, MODIFYING, FAILED))
   }
-
-  object ApiCacheTypeEnum {
-    val T2_SMALL   = "T2_SMALL"
-    val T2_MEDIUM  = "T2_MEDIUM"
-    val R4_LARGE   = "R4_LARGE"
-    val R4_XLARGE  = "R4_XLARGE"
-    val R4_2XLARGE = "R4_2XLARGE"
-    val R4_4XLARGE = "R4_4XLARGE"
-    val R4_8XLARGE = "R4_8XLARGE"
+  @js.native
+  sealed trait ApiCacheType extends js.Any
+  object ApiCacheType extends js.Object {
+    val T2_SMALL   = "T2_SMALL".asInstanceOf[ApiCacheType]
+    val T2_MEDIUM  = "T2_MEDIUM".asInstanceOf[ApiCacheType]
+    val R4_LARGE   = "R4_LARGE".asInstanceOf[ApiCacheType]
+    val R4_XLARGE  = "R4_XLARGE".asInstanceOf[ApiCacheType]
+    val R4_2XLARGE = "R4_2XLARGE".asInstanceOf[ApiCacheType]
+    val R4_4XLARGE = "R4_4XLARGE".asInstanceOf[ApiCacheType]
+    val R4_8XLARGE = "R4_8XLARGE".asInstanceOf[ApiCacheType]
 
     val values =
       js.Object.freeze(js.Array(T2_SMALL, T2_MEDIUM, R4_LARGE, R4_XLARGE, R4_2XLARGE, R4_4XLARGE, R4_8XLARGE))
   }
-
-  object ApiCachingBehaviorEnum {
-    val FULL_REQUEST_CACHING = "FULL_REQUEST_CACHING"
-    val PER_RESOLVER_CACHING = "PER_RESOLVER_CACHING"
+  @js.native
+  sealed trait ApiCachingBehavior extends js.Any
+  object ApiCachingBehavior extends js.Object {
+    val FULL_REQUEST_CACHING = "FULL_REQUEST_CACHING".asInstanceOf[ApiCachingBehavior]
+    val PER_RESOLVER_CACHING = "PER_RESOLVER_CACHING".asInstanceOf[ApiCachingBehavior]
 
     val values = js.Object.freeze(js.Array(FULL_REQUEST_CACHING, PER_RESOLVER_CACHING))
   }
@@ -312,12 +300,13 @@ package appsync {
       __obj.asInstanceOf[ApiKey]
     }
   }
-
-  object AuthenticationTypeEnum {
-    val API_KEY                   = "API_KEY"
-    val AWS_IAM                   = "AWS_IAM"
-    val AMAZON_COGNITO_USER_POOLS = "AMAZON_COGNITO_USER_POOLS"
-    val OPENID_CONNECT            = "OPENID_CONNECT"
+  @js.native
+  sealed trait AuthenticationType extends js.Any
+  object AuthenticationType extends js.Object {
+    val API_KEY                   = "API_KEY".asInstanceOf[AuthenticationType]
+    val AWS_IAM                   = "AWS_IAM".asInstanceOf[AuthenticationType]
+    val AMAZON_COGNITO_USER_POOLS = "AMAZON_COGNITO_USER_POOLS".asInstanceOf[AuthenticationType]
+    val OPENID_CONNECT            = "OPENID_CONNECT".asInstanceOf[AuthenticationType]
 
     val values = js.Object.freeze(js.Array(API_KEY, AWS_IAM, AMAZON_COGNITO_USER_POOLS, OPENID_CONNECT))
   }
@@ -345,9 +334,10 @@ package appsync {
       __obj.asInstanceOf[AuthorizationConfig]
     }
   }
-
-  object AuthorizationTypeEnum {
-    val AWS_IAM = "AWS_IAM"
+  @js.native
+  sealed trait AuthorizationType extends js.Any
+  object AuthorizationType extends js.Object {
+    val AWS_IAM = "AWS_IAM".asInstanceOf[AuthorizationType]
 
     val values = js.Object.freeze(js.Array(AWS_IAM))
   }
@@ -422,19 +412,21 @@ package appsync {
       __obj.asInstanceOf[CognitoUserPoolConfig]
     }
   }
-
-  object ConflictDetectionTypeEnum {
-    val VERSION = "VERSION"
-    val NONE    = "NONE"
+  @js.native
+  sealed trait ConflictDetectionType extends js.Any
+  object ConflictDetectionType extends js.Object {
+    val VERSION = "VERSION".asInstanceOf[ConflictDetectionType]
+    val NONE    = "NONE".asInstanceOf[ConflictDetectionType]
 
     val values = js.Object.freeze(js.Array(VERSION, NONE))
   }
-
-  object ConflictHandlerTypeEnum {
-    val OPTIMISTIC_CONCURRENCY = "OPTIMISTIC_CONCURRENCY"
-    val LAMBDA                 = "LAMBDA"
-    val AUTOMERGE              = "AUTOMERGE"
-    val NONE                   = "NONE"
+  @js.native
+  sealed trait ConflictHandlerType extends js.Any
+  object ConflictHandlerType extends js.Object {
+    val OPTIMISTIC_CONCURRENCY = "OPTIMISTIC_CONCURRENCY".asInstanceOf[ConflictHandlerType]
+    val LAMBDA                 = "LAMBDA".asInstanceOf[ConflictHandlerType]
+    val AUTOMERGE              = "AUTOMERGE".asInstanceOf[ConflictHandlerType]
+    val NONE                   = "NONE".asInstanceOf[ConflictHandlerType]
 
     val values = js.Object.freeze(js.Array(OPTIMISTIC_CONCURRENCY, LAMBDA, AUTOMERGE, NONE))
   }
@@ -850,22 +842,24 @@ package appsync {
       __obj.asInstanceOf[DataSource]
     }
   }
-
-  object DataSourceTypeEnum {
-    val AWS_LAMBDA           = "AWS_LAMBDA"
-    val AMAZON_DYNAMODB      = "AMAZON_DYNAMODB"
-    val AMAZON_ELASTICSEARCH = "AMAZON_ELASTICSEARCH"
-    val NONE                 = "NONE"
-    val HTTP                 = "HTTP"
-    val RELATIONAL_DATABASE  = "RELATIONAL_DATABASE"
+  @js.native
+  sealed trait DataSourceType extends js.Any
+  object DataSourceType extends js.Object {
+    val AWS_LAMBDA           = "AWS_LAMBDA".asInstanceOf[DataSourceType]
+    val AMAZON_DYNAMODB      = "AMAZON_DYNAMODB".asInstanceOf[DataSourceType]
+    val AMAZON_ELASTICSEARCH = "AMAZON_ELASTICSEARCH".asInstanceOf[DataSourceType]
+    val NONE                 = "NONE".asInstanceOf[DataSourceType]
+    val HTTP                 = "HTTP".asInstanceOf[DataSourceType]
+    val RELATIONAL_DATABASE  = "RELATIONAL_DATABASE".asInstanceOf[DataSourceType]
 
     val values =
       js.Object.freeze(js.Array(AWS_LAMBDA, AMAZON_DYNAMODB, AMAZON_ELASTICSEARCH, NONE, HTTP, RELATIONAL_DATABASE))
   }
-
-  object DefaultActionEnum {
-    val ALLOW = "ALLOW"
-    val DENY  = "DENY"
+  @js.native
+  sealed trait DefaultAction extends js.Any
+  object DefaultAction extends js.Object {
+    val ALLOW = "ALLOW".asInstanceOf[DefaultAction]
+    val DENY  = "DENY".asInstanceOf[DefaultAction]
 
     val values = js.Object.freeze(js.Array(ALLOW, DENY))
   }
@@ -1192,11 +1186,12 @@ package appsync {
       __obj.asInstanceOf[ElasticsearchDataSourceConfig]
     }
   }
-
-  object FieldLogLevelEnum {
-    val NONE  = "NONE"
-    val ERROR = "ERROR"
-    val ALL   = "ALL"
+  @js.native
+  sealed trait FieldLogLevel extends js.Any
+  object FieldLogLevel extends js.Object {
+    val NONE  = "NONE".asInstanceOf[FieldLogLevel]
+    val ERROR = "ERROR".asInstanceOf[FieldLogLevel]
+    val ALL   = "ALL".asInstanceOf[FieldLogLevel]
 
     val values = js.Object.freeze(js.Array(NONE, ERROR, ALL))
   }
@@ -2091,10 +2086,11 @@ package appsync {
       __obj.asInstanceOf[OpenIDConnectConfig]
     }
   }
-
-  object OutputTypeEnum {
-    val SDL  = "SDL"
-    val JSON = "JSON"
+  @js.native
+  sealed trait OutputType extends js.Any
+  object OutputType extends js.Object {
+    val SDL  = "SDL".asInstanceOf[OutputType]
+    val JSON = "JSON".asInstanceOf[OutputType]
 
     val values = js.Object.freeze(js.Array(SDL, JSON))
   }
@@ -2172,9 +2168,10 @@ package appsync {
       __obj.asInstanceOf[RelationalDatabaseDataSourceConfig]
     }
   }
-
-  object RelationalDatabaseSourceTypeEnum {
-    val RDS_HTTP_ENDPOINT = "RDS_HTTP_ENDPOINT"
+  @js.native
+  sealed trait RelationalDatabaseSourceType extends js.Any
+  object RelationalDatabaseSourceType extends js.Object {
+    val RDS_HTTP_ENDPOINT = "RDS_HTTP_ENDPOINT".asInstanceOf[RelationalDatabaseSourceType]
 
     val values = js.Object.freeze(js.Array(RDS_HTTP_ENDPOINT))
   }
@@ -2224,21 +2221,23 @@ package appsync {
       __obj.asInstanceOf[Resolver]
     }
   }
-
-  object ResolverKindEnum {
-    val UNIT     = "UNIT"
-    val PIPELINE = "PIPELINE"
+  @js.native
+  sealed trait ResolverKind extends js.Any
+  object ResolverKind extends js.Object {
+    val UNIT     = "UNIT".asInstanceOf[ResolverKind]
+    val PIPELINE = "PIPELINE".asInstanceOf[ResolverKind]
 
     val values = js.Object.freeze(js.Array(UNIT, PIPELINE))
   }
-
-  object SchemaStatusEnum {
-    val PROCESSING     = "PROCESSING"
-    val ACTIVE         = "ACTIVE"
-    val DELETING       = "DELETING"
-    val FAILED         = "FAILED"
-    val SUCCESS        = "SUCCESS"
-    val NOT_APPLICABLE = "NOT_APPLICABLE"
+  @js.native
+  sealed trait SchemaStatus extends js.Any
+  object SchemaStatus extends js.Object {
+    val PROCESSING     = "PROCESSING".asInstanceOf[SchemaStatus]
+    val ACTIVE         = "ACTIVE".asInstanceOf[SchemaStatus]
+    val DELETING       = "DELETING".asInstanceOf[SchemaStatus]
+    val FAILED         = "FAILED".asInstanceOf[SchemaStatus]
+    val SUCCESS        = "SUCCESS".asInstanceOf[SchemaStatus]
+    val NOT_APPLICABLE = "NOT_APPLICABLE".asInstanceOf[SchemaStatus]
 
     val values = js.Object.freeze(js.Array(PROCESSING, ACTIVE, DELETING, FAILED, SUCCESS, NOT_APPLICABLE))
   }
@@ -2372,10 +2371,11 @@ package appsync {
       __obj.asInstanceOf[Type]
     }
   }
-
-  object TypeDefinitionFormatEnum {
-    val SDL  = "SDL"
-    val JSON = "JSON"
+  @js.native
+  sealed trait TypeDefinitionFormat extends js.Any
+  object TypeDefinitionFormat extends js.Object {
+    val SDL  = "SDL".asInstanceOf[TypeDefinitionFormat]
+    val JSON = "JSON".asInstanceOf[TypeDefinitionFormat]
 
     val values = js.Object.freeze(js.Array(SDL, JSON))
   }

--- a/services/athena/src/main/scala/facade/amazonaws/services/Athena.scala
+++ b/services/athena/src/main/scala/facade/amazonaws/services/Athena.scala
@@ -11,11 +11,9 @@ package object athena {
   type BoxedBoolean                    = Boolean
   type BytesScannedCutoffValue         = Double
   type ColumnInfoList                  = js.Array[ColumnInfo]
-  type ColumnNullable                  = String
   type DatabaseString                  = String
   type Date                            = js.Date
   type DescriptionString               = String
-  type EncryptionOption                = String
   type ErrorCode                       = String
   type ErrorMessage                    = String
   type IdempotencyToken                = String
@@ -31,10 +29,8 @@ package object athena {
   type QueryExecutionId                = String
   type QueryExecutionIdList            = js.Array[QueryExecutionId]
   type QueryExecutionList              = js.Array[QueryExecution]
-  type QueryExecutionState             = String
   type QueryString                     = String
   type RowList                         = js.Array[Row]
-  type StatementType                   = String
   type TagKey                          = String
   type TagKeyList                      = js.Array[TagKey]
   type TagList                         = js.Array[Tag]
@@ -44,7 +40,6 @@ package object athena {
   type UnprocessedQueryExecutionIdList = js.Array[UnprocessedQueryExecutionId]
   type WorkGroupDescriptionString      = String
   type WorkGroupName                   = String
-  type WorkGroupState                  = String
   type WorkGroupsList                  = js.Array[WorkGroupSummary]
   type datumList                       = js.Array[Datum]
   type datumString                     = String
@@ -243,11 +238,12 @@ package athena {
       __obj.asInstanceOf[ColumnInfo]
     }
   }
-
-  object ColumnNullableEnum {
-    val NOT_NULL = "NOT_NULL"
-    val NULLABLE = "NULLABLE"
-    val UNKNOWN  = "UNKNOWN"
+  @js.native
+  sealed trait ColumnNullable extends js.Any
+  object ColumnNullable extends js.Object {
+    val NOT_NULL = "NOT_NULL".asInstanceOf[ColumnNullable]
+    val NULLABLE = "NULLABLE".asInstanceOf[ColumnNullable]
+    val UNKNOWN  = "UNKNOWN".asInstanceOf[ColumnNullable]
 
     val values = js.Object.freeze(js.Array(NOT_NULL, NULLABLE, UNKNOWN))
   }
@@ -448,11 +444,12 @@ package athena {
       __obj.asInstanceOf[EncryptionConfiguration]
     }
   }
-
-  object EncryptionOptionEnum {
-    val SSE_S3  = "SSE_S3"
-    val SSE_KMS = "SSE_KMS"
-    val CSE_KMS = "CSE_KMS"
+  @js.native
+  sealed trait EncryptionOption extends js.Any
+  object EncryptionOption extends js.Object {
+    val SSE_S3  = "SSE_S3".asInstanceOf[EncryptionOption]
+    val SSE_KMS = "SSE_KMS".asInstanceOf[EncryptionOption]
+    val CSE_KMS = "CSE_KMS".asInstanceOf[EncryptionOption]
 
     val values = js.Object.freeze(js.Array(SSE_S3, SSE_KMS, CSE_KMS))
   }
@@ -862,13 +859,14 @@ package athena {
       __obj.asInstanceOf[QueryExecutionContext]
     }
   }
-
-  object QueryExecutionStateEnum {
-    val QUEUED    = "QUEUED"
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
-    val CANCELLED = "CANCELLED"
+  @js.native
+  sealed trait QueryExecutionState extends js.Any
+  object QueryExecutionState extends js.Object {
+    val QUEUED    = "QUEUED".asInstanceOf[QueryExecutionState]
+    val RUNNING   = "RUNNING".asInstanceOf[QueryExecutionState]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[QueryExecutionState]
+    val FAILED    = "FAILED".asInstanceOf[QueryExecutionState]
+    val CANCELLED = "CANCELLED".asInstanceOf[QueryExecutionState]
 
     val values = js.Object.freeze(js.Array(QUEUED, RUNNING, SUCCEEDED, FAILED, CANCELLED))
   }
@@ -1103,11 +1101,12 @@ package athena {
       __obj.asInstanceOf[StartQueryExecutionOutput]
     }
   }
-
-  object StatementTypeEnum {
-    val DDL     = "DDL"
-    val DML     = "DML"
-    val UTILITY = "UTILITY"
+  @js.native
+  sealed trait StatementType extends js.Any
+  object StatementType extends js.Object {
+    val DDL     = "DDL".asInstanceOf[StatementType]
+    val DML     = "DML".asInstanceOf[StatementType]
+    val UTILITY = "UTILITY".asInstanceOf[StatementType]
 
     val values = js.Object.freeze(js.Array(DDL, DML, UTILITY))
   }
@@ -1436,10 +1435,11 @@ package athena {
       __obj.asInstanceOf[WorkGroupConfigurationUpdates]
     }
   }
-
-  object WorkGroupStateEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait WorkGroupState extends js.Any
+  object WorkGroupState extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[WorkGroupState]
+    val DISABLED = "DISABLED".asInstanceOf[WorkGroupState]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }

--- a/services/augmentedairuntime/src/main/scala/facade/amazonaws/services/AugmentedAIRuntime.scala
+++ b/services/augmentedairuntime/src/main/scala/facade/amazonaws/services/AugmentedAIRuntime.scala
@@ -7,18 +7,15 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object augmentedairuntime {
-  type ContentClassifier  = String
   type ContentClassifiers = js.Array[ContentClassifier]
   type FailureReason      = String
   type FlowDefinitionArn  = String
   type HumanLoopArn       = String
   type HumanLoopName      = String
-  type HumanLoopStatus    = String
   type HumanLoopSummaries = js.Array[HumanLoopSummary]
   type InputContent       = String
   type MaxResults         = Int
   type NextToken          = String
-  type SortOrder          = String
   type Timestamp          = js.Date
 
   implicit final class AugmentedAIRuntimeOps(private val service: AugmentedAIRuntime) extends AnyVal {
@@ -48,10 +45,12 @@ package augmentedairuntime {
     def startHumanLoop(params: StartHumanLoopRequest): Request[StartHumanLoopResponse]          = js.native
     def stopHumanLoop(params: StopHumanLoopRequest): Request[StopHumanLoopResponse]             = js.native
   }
-
-  object ContentClassifierEnum {
-    val FreeOfPersonallyIdentifiableInformation = "FreeOfPersonallyIdentifiableInformation"
-    val FreeOfAdultContent                      = "FreeOfAdultContent"
+  @js.native
+  sealed trait ContentClassifier extends js.Any
+  object ContentClassifier extends js.Object {
+    val FreeOfPersonallyIdentifiableInformation =
+      "FreeOfPersonallyIdentifiableInformation".asInstanceOf[ContentClassifier]
+    val FreeOfAdultContent = "FreeOfAdultContent".asInstanceOf[ContentClassifier]
 
     val values = js.Object.freeze(js.Array(FreeOfPersonallyIdentifiableInformation, FreeOfAdultContent))
   }
@@ -233,13 +232,14 @@ package augmentedairuntime {
       __obj.asInstanceOf[HumanLoopOutputContent]
     }
   }
-
-  object HumanLoopStatusEnum {
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Completed  = "Completed"
-    val Stopped    = "Stopped"
-    val Stopping   = "Stopping"
+  @js.native
+  sealed trait HumanLoopStatus extends js.Any
+  object HumanLoopStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[HumanLoopStatus]
+    val Failed     = "Failed".asInstanceOf[HumanLoopStatus]
+    val Completed  = "Completed".asInstanceOf[HumanLoopStatus]
+    val Stopped    = "Stopped".asInstanceOf[HumanLoopStatus]
+    val Stopping   = "Stopping".asInstanceOf[HumanLoopStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Failed, Completed, Stopped, Stopping))
   }
@@ -344,10 +344,11 @@ package augmentedairuntime {
       __obj.asInstanceOf[ListHumanLoopsResponse]
     }
   }
-
-  object SortOrderEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[SortOrder]
+    val Descending = "Descending".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }

--- a/services/autoscaling/src/main/scala/facade/amazonaws/services/AutoScaling.scala
+++ b/services/autoscaling/src/main/scala/facade/amazonaws/services/AutoScaling.scala
@@ -51,7 +51,6 @@ package object autoscaling {
   type LifecycleHookNames                       = js.Array[AsciiStringMaxLen255]
   type LifecycleHookSpecifications              = js.Array[LifecycleHookSpecification]
   type LifecycleHooks                           = js.Array[LifecycleHook]
-  type LifecycleState                           = String
   type LifecycleTransition                      = String
   type LoadBalancerNames                        = js.Array[XmlStringMaxLen255]
   type LoadBalancerStates                       = js.Array[LoadBalancerState]
@@ -68,8 +67,6 @@ package object autoscaling {
   type MetricName                               = String
   type MetricNamespace                          = String
   type MetricScale                              = Double
-  type MetricStatistic                          = String
-  type MetricType                               = String
   type MetricUnit                               = String
   type Metrics                                  = js.Array[XmlStringMaxLen255]
   type MinAdjustmentMagnitude                   = Int
@@ -94,7 +91,6 @@ package object autoscaling {
   type PropagateAtLaunch                   = Boolean
   type ProtectedFromScaleIn                = Boolean
   type ResourceName                        = String
-  type ScalingActivityStatusCode           = String
   type ScalingPolicies                     = js.Array[ScalingPolicy]
   type ScalingPolicyEnabled                = Boolean
   type ScheduledActionNames                = js.Array[ResourceName]
@@ -2436,21 +2432,22 @@ package autoscaling {
       __obj.asInstanceOf[LifecycleHookSpecification]
     }
   }
-
-  object LifecycleStateEnum {
-    val Pending               = "Pending"
-    val `Pending:Wait`        = "Pending:Wait"
-    val `Pending:Proceed`     = "Pending:Proceed"
-    val Quarantined           = "Quarantined"
-    val InService             = "InService"
-    val Terminating           = "Terminating"
-    val `Terminating:Wait`    = "Terminating:Wait"
-    val `Terminating:Proceed` = "Terminating:Proceed"
-    val Terminated            = "Terminated"
-    val Detaching             = "Detaching"
-    val Detached              = "Detached"
-    val EnteringStandby       = "EnteringStandby"
-    val Standby               = "Standby"
+  @js.native
+  sealed trait LifecycleState extends js.Any
+  object LifecycleState extends js.Object {
+    val Pending               = "Pending".asInstanceOf[LifecycleState]
+    val `Pending:Wait`        = "Pending:Wait".asInstanceOf[LifecycleState]
+    val `Pending:Proceed`     = "Pending:Proceed".asInstanceOf[LifecycleState]
+    val Quarantined           = "Quarantined".asInstanceOf[LifecycleState]
+    val InService             = "InService".asInstanceOf[LifecycleState]
+    val Terminating           = "Terminating".asInstanceOf[LifecycleState]
+    val `Terminating:Wait`    = "Terminating:Wait".asInstanceOf[LifecycleState]
+    val `Terminating:Proceed` = "Terminating:Proceed".asInstanceOf[LifecycleState]
+    val Terminated            = "Terminated".asInstanceOf[LifecycleState]
+    val Detaching             = "Detaching".asInstanceOf[LifecycleState]
+    val Detached              = "Detached".asInstanceOf[LifecycleState]
+    val EnteringStandby       = "EnteringStandby".asInstanceOf[LifecycleState]
+    val Standby               = "Standby".asInstanceOf[LifecycleState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2581,22 +2578,24 @@ package autoscaling {
       __obj.asInstanceOf[MetricGranularityType]
     }
   }
-
-  object MetricStatisticEnum {
-    val Average     = "Average"
-    val Minimum     = "Minimum"
-    val Maximum     = "Maximum"
-    val SampleCount = "SampleCount"
-    val Sum         = "Sum"
+  @js.native
+  sealed trait MetricStatistic extends js.Any
+  object MetricStatistic extends js.Object {
+    val Average     = "Average".asInstanceOf[MetricStatistic]
+    val Minimum     = "Minimum".asInstanceOf[MetricStatistic]
+    val Maximum     = "Maximum".asInstanceOf[MetricStatistic]
+    val SampleCount = "SampleCount".asInstanceOf[MetricStatistic]
+    val Sum         = "Sum".asInstanceOf[MetricStatistic]
 
     val values = js.Object.freeze(js.Array(Average, Minimum, Maximum, SampleCount, Sum))
   }
-
-  object MetricTypeEnum {
-    val ASGAverageCPUUtilization = "ASGAverageCPUUtilization"
-    val ASGAverageNetworkIn      = "ASGAverageNetworkIn"
-    val ASGAverageNetworkOut     = "ASGAverageNetworkOut"
-    val ALBRequestCountPerTarget = "ALBRequestCountPerTarget"
+  @js.native
+  sealed trait MetricType extends js.Any
+  object MetricType extends js.Object {
+    val ASGAverageCPUUtilization = "ASGAverageCPUUtilization".asInstanceOf[MetricType]
+    val ASGAverageNetworkIn      = "ASGAverageNetworkIn".asInstanceOf[MetricType]
+    val ASGAverageNetworkOut     = "ASGAverageNetworkOut".asInstanceOf[MetricType]
+    val ALBRequestCountPerTarget = "ALBRequestCountPerTarget".asInstanceOf[MetricType]
 
     val values = js.Object.freeze(
       js.Array(ASGAverageCPUUtilization, ASGAverageNetworkIn, ASGAverageNetworkOut, ALBRequestCountPerTarget)
@@ -2967,20 +2966,21 @@ package autoscaling {
       __obj.asInstanceOf[RecordLifecycleActionHeartbeatType]
     }
   }
-
-  object ScalingActivityStatusCodeEnum {
-    val PendingSpotBidPlacement         = "PendingSpotBidPlacement"
-    val WaitingForSpotInstanceRequestId = "WaitingForSpotInstanceRequestId"
-    val WaitingForSpotInstanceId        = "WaitingForSpotInstanceId"
-    val WaitingForInstanceId            = "WaitingForInstanceId"
-    val PreInService                    = "PreInService"
-    val InProgress                      = "InProgress"
-    val WaitingForELBConnectionDraining = "WaitingForELBConnectionDraining"
-    val MidLifecycleAction              = "MidLifecycleAction"
-    val WaitingForInstanceWarmup        = "WaitingForInstanceWarmup"
-    val Successful                      = "Successful"
-    val Failed                          = "Failed"
-    val Cancelled                       = "Cancelled"
+  @js.native
+  sealed trait ScalingActivityStatusCode extends js.Any
+  object ScalingActivityStatusCode extends js.Object {
+    val PendingSpotBidPlacement         = "PendingSpotBidPlacement".asInstanceOf[ScalingActivityStatusCode]
+    val WaitingForSpotInstanceRequestId = "WaitingForSpotInstanceRequestId".asInstanceOf[ScalingActivityStatusCode]
+    val WaitingForSpotInstanceId        = "WaitingForSpotInstanceId".asInstanceOf[ScalingActivityStatusCode]
+    val WaitingForInstanceId            = "WaitingForInstanceId".asInstanceOf[ScalingActivityStatusCode]
+    val PreInService                    = "PreInService".asInstanceOf[ScalingActivityStatusCode]
+    val InProgress                      = "InProgress".asInstanceOf[ScalingActivityStatusCode]
+    val WaitingForELBConnectionDraining = "WaitingForELBConnectionDraining".asInstanceOf[ScalingActivityStatusCode]
+    val MidLifecycleAction              = "MidLifecycleAction".asInstanceOf[ScalingActivityStatusCode]
+    val WaitingForInstanceWarmup        = "WaitingForInstanceWarmup".asInstanceOf[ScalingActivityStatusCode]
+    val Successful                      = "Successful".asInstanceOf[ScalingActivityStatusCode]
+    val Failed                          = "Failed".asInstanceOf[ScalingActivityStatusCode]
+    val Cancelled                       = "Cancelled".asInstanceOf[ScalingActivityStatusCode]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/autoscalingplans/src/main/scala/facade/amazonaws/services/AutoScalingPlans.scala
+++ b/services/autoscalingplans/src/main/scala/facade/amazonaws/services/AutoScalingPlans.scala
@@ -7,51 +7,39 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object autoscalingplans {
-  type ApplicationSources                   = js.Array[ApplicationSource]
-  type Cooldown                             = Int
-  type Datapoints                           = js.Array[Datapoint]
-  type DisableDynamicScaling                = Boolean
-  type DisableScaleIn                       = Boolean
-  type ForecastDataType                     = String
-  type LoadMetricType                       = String
-  type MaxResults                           = Int
-  type MetricDimensionName                  = String
-  type MetricDimensionValue                 = String
-  type MetricDimensions                     = js.Array[MetricDimension]
-  type MetricName                           = String
-  type MetricNamespace                      = String
-  type MetricScale                          = Double
-  type MetricStatistic                      = String
-  type MetricUnit                           = String
-  type NextToken                            = String
-  type PolicyName                           = String
-  type PolicyType                           = String
-  type PredictiveScalingMaxCapacityBehavior = String
-  type PredictiveScalingMode                = String
-  type ResourceCapacity                     = Int
-  type ResourceIdMaxLen1600                 = String
-  type ResourceLabel                        = String
-  type ScalableDimension                    = String
-  type ScalingInstructions                  = js.Array[ScalingInstruction]
-  type ScalingMetricType                    = String
-  type ScalingPlanName                      = String
-  type ScalingPlanNames                     = js.Array[ScalingPlanName]
-  type ScalingPlanResources                 = js.Array[ScalingPlanResource]
-  type ScalingPlanStatusCode                = String
-  type ScalingPlanVersion                   = Double
-  type ScalingPlans                         = js.Array[ScalingPlan]
-  type ScalingPolicies                      = js.Array[ScalingPolicy]
-  type ScalingPolicyUpdateBehavior          = String
-  type ScalingStatusCode                    = String
-  type ScheduledActionBufferTime            = Int
-  type ServiceNamespace                     = String
-  type TagFilters                           = js.Array[TagFilter]
-  type TagValues                            = js.Array[XmlStringMaxLen256]
-  type TargetTrackingConfigurations         = js.Array[TargetTrackingConfiguration]
-  type TimestampType                        = js.Date
-  type XmlString                            = String
-  type XmlStringMaxLen128                   = String
-  type XmlStringMaxLen256                   = String
+  type ApplicationSources           = js.Array[ApplicationSource]
+  type Cooldown                     = Int
+  type Datapoints                   = js.Array[Datapoint]
+  type DisableDynamicScaling        = Boolean
+  type DisableScaleIn               = Boolean
+  type MaxResults                   = Int
+  type MetricDimensionName          = String
+  type MetricDimensionValue         = String
+  type MetricDimensions             = js.Array[MetricDimension]
+  type MetricName                   = String
+  type MetricNamespace              = String
+  type MetricScale                  = Double
+  type MetricUnit                   = String
+  type NextToken                    = String
+  type PolicyName                   = String
+  type ResourceCapacity             = Int
+  type ResourceIdMaxLen1600         = String
+  type ResourceLabel                = String
+  type ScalingInstructions          = js.Array[ScalingInstruction]
+  type ScalingPlanName              = String
+  type ScalingPlanNames             = js.Array[ScalingPlanName]
+  type ScalingPlanResources         = js.Array[ScalingPlanResource]
+  type ScalingPlanVersion           = Double
+  type ScalingPlans                 = js.Array[ScalingPlan]
+  type ScalingPolicies              = js.Array[ScalingPolicy]
+  type ScheduledActionBufferTime    = Int
+  type TagFilters                   = js.Array[TagFilter]
+  type TagValues                    = js.Array[XmlStringMaxLen256]
+  type TargetTrackingConfigurations = js.Array[TargetTrackingConfiguration]
+  type TimestampType                = js.Date
+  type XmlString                    = String
+  type XmlStringMaxLen128           = String
+  type XmlStringMaxLen256           = String
 
   implicit final class AutoScalingPlansOps(private val service: AutoScalingPlans) extends AnyVal {
 
@@ -376,12 +364,13 @@ package autoscalingplans {
       __obj.asInstanceOf[DescribeScalingPlansResponse]
     }
   }
-
-  object ForecastDataTypeEnum {
-    val CapacityForecast           = "CapacityForecast"
-    val LoadForecast               = "LoadForecast"
-    val ScheduledActionMinCapacity = "ScheduledActionMinCapacity"
-    val ScheduledActionMaxCapacity = "ScheduledActionMaxCapacity"
+  @js.native
+  sealed trait ForecastDataType extends js.Any
+  object ForecastDataType extends js.Object {
+    val CapacityForecast           = "CapacityForecast".asInstanceOf[ForecastDataType]
+    val LoadForecast               = "LoadForecast".asInstanceOf[ForecastDataType]
+    val ScheduledActionMinCapacity = "ScheduledActionMinCapacity".asInstanceOf[ForecastDataType]
+    val ScheduledActionMaxCapacity = "ScheduledActionMaxCapacity".asInstanceOf[ForecastDataType]
 
     val values =
       js.Object.freeze(js.Array(CapacityForecast, LoadForecast, ScheduledActionMinCapacity, ScheduledActionMaxCapacity))
@@ -443,12 +432,13 @@ package autoscalingplans {
       __obj.asInstanceOf[GetScalingPlanResourceForecastDataResponse]
     }
   }
-
-  object LoadMetricTypeEnum {
-    val ASGTotalCPUUtilization     = "ASGTotalCPUUtilization"
-    val ASGTotalNetworkIn          = "ASGTotalNetworkIn"
-    val ASGTotalNetworkOut         = "ASGTotalNetworkOut"
-    val ALBTargetGroupRequestCount = "ALBTargetGroupRequestCount"
+  @js.native
+  sealed trait LoadMetricType extends js.Any
+  object LoadMetricType extends js.Object {
+    val ASGTotalCPUUtilization     = "ASGTotalCPUUtilization".asInstanceOf[LoadMetricType]
+    val ASGTotalNetworkIn          = "ASGTotalNetworkIn".asInstanceOf[LoadMetricType]
+    val ASGTotalNetworkOut         = "ASGTotalNetworkOut".asInstanceOf[LoadMetricType]
+    val ALBTargetGroupRequestCount = "ALBTargetGroupRequestCount".asInstanceOf[LoadMetricType]
 
     val values = js.Object.freeze(
       js.Array(ASGTotalCPUUtilization, ASGTotalNetworkIn, ASGTotalNetworkOut, ALBTargetGroupRequestCount)
@@ -478,19 +468,21 @@ package autoscalingplans {
       __obj.asInstanceOf[MetricDimension]
     }
   }
-
-  object MetricStatisticEnum {
-    val Average     = "Average"
-    val Minimum     = "Minimum"
-    val Maximum     = "Maximum"
-    val SampleCount = "SampleCount"
-    val Sum         = "Sum"
+  @js.native
+  sealed trait MetricStatistic extends js.Any
+  object MetricStatistic extends js.Object {
+    val Average     = "Average".asInstanceOf[MetricStatistic]
+    val Minimum     = "Minimum".asInstanceOf[MetricStatistic]
+    val Maximum     = "Maximum".asInstanceOf[MetricStatistic]
+    val SampleCount = "SampleCount".asInstanceOf[MetricStatistic]
+    val Sum         = "Sum".asInstanceOf[MetricStatistic]
 
     val values = js.Object.freeze(js.Array(Average, Minimum, Maximum, SampleCount, Sum))
   }
-
-  object PolicyTypeEnum {
-    val TargetTrackingScaling = "TargetTrackingScaling"
+  @js.native
+  sealed trait PolicyType extends js.Any
+  object PolicyType extends js.Object {
+    val TargetTrackingScaling = "TargetTrackingScaling".asInstanceOf[PolicyType]
 
     val values = js.Object.freeze(js.Array(TargetTrackingScaling))
   }
@@ -542,33 +534,41 @@ package autoscalingplans {
       __obj.asInstanceOf[PredefinedScalingMetricSpecification]
     }
   }
-
-  object PredictiveScalingMaxCapacityBehaviorEnum {
-    val SetForecastCapacityToMaxCapacity    = "SetForecastCapacityToMaxCapacity"
-    val SetMaxCapacityToForecastCapacity    = "SetMaxCapacityToForecastCapacity"
-    val SetMaxCapacityAboveForecastCapacity = "SetMaxCapacityAboveForecastCapacity"
+  @js.native
+  sealed trait PredictiveScalingMaxCapacityBehavior extends js.Any
+  object PredictiveScalingMaxCapacityBehavior extends js.Object {
+    val SetForecastCapacityToMaxCapacity =
+      "SetForecastCapacityToMaxCapacity".asInstanceOf[PredictiveScalingMaxCapacityBehavior]
+    val SetMaxCapacityToForecastCapacity =
+      "SetMaxCapacityToForecastCapacity".asInstanceOf[PredictiveScalingMaxCapacityBehavior]
+    val SetMaxCapacityAboveForecastCapacity =
+      "SetMaxCapacityAboveForecastCapacity".asInstanceOf[PredictiveScalingMaxCapacityBehavior]
 
     val values = js.Object.freeze(
       js.Array(SetForecastCapacityToMaxCapacity, SetMaxCapacityToForecastCapacity, SetMaxCapacityAboveForecastCapacity)
     )
   }
-
-  object PredictiveScalingModeEnum {
-    val ForecastAndScale = "ForecastAndScale"
-    val ForecastOnly     = "ForecastOnly"
+  @js.native
+  sealed trait PredictiveScalingMode extends js.Any
+  object PredictiveScalingMode extends js.Object {
+    val ForecastAndScale = "ForecastAndScale".asInstanceOf[PredictiveScalingMode]
+    val ForecastOnly     = "ForecastOnly".asInstanceOf[PredictiveScalingMode]
 
     val values = js.Object.freeze(js.Array(ForecastAndScale, ForecastOnly))
   }
-
-  object ScalableDimensionEnum {
-    val `autoscaling:autoScalingGroup:DesiredCapacity` = "autoscaling:autoScalingGroup:DesiredCapacity"
-    val `ecs:service:DesiredCount`                     = "ecs:service:DesiredCount"
-    val `ec2:spot-fleet-request:TargetCapacity`        = "ec2:spot-fleet-request:TargetCapacity"
-    val `rds:cluster:ReadReplicaCount`                 = "rds:cluster:ReadReplicaCount"
-    val `dynamodb:table:ReadCapacityUnits`             = "dynamodb:table:ReadCapacityUnits"
-    val `dynamodb:table:WriteCapacityUnits`            = "dynamodb:table:WriteCapacityUnits"
-    val `dynamodb:index:ReadCapacityUnits`             = "dynamodb:index:ReadCapacityUnits"
-    val `dynamodb:index:WriteCapacityUnits`            = "dynamodb:index:WriteCapacityUnits"
+  @js.native
+  sealed trait ScalableDimension extends js.Any
+  object ScalableDimension extends js.Object {
+    val `autoscaling:autoScalingGroup:DesiredCapacity` =
+      "autoscaling:autoScalingGroup:DesiredCapacity".asInstanceOf[ScalableDimension]
+    val `ecs:service:DesiredCount` = "ecs:service:DesiredCount".asInstanceOf[ScalableDimension]
+    val `ec2:spot-fleet-request:TargetCapacity` =
+      "ec2:spot-fleet-request:TargetCapacity".asInstanceOf[ScalableDimension]
+    val `rds:cluster:ReadReplicaCount`      = "rds:cluster:ReadReplicaCount".asInstanceOf[ScalableDimension]
+    val `dynamodb:table:ReadCapacityUnits`  = "dynamodb:table:ReadCapacityUnits".asInstanceOf[ScalableDimension]
+    val `dynamodb:table:WriteCapacityUnits` = "dynamodb:table:WriteCapacityUnits".asInstanceOf[ScalableDimension]
+    val `dynamodb:index:ReadCapacityUnits`  = "dynamodb:index:ReadCapacityUnits".asInstanceOf[ScalableDimension]
+    val `dynamodb:index:WriteCapacityUnits` = "dynamodb:index:WriteCapacityUnits".asInstanceOf[ScalableDimension]
 
     val values = js.Object.freeze(
       js.Array(
@@ -660,21 +660,23 @@ package autoscalingplans {
       __obj.asInstanceOf[ScalingInstruction]
     }
   }
-
-  object ScalingMetricTypeEnum {
-    val ASGAverageCPUUtilization                 = "ASGAverageCPUUtilization"
-    val ASGAverageNetworkIn                      = "ASGAverageNetworkIn"
-    val ASGAverageNetworkOut                     = "ASGAverageNetworkOut"
-    val DynamoDBReadCapacityUtilization          = "DynamoDBReadCapacityUtilization"
-    val DynamoDBWriteCapacityUtilization         = "DynamoDBWriteCapacityUtilization"
-    val ECSServiceAverageCPUUtilization          = "ECSServiceAverageCPUUtilization"
-    val ECSServiceAverageMemoryUtilization       = "ECSServiceAverageMemoryUtilization"
-    val ALBRequestCountPerTarget                 = "ALBRequestCountPerTarget"
-    val RDSReaderAverageCPUUtilization           = "RDSReaderAverageCPUUtilization"
-    val RDSReaderAverageDatabaseConnections      = "RDSReaderAverageDatabaseConnections"
-    val EC2SpotFleetRequestAverageCPUUtilization = "EC2SpotFleetRequestAverageCPUUtilization"
-    val EC2SpotFleetRequestAverageNetworkIn      = "EC2SpotFleetRequestAverageNetworkIn"
-    val EC2SpotFleetRequestAverageNetworkOut     = "EC2SpotFleetRequestAverageNetworkOut"
+  @js.native
+  sealed trait ScalingMetricType extends js.Any
+  object ScalingMetricType extends js.Object {
+    val ASGAverageCPUUtilization            = "ASGAverageCPUUtilization".asInstanceOf[ScalingMetricType]
+    val ASGAverageNetworkIn                 = "ASGAverageNetworkIn".asInstanceOf[ScalingMetricType]
+    val ASGAverageNetworkOut                = "ASGAverageNetworkOut".asInstanceOf[ScalingMetricType]
+    val DynamoDBReadCapacityUtilization     = "DynamoDBReadCapacityUtilization".asInstanceOf[ScalingMetricType]
+    val DynamoDBWriteCapacityUtilization    = "DynamoDBWriteCapacityUtilization".asInstanceOf[ScalingMetricType]
+    val ECSServiceAverageCPUUtilization     = "ECSServiceAverageCPUUtilization".asInstanceOf[ScalingMetricType]
+    val ECSServiceAverageMemoryUtilization  = "ECSServiceAverageMemoryUtilization".asInstanceOf[ScalingMetricType]
+    val ALBRequestCountPerTarget            = "ALBRequestCountPerTarget".asInstanceOf[ScalingMetricType]
+    val RDSReaderAverageCPUUtilization      = "RDSReaderAverageCPUUtilization".asInstanceOf[ScalingMetricType]
+    val RDSReaderAverageDatabaseConnections = "RDSReaderAverageDatabaseConnections".asInstanceOf[ScalingMetricType]
+    val EC2SpotFleetRequestAverageCPUUtilization =
+      "EC2SpotFleetRequestAverageCPUUtilization".asInstanceOf[ScalingMetricType]
+    val EC2SpotFleetRequestAverageNetworkIn  = "EC2SpotFleetRequestAverageNetworkIn".asInstanceOf[ScalingMetricType]
+    val EC2SpotFleetRequestAverageNetworkOut = "EC2SpotFleetRequestAverageNetworkOut".asInstanceOf[ScalingMetricType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -778,16 +780,17 @@ package autoscalingplans {
       __obj.asInstanceOf[ScalingPlanResource]
     }
   }
-
-  object ScalingPlanStatusCodeEnum {
-    val Active             = "Active"
-    val ActiveWithProblems = "ActiveWithProblems"
-    val CreationInProgress = "CreationInProgress"
-    val CreationFailed     = "CreationFailed"
-    val DeletionInProgress = "DeletionInProgress"
-    val DeletionFailed     = "DeletionFailed"
-    val UpdateInProgress   = "UpdateInProgress"
-    val UpdateFailed       = "UpdateFailed"
+  @js.native
+  sealed trait ScalingPlanStatusCode extends js.Any
+  object ScalingPlanStatusCode extends js.Object {
+    val Active             = "Active".asInstanceOf[ScalingPlanStatusCode]
+    val ActiveWithProblems = "ActiveWithProblems".asInstanceOf[ScalingPlanStatusCode]
+    val CreationInProgress = "CreationInProgress".asInstanceOf[ScalingPlanStatusCode]
+    val CreationFailed     = "CreationFailed".asInstanceOf[ScalingPlanStatusCode]
+    val DeletionInProgress = "DeletionInProgress".asInstanceOf[ScalingPlanStatusCode]
+    val DeletionFailed     = "DeletionFailed".asInstanceOf[ScalingPlanStatusCode]
+    val UpdateInProgress   = "UpdateInProgress".asInstanceOf[ScalingPlanStatusCode]
+    val UpdateFailed       = "UpdateFailed".asInstanceOf[ScalingPlanStatusCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -831,28 +834,31 @@ package autoscalingplans {
       __obj.asInstanceOf[ScalingPolicy]
     }
   }
-
-  object ScalingPolicyUpdateBehaviorEnum {
-    val KeepExternalPolicies    = "KeepExternalPolicies"
-    val ReplaceExternalPolicies = "ReplaceExternalPolicies"
+  @js.native
+  sealed trait ScalingPolicyUpdateBehavior extends js.Any
+  object ScalingPolicyUpdateBehavior extends js.Object {
+    val KeepExternalPolicies    = "KeepExternalPolicies".asInstanceOf[ScalingPolicyUpdateBehavior]
+    val ReplaceExternalPolicies = "ReplaceExternalPolicies".asInstanceOf[ScalingPolicyUpdateBehavior]
 
     val values = js.Object.freeze(js.Array(KeepExternalPolicies, ReplaceExternalPolicies))
   }
-
-  object ScalingStatusCodeEnum {
-    val Inactive        = "Inactive"
-    val PartiallyActive = "PartiallyActive"
-    val Active          = "Active"
+  @js.native
+  sealed trait ScalingStatusCode extends js.Any
+  object ScalingStatusCode extends js.Object {
+    val Inactive        = "Inactive".asInstanceOf[ScalingStatusCode]
+    val PartiallyActive = "PartiallyActive".asInstanceOf[ScalingStatusCode]
+    val Active          = "Active".asInstanceOf[ScalingStatusCode]
 
     val values = js.Object.freeze(js.Array(Inactive, PartiallyActive, Active))
   }
-
-  object ServiceNamespaceEnum {
-    val autoscaling = "autoscaling"
-    val ecs         = "ecs"
-    val ec2         = "ec2"
-    val rds         = "rds"
-    val dynamodb    = "dynamodb"
+  @js.native
+  sealed trait ServiceNamespace extends js.Any
+  object ServiceNamespace extends js.Object {
+    val autoscaling = "autoscaling".asInstanceOf[ServiceNamespace]
+    val ecs         = "ecs".asInstanceOf[ServiceNamespace]
+    val ec2         = "ec2".asInstanceOf[ServiceNamespace]
+    val rds         = "rds".asInstanceOf[ServiceNamespace]
+    val dynamodb    = "dynamodb".asInstanceOf[ServiceNamespace]
 
     val values = js.Object.freeze(js.Array(autoscaling, ecs, ec2, rds, dynamodb))
   }

--- a/services/backup/src/main/scala/facade/amazonaws/services/Backup.scala
+++ b/services/backup/src/main/scala/facade/amazonaws/services/Backup.scala
@@ -8,7 +8,6 @@ import facade.amazonaws._
 
 package object backup {
   type ARN                            = String
-  type BackupJobState                 = String
   type BackupJobsList                 = js.Array[BackupJob]
   type BackupPlanName                 = String
   type BackupPlanTemplatesList        = js.Array[BackupPlanTemplatesListMember]
@@ -19,15 +18,12 @@ package object backup {
   type BackupRulesInput               = js.Array[BackupRuleInput]
   type BackupSelectionName            = String
   type BackupSelectionsList           = js.Array[BackupSelectionsListMember]
-  type BackupVaultEvent               = String
   type BackupVaultEvents              = js.Array[BackupVaultEvent]
   type BackupVaultList                = js.Array[BackupVaultListMember]
   type BackupVaultName                = String
   type ConditionKey                   = String
-  type ConditionType                  = String
   type ConditionValue                 = String
   type CopyActions                    = js.Array[CopyAction]
-  type CopyJobState                   = String
   type CopyJobsList                   = js.Array[CopyJob]
   type CronExpression                 = String
   type IAMPolicy                      = String
@@ -40,14 +36,11 @@ package object backup {
   type ProtectedResourcesList         = js.Array[ProtectedResource]
   type RecoveryPointByBackupVaultList = js.Array[RecoveryPointByBackupVault]
   type RecoveryPointByResourceList    = js.Array[RecoveryPointByResource]
-  type RecoveryPointStatus            = String
   type ResourceArns                   = js.Array[ARN]
   type ResourceType                   = String
   type ResourceTypes                  = js.Array[ResourceType]
   type RestoreJobId                   = String
-  type RestoreJobStatus               = String
   type RestoreJobsList                = js.Array[RestoreJobsListMember]
-  type StorageClass                   = String
   type TagKey                         = String
   type TagKeyList                     = js.Array[String]
   type TagValue                       = String
@@ -299,16 +292,17 @@ package backup {
       __obj.asInstanceOf[BackupJob]
     }
   }
-
-  object BackupJobStateEnum {
-    val CREATED   = "CREATED"
-    val PENDING   = "PENDING"
-    val RUNNING   = "RUNNING"
-    val ABORTING  = "ABORTING"
-    val ABORTED   = "ABORTED"
-    val COMPLETED = "COMPLETED"
-    val FAILED    = "FAILED"
-    val EXPIRED   = "EXPIRED"
+  @js.native
+  sealed trait BackupJobState extends js.Any
+  object BackupJobState extends js.Object {
+    val CREATED   = "CREATED".asInstanceOf[BackupJobState]
+    val PENDING   = "PENDING".asInstanceOf[BackupJobState]
+    val RUNNING   = "RUNNING".asInstanceOf[BackupJobState]
+    val ABORTING  = "ABORTING".asInstanceOf[BackupJobState]
+    val ABORTED   = "ABORTED".asInstanceOf[BackupJobState]
+    val COMPLETED = "COMPLETED".asInstanceOf[BackupJobState]
+    val FAILED    = "FAILED".asInstanceOf[BackupJobState]
+    val EXPIRED   = "EXPIRED".asInstanceOf[BackupJobState]
 
     val values = js.Object.freeze(js.Array(CREATED, PENDING, RUNNING, ABORTING, ABORTED, COMPLETED, FAILED, EXPIRED))
   }
@@ -573,23 +567,24 @@ package backup {
       __obj.asInstanceOf[BackupSelectionsListMember]
     }
   }
-
-  object BackupVaultEventEnum {
-    val BACKUP_JOB_STARTED      = "BACKUP_JOB_STARTED"
-    val BACKUP_JOB_COMPLETED    = "BACKUP_JOB_COMPLETED"
-    val BACKUP_JOB_SUCCESSFUL   = "BACKUP_JOB_SUCCESSFUL"
-    val BACKUP_JOB_FAILED       = "BACKUP_JOB_FAILED"
-    val BACKUP_JOB_EXPIRED      = "BACKUP_JOB_EXPIRED"
-    val RESTORE_JOB_STARTED     = "RESTORE_JOB_STARTED"
-    val RESTORE_JOB_COMPLETED   = "RESTORE_JOB_COMPLETED"
-    val RESTORE_JOB_SUCCESSFUL  = "RESTORE_JOB_SUCCESSFUL"
-    val RESTORE_JOB_FAILED      = "RESTORE_JOB_FAILED"
-    val COPY_JOB_STARTED        = "COPY_JOB_STARTED"
-    val COPY_JOB_SUCCESSFUL     = "COPY_JOB_SUCCESSFUL"
-    val COPY_JOB_FAILED         = "COPY_JOB_FAILED"
-    val RECOVERY_POINT_MODIFIED = "RECOVERY_POINT_MODIFIED"
-    val BACKUP_PLAN_CREATED     = "BACKUP_PLAN_CREATED"
-    val BACKUP_PLAN_MODIFIED    = "BACKUP_PLAN_MODIFIED"
+  @js.native
+  sealed trait BackupVaultEvent extends js.Any
+  object BackupVaultEvent extends js.Object {
+    val BACKUP_JOB_STARTED      = "BACKUP_JOB_STARTED".asInstanceOf[BackupVaultEvent]
+    val BACKUP_JOB_COMPLETED    = "BACKUP_JOB_COMPLETED".asInstanceOf[BackupVaultEvent]
+    val BACKUP_JOB_SUCCESSFUL   = "BACKUP_JOB_SUCCESSFUL".asInstanceOf[BackupVaultEvent]
+    val BACKUP_JOB_FAILED       = "BACKUP_JOB_FAILED".asInstanceOf[BackupVaultEvent]
+    val BACKUP_JOB_EXPIRED      = "BACKUP_JOB_EXPIRED".asInstanceOf[BackupVaultEvent]
+    val RESTORE_JOB_STARTED     = "RESTORE_JOB_STARTED".asInstanceOf[BackupVaultEvent]
+    val RESTORE_JOB_COMPLETED   = "RESTORE_JOB_COMPLETED".asInstanceOf[BackupVaultEvent]
+    val RESTORE_JOB_SUCCESSFUL  = "RESTORE_JOB_SUCCESSFUL".asInstanceOf[BackupVaultEvent]
+    val RESTORE_JOB_FAILED      = "RESTORE_JOB_FAILED".asInstanceOf[BackupVaultEvent]
+    val COPY_JOB_STARTED        = "COPY_JOB_STARTED".asInstanceOf[BackupVaultEvent]
+    val COPY_JOB_SUCCESSFUL     = "COPY_JOB_SUCCESSFUL".asInstanceOf[BackupVaultEvent]
+    val COPY_JOB_FAILED         = "COPY_JOB_FAILED".asInstanceOf[BackupVaultEvent]
+    val RECOVERY_POINT_MODIFIED = "RECOVERY_POINT_MODIFIED".asInstanceOf[BackupVaultEvent]
+    val BACKUP_PLAN_CREATED     = "BACKUP_PLAN_CREATED".asInstanceOf[BackupVaultEvent]
+    val BACKUP_PLAN_MODIFIED    = "BACKUP_PLAN_MODIFIED".asInstanceOf[BackupVaultEvent]
 
     val values = js.Object.freeze(
       js.Array(
@@ -696,9 +691,10 @@ package backup {
       __obj.asInstanceOf[Condition]
     }
   }
-
-  object ConditionTypeEnum {
-    val STRINGEQUALS = "STRINGEQUALS"
+  @js.native
+  sealed trait ConditionType extends js.Any
+  object ConditionType extends js.Object {
+    val STRINGEQUALS = "STRINGEQUALS".asInstanceOf[ConditionType]
 
     val values = js.Object.freeze(js.Array(STRINGEQUALS))
   }
@@ -788,12 +784,13 @@ package backup {
       __obj.asInstanceOf[CopyJob]
     }
   }
-
-  object CopyJobStateEnum {
-    val CREATED   = "CREATED"
-    val RUNNING   = "RUNNING"
-    val COMPLETED = "COMPLETED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait CopyJobState extends js.Any
+  object CopyJobState extends js.Object {
+    val CREATED   = "CREATED".asInstanceOf[CopyJobState]
+    val RUNNING   = "RUNNING".asInstanceOf[CopyJobState]
+    val COMPLETED = "COMPLETED".asInstanceOf[CopyJobState]
+    val FAILED    = "FAILED".asInstanceOf[CopyJobState]
 
     val values = js.Object.freeze(js.Array(CREATED, RUNNING, COMPLETED, FAILED))
   }
@@ -2543,22 +2540,24 @@ package backup {
       __obj.asInstanceOf[RecoveryPointCreator]
     }
   }
-
-  object RecoveryPointStatusEnum {
-    val COMPLETED = "COMPLETED"
-    val PARTIAL   = "PARTIAL"
-    val DELETING  = "DELETING"
-    val EXPIRED   = "EXPIRED"
+  @js.native
+  sealed trait RecoveryPointStatus extends js.Any
+  object RecoveryPointStatus extends js.Object {
+    val COMPLETED = "COMPLETED".asInstanceOf[RecoveryPointStatus]
+    val PARTIAL   = "PARTIAL".asInstanceOf[RecoveryPointStatus]
+    val DELETING  = "DELETING".asInstanceOf[RecoveryPointStatus]
+    val EXPIRED   = "EXPIRED".asInstanceOf[RecoveryPointStatus]
 
     val values = js.Object.freeze(js.Array(COMPLETED, PARTIAL, DELETING, EXPIRED))
   }
-
-  object RestoreJobStatusEnum {
-    val PENDING   = "PENDING"
-    val RUNNING   = "RUNNING"
-    val COMPLETED = "COMPLETED"
-    val ABORTED   = "ABORTED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait RestoreJobStatus extends js.Any
+  object RestoreJobStatus extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[RestoreJobStatus]
+    val RUNNING   = "RUNNING".asInstanceOf[RestoreJobStatus]
+    val COMPLETED = "COMPLETED".asInstanceOf[RestoreJobStatus]
+    val ABORTED   = "ABORTED".asInstanceOf[RestoreJobStatus]
+    val FAILED    = "FAILED".asInstanceOf[RestoreJobStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, RUNNING, COMPLETED, ABORTED, FAILED))
   }
@@ -2790,11 +2789,12 @@ package backup {
       __obj.asInstanceOf[StopBackupJobInput]
     }
   }
-
-  object StorageClassEnum {
-    val WARM    = "WARM"
-    val COLD    = "COLD"
-    val DELETED = "DELETED"
+  @js.native
+  sealed trait StorageClass extends js.Any
+  object StorageClass extends js.Object {
+    val WARM    = "WARM".asInstanceOf[StorageClass]
+    val COLD    = "COLD".asInstanceOf[StorageClass]
+    val DELETED = "DELETED".asInstanceOf[StorageClass]
 
     val values = js.Object.freeze(js.Array(WARM, COLD, DELETED))
   }

--- a/services/batch/src/main/scala/facade/amazonaws/services/Batch.scala
+++ b/services/batch/src/main/scala/facade/amazonaws/services/Batch.scala
@@ -7,28 +7,17 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object batch {
-  type ArrayJobDependency           = String
   type ArrayJobStatusSummary        = js.Dictionary[Int]
   type AttemptDetails               = js.Array[AttemptDetail]
-  type CEState                      = String
-  type CEStatus                     = String
-  type CEType                       = String
-  type CRAllocationStrategy         = String
-  type CRType                       = String
   type ComputeEnvironmentDetailList = js.Array[ComputeEnvironmentDetail]
   type ComputeEnvironmentOrders     = js.Array[ComputeEnvironmentOrder]
-  type DeviceCgroupPermission       = String
   type DeviceCgroupPermissions      = js.Array[DeviceCgroupPermission]
   type DevicesList                  = js.Array[Device]
   type EnvironmentVariables         = js.Array[KeyValuePair]
-  type JQState                      = String
-  type JQStatus                     = String
   type JobDefinitionList            = js.Array[JobDefinition]
-  type JobDefinitionType            = String
   type JobDependencyList            = js.Array[JobDependency]
   type JobDetailList                = js.Array[JobDetail]
   type JobQueueDetailList           = js.Array[JobQueueDetail]
-  type JobStatus                    = String
   type JobSummaryList               = js.Array[JobSummary]
   type MountPoints                  = js.Array[MountPoint]
   type NetworkInterfaceList         = js.Array[NetworkInterface]
@@ -36,7 +25,6 @@ package object batch {
   type NodeRangeProperties          = js.Array[NodeRangeProperty]
   type ParametersMap                = js.Dictionary[String]
   type ResourceRequirements         = js.Array[ResourceRequirement]
-  type ResourceType                 = String
   type StringList                   = js.Array[String]
   type TagsMap                      = js.Dictionary[String]
   type Ulimits                      = js.Array[Ulimit]
@@ -116,10 +104,11 @@ package batch {
       js.native
     def updateJobQueue(params: UpdateJobQueueRequest): Request[UpdateJobQueueResponse] = js.native
   }
-
-  object ArrayJobDependencyEnum {
-    val N_TO_N     = "N_TO_N"
-    val SEQUENTIAL = "SEQUENTIAL"
+  @js.native
+  sealed trait ArrayJobDependency extends js.Any
+  object ArrayJobDependency extends js.Object {
+    val N_TO_N     = "N_TO_N".asInstanceOf[ArrayJobDependency]
+    val SEQUENTIAL = "SEQUENTIAL".asInstanceOf[ArrayJobDependency]
 
     val values = js.Object.freeze(js.Array(N_TO_N, SEQUENTIAL))
   }
@@ -251,43 +240,48 @@ package batch {
       __obj.asInstanceOf[AttemptDetail]
     }
   }
-
-  object CEStateEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait CEState extends js.Any
+  object CEState extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[CEState]
+    val DISABLED = "DISABLED".asInstanceOf[CEState]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
-
-  object CEStatusEnum {
-    val CREATING = "CREATING"
-    val UPDATING = "UPDATING"
-    val DELETING = "DELETING"
-    val DELETED  = "DELETED"
-    val VALID    = "VALID"
-    val INVALID  = "INVALID"
+  @js.native
+  sealed trait CEStatus extends js.Any
+  object CEStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[CEStatus]
+    val UPDATING = "UPDATING".asInstanceOf[CEStatus]
+    val DELETING = "DELETING".asInstanceOf[CEStatus]
+    val DELETED  = "DELETED".asInstanceOf[CEStatus]
+    val VALID    = "VALID".asInstanceOf[CEStatus]
+    val INVALID  = "INVALID".asInstanceOf[CEStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, UPDATING, DELETING, DELETED, VALID, INVALID))
   }
-
-  object CETypeEnum {
-    val MANAGED   = "MANAGED"
-    val UNMANAGED = "UNMANAGED"
+  @js.native
+  sealed trait CEType extends js.Any
+  object CEType extends js.Object {
+    val MANAGED   = "MANAGED".asInstanceOf[CEType]
+    val UNMANAGED = "UNMANAGED".asInstanceOf[CEType]
 
     val values = js.Object.freeze(js.Array(MANAGED, UNMANAGED))
   }
-
-  object CRAllocationStrategyEnum {
-    val BEST_FIT                = "BEST_FIT"
-    val BEST_FIT_PROGRESSIVE    = "BEST_FIT_PROGRESSIVE"
-    val SPOT_CAPACITY_OPTIMIZED = "SPOT_CAPACITY_OPTIMIZED"
+  @js.native
+  sealed trait CRAllocationStrategy extends js.Any
+  object CRAllocationStrategy extends js.Object {
+    val BEST_FIT                = "BEST_FIT".asInstanceOf[CRAllocationStrategy]
+    val BEST_FIT_PROGRESSIVE    = "BEST_FIT_PROGRESSIVE".asInstanceOf[CRAllocationStrategy]
+    val SPOT_CAPACITY_OPTIMIZED = "SPOT_CAPACITY_OPTIMIZED".asInstanceOf[CRAllocationStrategy]
 
     val values = js.Object.freeze(js.Array(BEST_FIT, BEST_FIT_PROGRESSIVE, SPOT_CAPACITY_OPTIMIZED))
   }
-
-  object CRTypeEnum {
-    val EC2  = "EC2"
-    val SPOT = "SPOT"
+  @js.native
+  sealed trait CRType extends js.Any
+  object CRType extends js.Object {
+    val EC2  = "EC2".asInstanceOf[CRType]
+    val SPOT = "SPOT".asInstanceOf[CRType]
 
     val values = js.Object.freeze(js.Array(EC2, SPOT))
   }
@@ -1061,11 +1055,12 @@ package batch {
       __obj.asInstanceOf[Device]
     }
   }
-
-  object DeviceCgroupPermissionEnum {
-    val READ  = "READ"
-    val WRITE = "WRITE"
-    val MKNOD = "MKNOD"
+  @js.native
+  sealed trait DeviceCgroupPermission extends js.Any
+  object DeviceCgroupPermission extends js.Object {
+    val READ  = "READ".asInstanceOf[DeviceCgroupPermission]
+    val WRITE = "WRITE".asInstanceOf[DeviceCgroupPermission]
+    val MKNOD = "MKNOD".asInstanceOf[DeviceCgroupPermission]
 
     val values = js.Object.freeze(js.Array(READ, WRITE, MKNOD))
   }
@@ -1088,21 +1083,23 @@ package batch {
       __obj.asInstanceOf[Host]
     }
   }
-
-  object JQStateEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait JQState extends js.Any
+  object JQState extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[JQState]
+    val DISABLED = "DISABLED".asInstanceOf[JQState]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
-
-  object JQStatusEnum {
-    val CREATING = "CREATING"
-    val UPDATING = "UPDATING"
-    val DELETING = "DELETING"
-    val DELETED  = "DELETED"
-    val VALID    = "VALID"
-    val INVALID  = "INVALID"
+  @js.native
+  sealed trait JQStatus extends js.Any
+  object JQStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[JQStatus]
+    val UPDATING = "UPDATING".asInstanceOf[JQStatus]
+    val DELETING = "DELETING".asInstanceOf[JQStatus]
+    val DELETED  = "DELETED".asInstanceOf[JQStatus]
+    val VALID    = "VALID".asInstanceOf[JQStatus]
+    val INVALID  = "INVALID".asInstanceOf[JQStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, UPDATING, DELETING, DELETED, VALID, INVALID))
   }
@@ -1154,10 +1151,11 @@ package batch {
       __obj.asInstanceOf[JobDefinition]
     }
   }
-
-  object JobDefinitionTypeEnum {
-    val container = "container"
-    val multinode = "multinode"
+  @js.native
+  sealed trait JobDefinitionType extends js.Any
+  object JobDefinitionType extends js.Object {
+    val container = "container".asInstanceOf[JobDefinitionType]
+    val multinode = "multinode".asInstanceOf[JobDefinitionType]
 
     val values = js.Object.freeze(js.Array(container, multinode))
   }
@@ -1294,15 +1292,16 @@ package batch {
       __obj.asInstanceOf[JobQueueDetail]
     }
   }
-
-  object JobStatusEnum {
-    val SUBMITTED = "SUBMITTED"
-    val PENDING   = "PENDING"
-    val RUNNABLE  = "RUNNABLE"
-    val STARTING  = "STARTING"
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val SUBMITTED = "SUBMITTED".asInstanceOf[JobStatus]
+    val PENDING   = "PENDING".asInstanceOf[JobStatus]
+    val RUNNABLE  = "RUNNABLE".asInstanceOf[JobStatus]
+    val STARTING  = "STARTING".asInstanceOf[JobStatus]
+    val RUNNING   = "RUNNING".asInstanceOf[JobStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[JobStatus]
+    val FAILED    = "FAILED".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(js.Array(SUBMITTED, PENDING, RUNNABLE, STARTING, RUNNING, SUCCEEDED, FAILED))
   }
@@ -1769,9 +1768,10 @@ package batch {
       __obj.asInstanceOf[ResourceRequirement]
     }
   }
-
-  object ResourceTypeEnum {
-    val GPU = "GPU"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val GPU = "GPU".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(GPU))
   }

--- a/services/budgetsservice/src/main/scala/facade/amazonaws/services/BudgetsService.scala
+++ b/services/budgetsservice/src/main/scala/facade/amazonaws/services/BudgetsService.scala
@@ -9,18 +9,14 @@ import facade.amazonaws._
 package object budgetsservice {
   type AccountId                       = String
   type BudgetName                      = String
-  type BudgetType                      = String
   type BudgetedAndActualAmountsList    = js.Array[BudgetedAndActualAmounts]
   type Budgets                         = js.Array[Budget]
-  type ComparisonOperator              = String
   type CostFilters                     = js.Dictionary[DimensionValues]
   type DimensionValues                 = js.Array[GenericString]
   type GenericString                   = String
   type GenericTimestamp                = js.Date
   type MaxResults                      = Int
-  type NotificationState               = String
   type NotificationThreshold           = Double
-  type NotificationType                = String
   type NotificationWithSubscribersList = js.Array[NotificationWithSubscribers]
   type Notifications                   = js.Array[Notification]
   type NullableBoolean                 = Boolean
@@ -28,9 +24,6 @@ package object budgetsservice {
   type PlannedBudgetLimits             = js.Dictionary[Spend]
   type SubscriberAddress               = String
   type Subscribers                     = js.Array[Subscriber]
-  type SubscriptionType                = String
-  type ThresholdType                   = String
-  type TimeUnit                        = String
   type UnitValue                       = String
 
   implicit final class BudgetsServiceOps(private val service: BudgetsService) extends AnyVal {
@@ -189,13 +182,15 @@ package budgetsservice {
     * The type of a budget. It must be one of the following types:
     *  <code>COST</code>, <code>USAGE</code>, <code>RI_UTILIZATION</code>, or <code>RI_COVERAGE</code>.
     */
-  object BudgetTypeEnum {
-    val USAGE                     = "USAGE"
-    val COST                      = "COST"
-    val RI_UTILIZATION            = "RI_UTILIZATION"
-    val RI_COVERAGE               = "RI_COVERAGE"
-    val SAVINGS_PLANS_UTILIZATION = "SAVINGS_PLANS_UTILIZATION"
-    val SAVINGS_PLANS_COVERAGE    = "SAVINGS_PLANS_COVERAGE"
+  @js.native
+  sealed trait BudgetType extends js.Any
+  object BudgetType extends js.Object {
+    val USAGE                     = "USAGE".asInstanceOf[BudgetType]
+    val COST                      = "COST".asInstanceOf[BudgetType]
+    val RI_UTILIZATION            = "RI_UTILIZATION".asInstanceOf[BudgetType]
+    val RI_COVERAGE               = "RI_COVERAGE".asInstanceOf[BudgetType]
+    val SAVINGS_PLANS_UTILIZATION = "SAVINGS_PLANS_UTILIZATION".asInstanceOf[BudgetType]
+    val SAVINGS_PLANS_COVERAGE    = "SAVINGS_PLANS_COVERAGE".asInstanceOf[BudgetType]
 
     val values = js.Object.freeze(
       js.Array(USAGE, COST, RI_UTILIZATION, RI_COVERAGE, SAVINGS_PLANS_UTILIZATION, SAVINGS_PLANS_COVERAGE)
@@ -256,10 +251,12 @@ package budgetsservice {
     * The comparison operator of a notification. Currently the service supports the following operators:
     *  <code>GREATER_THAN</code>, <code>LESS_THAN</code>, <code>EQUAL_TO</code>
     */
-  object ComparisonOperatorEnum {
-    val GREATER_THAN = "GREATER_THAN"
-    val LESS_THAN    = "LESS_THAN"
-    val EQUAL_TO     = "EQUAL_TO"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val GREATER_THAN = "GREATER_THAN".asInstanceOf[ComparisonOperator]
+    val LESS_THAN    = "LESS_THAN".asInstanceOf[ComparisonOperator]
+    val EQUAL_TO     = "EQUAL_TO".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(js.Array(GREATER_THAN, LESS_THAN, EQUAL_TO))
   }
@@ -866,10 +863,11 @@ package budgetsservice {
       __obj.asInstanceOf[Notification]
     }
   }
-
-  object NotificationStateEnum {
-    val OK    = "OK"
-    val ALARM = "ALARM"
+  @js.native
+  sealed trait NotificationState extends js.Any
+  object NotificationState extends js.Object {
+    val OK    = "OK".asInstanceOf[NotificationState]
+    val ALARM = "ALARM".asInstanceOf[NotificationState]
 
     val values = js.Object.freeze(js.Array(OK, ALARM))
   }
@@ -877,9 +875,11 @@ package budgetsservice {
   /**
     * The type of a notification. It must be ACTUAL or FORECASTED.
     */
-  object NotificationTypeEnum {
-    val ACTUAL     = "ACTUAL"
-    val FORECASTED = "FORECASTED"
+  @js.native
+  sealed trait NotificationType extends js.Any
+  object NotificationType extends js.Object {
+    val ACTUAL     = "ACTUAL".asInstanceOf[NotificationType]
+    val FORECASTED = "FORECASTED".asInstanceOf[NotificationType]
 
     val values = js.Object.freeze(js.Array(ACTUAL, FORECASTED))
   }
@@ -965,9 +965,11 @@ package budgetsservice {
   /**
     * The subscription type of the subscriber. It can be SMS or EMAIL.
     */
-  object SubscriptionTypeEnum {
-    val SNS   = "SNS"
-    val EMAIL = "EMAIL"
+  @js.native
+  sealed trait SubscriptionType extends js.Any
+  object SubscriptionType extends js.Object {
+    val SNS   = "SNS".asInstanceOf[SubscriptionType]
+    val EMAIL = "EMAIL".asInstanceOf[SubscriptionType]
 
     val values = js.Object.freeze(js.Array(SNS, EMAIL))
   }
@@ -975,9 +977,11 @@ package budgetsservice {
   /**
     * The type of threshold for a notification. It can be PERCENTAGE or ABSOLUTE_VALUE.
     */
-  object ThresholdTypeEnum {
-    val PERCENTAGE     = "PERCENTAGE"
-    val ABSOLUTE_VALUE = "ABSOLUTE_VALUE"
+  @js.native
+  sealed trait ThresholdType extends js.Any
+  object ThresholdType extends js.Object {
+    val PERCENTAGE     = "PERCENTAGE".asInstanceOf[ThresholdType]
+    val ABSOLUTE_VALUE = "ABSOLUTE_VALUE".asInstanceOf[ThresholdType]
 
     val values = js.Object.freeze(js.Array(PERCENTAGE, ABSOLUTE_VALUE))
   }
@@ -1007,11 +1011,13 @@ package budgetsservice {
   /**
     * The time unit of the budget, such as MONTHLY or QUARTERLY.
     */
-  object TimeUnitEnum {
-    val DAILY     = "DAILY"
-    val MONTHLY   = "MONTHLY"
-    val QUARTERLY = "QUARTERLY"
-    val ANNUALLY  = "ANNUALLY"
+  @js.native
+  sealed trait TimeUnit extends js.Any
+  object TimeUnit extends js.Object {
+    val DAILY     = "DAILY".asInstanceOf[TimeUnit]
+    val MONTHLY   = "MONTHLY".asInstanceOf[TimeUnit]
+    val QUARTERLY = "QUARTERLY".asInstanceOf[TimeUnit]
+    val ANNUALLY  = "ANNUALLY".asInstanceOf[TimeUnit]
 
     val values = js.Object.freeze(js.Array(DAILY, MONTHLY, QUARTERLY, ANNUALLY))
   }

--- a/services/chime/src/main/scala/facade/amazonaws/services/Chime.scala
+++ b/services/chime/src/main/scala/facade/amazonaws/services/Chime.scala
@@ -9,14 +9,11 @@ import facade.amazonaws._
 package object chime {
   type AccountList                      = js.Array[Account]
   type AccountName                      = String
-  type AccountType                      = String
   type Arn                              = String
   type AttendeeList                     = js.Array[Attendee]
   type BatchCreateAttendeeErrorList     = js.Array[CreateAttendeeError]
   type BotList                          = js.Array[Bot]
-  type BotType                          = String
   type CallingName                      = String
-  type CallingNameStatus                = String
   type CallingRegion                    = String
   type CallingRegionList                = js.Array[CallingRegion]
   type ClientRequestToken               = String
@@ -27,46 +24,32 @@ package object chime {
   type E164PhoneNumber                  = String
   type E164PhoneNumberList              = js.Array[E164PhoneNumber]
   type EmailAddress                     = String
-  type EmailStatus                      = String
-  type ErrorCode                        = String
   type ExternalUserIdType               = String
   type GuidString                       = String
   type InviteList                       = js.Array[Invite]
-  type InviteStatus                     = String
   type Iso8601Timestamp                 = js.Date
   type JoinTokenString                  = String
-  type License                          = String
   type LicenseList                      = js.Array[License]
   type MeetingList                      = js.Array[Meeting]
   type MemberErrorList                  = js.Array[MemberError]
-  type MemberType                       = String
   type MembershipItemList               = js.Array[MembershipItem]
   type NonEmptyString                   = String
   type NonEmptyStringList               = js.Array[String]
   type NullableBoolean                  = Boolean
   type OrderedPhoneNumberList           = js.Array[OrderedPhoneNumber]
-  type OrderedPhoneNumberStatus         = String
   type OriginationRouteList             = js.Array[OriginationRoute]
   type OriginationRoutePriority         = Int
-  type OriginationRouteProtocol         = String
   type OriginationRouteWeight           = Int
   type PhoneNumberAssociationList       = js.Array[PhoneNumberAssociation]
-  type PhoneNumberAssociationName       = String
   type PhoneNumberErrorList             = js.Array[PhoneNumberError]
   type PhoneNumberList                  = js.Array[PhoneNumber]
   type PhoneNumberMaxResults            = Int
   type PhoneNumberOrderList             = js.Array[PhoneNumberOrder]
-  type PhoneNumberOrderStatus           = String
-  type PhoneNumberProductType           = String
-  type PhoneNumberStatus                = String
-  type PhoneNumberType                  = String
   type Port                             = Int
   type ProfileServiceMaxResults         = Int
-  type RegistrationStatus               = String
   type ResultMax                        = Int
   type RoomList                         = js.Array[Room]
   type RoomMembershipList               = js.Array[RoomMembership]
-  type RoomMembershipRole               = String
   type SensitiveString                  = String
   type SensitiveStringList              = js.Array[SensitiveString]
   type SigninDelegateGroupList          = js.Array[SigninDelegateGroup]
@@ -79,8 +62,6 @@ package object chime {
   type UserErrorList                    = js.Array[UserError]
   type UserIdList                       = js.Array[NonEmptyString]
   type UserList                         = js.Array[User]
-  type UserType                         = String
-  type VoiceConnectorAwsRegion          = String
   type VoiceConnectorGroupList          = js.Array[VoiceConnectorGroup]
   type VoiceConnectorGroupName          = String
   type VoiceConnectorItemList           = js.Array[VoiceConnectorItem]
@@ -553,12 +534,13 @@ package chime {
       __obj.asInstanceOf[AccountSettings]
     }
   }
-
-  object AccountTypeEnum {
-    val Team                = "Team"
-    val EnterpriseDirectory = "EnterpriseDirectory"
-    val EnterpriseLWA       = "EnterpriseLWA"
-    val EnterpriseOIDC      = "EnterpriseOIDC"
+  @js.native
+  sealed trait AccountType extends js.Any
+  object AccountType extends js.Object {
+    val Team                = "Team".asInstanceOf[AccountType]
+    val EnterpriseDirectory = "EnterpriseDirectory".asInstanceOf[AccountType]
+    val EnterpriseLWA       = "EnterpriseLWA".asInstanceOf[AccountType]
+    val EnterpriseOIDC      = "EnterpriseOIDC".asInstanceOf[AccountType]
 
     val values = js.Object.freeze(js.Array(Team, EnterpriseDirectory, EnterpriseLWA, EnterpriseOIDC))
   }
@@ -1065,9 +1047,10 @@ package chime {
       __obj.asInstanceOf[Bot]
     }
   }
-
-  object BotTypeEnum {
-    val ChatBot = "ChatBot"
+  @js.native
+  sealed trait BotType extends js.Any
+  object BotType extends js.Object {
+    val ChatBot = "ChatBot".asInstanceOf[BotType]
 
     val values = js.Object.freeze(js.Array(ChatBot))
   }
@@ -1090,12 +1073,13 @@ package chime {
       __obj.asInstanceOf[BusinessCallingSettings]
     }
   }
-
-  object CallingNameStatusEnum {
-    val Unassigned       = "Unassigned"
-    val UpdateInProgress = "UpdateInProgress"
-    val UpdateSucceeded  = "UpdateSucceeded"
-    val UpdateFailed     = "UpdateFailed"
+  @js.native
+  sealed trait CallingNameStatus extends js.Any
+  object CallingNameStatus extends js.Object {
+    val Unassigned       = "Unassigned".asInstanceOf[CallingNameStatus]
+    val UpdateInProgress = "UpdateInProgress".asInstanceOf[CallingNameStatus]
+    val UpdateSucceeded  = "UpdateSucceeded".asInstanceOf[CallingNameStatus]
+    val UpdateFailed     = "UpdateFailed".asInstanceOf[CallingNameStatus]
 
     val values = js.Object.freeze(js.Array(Unassigned, UpdateInProgress, UpdateSucceeded, UpdateFailed))
   }
@@ -1970,30 +1954,32 @@ package chime {
       __obj.asInstanceOf[DisassociateSigninDelegateGroupsFromAccountResponse]
     }
   }
-
-  object EmailStatusEnum {
-    val NotSent = "NotSent"
-    val Sent    = "Sent"
-    val Failed  = "Failed"
+  @js.native
+  sealed trait EmailStatus extends js.Any
+  object EmailStatus extends js.Object {
+    val NotSent = "NotSent".asInstanceOf[EmailStatus]
+    val Sent    = "Sent".asInstanceOf[EmailStatus]
+    val Failed  = "Failed".asInstanceOf[EmailStatus]
 
     val values = js.Object.freeze(js.Array(NotSent, Sent, Failed))
   }
-
-  object ErrorCodeEnum {
-    val BadRequest                           = "BadRequest"
-    val Conflict                             = "Conflict"
-    val Forbidden                            = "Forbidden"
-    val NotFound                             = "NotFound"
-    val PreconditionFailed                   = "PreconditionFailed"
-    val ResourceLimitExceeded                = "ResourceLimitExceeded"
-    val ServiceFailure                       = "ServiceFailure"
-    val AccessDenied                         = "AccessDenied"
-    val ServiceUnavailable                   = "ServiceUnavailable"
-    val Throttled                            = "Throttled"
-    val Unauthorized                         = "Unauthorized"
-    val Unprocessable                        = "Unprocessable"
-    val VoiceConnectorGroupAssociationsExist = "VoiceConnectorGroupAssociationsExist"
-    val PhoneNumberAssociationsExist         = "PhoneNumberAssociationsExist"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val BadRequest                           = "BadRequest".asInstanceOf[ErrorCode]
+    val Conflict                             = "Conflict".asInstanceOf[ErrorCode]
+    val Forbidden                            = "Forbidden".asInstanceOf[ErrorCode]
+    val NotFound                             = "NotFound".asInstanceOf[ErrorCode]
+    val PreconditionFailed                   = "PreconditionFailed".asInstanceOf[ErrorCode]
+    val ResourceLimitExceeded                = "ResourceLimitExceeded".asInstanceOf[ErrorCode]
+    val ServiceFailure                       = "ServiceFailure".asInstanceOf[ErrorCode]
+    val AccessDenied                         = "AccessDenied".asInstanceOf[ErrorCode]
+    val ServiceUnavailable                   = "ServiceUnavailable".asInstanceOf[ErrorCode]
+    val Throttled                            = "Throttled".asInstanceOf[ErrorCode]
+    val Unauthorized                         = "Unauthorized".asInstanceOf[ErrorCode]
+    val Unprocessable                        = "Unprocessable".asInstanceOf[ErrorCode]
+    val VoiceConnectorGroupAssociationsExist = "VoiceConnectorGroupAssociationsExist".asInstanceOf[ErrorCode]
+    val PhoneNumberAssociationsExist         = "PhoneNumberAssociationsExist".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2739,11 +2725,12 @@ package chime {
       __obj.asInstanceOf[Invite]
     }
   }
-
-  object InviteStatusEnum {
-    val Pending  = "Pending"
-    val Accepted = "Accepted"
-    val Failed   = "Failed"
+  @js.native
+  sealed trait InviteStatus extends js.Any
+  object InviteStatus extends js.Object {
+    val Pending  = "Pending".asInstanceOf[InviteStatus]
+    val Accepted = "Accepted".asInstanceOf[InviteStatus]
+    val Failed   = "Failed".asInstanceOf[InviteStatus]
 
     val values = js.Object.freeze(js.Array(Pending, Accepted, Failed))
   }
@@ -2787,12 +2774,13 @@ package chime {
       __obj.asInstanceOf[InviteUsersResponse]
     }
   }
-
-  object LicenseEnum {
-    val Basic    = "Basic"
-    val Plus     = "Plus"
-    val Pro      = "Pro"
-    val ProTrial = "ProTrial"
+  @js.native
+  sealed trait License extends js.Any
+  object License extends js.Object {
+    val Basic    = "Basic".asInstanceOf[License]
+    val Plus     = "Plus".asInstanceOf[License]
+    val Pro      = "Pro".asInstanceOf[License]
+    val ProTrial = "ProTrial".asInstanceOf[License]
 
     val values = js.Object.freeze(js.Array(Basic, Plus, Pro, ProTrial))
   }
@@ -3496,11 +3484,12 @@ package chime {
       __obj.asInstanceOf[MemberError]
     }
   }
-
-  object MemberTypeEnum {
-    val User    = "User"
-    val Bot     = "Bot"
-    val Webhook = "Webhook"
+  @js.native
+  sealed trait MemberType extends js.Any
+  object MemberType extends js.Object {
+    val User    = "User".asInstanceOf[MemberType]
+    val Bot     = "Bot".asInstanceOf[MemberType]
+    val Webhook = "Webhook".asInstanceOf[MemberType]
 
     val values = js.Object.freeze(js.Array(User, Bot, Webhook))
   }
@@ -3548,11 +3537,12 @@ package chime {
       __obj.asInstanceOf[OrderedPhoneNumber]
     }
   }
-
-  object OrderedPhoneNumberStatusEnum {
-    val Processing = "Processing"
-    val Acquired   = "Acquired"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait OrderedPhoneNumberStatus extends js.Any
+  object OrderedPhoneNumberStatus extends js.Object {
+    val Processing = "Processing".asInstanceOf[OrderedPhoneNumberStatus]
+    val Acquired   = "Acquired".asInstanceOf[OrderedPhoneNumberStatus]
+    val Failed     = "Failed".asInstanceOf[OrderedPhoneNumberStatus]
 
     val values = js.Object.freeze(js.Array(Processing, Acquired, Failed))
   }
@@ -3609,10 +3599,11 @@ package chime {
       __obj.asInstanceOf[OriginationRoute]
     }
   }
-
-  object OriginationRouteProtocolEnum {
-    val TCP = "TCP"
-    val UDP = "UDP"
+  @js.native
+  sealed trait OriginationRouteProtocol extends js.Any
+  object OriginationRouteProtocol extends js.Object {
+    val TCP = "TCP".asInstanceOf[OriginationRouteProtocol]
+    val UDP = "UDP".asInstanceOf[OriginationRouteProtocol]
 
     val values = js.Object.freeze(js.Array(TCP, UDP))
   }
@@ -3693,12 +3684,13 @@ package chime {
       __obj.asInstanceOf[PhoneNumberAssociation]
     }
   }
-
-  object PhoneNumberAssociationNameEnum {
-    val AccountId             = "AccountId"
-    val UserId                = "UserId"
-    val VoiceConnectorId      = "VoiceConnectorId"
-    val VoiceConnectorGroupId = "VoiceConnectorGroupId"
+  @js.native
+  sealed trait PhoneNumberAssociationName extends js.Any
+  object PhoneNumberAssociationName extends js.Object {
+    val AccountId             = "AccountId".asInstanceOf[PhoneNumberAssociationName]
+    val UserId                = "UserId".asInstanceOf[PhoneNumberAssociationName]
+    val VoiceConnectorId      = "VoiceConnectorId".asInstanceOf[PhoneNumberAssociationName]
+    val VoiceConnectorGroupId = "VoiceConnectorGroupId".asInstanceOf[PhoneNumberAssociationName]
 
     val values = js.Object.freeze(js.Array(AccountId, UserId, VoiceConnectorId, VoiceConnectorGroupId))
   }
@@ -3795,32 +3787,35 @@ package chime {
       __obj.asInstanceOf[PhoneNumberOrder]
     }
   }
-
-  object PhoneNumberOrderStatusEnum {
-    val Processing = "Processing"
-    val Successful = "Successful"
-    val Failed     = "Failed"
-    val Partial    = "Partial"
+  @js.native
+  sealed trait PhoneNumberOrderStatus extends js.Any
+  object PhoneNumberOrderStatus extends js.Object {
+    val Processing = "Processing".asInstanceOf[PhoneNumberOrderStatus]
+    val Successful = "Successful".asInstanceOf[PhoneNumberOrderStatus]
+    val Failed     = "Failed".asInstanceOf[PhoneNumberOrderStatus]
+    val Partial    = "Partial".asInstanceOf[PhoneNumberOrderStatus]
 
     val values = js.Object.freeze(js.Array(Processing, Successful, Failed, Partial))
   }
-
-  object PhoneNumberProductTypeEnum {
-    val BusinessCalling = "BusinessCalling"
-    val VoiceConnector  = "VoiceConnector"
+  @js.native
+  sealed trait PhoneNumberProductType extends js.Any
+  object PhoneNumberProductType extends js.Object {
+    val BusinessCalling = "BusinessCalling".asInstanceOf[PhoneNumberProductType]
+    val VoiceConnector  = "VoiceConnector".asInstanceOf[PhoneNumberProductType]
 
     val values = js.Object.freeze(js.Array(BusinessCalling, VoiceConnector))
   }
-
-  object PhoneNumberStatusEnum {
-    val AcquireInProgress = "AcquireInProgress"
-    val AcquireFailed     = "AcquireFailed"
-    val Unassigned        = "Unassigned"
-    val Assigned          = "Assigned"
-    val ReleaseInProgress = "ReleaseInProgress"
-    val DeleteInProgress  = "DeleteInProgress"
-    val ReleaseFailed     = "ReleaseFailed"
-    val DeleteFailed      = "DeleteFailed"
+  @js.native
+  sealed trait PhoneNumberStatus extends js.Any
+  object PhoneNumberStatus extends js.Object {
+    val AcquireInProgress = "AcquireInProgress".asInstanceOf[PhoneNumberStatus]
+    val AcquireFailed     = "AcquireFailed".asInstanceOf[PhoneNumberStatus]
+    val Unassigned        = "Unassigned".asInstanceOf[PhoneNumberStatus]
+    val Assigned          = "Assigned".asInstanceOf[PhoneNumberStatus]
+    val ReleaseInProgress = "ReleaseInProgress".asInstanceOf[PhoneNumberStatus]
+    val DeleteInProgress  = "DeleteInProgress".asInstanceOf[PhoneNumberStatus]
+    val ReleaseFailed     = "ReleaseFailed".asInstanceOf[PhoneNumberStatus]
+    val DeleteFailed      = "DeleteFailed".asInstanceOf[PhoneNumberStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3835,10 +3830,11 @@ package chime {
       )
     )
   }
-
-  object PhoneNumberTypeEnum {
-    val Local    = "Local"
-    val TollFree = "TollFree"
+  @js.native
+  sealed trait PhoneNumberType extends js.Any
+  object PhoneNumberType extends js.Object {
+    val Local    = "Local".asInstanceOf[PhoneNumberType]
+    val TollFree = "TollFree".asInstanceOf[PhoneNumberType]
 
     val values = js.Object.freeze(js.Array(Local, TollFree))
   }
@@ -4093,11 +4089,12 @@ package chime {
       __obj.asInstanceOf[RegenerateSecurityTokenResponse]
     }
   }
-
-  object RegistrationStatusEnum {
-    val Unregistered = "Unregistered"
-    val Registered   = "Registered"
-    val Suspended    = "Suspended"
+  @js.native
+  sealed trait RegistrationStatus extends js.Any
+  object RegistrationStatus extends js.Object {
+    val Unregistered = "Unregistered".asInstanceOf[RegistrationStatus]
+    val Registered   = "Registered".asInstanceOf[RegistrationStatus]
+    val Suspended    = "Suspended".asInstanceOf[RegistrationStatus]
 
     val values = js.Object.freeze(js.Array(Unregistered, Registered, Suspended))
   }
@@ -4237,10 +4234,11 @@ package chime {
       __obj.asInstanceOf[RoomMembership]
     }
   }
-
-  object RoomMembershipRoleEnum {
-    val Administrator = "Administrator"
-    val Member        = "Member"
+  @js.native
+  sealed trait RoomMembershipRole extends js.Any
+  object RoomMembershipRole extends js.Object {
+    val Administrator = "Administrator".asInstanceOf[RoomMembershipRole]
+    val Member        = "Member".asInstanceOf[RoomMembershipRole]
 
     val values = js.Object.freeze(js.Array(Administrator, Member))
   }
@@ -5000,10 +4998,11 @@ package chime {
       __obj.asInstanceOf[UserSettings]
     }
   }
-
-  object UserTypeEnum {
-    val PrivateUser  = "PrivateUser"
-    val SharedDevice = "SharedDevice"
+  @js.native
+  sealed trait UserType extends js.Any
+  object UserType extends js.Object {
+    val PrivateUser  = "PrivateUser".asInstanceOf[UserType]
+    val SharedDevice = "SharedDevice".asInstanceOf[UserType]
 
     val values = js.Object.freeze(js.Array(PrivateUser, SharedDevice))
   }
@@ -5044,10 +5043,11 @@ package chime {
       __obj.asInstanceOf[VoiceConnector]
     }
   }
-
-  object VoiceConnectorAwsRegionEnum {
-    val `us-east-1` = "us-east-1"
-    val `us-west-2` = "us-west-2"
+  @js.native
+  sealed trait VoiceConnectorAwsRegion extends js.Any
+  object VoiceConnectorAwsRegion extends js.Object {
+    val `us-east-1` = "us-east-1".asInstanceOf[VoiceConnectorAwsRegion]
+    val `us-west-2` = "us-west-2".asInstanceOf[VoiceConnectorAwsRegion]
 
     val values = js.Object.freeze(js.Array(`us-east-1`, `us-west-2`))
   }

--- a/services/cloud9/src/main/scala/facade/amazonaws/services/Cloud9.scala
+++ b/services/cloud9/src/main/scala/facade/amazonaws/services/Cloud9.scala
@@ -7,31 +7,26 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object cloud9 {
-  type AutomaticStopTimeMinutes   = Int
-  type BoundedEnvironmentIdList   = js.Array[EnvironmentId]
-  type ClientRequestToken         = String
-  type EnvironmentArn             = String
-  type EnvironmentDescription     = String
-  type EnvironmentId              = String
-  type EnvironmentIdList          = js.Array[EnvironmentId]
-  type EnvironmentLifecycleStatus = String
-  type EnvironmentList            = js.Array[Environment]
-  type EnvironmentMembersList     = js.Array[EnvironmentMember]
-  type EnvironmentName            = String
-  type EnvironmentStatus          = String
-  type EnvironmentType            = String
-  type InstanceType               = String
-  type MaxResults                 = Int
-  type MemberPermissions          = String
-  type Permissions                = String
-  type PermissionsList            = js.Array[Permissions]
-  type SubnetId                   = String
-  type TagKey                     = String
-  type TagKeyList                 = js.Array[TagKey]
-  type TagList                    = js.Array[Tag]
-  type TagValue                   = String
-  type Timestamp                  = js.Date
-  type UserArn                    = String
+  type AutomaticStopTimeMinutes = Int
+  type BoundedEnvironmentIdList = js.Array[EnvironmentId]
+  type ClientRequestToken       = String
+  type EnvironmentArn           = String
+  type EnvironmentDescription   = String
+  type EnvironmentId            = String
+  type EnvironmentIdList        = js.Array[EnvironmentId]
+  type EnvironmentList          = js.Array[Environment]
+  type EnvironmentMembersList   = js.Array[EnvironmentMember]
+  type EnvironmentName          = String
+  type InstanceType             = String
+  type MaxResults               = Int
+  type PermissionsList          = js.Array[Permissions]
+  type SubnetId                 = String
+  type TagKey                   = String
+  type TagKeyList               = js.Array[TagKey]
+  type TagList                  = js.Array[Tag]
+  type TagValue                 = String
+  type Timestamp                = js.Date
+  type UserArn                  = String
 
   implicit final class Cloud9Ops(private val service: Cloud9) extends AnyVal {
 
@@ -438,13 +433,14 @@ package cloud9 {
       __obj.asInstanceOf[EnvironmentLifecycle]
     }
   }
-
-  object EnvironmentLifecycleStatusEnum {
-    val CREATING      = "CREATING"
-    val CREATED       = "CREATED"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val DELETING      = "DELETING"
-    val DELETE_FAILED = "DELETE_FAILED"
+  @js.native
+  sealed trait EnvironmentLifecycleStatus extends js.Any
+  object EnvironmentLifecycleStatus extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[EnvironmentLifecycleStatus]
+    val CREATED       = "CREATED".asInstanceOf[EnvironmentLifecycleStatus]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[EnvironmentLifecycleStatus]
+    val DELETING      = "DELETING".asInstanceOf[EnvironmentLifecycleStatus]
+    val DELETE_FAILED = "DELETE_FAILED".asInstanceOf[EnvironmentLifecycleStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, CREATED, CREATE_FAILED, DELETING, DELETE_FAILED))
   }
@@ -479,22 +475,24 @@ package cloud9 {
       __obj.asInstanceOf[EnvironmentMember]
     }
   }
-
-  object EnvironmentStatusEnum {
-    val error      = "error"
-    val creating   = "creating"
-    val connecting = "connecting"
-    val ready      = "ready"
-    val stopping   = "stopping"
-    val stopped    = "stopped"
-    val deleting   = "deleting"
+  @js.native
+  sealed trait EnvironmentStatus extends js.Any
+  object EnvironmentStatus extends js.Object {
+    val error      = "error".asInstanceOf[EnvironmentStatus]
+    val creating   = "creating".asInstanceOf[EnvironmentStatus]
+    val connecting = "connecting".asInstanceOf[EnvironmentStatus]
+    val ready      = "ready".asInstanceOf[EnvironmentStatus]
+    val stopping   = "stopping".asInstanceOf[EnvironmentStatus]
+    val stopped    = "stopped".asInstanceOf[EnvironmentStatus]
+    val deleting   = "deleting".asInstanceOf[EnvironmentStatus]
 
     val values = js.Object.freeze(js.Array(error, creating, connecting, ready, stopping, stopped, deleting))
   }
-
-  object EnvironmentTypeEnum {
-    val ssh = "ssh"
-    val ec2 = "ec2"
+  @js.native
+  sealed trait EnvironmentType extends js.Any
+  object EnvironmentType extends js.Object {
+    val ssh = "ssh".asInstanceOf[EnvironmentType]
+    val ec2 = "ec2".asInstanceOf[EnvironmentType]
 
     val values = js.Object.freeze(js.Array(ssh, ec2))
   }
@@ -570,18 +568,20 @@ package cloud9 {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object MemberPermissionsEnum {
-    val `read-write` = "read-write"
-    val `read-only`  = "read-only"
+  @js.native
+  sealed trait MemberPermissions extends js.Any
+  object MemberPermissions extends js.Object {
+    val `read-write` = "read-write".asInstanceOf[MemberPermissions]
+    val `read-only`  = "read-only".asInstanceOf[MemberPermissions]
 
     val values = js.Object.freeze(js.Array(`read-write`, `read-only`))
   }
-
-  object PermissionsEnum {
-    val owner        = "owner"
-    val `read-write` = "read-write"
-    val `read-only`  = "read-only"
+  @js.native
+  sealed trait Permissions extends js.Any
+  object Permissions extends js.Object {
+    val owner        = "owner".asInstanceOf[Permissions]
+    val `read-write` = "read-write".asInstanceOf[Permissions]
+    val `read-only`  = "read-only".asInstanceOf[Permissions]
 
     val values = js.Object.freeze(js.Array(owner, `read-write`, `read-only`))
   }

--- a/services/clouddirectory/src/main/scala/facade/amazonaws/services/CloudDirectory.scala
+++ b/services/clouddirectory/src/main/scala/facade/amazonaws/services/CloudDirectory.scala
@@ -14,7 +14,6 @@ package object clouddirectory {
   type AttributeName                     = String
   type AttributeNameAndValueList         = js.Array[AttributeNameAndValue]
   type AttributeNameList                 = js.Array[AttributeName]
-  type BatchReadExceptionType            = String
   type BatchReadOperationList            = js.Array[BatchReadOperation]
   type BatchReadOperationResponseList    = js.Array[BatchReadOperationResponse]
   type BatchReferenceName                = String
@@ -22,20 +21,16 @@ package object clouddirectory {
   type BatchWriteOperationResponseList   = js.Array[BatchWriteOperationResponse]
   type BinaryAttributeValue              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type BooleanAttributeValue             = Boolean
-  type ConsistencyLevel                  = String
   type Date                              = js.Date
   type DatetimeAttributeValue            = js.Date
   type DirectoryArn                      = String
   type DirectoryList                     = js.Array[Directory]
   type DirectoryName                     = String
-  type DirectoryState                    = String
   type ExceptionMessage                  = String
   type FacetAttributeList                = js.Array[FacetAttribute]
-  type FacetAttributeType                = String
   type FacetAttributeUpdateList          = js.Array[FacetAttributeUpdate]
   type FacetName                         = String
   type FacetNameList                     = js.Array[FacetName]
-  type FacetStyle                        = String
   type IndexAttachmentList               = js.Array[IndexAttachment]
   type LinkAttributeUpdateList           = js.Array[LinkAttributeUpdate]
   type LinkName                          = String
@@ -49,20 +44,16 @@ package object clouddirectory {
   type ObjectIdentifierAndLinkNameList   = js.Array[ObjectIdentifierAndLinkNameTuple]
   type ObjectIdentifierList              = js.Array[ObjectIdentifier]
   type ObjectIdentifierToLinkNameMap     = js.Dictionary[LinkName]
-  type ObjectType                        = String
   type PathString                        = String
   type PathToObjectIdentifiersList       = js.Array[PathToObjectIdentifiers]
   type PolicyAttachmentList              = js.Array[PolicyAttachment]
   type PolicyToPathList                  = js.Array[PolicyToPath]
   type PolicyType                        = String
-  type RangeMode                         = String
-  type RequiredAttributeBehavior         = String
   type RuleKey                           = String
   type RuleMap                           = js.Dictionary[Rule]
   type RuleParameterKey                  = String
   type RuleParameterMap                  = js.Dictionary[RuleParameterValue]
   type RuleParameterValue                = String
-  type RuleType                          = String
   type SchemaFacetList                   = js.Array[SchemaFacet]
   type SchemaJsonDocument                = String
   type SchemaName                        = String
@@ -79,7 +70,6 @@ package object clouddirectory {
   type TypedLinkName                     = String
   type TypedLinkNameList                 = js.Array[TypedLinkName]
   type TypedLinkSpecifierList            = js.Array[TypedLinkSpecifier]
-  type UpdateActionType                  = String
   type Version                           = String
 
   implicit final class CloudDirectoryOps(private val service: CloudDirectory) extends AnyVal {
@@ -1876,21 +1866,22 @@ package clouddirectory {
       __obj.asInstanceOf[BatchReadException]
     }
   }
-
-  object BatchReadExceptionTypeEnum {
-    val ValidationException             = "ValidationException"
-    val InvalidArnException             = "InvalidArnException"
-    val ResourceNotFoundException       = "ResourceNotFoundException"
-    val InvalidNextTokenException       = "InvalidNextTokenException"
-    val AccessDeniedException           = "AccessDeniedException"
-    val NotNodeException                = "NotNodeException"
-    val FacetValidationException        = "FacetValidationException"
-    val CannotListParentOfRootException = "CannotListParentOfRootException"
-    val NotIndexException               = "NotIndexException"
-    val NotPolicyException              = "NotPolicyException"
-    val DirectoryNotEnabledException    = "DirectoryNotEnabledException"
-    val LimitExceededException          = "LimitExceededException"
-    val InternalServiceException        = "InternalServiceException"
+  @js.native
+  sealed trait BatchReadExceptionType extends js.Any
+  object BatchReadExceptionType extends js.Object {
+    val ValidationException             = "ValidationException".asInstanceOf[BatchReadExceptionType]
+    val InvalidArnException             = "InvalidArnException".asInstanceOf[BatchReadExceptionType]
+    val ResourceNotFoundException       = "ResourceNotFoundException".asInstanceOf[BatchReadExceptionType]
+    val InvalidNextTokenException       = "InvalidNextTokenException".asInstanceOf[BatchReadExceptionType]
+    val AccessDeniedException           = "AccessDeniedException".asInstanceOf[BatchReadExceptionType]
+    val NotNodeException                = "NotNodeException".asInstanceOf[BatchReadExceptionType]
+    val FacetValidationException        = "FacetValidationException".asInstanceOf[BatchReadExceptionType]
+    val CannotListParentOfRootException = "CannotListParentOfRootException".asInstanceOf[BatchReadExceptionType]
+    val NotIndexException               = "NotIndexException".asInstanceOf[BatchReadExceptionType]
+    val NotPolicyException              = "NotPolicyException".asInstanceOf[BatchReadExceptionType]
+    val DirectoryNotEnabledException    = "DirectoryNotEnabledException".asInstanceOf[BatchReadExceptionType]
+    val LimitExceededException          = "LimitExceededException".asInstanceOf[BatchReadExceptionType]
+    val InternalServiceException        = "InternalServiceException".asInstanceOf[BatchReadExceptionType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2370,10 +2361,11 @@ package clouddirectory {
       __obj.asInstanceOf[BatchWriteResponse]
     }
   }
-
-  object ConsistencyLevelEnum {
-    val SERIALIZABLE = "SERIALIZABLE"
-    val EVENTUAL     = "EVENTUAL"
+  @js.native
+  sealed trait ConsistencyLevel extends js.Any
+  object ConsistencyLevel extends js.Object {
+    val SERIALIZABLE = "SERIALIZABLE".asInstanceOf[ConsistencyLevel]
+    val EVENTUAL     = "EVENTUAL".asInstanceOf[ConsistencyLevel]
 
     val values = js.Object.freeze(js.Array(SERIALIZABLE, EVENTUAL))
   }
@@ -2966,11 +2958,12 @@ package clouddirectory {
       __obj.asInstanceOf[Directory]
     }
   }
-
-  object DirectoryStateEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
-    val DELETED  = "DELETED"
+  @js.native
+  sealed trait DirectoryState extends js.Any
+  object DirectoryState extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[DirectoryState]
+    val DISABLED = "DISABLED".asInstanceOf[DirectoryState]
+    val DELETED  = "DELETED".asInstanceOf[DirectoryState]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED, DELETED))
   }
@@ -3155,14 +3148,15 @@ package clouddirectory {
       __obj.asInstanceOf[FacetAttributeReference]
     }
   }
-
-  object FacetAttributeTypeEnum {
-    val STRING   = "STRING"
-    val BINARY   = "BINARY"
-    val BOOLEAN  = "BOOLEAN"
-    val NUMBER   = "NUMBER"
-    val DATETIME = "DATETIME"
-    val VARIANT  = "VARIANT"
+  @js.native
+  sealed trait FacetAttributeType extends js.Any
+  object FacetAttributeType extends js.Object {
+    val STRING   = "STRING".asInstanceOf[FacetAttributeType]
+    val BINARY   = "BINARY".asInstanceOf[FacetAttributeType]
+    val BOOLEAN  = "BOOLEAN".asInstanceOf[FacetAttributeType]
+    val NUMBER   = "NUMBER".asInstanceOf[FacetAttributeType]
+    val DATETIME = "DATETIME".asInstanceOf[FacetAttributeType]
+    val VARIANT  = "VARIANT".asInstanceOf[FacetAttributeType]
 
     val values = js.Object.freeze(js.Array(STRING, BINARY, BOOLEAN, NUMBER, DATETIME, VARIANT))
   }
@@ -3188,10 +3182,11 @@ package clouddirectory {
       __obj.asInstanceOf[FacetAttributeUpdate]
     }
   }
-
-  object FacetStyleEnum {
-    val STATIC  = "STATIC"
-    val DYNAMIC = "DYNAMIC"
+  @js.native
+  sealed trait FacetStyle extends js.Any
+  object FacetStyle extends js.Object {
+    val STATIC  = "STATIC".asInstanceOf[FacetStyle]
+    val DYNAMIC = "DYNAMIC".asInstanceOf[FacetStyle]
 
     val values = js.Object.freeze(js.Array(STATIC, DYNAMIC))
   }
@@ -4676,12 +4671,13 @@ package clouddirectory {
       __obj.asInstanceOf[ObjectReference]
     }
   }
-
-  object ObjectTypeEnum {
-    val NODE      = "NODE"
-    val LEAF_NODE = "LEAF_NODE"
-    val POLICY    = "POLICY"
-    val INDEX     = "INDEX"
+  @js.native
+  sealed trait ObjectType extends js.Any
+  object ObjectType extends js.Object {
+    val NODE      = "NODE".asInstanceOf[ObjectType]
+    val LEAF_NODE = "LEAF_NODE".asInstanceOf[ObjectType]
+    val POLICY    = "POLICY".asInstanceOf[ObjectType]
+    val INDEX     = "INDEX".asInstanceOf[ObjectType]
 
     val values = js.Object.freeze(js.Array(NODE, LEAF_NODE, POLICY, INDEX))
   }
@@ -4834,13 +4830,14 @@ package clouddirectory {
       __obj.asInstanceOf[PutSchemaFromJsonResponse]
     }
   }
-
-  object RangeModeEnum {
-    val FIRST                      = "FIRST"
-    val LAST                       = "LAST"
-    val LAST_BEFORE_MISSING_VALUES = "LAST_BEFORE_MISSING_VALUES"
-    val INCLUSIVE                  = "INCLUSIVE"
-    val EXCLUSIVE                  = "EXCLUSIVE"
+  @js.native
+  sealed trait RangeMode extends js.Any
+  object RangeMode extends js.Object {
+    val FIRST                      = "FIRST".asInstanceOf[RangeMode]
+    val LAST                       = "LAST".asInstanceOf[RangeMode]
+    val LAST_BEFORE_MISSING_VALUES = "LAST_BEFORE_MISSING_VALUES".asInstanceOf[RangeMode]
+    val INCLUSIVE                  = "INCLUSIVE".asInstanceOf[RangeMode]
+    val EXCLUSIVE                  = "EXCLUSIVE".asInstanceOf[RangeMode]
 
     val values = js.Object.freeze(js.Array(FIRST, LAST, LAST_BEFORE_MISSING_VALUES, INCLUSIVE, EXCLUSIVE))
   }
@@ -4881,10 +4878,11 @@ package clouddirectory {
       __obj.asInstanceOf[RemoveFacetFromObjectResponse]
     }
   }
-
-  object RequiredAttributeBehaviorEnum {
-    val REQUIRED_ALWAYS = "REQUIRED_ALWAYS"
-    val NOT_REQUIRED    = "NOT_REQUIRED"
+  @js.native
+  sealed trait RequiredAttributeBehavior extends js.Any
+  object RequiredAttributeBehavior extends js.Object {
+    val REQUIRED_ALWAYS = "REQUIRED_ALWAYS".asInstanceOf[RequiredAttributeBehavior]
+    val NOT_REQUIRED    = "NOT_REQUIRED".asInstanceOf[RequiredAttributeBehavior]
 
     val values = js.Object.freeze(js.Array(REQUIRED_ALWAYS, NOT_REQUIRED))
   }
@@ -4910,12 +4908,13 @@ package clouddirectory {
       __obj.asInstanceOf[Rule]
     }
   }
-
-  object RuleTypeEnum {
-    val BINARY_LENGTH     = "BINARY_LENGTH"
-    val NUMBER_COMPARISON = "NUMBER_COMPARISON"
-    val STRING_FROM_SET   = "STRING_FROM_SET"
-    val STRING_LENGTH     = "STRING_LENGTH"
+  @js.native
+  sealed trait RuleType extends js.Any
+  object RuleType extends js.Object {
+    val BINARY_LENGTH     = "BINARY_LENGTH".asInstanceOf[RuleType]
+    val NUMBER_COMPARISON = "NUMBER_COMPARISON".asInstanceOf[RuleType]
+    val STRING_FROM_SET   = "STRING_FROM_SET".asInstanceOf[RuleType]
+    val STRING_LENGTH     = "STRING_LENGTH".asInstanceOf[RuleType]
 
     val values = js.Object.freeze(js.Array(BINARY_LENGTH, NUMBER_COMPARISON, STRING_FROM_SET, STRING_LENGTH))
   }
@@ -5257,10 +5256,11 @@ package clouddirectory {
       __obj.asInstanceOf[UntagResourceResponse]
     }
   }
-
-  object UpdateActionTypeEnum {
-    val CREATE_OR_UPDATE = "CREATE_OR_UPDATE"
-    val DELETE           = "DELETE"
+  @js.native
+  sealed trait UpdateActionType extends js.Any
+  object UpdateActionType extends js.Object {
+    val CREATE_OR_UPDATE = "CREATE_OR_UPDATE".asInstanceOf[UpdateActionType]
+    val DELETE           = "DELETE".asInstanceOf[UpdateActionType]
 
     val values = js.Object.freeze(js.Array(CREATE_OR_UPDATE, DELETE))
   }

--- a/services/cloudformation/src/main/scala/facade/amazonaws/services/CloudFormation.scala
+++ b/services/cloudformation/src/main/scala/facade/amazonaws/services/CloudFormation.scala
@@ -8,7 +8,6 @@ import facade.amazonaws._
 
 package object cloudformation {
   type Account                              = String
-  type AccountGateStatus                    = String
   type AccountGateStatusReason              = String
   type AccountLimitList                     = js.Array[AccountLimit]
   type AccountList                          = js.Array[Account]
@@ -20,40 +19,29 @@ package object cloudformation {
   type BoxedMaxResults                      = Int
   type Capabilities                         = js.Array[Capability]
   type CapabilitiesReason                   = String
-  type Capability                           = String
   type CausingEntity                        = String
-  type ChangeAction                         = String
   type ChangeSetId                          = String
   type ChangeSetName                        = String
   type ChangeSetNameOrId                    = String
-  type ChangeSetStatus                      = String
   type ChangeSetStatusReason                = String
   type ChangeSetSummaries                   = js.Array[ChangeSetSummary]
-  type ChangeSetType                        = String
-  type ChangeSource                         = String
-  type ChangeType                           = String
   type Changes                              = js.Array[Change]
   type ClientRequestToken                   = String
   type ClientToken                          = String
   type CreationTime                         = js.Date
   type DeletionTime                         = js.Date
-  type DeprecatedStatus                     = String
   type Description                          = String
-  type DifferenceType                       = String
   type DisableRollback                      = Boolean
   type DriftedStackInstancesCount           = Int
   type EnableTerminationProtection          = Boolean
-  type EvaluationType                       = String
   type EventId                              = String
   type ExecutionRoleName                    = String
-  type ExecutionStatus                      = String
   type ExportName                           = String
   type ExportValue                          = String
   type Exports                              = js.Array[Export]
   type FailedStackInstancesCount            = Int
   type FailureToleranceCount                = Int
   type FailureTolerancePercentage           = Int
-  type HandlerErrorCode                     = String
   type Imports                              = js.Array[StackName]
   type InProgressStackInstancesCount        = Int
   type InSyncStackInstancesCount            = Int
@@ -73,8 +61,6 @@ package object cloudformation {
   type NoEcho                               = Boolean
   type NotificationARN                      = String
   type NotificationARNs                     = js.Array[NotificationARN]
-  type OnFailure                            = String
-  type OperationStatus                      = String
   type OptionalSecureUrl                    = String
   type OrganizationalUnitId                 = String
   type OrganizationalUnitIdList             = js.Array[OrganizationalUnitId]
@@ -86,7 +72,6 @@ package object cloudformation {
   type ParameterType                        = String
   type ParameterValue                       = String
   type Parameters                           = js.Array[Parameter]
-  type PermissionModels                     = String
   type PhysicalResourceId                   = String
   type PhysicalResourceIdContext            = js.Array[PhysicalResourceIdContextKeyValuePair]
   type PrivateTypeArn                       = String
@@ -95,18 +80,12 @@ package object cloudformation {
   type PropertyName                         = String
   type PropertyPath                         = String
   type PropertyValue                        = String
-  type ProvisioningType                     = String
   type Reason                               = String
   type Region                               = String
   type RegionList                           = js.Array[Region]
-  type RegistrationStatus                   = String
   type RegistrationToken                    = String
   type RegistrationTokenList                = js.Array[RegistrationToken]
-  type RegistryType                         = String
-  type Replacement                          = String
   type RequestToken                         = String
-  type RequiresRecreation                   = String
-  type ResourceAttribute                    = String
   type ResourceChangeDetails                = js.Array[ResourceChangeDetail]
   type ResourceIdentifierProperties         = js.Dictionary[ResourceIdentifierPropertyValue]
   type ResourceIdentifierPropertyKey        = String
@@ -115,9 +94,7 @@ package object cloudformation {
   type ResourceIdentifiers                  = js.Array[ResourceIdentifierPropertyKey]
   type ResourceModel                        = String
   type ResourceProperties                   = String
-  type ResourceSignalStatus                 = String
   type ResourceSignalUniqueId               = String
-  type ResourceStatus                       = String
   type ResourceStatusReason                 = String
   type ResourceToSkip                       = String
   type ResourceType                         = String
@@ -134,12 +111,9 @@ package object cloudformation {
   type S3Url                                = String
   type Scope                                = js.Array[ResourceAttribute]
   type StackDriftDetectionId                = String
-  type StackDriftDetectionStatus            = String
   type StackDriftDetectionStatusReason      = String
-  type StackDriftStatus                     = String
   type StackEvents                          = js.Array[StackEvent]
   type StackId                              = String
-  type StackInstanceStatus                  = String
   type StackInstanceSummaries               = js.Array[StackInstanceSummary]
   type StackName                            = String
   type StackNameOrId                        = String
@@ -147,25 +121,17 @@ package object cloudformation {
   type StackPolicyDuringUpdateBody          = String
   type StackPolicyDuringUpdateURL           = String
   type StackPolicyURL                       = String
-  type StackResourceDriftStatus             = String
   type StackResourceDriftStatusFilters      = js.Array[StackResourceDriftStatus]
   type StackResourceDrifts                  = js.Array[StackResourceDrift]
   type StackResourceSummaries               = js.Array[StackResourceSummary]
   type StackResources                       = js.Array[StackResource]
   type StackSetARN                          = String
-  type StackSetDriftDetectionStatus         = String
-  type StackSetDriftStatus                  = String
   type StackSetId                           = String
   type StackSetName                         = String
   type StackSetNameOrId                     = String
-  type StackSetOperationAction              = String
-  type StackSetOperationResultStatus        = String
   type StackSetOperationResultSummaries     = js.Array[StackSetOperationResultSummary]
-  type StackSetOperationStatus              = String
   type StackSetOperationSummaries           = js.Array[StackSetOperationSummary]
-  type StackSetStatus                       = String
   type StackSetSummaries                    = js.Array[StackSetSummary]
-  type StackStatus                          = String
   type StackStatusFilter                    = js.Array[StackStatus]
   type StackStatusReason                    = String
   type StackSummaries                       = js.Array[StackSummary]
@@ -178,7 +144,6 @@ package object cloudformation {
   type TemplateBody                         = String
   type TemplateDescription                  = String
   type TemplateParameters                   = js.Array[TemplateParameter]
-  type TemplateStage                        = String
   type TemplateURL                          = String
   type TimeoutMinutes                       = Int
   type Timestamp                            = js.Date
@@ -197,7 +162,6 @@ package object cloudformation {
   type UsePreviousValue                     = Boolean
   type Value                                = String
   type Version                              = String
-  type Visibility                           = String
 
   implicit final class CloudFormationOps(private val service: CloudFormation) extends AnyVal {
 
@@ -422,11 +386,12 @@ package cloudformation {
       __obj.asInstanceOf[AccountGateResult]
     }
   }
-
-  object AccountGateStatusEnum {
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
-    val SKIPPED   = "SKIPPED"
+  @js.native
+  sealed trait AccountGateStatus extends js.Any
+  object AccountGateStatus extends js.Object {
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[AccountGateStatus]
+    val FAILED    = "FAILED".asInstanceOf[AccountGateStatus]
+    val SKIPPED   = "SKIPPED".asInstanceOf[AccountGateStatus]
 
     val values = js.Object.freeze(js.Array(SUCCEEDED, FAILED, SKIPPED))
   }
@@ -505,11 +470,12 @@ package cloudformation {
       __obj.asInstanceOf[CancelUpdateStackInput]
     }
   }
-
-  object CapabilityEnum {
-    val CAPABILITY_IAM         = "CAPABILITY_IAM"
-    val CAPABILITY_NAMED_IAM   = "CAPABILITY_NAMED_IAM"
-    val CAPABILITY_AUTO_EXPAND = "CAPABILITY_AUTO_EXPAND"
+  @js.native
+  sealed trait Capability extends js.Any
+  object Capability extends js.Object {
+    val CAPABILITY_IAM         = "CAPABILITY_IAM".asInstanceOf[Capability]
+    val CAPABILITY_NAMED_IAM   = "CAPABILITY_NAMED_IAM".asInstanceOf[Capability]
+    val CAPABILITY_AUTO_EXPAND = "CAPABILITY_AUTO_EXPAND".asInstanceOf[Capability]
 
     val values = js.Object.freeze(js.Array(CAPABILITY_IAM, CAPABILITY_NAMED_IAM, CAPABILITY_AUTO_EXPAND))
   }
@@ -535,22 +501,24 @@ package cloudformation {
       __obj.asInstanceOf[Change]
     }
   }
-
-  object ChangeActionEnum {
-    val Add    = "Add"
-    val Modify = "Modify"
-    val Remove = "Remove"
-    val Import = "Import"
+  @js.native
+  sealed trait ChangeAction extends js.Any
+  object ChangeAction extends js.Object {
+    val Add    = "Add".asInstanceOf[ChangeAction]
+    val Modify = "Modify".asInstanceOf[ChangeAction]
+    val Remove = "Remove".asInstanceOf[ChangeAction]
+    val Import = "Import".asInstanceOf[ChangeAction]
 
     val values = js.Object.freeze(js.Array(Add, Modify, Remove, Import))
   }
-
-  object ChangeSetStatusEnum {
-    val CREATE_PENDING     = "CREATE_PENDING"
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_COMPLETE    = "CREATE_COMPLETE"
-    val DELETE_COMPLETE    = "DELETE_COMPLETE"
-    val FAILED             = "FAILED"
+  @js.native
+  sealed trait ChangeSetStatus extends js.Any
+  object ChangeSetStatus extends js.Object {
+    val CREATE_PENDING     = "CREATE_PENDING".asInstanceOf[ChangeSetStatus]
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[ChangeSetStatus]
+    val CREATE_COMPLETE    = "CREATE_COMPLETE".asInstanceOf[ChangeSetStatus]
+    val DELETE_COMPLETE    = "DELETE_COMPLETE".asInstanceOf[ChangeSetStatus]
+    val FAILED             = "FAILED".asInstanceOf[ChangeSetStatus]
 
     val values =
       js.Object.freeze(js.Array(CREATE_PENDING, CREATE_IN_PROGRESS, CREATE_COMPLETE, DELETE_COMPLETE, FAILED))
@@ -598,29 +566,32 @@ package cloudformation {
       __obj.asInstanceOf[ChangeSetSummary]
     }
   }
-
-  object ChangeSetTypeEnum {
-    val CREATE = "CREATE"
-    val UPDATE = "UPDATE"
-    val IMPORT = "IMPORT"
+  @js.native
+  sealed trait ChangeSetType extends js.Any
+  object ChangeSetType extends js.Object {
+    val CREATE = "CREATE".asInstanceOf[ChangeSetType]
+    val UPDATE = "UPDATE".asInstanceOf[ChangeSetType]
+    val IMPORT = "IMPORT".asInstanceOf[ChangeSetType]
 
     val values = js.Object.freeze(js.Array(CREATE, UPDATE, IMPORT))
   }
-
-  object ChangeSourceEnum {
-    val ResourceReference  = "ResourceReference"
-    val ParameterReference = "ParameterReference"
-    val ResourceAttribute  = "ResourceAttribute"
-    val DirectModification = "DirectModification"
-    val Automatic          = "Automatic"
+  @js.native
+  sealed trait ChangeSource extends js.Any
+  object ChangeSource extends js.Object {
+    val ResourceReference  = "ResourceReference".asInstanceOf[ChangeSource]
+    val ParameterReference = "ParameterReference".asInstanceOf[ChangeSource]
+    val ResourceAttribute  = "ResourceAttribute".asInstanceOf[ChangeSource]
+    val DirectModification = "DirectModification".asInstanceOf[ChangeSource]
+    val Automatic          = "Automatic".asInstanceOf[ChangeSource]
 
     val values = js.Object.freeze(
       js.Array(ResourceReference, ParameterReference, ResourceAttribute, DirectModification, Automatic)
     )
   }
-
-  object ChangeTypeEnum {
-    val Resource = "Resource"
+  @js.native
+  sealed trait ChangeType extends js.Any
+  object ChangeType extends js.Object {
+    val Resource = "Resource".asInstanceOf[ChangeType]
 
     val values = js.Object.freeze(js.Array(Resource))
   }
@@ -1143,10 +1114,11 @@ package cloudformation {
       __obj.asInstanceOf[DeploymentTargets]
     }
   }
-
-  object DeprecatedStatusEnum {
-    val LIVE       = "LIVE"
-    val DEPRECATED = "DEPRECATED"
+  @js.native
+  sealed trait DeprecatedStatus extends js.Any
+  object DeprecatedStatus extends js.Object {
+    val LIVE       = "LIVE".asInstanceOf[DeprecatedStatus]
+    val DEPRECATED = "DEPRECATED".asInstanceOf[DeprecatedStatus]
 
     val values = js.Object.freeze(js.Array(LIVE, DEPRECATED))
   }
@@ -1956,11 +1928,12 @@ package cloudformation {
       __obj.asInstanceOf[DetectStackSetDriftOutput]
     }
   }
-
-  object DifferenceTypeEnum {
-    val ADD       = "ADD"
-    val REMOVE    = "REMOVE"
-    val NOT_EQUAL = "NOT_EQUAL"
+  @js.native
+  sealed trait DifferenceType extends js.Any
+  object DifferenceType extends js.Object {
+    val ADD       = "ADD".asInstanceOf[DifferenceType]
+    val REMOVE    = "REMOVE".asInstanceOf[DifferenceType]
+    val NOT_EQUAL = "NOT_EQUAL".asInstanceOf[DifferenceType]
 
     val values = js.Object.freeze(js.Array(ADD, REMOVE, NOT_EQUAL))
   }
@@ -2008,10 +1981,11 @@ package cloudformation {
       __obj.asInstanceOf[EstimateTemplateCostOutput]
     }
   }
-
-  object EvaluationTypeEnum {
-    val Static  = "Static"
-    val Dynamic = "Dynamic"
+  @js.native
+  sealed trait EvaluationType extends js.Any
+  object EvaluationType extends js.Object {
+    val Static  = "Static".asInstanceOf[EvaluationType]
+    val Dynamic = "Dynamic".asInstanceOf[EvaluationType]
 
     val values = js.Object.freeze(js.Array(Static, Dynamic))
   }
@@ -2058,14 +2032,15 @@ package cloudformation {
       __obj.asInstanceOf[ExecuteChangeSetOutput]
     }
   }
-
-  object ExecutionStatusEnum {
-    val UNAVAILABLE         = "UNAVAILABLE"
-    val AVAILABLE           = "AVAILABLE"
-    val EXECUTE_IN_PROGRESS = "EXECUTE_IN_PROGRESS"
-    val EXECUTE_COMPLETE    = "EXECUTE_COMPLETE"
-    val EXECUTE_FAILED      = "EXECUTE_FAILED"
-    val OBSOLETE            = "OBSOLETE"
+  @js.native
+  sealed trait ExecutionStatus extends js.Any
+  object ExecutionStatus extends js.Object {
+    val UNAVAILABLE         = "UNAVAILABLE".asInstanceOf[ExecutionStatus]
+    val AVAILABLE           = "AVAILABLE".asInstanceOf[ExecutionStatus]
+    val EXECUTE_IN_PROGRESS = "EXECUTE_IN_PROGRESS".asInstanceOf[ExecutionStatus]
+    val EXECUTE_COMPLETE    = "EXECUTE_COMPLETE".asInstanceOf[ExecutionStatus]
+    val EXECUTE_FAILED      = "EXECUTE_FAILED".asInstanceOf[ExecutionStatus]
+    val OBSOLETE            = "OBSOLETE".asInstanceOf[ExecutionStatus]
 
     val values = js.Object.freeze(
       js.Array(UNAVAILABLE, AVAILABLE, EXECUTE_IN_PROGRESS, EXECUTE_COMPLETE, EXECUTE_FAILED, OBSOLETE)
@@ -2256,22 +2231,23 @@ package cloudformation {
       __obj.asInstanceOf[GetTemplateSummaryOutput]
     }
   }
-
-  object HandlerErrorCodeEnum {
-    val NotUpdatable            = "NotUpdatable"
-    val InvalidRequest          = "InvalidRequest"
-    val AccessDenied            = "AccessDenied"
-    val InvalidCredentials      = "InvalidCredentials"
-    val AlreadyExists           = "AlreadyExists"
-    val NotFound                = "NotFound"
-    val ResourceConflict        = "ResourceConflict"
-    val Throttling              = "Throttling"
-    val ServiceLimitExceeded    = "ServiceLimitExceeded"
-    val NotStabilized           = "NotStabilized"
-    val GeneralServiceException = "GeneralServiceException"
-    val ServiceInternalError    = "ServiceInternalError"
-    val NetworkFailure          = "NetworkFailure"
-    val InternalFailure         = "InternalFailure"
+  @js.native
+  sealed trait HandlerErrorCode extends js.Any
+  object HandlerErrorCode extends js.Object {
+    val NotUpdatable            = "NotUpdatable".asInstanceOf[HandlerErrorCode]
+    val InvalidRequest          = "InvalidRequest".asInstanceOf[HandlerErrorCode]
+    val AccessDenied            = "AccessDenied".asInstanceOf[HandlerErrorCode]
+    val InvalidCredentials      = "InvalidCredentials".asInstanceOf[HandlerErrorCode]
+    val AlreadyExists           = "AlreadyExists".asInstanceOf[HandlerErrorCode]
+    val NotFound                = "NotFound".asInstanceOf[HandlerErrorCode]
+    val ResourceConflict        = "ResourceConflict".asInstanceOf[HandlerErrorCode]
+    val Throttling              = "Throttling".asInstanceOf[HandlerErrorCode]
+    val ServiceLimitExceeded    = "ServiceLimitExceeded".asInstanceOf[HandlerErrorCode]
+    val NotStabilized           = "NotStabilized".asInstanceOf[HandlerErrorCode]
+    val GeneralServiceException = "GeneralServiceException".asInstanceOf[HandlerErrorCode]
+    val ServiceInternalError    = "ServiceInternalError".asInstanceOf[HandlerErrorCode]
+    val NetworkFailure          = "NetworkFailure".asInstanceOf[HandlerErrorCode]
+    val InternalFailure         = "InternalFailure".asInstanceOf[HandlerErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2853,20 +2829,22 @@ package cloudformation {
       __obj.asInstanceOf[LoggingConfig]
     }
   }
-
-  object OnFailureEnum {
-    val DO_NOTHING = "DO_NOTHING"
-    val ROLLBACK   = "ROLLBACK"
-    val DELETE     = "DELETE"
+  @js.native
+  sealed trait OnFailure extends js.Any
+  object OnFailure extends js.Object {
+    val DO_NOTHING = "DO_NOTHING".asInstanceOf[OnFailure]
+    val ROLLBACK   = "ROLLBACK".asInstanceOf[OnFailure]
+    val DELETE     = "DELETE".asInstanceOf[OnFailure]
 
     val values = js.Object.freeze(js.Array(DO_NOTHING, ROLLBACK, DELETE))
   }
-
-  object OperationStatusEnum {
-    val PENDING     = "PENDING"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCESS     = "SUCCESS"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait OperationStatus extends js.Any
+  object OperationStatus extends js.Object {
+    val PENDING     = "PENDING".asInstanceOf[OperationStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[OperationStatus]
+    val SUCCESS     = "SUCCESS".asInstanceOf[OperationStatus]
+    val FAILED      = "FAILED".asInstanceOf[OperationStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, IN_PROGRESS, SUCCESS, FAILED))
   }
@@ -2979,10 +2957,11 @@ package cloudformation {
       __obj.asInstanceOf[ParameterDeclaration]
     }
   }
-
-  object PermissionModelsEnum {
-    val SERVICE_MANAGED = "SERVICE_MANAGED"
-    val SELF_MANAGED    = "SELF_MANAGED"
+  @js.native
+  sealed trait PermissionModels extends js.Any
+  object PermissionModels extends js.Object {
+    val SERVICE_MANAGED = "SERVICE_MANAGED".asInstanceOf[PermissionModels]
+    val SELF_MANAGED    = "SELF_MANAGED".asInstanceOf[PermissionModels]
 
     val values = js.Object.freeze(js.Array(SERVICE_MANAGED, SELF_MANAGED))
   }
@@ -3040,11 +3019,12 @@ package cloudformation {
       __obj.asInstanceOf[PropertyDifference]
     }
   }
-
-  object ProvisioningTypeEnum {
-    val NON_PROVISIONABLE = "NON_PROVISIONABLE"
-    val IMMUTABLE         = "IMMUTABLE"
-    val FULLY_MUTABLE     = "FULLY_MUTABLE"
+  @js.native
+  sealed trait ProvisioningType extends js.Any
+  object ProvisioningType extends js.Object {
+    val NON_PROVISIONABLE = "NON_PROVISIONABLE".asInstanceOf[ProvisioningType]
+    val IMMUTABLE         = "IMMUTABLE".asInstanceOf[ProvisioningType]
+    val FULLY_MUTABLE     = "FULLY_MUTABLE".asInstanceOf[ProvisioningType]
 
     val values = js.Object.freeze(js.Array(NON_PROVISIONABLE, IMMUTABLE, FULLY_MUTABLE))
   }
@@ -3146,44 +3126,49 @@ package cloudformation {
       __obj.asInstanceOf[RegisterTypeOutput]
     }
   }
-
-  object RegistrationStatusEnum {
-    val COMPLETE    = "COMPLETE"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait RegistrationStatus extends js.Any
+  object RegistrationStatus extends js.Object {
+    val COMPLETE    = "COMPLETE".asInstanceOf[RegistrationStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[RegistrationStatus]
+    val FAILED      = "FAILED".asInstanceOf[RegistrationStatus]
 
     val values = js.Object.freeze(js.Array(COMPLETE, IN_PROGRESS, FAILED))
   }
-
-  object RegistryTypeEnum {
-    val RESOURCE = "RESOURCE"
+  @js.native
+  sealed trait RegistryType extends js.Any
+  object RegistryType extends js.Object {
+    val RESOURCE = "RESOURCE".asInstanceOf[RegistryType]
 
     val values = js.Object.freeze(js.Array(RESOURCE))
   }
-
-  object ReplacementEnum {
-    val True        = "True"
-    val False       = "False"
-    val Conditional = "Conditional"
+  @js.native
+  sealed trait Replacement extends js.Any
+  object Replacement extends js.Object {
+    val True        = "True".asInstanceOf[Replacement]
+    val False       = "False".asInstanceOf[Replacement]
+    val Conditional = "Conditional".asInstanceOf[Replacement]
 
     val values = js.Object.freeze(js.Array(True, False, Conditional))
   }
-
-  object RequiresRecreationEnum {
-    val Never         = "Never"
-    val Conditionally = "Conditionally"
-    val Always        = "Always"
+  @js.native
+  sealed trait RequiresRecreation extends js.Any
+  object RequiresRecreation extends js.Object {
+    val Never         = "Never".asInstanceOf[RequiresRecreation]
+    val Conditionally = "Conditionally".asInstanceOf[RequiresRecreation]
+    val Always        = "Always".asInstanceOf[RequiresRecreation]
 
     val values = js.Object.freeze(js.Array(Never, Conditionally, Always))
   }
-
-  object ResourceAttributeEnum {
-    val Properties     = "Properties"
-    val Metadata       = "Metadata"
-    val CreationPolicy = "CreationPolicy"
-    val UpdatePolicy   = "UpdatePolicy"
-    val DeletionPolicy = "DeletionPolicy"
-    val Tags           = "Tags"
+  @js.native
+  sealed trait ResourceAttribute extends js.Any
+  object ResourceAttribute extends js.Object {
+    val Properties     = "Properties".asInstanceOf[ResourceAttribute]
+    val Metadata       = "Metadata".asInstanceOf[ResourceAttribute]
+    val CreationPolicy = "CreationPolicy".asInstanceOf[ResourceAttribute]
+    val UpdatePolicy   = "UpdatePolicy".asInstanceOf[ResourceAttribute]
+    val DeletionPolicy = "DeletionPolicy".asInstanceOf[ResourceAttribute]
+    val Tags           = "Tags".asInstanceOf[ResourceAttribute]
 
     val values = js.Object.freeze(js.Array(Properties, Metadata, CreationPolicy, UpdatePolicy, DeletionPolicy, Tags))
   }
@@ -3277,31 +3262,33 @@ package cloudformation {
       __obj.asInstanceOf[ResourceIdentifierSummary]
     }
   }
-
-  object ResourceSignalStatusEnum {
-    val SUCCESS = "SUCCESS"
-    val FAILURE = "FAILURE"
+  @js.native
+  sealed trait ResourceSignalStatus extends js.Any
+  object ResourceSignalStatus extends js.Object {
+    val SUCCESS = "SUCCESS".asInstanceOf[ResourceSignalStatus]
+    val FAILURE = "FAILURE".asInstanceOf[ResourceSignalStatus]
 
     val values = js.Object.freeze(js.Array(SUCCESS, FAILURE))
   }
-
-  object ResourceStatusEnum {
-    val CREATE_IN_PROGRESS          = "CREATE_IN_PROGRESS"
-    val CREATE_FAILED               = "CREATE_FAILED"
-    val CREATE_COMPLETE             = "CREATE_COMPLETE"
-    val DELETE_IN_PROGRESS          = "DELETE_IN_PROGRESS"
-    val DELETE_FAILED               = "DELETE_FAILED"
-    val DELETE_COMPLETE             = "DELETE_COMPLETE"
-    val DELETE_SKIPPED              = "DELETE_SKIPPED"
-    val UPDATE_IN_PROGRESS          = "UPDATE_IN_PROGRESS"
-    val UPDATE_FAILED               = "UPDATE_FAILED"
-    val UPDATE_COMPLETE             = "UPDATE_COMPLETE"
-    val IMPORT_FAILED               = "IMPORT_FAILED"
-    val IMPORT_COMPLETE             = "IMPORT_COMPLETE"
-    val IMPORT_IN_PROGRESS          = "IMPORT_IN_PROGRESS"
-    val IMPORT_ROLLBACK_IN_PROGRESS = "IMPORT_ROLLBACK_IN_PROGRESS"
-    val IMPORT_ROLLBACK_FAILED      = "IMPORT_ROLLBACK_FAILED"
-    val IMPORT_ROLLBACK_COMPLETE    = "IMPORT_ROLLBACK_COMPLETE"
+  @js.native
+  sealed trait ResourceStatus extends js.Any
+  object ResourceStatus extends js.Object {
+    val CREATE_IN_PROGRESS          = "CREATE_IN_PROGRESS".asInstanceOf[ResourceStatus]
+    val CREATE_FAILED               = "CREATE_FAILED".asInstanceOf[ResourceStatus]
+    val CREATE_COMPLETE             = "CREATE_COMPLETE".asInstanceOf[ResourceStatus]
+    val DELETE_IN_PROGRESS          = "DELETE_IN_PROGRESS".asInstanceOf[ResourceStatus]
+    val DELETE_FAILED               = "DELETE_FAILED".asInstanceOf[ResourceStatus]
+    val DELETE_COMPLETE             = "DELETE_COMPLETE".asInstanceOf[ResourceStatus]
+    val DELETE_SKIPPED              = "DELETE_SKIPPED".asInstanceOf[ResourceStatus]
+    val UPDATE_IN_PROGRESS          = "UPDATE_IN_PROGRESS".asInstanceOf[ResourceStatus]
+    val UPDATE_FAILED               = "UPDATE_FAILED".asInstanceOf[ResourceStatus]
+    val UPDATE_COMPLETE             = "UPDATE_COMPLETE".asInstanceOf[ResourceStatus]
+    val IMPORT_FAILED               = "IMPORT_FAILED".asInstanceOf[ResourceStatus]
+    val IMPORT_COMPLETE             = "IMPORT_COMPLETE".asInstanceOf[ResourceStatus]
+    val IMPORT_IN_PROGRESS          = "IMPORT_IN_PROGRESS".asInstanceOf[ResourceStatus]
+    val IMPORT_ROLLBACK_IN_PROGRESS = "IMPORT_ROLLBACK_IN_PROGRESS".asInstanceOf[ResourceStatus]
+    val IMPORT_ROLLBACK_FAILED      = "IMPORT_ROLLBACK_FAILED".asInstanceOf[ResourceStatus]
+    val IMPORT_ROLLBACK_COMPLETE    = "IMPORT_ROLLBACK_COMPLETE".asInstanceOf[ResourceStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3604,11 +3591,12 @@ package cloudformation {
       __obj.asInstanceOf[Stack]
     }
   }
-
-  object StackDriftDetectionStatusEnum {
-    val DETECTION_IN_PROGRESS = "DETECTION_IN_PROGRESS"
-    val DETECTION_FAILED      = "DETECTION_FAILED"
-    val DETECTION_COMPLETE    = "DETECTION_COMPLETE"
+  @js.native
+  sealed trait StackDriftDetectionStatus extends js.Any
+  object StackDriftDetectionStatus extends js.Object {
+    val DETECTION_IN_PROGRESS = "DETECTION_IN_PROGRESS".asInstanceOf[StackDriftDetectionStatus]
+    val DETECTION_FAILED      = "DETECTION_FAILED".asInstanceOf[StackDriftDetectionStatus]
+    val DETECTION_COMPLETE    = "DETECTION_COMPLETE".asInstanceOf[StackDriftDetectionStatus]
 
     val values = js.Object.freeze(js.Array(DETECTION_IN_PROGRESS, DETECTION_FAILED, DETECTION_COMPLETE))
   }
@@ -3660,12 +3648,13 @@ package cloudformation {
       __obj.asInstanceOf[StackDriftInformationSummary]
     }
   }
-
-  object StackDriftStatusEnum {
-    val DRIFTED     = "DRIFTED"
-    val IN_SYNC     = "IN_SYNC"
-    val UNKNOWN     = "UNKNOWN"
-    val NOT_CHECKED = "NOT_CHECKED"
+  @js.native
+  sealed trait StackDriftStatus extends js.Any
+  object StackDriftStatus extends js.Object {
+    val DRIFTED     = "DRIFTED".asInstanceOf[StackDriftStatus]
+    val IN_SYNC     = "IN_SYNC".asInstanceOf[StackDriftStatus]
+    val UNKNOWN     = "UNKNOWN".asInstanceOf[StackDriftStatus]
+    val NOT_CHECKED = "NOT_CHECKED".asInstanceOf[StackDriftStatus]
 
     val values = js.Object.freeze(js.Array(DRIFTED, IN_SYNC, UNKNOWN, NOT_CHECKED))
   }
@@ -3766,11 +3755,12 @@ package cloudformation {
       __obj.asInstanceOf[StackInstance]
     }
   }
-
-  object StackInstanceStatusEnum {
-    val CURRENT    = "CURRENT"
-    val OUTDATED   = "OUTDATED"
-    val INOPERABLE = "INOPERABLE"
+  @js.native
+  sealed trait StackInstanceStatus extends js.Any
+  object StackInstanceStatus extends js.Object {
+    val CURRENT    = "CURRENT".asInstanceOf[StackInstanceStatus]
+    val OUTDATED   = "OUTDATED".asInstanceOf[StackInstanceStatus]
+    val INOPERABLE = "INOPERABLE".asInstanceOf[StackInstanceStatus]
 
     val values = js.Object.freeze(js.Array(CURRENT, OUTDATED, INOPERABLE))
   }
@@ -4016,12 +4006,13 @@ package cloudformation {
       __obj.asInstanceOf[StackResourceDriftInformationSummary]
     }
   }
-
-  object StackResourceDriftStatusEnum {
-    val IN_SYNC     = "IN_SYNC"
-    val MODIFIED    = "MODIFIED"
-    val DELETED     = "DELETED"
-    val NOT_CHECKED = "NOT_CHECKED"
+  @js.native
+  sealed trait StackResourceDriftStatus extends js.Any
+  object StackResourceDriftStatus extends js.Object {
+    val IN_SYNC     = "IN_SYNC".asInstanceOf[StackResourceDriftStatus]
+    val MODIFIED    = "MODIFIED".asInstanceOf[StackResourceDriftStatus]
+    val DELETED     = "DELETED".asInstanceOf[StackResourceDriftStatus]
+    val NOT_CHECKED = "NOT_CHECKED".asInstanceOf[StackResourceDriftStatus]
 
     val values = js.Object.freeze(js.Array(IN_SYNC, MODIFIED, DELETED, NOT_CHECKED))
   }
@@ -4178,21 +4169,23 @@ package cloudformation {
       __obj.asInstanceOf[StackSetDriftDetectionDetails]
     }
   }
-
-  object StackSetDriftDetectionStatusEnum {
-    val COMPLETED       = "COMPLETED"
-    val FAILED          = "FAILED"
-    val PARTIAL_SUCCESS = "PARTIAL_SUCCESS"
-    val IN_PROGRESS     = "IN_PROGRESS"
-    val STOPPED         = "STOPPED"
+  @js.native
+  sealed trait StackSetDriftDetectionStatus extends js.Any
+  object StackSetDriftDetectionStatus extends js.Object {
+    val COMPLETED       = "COMPLETED".asInstanceOf[StackSetDriftDetectionStatus]
+    val FAILED          = "FAILED".asInstanceOf[StackSetDriftDetectionStatus]
+    val PARTIAL_SUCCESS = "PARTIAL_SUCCESS".asInstanceOf[StackSetDriftDetectionStatus]
+    val IN_PROGRESS     = "IN_PROGRESS".asInstanceOf[StackSetDriftDetectionStatus]
+    val STOPPED         = "STOPPED".asInstanceOf[StackSetDriftDetectionStatus]
 
     val values = js.Object.freeze(js.Array(COMPLETED, FAILED, PARTIAL_SUCCESS, IN_PROGRESS, STOPPED))
   }
-
-  object StackSetDriftStatusEnum {
-    val DRIFTED     = "DRIFTED"
-    val IN_SYNC     = "IN_SYNC"
-    val NOT_CHECKED = "NOT_CHECKED"
+  @js.native
+  sealed trait StackSetDriftStatus extends js.Any
+  object StackSetDriftStatus extends js.Object {
+    val DRIFTED     = "DRIFTED".asInstanceOf[StackSetDriftStatus]
+    val IN_SYNC     = "IN_SYNC".asInstanceOf[StackSetDriftStatus]
+    val NOT_CHECKED = "NOT_CHECKED".asInstanceOf[StackSetDriftStatus]
 
     val values = js.Object.freeze(js.Array(DRIFTED, IN_SYNC, NOT_CHECKED))
   }
@@ -4250,12 +4243,13 @@ package cloudformation {
       __obj.asInstanceOf[StackSetOperation]
     }
   }
-
-  object StackSetOperationActionEnum {
-    val CREATE       = "CREATE"
-    val UPDATE       = "UPDATE"
-    val DELETE       = "DELETE"
-    val DETECT_DRIFT = "DETECT_DRIFT"
+  @js.native
+  sealed trait StackSetOperationAction extends js.Any
+  object StackSetOperationAction extends js.Object {
+    val CREATE       = "CREATE".asInstanceOf[StackSetOperationAction]
+    val UPDATE       = "UPDATE".asInstanceOf[StackSetOperationAction]
+    val DELETE       = "DELETE".asInstanceOf[StackSetOperationAction]
+    val DETECT_DRIFT = "DETECT_DRIFT".asInstanceOf[StackSetOperationAction]
 
     val values = js.Object.freeze(js.Array(CREATE, UPDATE, DELETE, DETECT_DRIFT))
   }
@@ -4293,13 +4287,14 @@ package cloudformation {
       __obj.asInstanceOf[StackSetOperationPreferences]
     }
   }
-
-  object StackSetOperationResultStatusEnum {
-    val PENDING   = "PENDING"
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
-    val CANCELLED = "CANCELLED"
+  @js.native
+  sealed trait StackSetOperationResultStatus extends js.Any
+  object StackSetOperationResultStatus extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[StackSetOperationResultStatus]
+    val RUNNING   = "RUNNING".asInstanceOf[StackSetOperationResultStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[StackSetOperationResultStatus]
+    val FAILED    = "FAILED".asInstanceOf[StackSetOperationResultStatus]
+    val CANCELLED = "CANCELLED".asInstanceOf[StackSetOperationResultStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, RUNNING, SUCCEEDED, FAILED, CANCELLED))
   }
@@ -4337,14 +4332,15 @@ package cloudformation {
       __obj.asInstanceOf[StackSetOperationResultSummary]
     }
   }
-
-  object StackSetOperationStatusEnum {
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
-    val STOPPING  = "STOPPING"
-    val STOPPED   = "STOPPED"
-    val QUEUED    = "QUEUED"
+  @js.native
+  sealed trait StackSetOperationStatus extends js.Any
+  object StackSetOperationStatus extends js.Object {
+    val RUNNING   = "RUNNING".asInstanceOf[StackSetOperationStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[StackSetOperationStatus]
+    val FAILED    = "FAILED".asInstanceOf[StackSetOperationStatus]
+    val STOPPING  = "STOPPING".asInstanceOf[StackSetOperationStatus]
+    val STOPPED   = "STOPPED".asInstanceOf[StackSetOperationStatus]
+    val QUEUED    = "QUEUED".asInstanceOf[StackSetOperationStatus]
 
     val values = js.Object.freeze(js.Array(RUNNING, SUCCEEDED, FAILED, STOPPING, STOPPED, QUEUED))
   }
@@ -4379,10 +4375,11 @@ package cloudformation {
       __obj.asInstanceOf[StackSetOperationSummary]
     }
   }
-
-  object StackSetStatusEnum {
-    val ACTIVE  = "ACTIVE"
-    val DELETED = "DELETED"
+  @js.native
+  sealed trait StackSetStatus extends js.Any
+  object StackSetStatus extends js.Object {
+    val ACTIVE  = "ACTIVE".asInstanceOf[StackSetStatus]
+    val DELETED = "DELETED".asInstanceOf[StackSetStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETED))
   }
@@ -4426,30 +4423,32 @@ package cloudformation {
       __obj.asInstanceOf[StackSetSummary]
     }
   }
-
-  object StackStatusEnum {
-    val CREATE_IN_PROGRESS                           = "CREATE_IN_PROGRESS"
-    val CREATE_FAILED                                = "CREATE_FAILED"
-    val CREATE_COMPLETE                              = "CREATE_COMPLETE"
-    val ROLLBACK_IN_PROGRESS                         = "ROLLBACK_IN_PROGRESS"
-    val ROLLBACK_FAILED                              = "ROLLBACK_FAILED"
-    val ROLLBACK_COMPLETE                            = "ROLLBACK_COMPLETE"
-    val DELETE_IN_PROGRESS                           = "DELETE_IN_PROGRESS"
-    val DELETE_FAILED                                = "DELETE_FAILED"
-    val DELETE_COMPLETE                              = "DELETE_COMPLETE"
-    val UPDATE_IN_PROGRESS                           = "UPDATE_IN_PROGRESS"
-    val UPDATE_COMPLETE_CLEANUP_IN_PROGRESS          = "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS"
-    val UPDATE_COMPLETE                              = "UPDATE_COMPLETE"
-    val UPDATE_ROLLBACK_IN_PROGRESS                  = "UPDATE_ROLLBACK_IN_PROGRESS"
-    val UPDATE_ROLLBACK_FAILED                       = "UPDATE_ROLLBACK_FAILED"
-    val UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS = "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS"
-    val UPDATE_ROLLBACK_COMPLETE                     = "UPDATE_ROLLBACK_COMPLETE"
-    val REVIEW_IN_PROGRESS                           = "REVIEW_IN_PROGRESS"
-    val IMPORT_IN_PROGRESS                           = "IMPORT_IN_PROGRESS"
-    val IMPORT_COMPLETE                              = "IMPORT_COMPLETE"
-    val IMPORT_ROLLBACK_IN_PROGRESS                  = "IMPORT_ROLLBACK_IN_PROGRESS"
-    val IMPORT_ROLLBACK_FAILED                       = "IMPORT_ROLLBACK_FAILED"
-    val IMPORT_ROLLBACK_COMPLETE                     = "IMPORT_ROLLBACK_COMPLETE"
+  @js.native
+  sealed trait StackStatus extends js.Any
+  object StackStatus extends js.Object {
+    val CREATE_IN_PROGRESS                  = "CREATE_IN_PROGRESS".asInstanceOf[StackStatus]
+    val CREATE_FAILED                       = "CREATE_FAILED".asInstanceOf[StackStatus]
+    val CREATE_COMPLETE                     = "CREATE_COMPLETE".asInstanceOf[StackStatus]
+    val ROLLBACK_IN_PROGRESS                = "ROLLBACK_IN_PROGRESS".asInstanceOf[StackStatus]
+    val ROLLBACK_FAILED                     = "ROLLBACK_FAILED".asInstanceOf[StackStatus]
+    val ROLLBACK_COMPLETE                   = "ROLLBACK_COMPLETE".asInstanceOf[StackStatus]
+    val DELETE_IN_PROGRESS                  = "DELETE_IN_PROGRESS".asInstanceOf[StackStatus]
+    val DELETE_FAILED                       = "DELETE_FAILED".asInstanceOf[StackStatus]
+    val DELETE_COMPLETE                     = "DELETE_COMPLETE".asInstanceOf[StackStatus]
+    val UPDATE_IN_PROGRESS                  = "UPDATE_IN_PROGRESS".asInstanceOf[StackStatus]
+    val UPDATE_COMPLETE_CLEANUP_IN_PROGRESS = "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS".asInstanceOf[StackStatus]
+    val UPDATE_COMPLETE                     = "UPDATE_COMPLETE".asInstanceOf[StackStatus]
+    val UPDATE_ROLLBACK_IN_PROGRESS         = "UPDATE_ROLLBACK_IN_PROGRESS".asInstanceOf[StackStatus]
+    val UPDATE_ROLLBACK_FAILED              = "UPDATE_ROLLBACK_FAILED".asInstanceOf[StackStatus]
+    val UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS =
+      "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS".asInstanceOf[StackStatus]
+    val UPDATE_ROLLBACK_COMPLETE    = "UPDATE_ROLLBACK_COMPLETE".asInstanceOf[StackStatus]
+    val REVIEW_IN_PROGRESS          = "REVIEW_IN_PROGRESS".asInstanceOf[StackStatus]
+    val IMPORT_IN_PROGRESS          = "IMPORT_IN_PROGRESS".asInstanceOf[StackStatus]
+    val IMPORT_COMPLETE             = "IMPORT_COMPLETE".asInstanceOf[StackStatus]
+    val IMPORT_ROLLBACK_IN_PROGRESS = "IMPORT_ROLLBACK_IN_PROGRESS".asInstanceOf[StackStatus]
+    val IMPORT_ROLLBACK_FAILED      = "IMPORT_ROLLBACK_FAILED".asInstanceOf[StackStatus]
+    val IMPORT_ROLLBACK_COMPLETE    = "IMPORT_ROLLBACK_COMPLETE".asInstanceOf[StackStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4615,10 +4614,11 @@ package cloudformation {
       __obj.asInstanceOf[TemplateParameter]
     }
   }
-
-  object TemplateStageEnum {
-    val Original  = "Original"
-    val Processed = "Processed"
+  @js.native
+  sealed trait TemplateStage extends js.Any
+  object TemplateStage extends js.Object {
+    val Original  = "Original".asInstanceOf[TemplateStage]
+    val Processed = "Processed".asInstanceOf[TemplateStage]
 
     val values = js.Object.freeze(js.Array(Original, Processed))
   }
@@ -5003,10 +5003,11 @@ package cloudformation {
       __obj.asInstanceOf[ValidateTemplateOutput]
     }
   }
-
-  object VisibilityEnum {
-    val PUBLIC  = "PUBLIC"
-    val PRIVATE = "PRIVATE"
+  @js.native
+  sealed trait Visibility extends js.Any
+  object Visibility extends js.Object {
+    val PUBLIC  = "PUBLIC".asInstanceOf[Visibility]
+    val PRIVATE = "PRIVATE".asInstanceOf[Visibility]
 
     val values = js.Object.freeze(js.Array(PUBLIC, PRIVATE))
   }

--- a/services/cloudfront/src/main/scala/facade/amazonaws/services/CloudFront.scala
+++ b/services/cloudfront/src/main/scala/facade/amazonaws/services/CloudFront.scala
@@ -11,7 +11,6 @@ package object cloudfront {
   type AliasList                                 = js.Array[String]
   type AwsAccountNumberList                      = js.Array[String]
   type CacheBehaviorList                         = js.Array[CacheBehavior]
-  type CertificateSource                         = String
   type CloudFrontOriginAccessIdentitySummaryList = js.Array[CloudFrontOriginAccessIdentitySummary]
   type CommentType                               = String
   type ContentTypeProfileList                    = js.Array[ContentTypeProfile]
@@ -19,38 +18,26 @@ package object cloudfront {
   type CustomErrorResponseList                   = js.Array[CustomErrorResponse]
   type DistributionSummaryList                   = js.Array[DistributionSummary]
   type EncryptionEntityList                      = js.Array[EncryptionEntity]
-  type EventType                                 = String
   type FieldLevelEncryptionProfileSummaryList    = js.Array[FieldLevelEncryptionProfileSummary]
   type FieldLevelEncryptionSummaryList           = js.Array[FieldLevelEncryptionSummary]
   type FieldPatternList                          = js.Array[String]
-  type Format                                    = String
-  type GeoRestrictionType                        = String
   type HeaderList                                = js.Array[String]
-  type HttpVersion                               = String
-  type ICPRecordalStatus                         = String
   type InvalidationSummaryList                   = js.Array[InvalidationSummary]
-  type ItemSelection                             = String
   type KeyPairIdList                             = js.Array[String]
   type LambdaFunctionARN                         = String
   type LambdaFunctionAssociationList             = js.Array[LambdaFunctionAssociation]
   type LocationList                              = js.Array[String]
-  type Method                                    = String
   type MethodsList                               = js.Array[Method]
-  type MinimumProtocolVersion                    = String
   type OriginCustomHeadersList                   = js.Array[OriginCustomHeader]
   type OriginGroupList                           = js.Array[OriginGroup]
   type OriginGroupMemberList                     = js.Array[OriginGroupMember]
   type OriginList                                = js.Array[Origin]
-  type OriginProtocolPolicy                      = String
   type PathList                                  = js.Array[String]
-  type PriceClass                                = String
   type PublicKeySummaryList                      = js.Array[PublicKeySummary]
   type QueryArgProfileList                       = js.Array[QueryArgProfile]
   type QueryStringCacheKeysList                  = js.Array[String]
   type ResourceARN                               = String
-  type SSLSupportMethod                          = String
   type SignerList                                = js.Array[Signer]
-  type SslProtocol                               = String
   type SslProtocolsList                          = js.Array[SslProtocol]
   type StatusCodeList                            = js.Array[Int]
   type StreamingDistributionSummaryList          = js.Array[StreamingDistributionSummary]
@@ -58,7 +45,6 @@ package object cloudfront {
   type TagKeyList                                = js.Array[TagKey]
   type TagList                                   = js.Array[Tag]
   type TagValue                                  = String
-  type ViewerProtocolPolicy                      = String
   type timestamp                                 = js.Date
 
   implicit final class CloudFrontOps(private val service: CloudFront) extends AnyVal {
@@ -516,11 +502,12 @@ package cloudfront {
       __obj.asInstanceOf[CachedMethods]
     }
   }
-
-  object CertificateSourceEnum {
-    val cloudfront = "cloudfront"
-    val iam        = "iam"
-    val acm        = "acm"
+  @js.native
+  sealed trait CertificateSource extends js.Any
+  object CertificateSource extends js.Object {
+    val cloudfront = "cloudfront".asInstanceOf[CertificateSource]
+    val iam        = "iam".asInstanceOf[CertificateSource]
+    val acm        = "acm".asInstanceOf[CertificateSource]
 
     val values = js.Object.freeze(js.Array(cloudfront, iam, acm))
   }
@@ -1787,12 +1774,13 @@ package cloudfront {
       __obj.asInstanceOf[EncryptionEntity]
     }
   }
-
-  object EventTypeEnum {
-    val `viewer-request`  = "viewer-request"
-    val `viewer-response` = "viewer-response"
-    val `origin-request`  = "origin-request"
-    val `origin-response` = "origin-response"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val `viewer-request`  = "viewer-request".asInstanceOf[EventType]
+    val `viewer-response` = "viewer-response".asInstanceOf[EventType]
+    val `origin-request`  = "origin-request".asInstanceOf[EventType]
+    val `origin-response` = "origin-response".asInstanceOf[EventType]
 
     val values = js.Object.freeze(js.Array(`viewer-request`, `viewer-response`, `origin-request`, `origin-response`))
   }
@@ -2060,9 +2048,10 @@ package cloudfront {
       __obj.asInstanceOf[FieldPatterns]
     }
   }
-
-  object FormatEnum {
-    val URLEncoded = "URLEncoded"
+  @js.native
+  sealed trait Format extends js.Any
+  object Format extends js.Object {
+    val URLEncoded = "URLEncoded".asInstanceOf[Format]
 
     val values = js.Object.freeze(js.Array(URLEncoded))
   }
@@ -2123,11 +2112,12 @@ package cloudfront {
       __obj.asInstanceOf[GeoRestriction]
     }
   }
-
-  object GeoRestrictionTypeEnum {
-    val blacklist = "blacklist"
-    val whitelist = "whitelist"
-    val none      = "none"
+  @js.native
+  sealed trait GeoRestrictionType extends js.Any
+  object GeoRestrictionType extends js.Object {
+    val blacklist = "blacklist".asInstanceOf[GeoRestrictionType]
+    val whitelist = "whitelist".asInstanceOf[GeoRestrictionType]
+    val none      = "none".asInstanceOf[GeoRestrictionType]
 
     val values = js.Object.freeze(js.Array(blacklist, whitelist, none))
   }
@@ -2691,18 +2681,20 @@ package cloudfront {
       __obj.asInstanceOf[Headers]
     }
   }
-
-  object HttpVersionEnum {
-    val `http1.1` = "http1.1"
-    val http2     = "http2"
+  @js.native
+  sealed trait HttpVersion extends js.Any
+  object HttpVersion extends js.Object {
+    val `http1.1` = "http1.1".asInstanceOf[HttpVersion]
+    val http2     = "http2".asInstanceOf[HttpVersion]
 
     val values = js.Object.freeze(js.Array(`http1.1`, http2))
   }
-
-  object ICPRecordalStatusEnum {
-    val APPROVED  = "APPROVED"
-    val SUSPENDED = "SUSPENDED"
-    val PENDING   = "PENDING"
+  @js.native
+  sealed trait ICPRecordalStatus extends js.Any
+  object ICPRecordalStatus extends js.Object {
+    val APPROVED  = "APPROVED".asInstanceOf[ICPRecordalStatus]
+    val SUSPENDED = "SUSPENDED".asInstanceOf[ICPRecordalStatus]
+    val PENDING   = "PENDING".asInstanceOf[ICPRecordalStatus]
 
     val values = js.Object.freeze(js.Array(APPROVED, SUSPENDED, PENDING))
   }
@@ -2823,11 +2815,12 @@ package cloudfront {
       __obj.asInstanceOf[InvalidationSummary]
     }
   }
-
-  object ItemSelectionEnum {
-    val none      = "none"
-    val whitelist = "whitelist"
-    val all       = "all"
+  @js.native
+  sealed trait ItemSelection extends js.Any
+  object ItemSelection extends js.Object {
+    val none      = "none".asInstanceOf[ItemSelection]
+    val whitelist = "whitelist".asInstanceOf[ItemSelection]
+    val all       = "all".asInstanceOf[ItemSelection]
 
     val values = js.Object.freeze(js.Array(none, whitelist, all))
   }
@@ -3307,25 +3300,27 @@ package cloudfront {
       __obj.asInstanceOf[LoggingConfig]
     }
   }
-
-  object MethodEnum {
-    val GET     = "GET"
-    val HEAD    = "HEAD"
-    val POST    = "POST"
-    val PUT     = "PUT"
-    val PATCH   = "PATCH"
-    val OPTIONS = "OPTIONS"
-    val DELETE  = "DELETE"
+  @js.native
+  sealed trait Method extends js.Any
+  object Method extends js.Object {
+    val GET     = "GET".asInstanceOf[Method]
+    val HEAD    = "HEAD".asInstanceOf[Method]
+    val POST    = "POST".asInstanceOf[Method]
+    val PUT     = "PUT".asInstanceOf[Method]
+    val PATCH   = "PATCH".asInstanceOf[Method]
+    val OPTIONS = "OPTIONS".asInstanceOf[Method]
+    val DELETE  = "DELETE".asInstanceOf[Method]
 
     val values = js.Object.freeze(js.Array(GET, HEAD, POST, PUT, PATCH, OPTIONS, DELETE))
   }
-
-  object MinimumProtocolVersionEnum {
-    val SSLv3          = "SSLv3"
-    val TLSv1          = "TLSv1"
-    val TLSv1_2016     = "TLSv1_2016"
-    val `TLSv1.1_2016` = "TLSv1.1_2016"
-    val `TLSv1.2_2018` = "TLSv1.2_2018"
+  @js.native
+  sealed trait MinimumProtocolVersion extends js.Any
+  object MinimumProtocolVersion extends js.Object {
+    val SSLv3          = "SSLv3".asInstanceOf[MinimumProtocolVersion]
+    val TLSv1          = "TLSv1".asInstanceOf[MinimumProtocolVersion]
+    val TLSv1_2016     = "TLSv1_2016".asInstanceOf[MinimumProtocolVersion]
+    val `TLSv1.1_2016` = "TLSv1.1_2016".asInstanceOf[MinimumProtocolVersion]
+    val `TLSv1.2_2018` = "TLSv1.2_2018".asInstanceOf[MinimumProtocolVersion]
 
     val values = js.Object.freeze(js.Array(SSLv3, TLSv1, TLSv1_2016, `TLSv1.1_2016`, `TLSv1.2_2018`))
   }
@@ -3507,11 +3502,12 @@ package cloudfront {
       __obj.asInstanceOf[OriginGroups]
     }
   }
-
-  object OriginProtocolPolicyEnum {
-    val `http-only`    = "http-only"
-    val `match-viewer` = "match-viewer"
-    val `https-only`   = "https-only"
+  @js.native
+  sealed trait OriginProtocolPolicy extends js.Any
+  object OriginProtocolPolicy extends js.Object {
+    val `http-only`    = "http-only".asInstanceOf[OriginProtocolPolicy]
+    val `match-viewer` = "match-viewer".asInstanceOf[OriginProtocolPolicy]
+    val `https-only`   = "https-only".asInstanceOf[OriginProtocolPolicy]
 
     val values = js.Object.freeze(js.Array(`http-only`, `match-viewer`, `https-only`))
   }
@@ -3587,11 +3583,12 @@ package cloudfront {
       __obj.asInstanceOf[Paths]
     }
   }
-
-  object PriceClassEnum {
-    val PriceClass_100 = "PriceClass_100"
-    val PriceClass_200 = "PriceClass_200"
-    val PriceClass_All = "PriceClass_All"
+  @js.native
+  sealed trait PriceClass extends js.Any
+  object PriceClass extends js.Object {
+    val PriceClass_100 = "PriceClass_100".asInstanceOf[PriceClass]
+    val PriceClass_200 = "PriceClass_200".asInstanceOf[PriceClass]
+    val PriceClass_All = "PriceClass_All".asInstanceOf[PriceClass]
 
     val values = js.Object.freeze(js.Array(PriceClass_100, PriceClass_200, PriceClass_All))
   }
@@ -3877,10 +3874,11 @@ package cloudfront {
       __obj.asInstanceOf[S3OriginConfig]
     }
   }
-
-  object SSLSupportMethodEnum {
-    val `sni-only` = "sni-only"
-    val vip        = "vip"
+  @js.native
+  sealed trait SSLSupportMethod extends js.Any
+  object SSLSupportMethod extends js.Object {
+    val `sni-only` = "sni-only".asInstanceOf[SSLSupportMethod]
+    val vip        = "vip".asInstanceOf[SSLSupportMethod]
 
     val values = js.Object.freeze(js.Array(`sni-only`, vip))
   }
@@ -3906,12 +3904,13 @@ package cloudfront {
       __obj.asInstanceOf[Signer]
     }
   }
-
-  object SslProtocolEnum {
-    val SSLv3     = "SSLv3"
-    val TLSv1     = "TLSv1"
-    val `TLSv1.1` = "TLSv1.1"
-    val `TLSv1.2` = "TLSv1.2"
+  @js.native
+  sealed trait SslProtocol extends js.Any
+  object SslProtocol extends js.Object {
+    val SSLv3     = "SSLv3".asInstanceOf[SslProtocol]
+    val TLSv1     = "TLSv1".asInstanceOf[SslProtocol]
+    val `TLSv1.1` = "TLSv1.1".asInstanceOf[SslProtocol]
+    val `TLSv1.2` = "TLSv1.2".asInstanceOf[SslProtocol]
 
     val values = js.Object.freeze(js.Array(SSLv3, TLSv1, `TLSv1.1`, `TLSv1.2`))
   }
@@ -4629,11 +4628,12 @@ package cloudfront {
       __obj.asInstanceOf[ViewerCertificate]
     }
   }
-
-  object ViewerProtocolPolicyEnum {
-    val `allow-all`         = "allow-all"
-    val `https-only`        = "https-only"
-    val `redirect-to-https` = "redirect-to-https"
+  @js.native
+  sealed trait ViewerProtocolPolicy extends js.Any
+  object ViewerProtocolPolicy extends js.Object {
+    val `allow-all`         = "allow-all".asInstanceOf[ViewerProtocolPolicy]
+    val `https-only`        = "https-only".asInstanceOf[ViewerProtocolPolicy]
+    val `redirect-to-https` = "redirect-to-https".asInstanceOf[ViewerProtocolPolicy]
 
     val values = js.Object.freeze(js.Array(`allow-all`, `https-only`, `redirect-to-https`))
   }

--- a/services/cloudhsm/src/main/scala/facade/amazonaws/services/CloudHSM.scala
+++ b/services/cloudhsm/src/main/scala/facade/amazonaws/services/CloudHSM.scala
@@ -15,8 +15,6 @@ package object cloudhsm {
   type ClientLabel            = String
   type ClientList             = js.Array[ClientArn]
   type ClientToken            = String
-  type ClientVersion          = String
-  type CloudHsmObjectState    = String
   type EniId                  = String
   type ExternalId             = String
   type HapgArn                = String
@@ -24,7 +22,6 @@ package object cloudhsm {
   type HsmArn                 = String
   type HsmList                = js.Array[HsmArn]
   type HsmSerialNumber        = String
-  type HsmStatus              = String
   type IamRoleArn             = String
   type IpAddress              = String
   type Label                  = String
@@ -35,7 +32,6 @@ package object cloudhsm {
   type PartitionSerialList    = js.Array[PartitionSerial]
   type SshKey                 = String
   type SubnetId               = String
-  type SubscriptionType       = String
   type TagKey                 = String
   type TagKeyList             = js.Array[TagKey]
   type TagList                = js.Array[Tag]
@@ -156,10 +152,11 @@ package cloudhsm {
       __obj.asInstanceOf[AddTagsToResourceResponse]
     }
   }
-
-  object ClientVersionEnum {
-    val `5.1` = "5.1"
-    val `5.3` = "5.3"
+  @js.native
+  sealed trait ClientVersion extends js.Any
+  object ClientVersion extends js.Object {
+    val `5.1` = "5.1".asInstanceOf[ClientVersion]
+    val `5.3` = "5.3".asInstanceOf[ClientVersion]
 
     val values = js.Object.freeze(js.Array(`5.1`, `5.3`))
   }
@@ -169,11 +166,12 @@ package cloudhsm {
     */
   @js.native
   trait CloudHsmInternalExceptionException extends js.Object {}
-
-  object CloudHsmObjectStateEnum {
-    val READY    = "READY"
-    val UPDATING = "UPDATING"
-    val DEGRADED = "DEGRADED"
+  @js.native
+  sealed trait CloudHsmObjectState extends js.Any
+  object CloudHsmObjectState extends js.Object {
+    val READY    = "READY".asInstanceOf[CloudHsmObjectState]
+    val UPDATING = "UPDATING".asInstanceOf[CloudHsmObjectState]
+    val DEGRADED = "DEGRADED".asInstanceOf[CloudHsmObjectState]
 
     val values = js.Object.freeze(js.Array(READY, UPDATING, DEGRADED))
   }
@@ -708,15 +706,16 @@ package cloudhsm {
       __obj.asInstanceOf[GetConfigResponse]
     }
   }
-
-  object HsmStatusEnum {
-    val PENDING     = "PENDING"
-    val RUNNING     = "RUNNING"
-    val UPDATING    = "UPDATING"
-    val SUSPENDED   = "SUSPENDED"
-    val TERMINATING = "TERMINATING"
-    val TERMINATED  = "TERMINATED"
-    val DEGRADED    = "DEGRADED"
+  @js.native
+  sealed trait HsmStatus extends js.Any
+  object HsmStatus extends js.Object {
+    val PENDING     = "PENDING".asInstanceOf[HsmStatus]
+    val RUNNING     = "RUNNING".asInstanceOf[HsmStatus]
+    val UPDATING    = "UPDATING".asInstanceOf[HsmStatus]
+    val SUSPENDED   = "SUSPENDED".asInstanceOf[HsmStatus]
+    val TERMINATING = "TERMINATING".asInstanceOf[HsmStatus]
+    val TERMINATED  = "TERMINATED".asInstanceOf[HsmStatus]
+    val DEGRADED    = "DEGRADED".asInstanceOf[HsmStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, RUNNING, UPDATING, SUSPENDED, TERMINATING, TERMINATED, DEGRADED))
   }
@@ -1083,8 +1082,10 @@ package cloudhsm {
     * * ```PRODUCTION``` - The HSM is being used in a production environment.
     *  * ```TRIAL``` - The HSM is being used in a product trial.
     */
-  object SubscriptionTypeEnum {
-    val PRODUCTION = "PRODUCTION"
+  @js.native
+  sealed trait SubscriptionType extends js.Any
+  object SubscriptionType extends js.Object {
+    val PRODUCTION = "PRODUCTION".asInstanceOf[SubscriptionType]
 
     val values = js.Object.freeze(js.Array(PRODUCTION))
   }

--- a/services/cloudhsmv2/src/main/scala/facade/amazonaws/services/CloudHSMV2.scala
+++ b/services/cloudhsmv2/src/main/scala/facade/amazonaws/services/CloudHSMV2.scala
@@ -8,12 +8,9 @@ import facade.amazonaws._
 
 package object cloudhsmv2 {
   type BackupId              = String
-  type BackupPolicy          = String
-  type BackupState           = String
   type Backups               = js.Array[Backup]
   type Cert                  = String
   type ClusterId             = String
-  type ClusterState          = String
   type Clusters              = js.Array[Cluster]
   type EniId                 = String
   type ExternalAz            = String
@@ -21,7 +18,6 @@ package object cloudhsmv2 {
   type Field                 = String
   type Filters               = js.Dictionary[Strings]
   type HsmId                 = String
-  type HsmState              = String
   type HsmType               = String
   type Hsms                  = js.Array[Hsm]
   type IpAddress             = String
@@ -141,18 +137,20 @@ package cloudhsmv2 {
       __obj.asInstanceOf[Backup]
     }
   }
-
-  object BackupPolicyEnum {
-    val DEFAULT = "DEFAULT"
+  @js.native
+  sealed trait BackupPolicy extends js.Any
+  object BackupPolicy extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[BackupPolicy]
 
     val values = js.Object.freeze(js.Array(DEFAULT))
   }
-
-  object BackupStateEnum {
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val READY              = "READY"
-    val DELETED            = "DELETED"
-    val PENDING_DELETION   = "PENDING_DELETION"
+  @js.native
+  sealed trait BackupState extends js.Any
+  object BackupState extends js.Object {
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[BackupState]
+    val READY              = "READY".asInstanceOf[BackupState]
+    val DELETED            = "DELETED".asInstanceOf[BackupState]
+    val PENDING_DELETION   = "PENDING_DELETION".asInstanceOf[BackupState]
 
     val values = js.Object.freeze(js.Array(CREATE_IN_PROGRESS, READY, DELETED, PENDING_DELETION))
   }
@@ -247,17 +245,18 @@ package cloudhsmv2 {
       __obj.asInstanceOf[Cluster]
     }
   }
-
-  object ClusterStateEnum {
-    val CREATE_IN_PROGRESS     = "CREATE_IN_PROGRESS"
-    val UNINITIALIZED          = "UNINITIALIZED"
-    val INITIALIZE_IN_PROGRESS = "INITIALIZE_IN_PROGRESS"
-    val INITIALIZED            = "INITIALIZED"
-    val ACTIVE                 = "ACTIVE"
-    val UPDATE_IN_PROGRESS     = "UPDATE_IN_PROGRESS"
-    val DELETE_IN_PROGRESS     = "DELETE_IN_PROGRESS"
-    val DELETED                = "DELETED"
-    val DEGRADED               = "DEGRADED"
+  @js.native
+  sealed trait ClusterState extends js.Any
+  object ClusterState extends js.Object {
+    val CREATE_IN_PROGRESS     = "CREATE_IN_PROGRESS".asInstanceOf[ClusterState]
+    val UNINITIALIZED          = "UNINITIALIZED".asInstanceOf[ClusterState]
+    val INITIALIZE_IN_PROGRESS = "INITIALIZE_IN_PROGRESS".asInstanceOf[ClusterState]
+    val INITIALIZED            = "INITIALIZED".asInstanceOf[ClusterState]
+    val ACTIVE                 = "ACTIVE".asInstanceOf[ClusterState]
+    val UPDATE_IN_PROGRESS     = "UPDATE_IN_PROGRESS".asInstanceOf[ClusterState]
+    val DELETE_IN_PROGRESS     = "DELETE_IN_PROGRESS".asInstanceOf[ClusterState]
+    val DELETED                = "DELETED".asInstanceOf[ClusterState]
+    val DEGRADED               = "DEGRADED".asInstanceOf[ClusterState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -662,13 +661,14 @@ package cloudhsmv2 {
       __obj.asInstanceOf[Hsm]
     }
   }
-
-  object HsmStateEnum {
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val ACTIVE             = "ACTIVE"
-    val DEGRADED           = "DEGRADED"
-    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
-    val DELETED            = "DELETED"
+  @js.native
+  sealed trait HsmState extends js.Any
+  object HsmState extends js.Object {
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[HsmState]
+    val ACTIVE             = "ACTIVE".asInstanceOf[HsmState]
+    val DEGRADED           = "DEGRADED".asInstanceOf[HsmState]
+    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS".asInstanceOf[HsmState]
+    val DELETED            = "DELETED".asInstanceOf[HsmState]
 
     val values = js.Object.freeze(js.Array(CREATE_IN_PROGRESS, ACTIVE, DEGRADED, DELETE_IN_PROGRESS, DELETED))
   }

--- a/services/cloudsearch/src/main/scala/facade/amazonaws/services/CloudSearch.scala
+++ b/services/cloudsearch/src/main/scala/facade/amazonaws/services/CloudSearch.scala
@@ -9,8 +9,6 @@ import facade.amazonaws._
 package object cloudsearch {
   type APIVersion               = String
   type ARN                      = String
-  type AlgorithmicStemming      = String
-  type AnalysisSchemeLanguage   = String
   type AnalysisSchemeStatusList = js.Array[AnalysisSchemeStatus]
   type DomainId                 = String
   type DomainName               = String
@@ -26,22 +24,17 @@ package object cloudsearch {
   type FieldNameList            = js.Array[FieldName]
   type FieldValue               = String
   type IndexFieldStatusList     = js.Array[IndexFieldStatus]
-  type IndexFieldType           = String
   type InstanceCount            = Int
   type MaximumPartitionCount    = Int
   type MaximumReplicationCount  = Int
   type MultiAZ                  = Boolean
-  type OptionState              = String
   type PartitionCount           = Int
-  type PartitionInstanceType    = String
   type PolicyDocument           = String
   type SearchInstanceType       = String
   type ServiceUrl               = String
   type StandardName             = String
   type StandardNameList         = js.Array[StandardName]
-  type SuggesterFuzzyMatching   = String
   type SuggesterStatusList      = js.Array[SuggesterStatus]
-  type TLSSecurityPolicy        = String
   type UIntValue                = Int
   type UpdateTimestamp          = js.Date
   type Word                     = String
@@ -184,12 +177,13 @@ package cloudsearch {
       __obj.asInstanceOf[AccessPoliciesStatus]
     }
   }
-
-  object AlgorithmicStemmingEnum {
-    val none    = "none"
-    val minimal = "minimal"
-    val light   = "light"
-    val full    = "full"
+  @js.native
+  sealed trait AlgorithmicStemming extends js.Any
+  object AlgorithmicStemming extends js.Object {
+    val none    = "none".asInstanceOf[AlgorithmicStemming]
+    val minimal = "minimal".asInstanceOf[AlgorithmicStemming]
+    val light   = "light".asInstanceOf[AlgorithmicStemming]
+    val full    = "full".asInstanceOf[AlgorithmicStemming]
 
     val values = js.Object.freeze(js.Array(none, minimal, light, full))
   }
@@ -257,42 +251,44 @@ package cloudsearch {
   /**
     * An <a href="http://tools.ietf.org/html/rfc4646" target="_blank">IETF RFC 4646</a> language code or <code>mul</code> for multiple languages.
     */
-  object AnalysisSchemeLanguageEnum {
-    val ar        = "ar"
-    val bg        = "bg"
-    val ca        = "ca"
-    val cs        = "cs"
-    val da        = "da"
-    val de        = "de"
-    val el        = "el"
-    val en        = "en"
-    val es        = "es"
-    val eu        = "eu"
-    val fa        = "fa"
-    val fi        = "fi"
-    val fr        = "fr"
-    val ga        = "ga"
-    val gl        = "gl"
-    val he        = "he"
-    val hi        = "hi"
-    val hu        = "hu"
-    val hy        = "hy"
-    val id        = "id"
-    val it        = "it"
-    val ja        = "ja"
-    val ko        = "ko"
-    val lv        = "lv"
-    val mul       = "mul"
-    val nl        = "nl"
-    val no        = "no"
-    val pt        = "pt"
-    val ro        = "ro"
-    val ru        = "ru"
-    val sv        = "sv"
-    val th        = "th"
-    val tr        = "tr"
-    val `zh-Hans` = "zh-Hans"
-    val `zh-Hant` = "zh-Hant"
+  @js.native
+  sealed trait AnalysisSchemeLanguage extends js.Any
+  object AnalysisSchemeLanguage extends js.Object {
+    val ar        = "ar".asInstanceOf[AnalysisSchemeLanguage]
+    val bg        = "bg".asInstanceOf[AnalysisSchemeLanguage]
+    val ca        = "ca".asInstanceOf[AnalysisSchemeLanguage]
+    val cs        = "cs".asInstanceOf[AnalysisSchemeLanguage]
+    val da        = "da".asInstanceOf[AnalysisSchemeLanguage]
+    val de        = "de".asInstanceOf[AnalysisSchemeLanguage]
+    val el        = "el".asInstanceOf[AnalysisSchemeLanguage]
+    val en        = "en".asInstanceOf[AnalysisSchemeLanguage]
+    val es        = "es".asInstanceOf[AnalysisSchemeLanguage]
+    val eu        = "eu".asInstanceOf[AnalysisSchemeLanguage]
+    val fa        = "fa".asInstanceOf[AnalysisSchemeLanguage]
+    val fi        = "fi".asInstanceOf[AnalysisSchemeLanguage]
+    val fr        = "fr".asInstanceOf[AnalysisSchemeLanguage]
+    val ga        = "ga".asInstanceOf[AnalysisSchemeLanguage]
+    val gl        = "gl".asInstanceOf[AnalysisSchemeLanguage]
+    val he        = "he".asInstanceOf[AnalysisSchemeLanguage]
+    val hi        = "hi".asInstanceOf[AnalysisSchemeLanguage]
+    val hu        = "hu".asInstanceOf[AnalysisSchemeLanguage]
+    val hy        = "hy".asInstanceOf[AnalysisSchemeLanguage]
+    val id        = "id".asInstanceOf[AnalysisSchemeLanguage]
+    val it        = "it".asInstanceOf[AnalysisSchemeLanguage]
+    val ja        = "ja".asInstanceOf[AnalysisSchemeLanguage]
+    val ko        = "ko".asInstanceOf[AnalysisSchemeLanguage]
+    val lv        = "lv".asInstanceOf[AnalysisSchemeLanguage]
+    val mul       = "mul".asInstanceOf[AnalysisSchemeLanguage]
+    val nl        = "nl".asInstanceOf[AnalysisSchemeLanguage]
+    val no        = "no".asInstanceOf[AnalysisSchemeLanguage]
+    val pt        = "pt".asInstanceOf[AnalysisSchemeLanguage]
+    val ro        = "ro".asInstanceOf[AnalysisSchemeLanguage]
+    val ru        = "ru".asInstanceOf[AnalysisSchemeLanguage]
+    val sv        = "sv".asInstanceOf[AnalysisSchemeLanguage]
+    val th        = "th".asInstanceOf[AnalysisSchemeLanguage]
+    val tr        = "tr".asInstanceOf[AnalysisSchemeLanguage]
+    val `zh-Hans` = "zh-Hans".asInstanceOf[AnalysisSchemeLanguage]
+    val `zh-Hant` = "zh-Hant".asInstanceOf[AnalysisSchemeLanguage]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1700,18 +1696,20 @@ package cloudsearch {
   /**
     * The type of field. The valid options for a field depend on the field type. For more information about the supported field types, see <a href="http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-index-fields.html" target="_blank">Configuring Index Fields</a> in the <i>Amazon CloudSearch Developer Guide</i>.
     */
-  object IndexFieldTypeEnum {
-    val int             = "int"
-    val double          = "double"
-    val literal         = "literal"
-    val text            = "text"
-    val date            = "date"
-    val latlon          = "latlon"
-    val `int-array`     = "int-array"
-    val `double-array`  = "double-array"
-    val `literal-array` = "literal-array"
-    val `text-array`    = "text-array"
-    val `date-array`    = "date-array"
+  @js.native
+  sealed trait IndexFieldType extends js.Any
+  object IndexFieldType extends js.Object {
+    val int             = "int".asInstanceOf[IndexFieldType]
+    val double          = "double".asInstanceOf[IndexFieldType]
+    val literal         = "literal".asInstanceOf[IndexFieldType]
+    val text            = "text".asInstanceOf[IndexFieldType]
+    val date            = "date".asInstanceOf[IndexFieldType]
+    val latlon          = "latlon".asInstanceOf[IndexFieldType]
+    val `int-array`     = "int-array".asInstanceOf[IndexFieldType]
+    val `double-array`  = "double-array".asInstanceOf[IndexFieldType]
+    val `literal-array` = "literal-array".asInstanceOf[IndexFieldType]
+    val `text-array`    = "text-array".asInstanceOf[IndexFieldType]
+    val `date-array`    = "date-array".asInstanceOf[IndexFieldType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1941,11 +1939,13 @@ package cloudsearch {
     *  * Active: The option's latest value is fully deployed.
     *  * FailedToValidate: The option value is not compatible with the domain's data and cannot be used to index the data. You must either modify the option value or update or remove the incompatible documents.
     */
-  object OptionStateEnum {
-    val RequiresIndexDocuments = "RequiresIndexDocuments"
-    val Processing             = "Processing"
-    val Active                 = "Active"
-    val FailedToValidate       = "FailedToValidate"
+  @js.native
+  sealed trait OptionState extends js.Any
+  object OptionState extends js.Object {
+    val RequiresIndexDocuments = "RequiresIndexDocuments".asInstanceOf[OptionState]
+    val Processing             = "Processing".asInstanceOf[OptionState]
+    val Active                 = "Active".asInstanceOf[OptionState]
+    val FailedToValidate       = "FailedToValidate".asInstanceOf[OptionState]
 
     val values = js.Object.freeze(js.Array(RequiresIndexDocuments, Processing, Active, FailedToValidate))
   }
@@ -1986,15 +1986,17 @@ package cloudsearch {
   /**
     * The instance type (such as <code>search.m1.small</code>) on which an index partition is hosted.
     */
-  object PartitionInstanceTypeEnum {
-    val `search.m1.small`   = "search.m1.small"
-    val `search.m1.large`   = "search.m1.large"
-    val `search.m2.xlarge`  = "search.m2.xlarge"
-    val `search.m2.2xlarge` = "search.m2.2xlarge"
-    val `search.m3.medium`  = "search.m3.medium"
-    val `search.m3.large`   = "search.m3.large"
-    val `search.m3.xlarge`  = "search.m3.xlarge"
-    val `search.m3.2xlarge` = "search.m3.2xlarge"
+  @js.native
+  sealed trait PartitionInstanceType extends js.Any
+  object PartitionInstanceType extends js.Object {
+    val `search.m1.small`   = "search.m1.small".asInstanceOf[PartitionInstanceType]
+    val `search.m1.large`   = "search.m1.large".asInstanceOf[PartitionInstanceType]
+    val `search.m2.xlarge`  = "search.m2.xlarge".asInstanceOf[PartitionInstanceType]
+    val `search.m2.2xlarge` = "search.m2.2xlarge".asInstanceOf[PartitionInstanceType]
+    val `search.m3.medium`  = "search.m3.medium".asInstanceOf[PartitionInstanceType]
+    val `search.m3.large`   = "search.m3.large".asInstanceOf[PartitionInstanceType]
+    val `search.m3.xlarge`  = "search.m3.xlarge".asInstanceOf[PartitionInstanceType]
+    val `search.m3.2xlarge` = "search.m3.2xlarge".asInstanceOf[PartitionInstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2101,11 +2103,12 @@ package cloudsearch {
       __obj.asInstanceOf[Suggester]
     }
   }
-
-  object SuggesterFuzzyMatchingEnum {
-    val none = "none"
-    val low  = "low"
-    val high = "high"
+  @js.native
+  sealed trait SuggesterFuzzyMatching extends js.Any
+  object SuggesterFuzzyMatching extends js.Object {
+    val none = "none".asInstanceOf[SuggesterFuzzyMatching]
+    val low  = "low".asInstanceOf[SuggesterFuzzyMatching]
+    val high = "high".asInstanceOf[SuggesterFuzzyMatching]
 
     val values = js.Object.freeze(js.Array(none, low, high))
   }
@@ -2137,9 +2140,11 @@ package cloudsearch {
   /**
     * The minimum required TLS version.
     */
-  object TLSSecurityPolicyEnum {
-    val `Policy-Min-TLS-1-0-2019-07` = "Policy-Min-TLS-1-0-2019-07"
-    val `Policy-Min-TLS-1-2-2019-07` = "Policy-Min-TLS-1-2-2019-07"
+  @js.native
+  sealed trait TLSSecurityPolicy extends js.Any
+  object TLSSecurityPolicy extends js.Object {
+    val `Policy-Min-TLS-1-0-2019-07` = "Policy-Min-TLS-1-0-2019-07".asInstanceOf[TLSSecurityPolicy]
+    val `Policy-Min-TLS-1-2-2019-07` = "Policy-Min-TLS-1-2-2019-07".asInstanceOf[TLSSecurityPolicy]
 
     val values = js.Object.freeze(js.Array(`Policy-Min-TLS-1-0-2019-07`, `Policy-Min-TLS-1-2-2019-07`))
   }

--- a/services/cloudsearchdomain/src/main/scala/facade/amazonaws/services/CloudSearchDomain.scala
+++ b/services/cloudsearchdomain/src/main/scala/facade/amazonaws/services/CloudSearchDomain.scala
@@ -10,7 +10,6 @@ package object cloudsearchdomain {
   type Adds                    = Double
   type Blob                    = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type BucketList              = js.Array[Bucket]
-  type ContentType             = String
   type Cursor                  = String
   type Deletes                 = Double
   type DocumentServiceWarnings = js.Array[DocumentServiceWarning]
@@ -27,7 +26,6 @@ package object cloudsearchdomain {
   type Partial                 = Boolean
   type Query                   = String
   type QueryOptions            = String
-  type QueryParser             = String
   type Return                  = String
   type Size                    = Double
   type Sort                    = String
@@ -99,10 +97,11 @@ package cloudsearchdomain {
       __obj.asInstanceOf[BucketInfo]
     }
   }
-
-  object ContentTypeEnum {
-    val `application/json` = "application/json"
-    val `application/xml`  = "application/xml"
+  @js.native
+  sealed trait ContentType extends js.Any
+  object ContentType extends js.Object {
+    val `application/json` = "application/json".asInstanceOf[ContentType]
+    val `application/xml`  = "application/xml".asInstanceOf[ContentType]
 
     val values = js.Object.freeze(js.Array(`application/json`, `application/xml`))
   }
@@ -230,12 +229,13 @@ package cloudsearchdomain {
       __obj.asInstanceOf[Hits]
     }
   }
-
-  object QueryParserEnum {
-    val simple     = "simple"
-    val structured = "structured"
-    val lucene     = "lucene"
-    val dismax     = "dismax"
+  @js.native
+  sealed trait QueryParser extends js.Any
+  object QueryParser extends js.Object {
+    val simple     = "simple".asInstanceOf[QueryParser]
+    val structured = "structured".asInstanceOf[QueryParser]
+    val lucene     = "lucene".asInstanceOf[QueryParser]
+    val dismax     = "dismax".asInstanceOf[QueryParser]
 
     val values = js.Object.freeze(js.Array(simple, structured, lucene, dismax))
   }

--- a/services/cloudtrail/src/main/scala/facade/amazonaws/services/CloudTrail.scala
+++ b/services/cloudtrail/src/main/scala/facade/amazonaws/services/CloudTrail.scala
@@ -11,18 +11,14 @@ package object cloudtrail {
   type DataResourceValues            = js.Array[String]
   type DataResources                 = js.Array[DataResource]
   type Date                          = js.Date
-  type EventCategory                 = String
   type EventSelectors                = js.Array[EventSelector]
   type EventsList                    = js.Array[Event]
   type ExcludeManagementEventSources = js.Array[String]
   type InsightSelectors              = js.Array[InsightSelector]
-  type InsightType                   = String
-  type LookupAttributeKey            = String
   type LookupAttributesList          = js.Array[LookupAttribute]
   type MaxResults                    = Int
   type NextToken                     = String
   type PublicKeyList                 = js.Array[PublicKey]
-  type ReadWriteType                 = String
   type ResourceIdList                = js.Array[String]
   type ResourceList                  = js.Array[Resource]
   type ResourceTagList               = js.Array[ResourceTag]
@@ -409,9 +405,10 @@ package cloudtrail {
       __obj.asInstanceOf[Event]
     }
   }
-
-  object EventCategoryEnum {
-    val insight = "insight"
+  @js.native
+  sealed trait EventCategory extends js.Any
+  object EventCategory extends js.Object {
+    val insight = "insight".asInstanceOf[EventCategory]
 
     val values = js.Object.freeze(js.Array(insight))
   }
@@ -675,9 +672,10 @@ package cloudtrail {
       __obj.asInstanceOf[InsightSelector]
     }
   }
-
-  object InsightTypeEnum {
-    val ApiCallRateInsight = "ApiCallRateInsight"
+  @js.native
+  sealed trait InsightType extends js.Any
+  object InsightType extends js.Object {
+    val ApiCallRateInsight = "ApiCallRateInsight".asInstanceOf[InsightType]
 
     val values = js.Object.freeze(js.Array(ApiCallRateInsight))
   }
@@ -833,16 +831,17 @@ package cloudtrail {
       __obj.asInstanceOf[LookupAttribute]
     }
   }
-
-  object LookupAttributeKeyEnum {
-    val EventId      = "EventId"
-    val EventName    = "EventName"
-    val ReadOnly     = "ReadOnly"
-    val Username     = "Username"
-    val ResourceType = "ResourceType"
-    val ResourceName = "ResourceName"
-    val EventSource  = "EventSource"
-    val AccessKeyId  = "AccessKeyId"
+  @js.native
+  sealed trait LookupAttributeKey extends js.Any
+  object LookupAttributeKey extends js.Object {
+    val EventId      = "EventId".asInstanceOf[LookupAttributeKey]
+    val EventName    = "EventName".asInstanceOf[LookupAttributeKey]
+    val ReadOnly     = "ReadOnly".asInstanceOf[LookupAttributeKey]
+    val Username     = "Username".asInstanceOf[LookupAttributeKey]
+    val ResourceType = "ResourceType".asInstanceOf[LookupAttributeKey]
+    val ResourceName = "ResourceName".asInstanceOf[LookupAttributeKey]
+    val EventSource  = "EventSource".asInstanceOf[LookupAttributeKey]
+    val AccessKeyId  = "AccessKeyId".asInstanceOf[LookupAttributeKey]
 
     val values = js.Object.freeze(
       js.Array(EventId, EventName, ReadOnly, Username, ResourceType, ResourceName, EventSource, AccessKeyId)
@@ -1012,11 +1011,12 @@ package cloudtrail {
       __obj.asInstanceOf[PutInsightSelectorsResponse]
     }
   }
-
-  object ReadWriteTypeEnum {
-    val ReadOnly  = "ReadOnly"
-    val WriteOnly = "WriteOnly"
-    val All       = "All"
+  @js.native
+  sealed trait ReadWriteType extends js.Any
+  object ReadWriteType extends js.Object {
+    val ReadOnly  = "ReadOnly".asInstanceOf[ReadWriteType]
+    val WriteOnly = "WriteOnly".asInstanceOf[ReadWriteType]
+    val All       = "All".asInstanceOf[ReadWriteType]
 
     val values = js.Object.freeze(js.Array(ReadOnly, WriteOnly, All))
   }

--- a/services/cloudwatch/src/main/scala/facade/amazonaws/services/CloudWatch.scala
+++ b/services/cloudwatch/src/main/scala/facade/amazonaws/services/CloudWatch.scala
@@ -18,10 +18,8 @@ package object cloudwatch {
   type AmazonResourceName                = String
   type AnomalyDetectorExcludedTimeRanges = js.Array[Range]
   type AnomalyDetectorMetricTimezone     = String
-  type AnomalyDetectorStateValue         = String
   type AnomalyDetectors                  = js.Array[AnomalyDetector]
   type BatchFailures                     = js.Array[PartialFailure]
-  type ComparisonOperator                = String
   type Counts                            = js.Array[DatapointValue]
   type DashboardArn                      = String
   type DashboardBody                     = String
@@ -50,7 +48,6 @@ package object cloudwatch {
   type FailureResource                   = String
   type GetMetricDataMaxDatapoints        = Int
   type HistoryData                       = String
-  type HistoryItemType                   = String
   type HistorySummary                    = String
   type InsightRuleAggregationStatistic   = String
   type InsightRuleContributorDatapoints  = js.Array[InsightRuleContributorDatapoint]
@@ -98,16 +95,11 @@ package object cloudwatch {
   type ResourceList                      = js.Array[ResourceName]
   type ResourceName                      = String
   type ReturnData                        = Boolean
-  type ScanBy                            = String
   type Size                              = Double
-  type StandardUnit                      = String
   type Stat                              = String
   type StateReason                       = String
   type StateReasonData                   = String
-  type StateValue                        = String
-  type Statistic                         = String
   type Statistics                        = js.Array[Statistic]
-  type StatusCode                        = String
   type StorageResolution                 = Int
   type TagKey                            = String
   type TagKeyList                        = js.Array[TagKey]
@@ -309,23 +301,26 @@ package cloudwatch {
       __obj.asInstanceOf[AnomalyDetectorConfiguration]
     }
   }
-
-  object AnomalyDetectorStateValueEnum {
-    val PENDING_TRAINING          = "PENDING_TRAINING"
-    val TRAINED_INSUFFICIENT_DATA = "TRAINED_INSUFFICIENT_DATA"
-    val TRAINED                   = "TRAINED"
+  @js.native
+  sealed trait AnomalyDetectorStateValue extends js.Any
+  object AnomalyDetectorStateValue extends js.Object {
+    val PENDING_TRAINING          = "PENDING_TRAINING".asInstanceOf[AnomalyDetectorStateValue]
+    val TRAINED_INSUFFICIENT_DATA = "TRAINED_INSUFFICIENT_DATA".asInstanceOf[AnomalyDetectorStateValue]
+    val TRAINED                   = "TRAINED".asInstanceOf[AnomalyDetectorStateValue]
 
     val values = js.Object.freeze(js.Array(PENDING_TRAINING, TRAINED_INSUFFICIENT_DATA, TRAINED))
   }
-
-  object ComparisonOperatorEnum {
-    val GreaterThanOrEqualToThreshold            = "GreaterThanOrEqualToThreshold"
-    val GreaterThanThreshold                     = "GreaterThanThreshold"
-    val LessThanThreshold                        = "LessThanThreshold"
-    val LessThanOrEqualToThreshold               = "LessThanOrEqualToThreshold"
-    val LessThanLowerOrGreaterThanUpperThreshold = "LessThanLowerOrGreaterThanUpperThreshold"
-    val LessThanLowerThreshold                   = "LessThanLowerThreshold"
-    val GreaterThanUpperThreshold                = "GreaterThanUpperThreshold"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val GreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold".asInstanceOf[ComparisonOperator]
+    val GreaterThanThreshold          = "GreaterThanThreshold".asInstanceOf[ComparisonOperator]
+    val LessThanThreshold             = "LessThanThreshold".asInstanceOf[ComparisonOperator]
+    val LessThanOrEqualToThreshold    = "LessThanOrEqualToThreshold".asInstanceOf[ComparisonOperator]
+    val LessThanLowerOrGreaterThanUpperThreshold =
+      "LessThanLowerOrGreaterThanUpperThreshold".asInstanceOf[ComparisonOperator]
+    val LessThanLowerThreshold    = "LessThanLowerThreshold".asInstanceOf[ComparisonOperator]
+    val GreaterThanUpperThreshold = "GreaterThanUpperThreshold".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1201,11 +1196,12 @@ package cloudwatch {
       __obj.asInstanceOf[GetMetricWidgetImageOutput]
     }
   }
-
-  object HistoryItemTypeEnum {
-    val ConfigurationUpdate = "ConfigurationUpdate"
-    val StateUpdate         = "StateUpdate"
-    val Action              = "Action"
+  @js.native
+  sealed trait HistoryItemType extends js.Any
+  object HistoryItemType extends js.Object {
+    val ConfigurationUpdate = "ConfigurationUpdate".asInstanceOf[HistoryItemType]
+    val StateUpdate         = "StateUpdate".asInstanceOf[HistoryItemType]
+    val Action              = "Action".asInstanceOf[HistoryItemType]
 
     val values = js.Object.freeze(js.Array(ConfigurationUpdate, StateUpdate, Action))
   }
@@ -2024,10 +2020,11 @@ package cloudwatch {
       __obj.asInstanceOf[Range]
     }
   }
-
-  object ScanByEnum {
-    val TimestampDescending = "TimestampDescending"
-    val TimestampAscending  = "TimestampAscending"
+  @js.native
+  sealed trait ScanBy extends js.Any
+  object ScanBy extends js.Object {
+    val TimestampDescending = "TimestampDescending".asInstanceOf[ScanBy]
+    val TimestampAscending  = "TimestampAscending".asInstanceOf[ScanBy]
 
     val values = js.Object.freeze(js.Array(TimestampDescending, TimestampAscending))
   }
@@ -2058,35 +2055,36 @@ package cloudwatch {
       __obj.asInstanceOf[SetAlarmStateInput]
     }
   }
-
-  object StandardUnitEnum {
-    val Seconds            = "Seconds"
-    val Microseconds       = "Microseconds"
-    val Milliseconds       = "Milliseconds"
-    val Bytes              = "Bytes"
-    val Kilobytes          = "Kilobytes"
-    val Megabytes          = "Megabytes"
-    val Gigabytes          = "Gigabytes"
-    val Terabytes          = "Terabytes"
-    val Bits               = "Bits"
-    val Kilobits           = "Kilobits"
-    val Megabits           = "Megabits"
-    val Gigabits           = "Gigabits"
-    val Terabits           = "Terabits"
-    val Percent            = "Percent"
-    val Count              = "Count"
-    val `Bytes/Second`     = "Bytes/Second"
-    val `Kilobytes/Second` = "Kilobytes/Second"
-    val `Megabytes/Second` = "Megabytes/Second"
-    val `Gigabytes/Second` = "Gigabytes/Second"
-    val `Terabytes/Second` = "Terabytes/Second"
-    val `Bits/Second`      = "Bits/Second"
-    val `Kilobits/Second`  = "Kilobits/Second"
-    val `Megabits/Second`  = "Megabits/Second"
-    val `Gigabits/Second`  = "Gigabits/Second"
-    val `Terabits/Second`  = "Terabits/Second"
-    val `Count/Second`     = "Count/Second"
-    val None               = "None"
+  @js.native
+  sealed trait StandardUnit extends js.Any
+  object StandardUnit extends js.Object {
+    val Seconds            = "Seconds".asInstanceOf[StandardUnit]
+    val Microseconds       = "Microseconds".asInstanceOf[StandardUnit]
+    val Milliseconds       = "Milliseconds".asInstanceOf[StandardUnit]
+    val Bytes              = "Bytes".asInstanceOf[StandardUnit]
+    val Kilobytes          = "Kilobytes".asInstanceOf[StandardUnit]
+    val Megabytes          = "Megabytes".asInstanceOf[StandardUnit]
+    val Gigabytes          = "Gigabytes".asInstanceOf[StandardUnit]
+    val Terabytes          = "Terabytes".asInstanceOf[StandardUnit]
+    val Bits               = "Bits".asInstanceOf[StandardUnit]
+    val Kilobits           = "Kilobits".asInstanceOf[StandardUnit]
+    val Megabits           = "Megabits".asInstanceOf[StandardUnit]
+    val Gigabits           = "Gigabits".asInstanceOf[StandardUnit]
+    val Terabits           = "Terabits".asInstanceOf[StandardUnit]
+    val Percent            = "Percent".asInstanceOf[StandardUnit]
+    val Count              = "Count".asInstanceOf[StandardUnit]
+    val `Bytes/Second`     = "Bytes/Second".asInstanceOf[StandardUnit]
+    val `Kilobytes/Second` = "Kilobytes/Second".asInstanceOf[StandardUnit]
+    val `Megabytes/Second` = "Megabytes/Second".asInstanceOf[StandardUnit]
+    val `Gigabytes/Second` = "Gigabytes/Second".asInstanceOf[StandardUnit]
+    val `Terabytes/Second` = "Terabytes/Second".asInstanceOf[StandardUnit]
+    val `Bits/Second`      = "Bits/Second".asInstanceOf[StandardUnit]
+    val `Kilobits/Second`  = "Kilobits/Second".asInstanceOf[StandardUnit]
+    val `Megabits/Second`  = "Megabits/Second".asInstanceOf[StandardUnit]
+    val `Gigabits/Second`  = "Gigabits/Second".asInstanceOf[StandardUnit]
+    val `Terabits/Second`  = "Terabits/Second".asInstanceOf[StandardUnit]
+    val `Count/Second`     = "Count/Second".asInstanceOf[StandardUnit]
+    val None               = "None".asInstanceOf[StandardUnit]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2120,21 +2118,23 @@ package cloudwatch {
       )
     )
   }
-
-  object StateValueEnum {
-    val OK                = "OK"
-    val ALARM             = "ALARM"
-    val INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+  @js.native
+  sealed trait StateValue extends js.Any
+  object StateValue extends js.Object {
+    val OK                = "OK".asInstanceOf[StateValue]
+    val ALARM             = "ALARM".asInstanceOf[StateValue]
+    val INSUFFICIENT_DATA = "INSUFFICIENT_DATA".asInstanceOf[StateValue]
 
     val values = js.Object.freeze(js.Array(OK, ALARM, INSUFFICIENT_DATA))
   }
-
-  object StatisticEnum {
-    val SampleCount = "SampleCount"
-    val Average     = "Average"
-    val Sum         = "Sum"
-    val Minimum     = "Minimum"
-    val Maximum     = "Maximum"
+  @js.native
+  sealed trait Statistic extends js.Any
+  object Statistic extends js.Object {
+    val SampleCount = "SampleCount".asInstanceOf[Statistic]
+    val Average     = "Average".asInstanceOf[Statistic]
+    val Sum         = "Sum".asInstanceOf[Statistic]
+    val Minimum     = "Minimum".asInstanceOf[Statistic]
+    val Maximum     = "Maximum".asInstanceOf[Statistic]
 
     val values = js.Object.freeze(js.Array(SampleCount, Average, Sum, Minimum, Maximum))
   }
@@ -2168,11 +2168,12 @@ package cloudwatch {
       __obj.asInstanceOf[StatisticSet]
     }
   }
-
-  object StatusCodeEnum {
-    val Complete      = "Complete"
-    val InternalError = "InternalError"
-    val PartialData   = "PartialData"
+  @js.native
+  sealed trait StatusCode extends js.Any
+  object StatusCode extends js.Object {
+    val Complete      = "Complete".asInstanceOf[StatusCode]
+    val InternalError = "InternalError".asInstanceOf[StatusCode]
+    val PartialData   = "PartialData".asInstanceOf[StatusCode]
 
     val values = js.Object.freeze(js.Array(Complete, InternalError, PartialData))
   }

--- a/services/cloudwatchevents/src/main/scala/facade/amazonaws/services/CloudWatchEvents.scala
+++ b/services/cloudwatchevents/src/main/scala/facade/amazonaws/services/CloudWatchEvents.scala
@@ -10,7 +10,6 @@ package object cloudwatchevents {
   type AccountId                        = String
   type Action                           = String
   type Arn                              = String
-  type AssignPublicIp                   = String
   type ErrorCode                        = String
   type ErrorMessage                     = String
   type EventBusList                     = js.Array[EventBus]
@@ -22,10 +21,8 @@ package object cloudwatchevents {
   type EventSourceList                  = js.Array[EventSource]
   type EventSourceName                  = String
   type EventSourceNamePrefix            = String
-  type EventSourceState                 = String
   type EventTime                        = js.Date
   type InputTransformerPathKey          = String
-  type LaunchType                       = String
   type LimitMax100                      = Int
   type LimitMin1                        = Int
   type ManagedBy                        = String
@@ -48,7 +45,6 @@ package object cloudwatchevents {
   type RuleName                         = String
   type RuleNameList                     = js.Array[RuleName]
   type RuleResponseList                 = js.Array[Rule]
-  type RuleState                        = String
   type RunCommandTargetKey              = String
   type RunCommandTargetValue            = String
   type RunCommandTargetValues           = js.Array[RunCommandTargetValue]
@@ -205,10 +201,11 @@ package cloudwatchevents {
       __obj.asInstanceOf[ActivateEventSourceRequest]
     }
   }
-
-  object AssignPublicIpEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait AssignPublicIp extends js.Any
+  object AssignPublicIp extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[AssignPublicIp]
+    val DISABLED = "DISABLED".asInstanceOf[AssignPublicIp]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -812,11 +809,12 @@ package cloudwatchevents {
       __obj.asInstanceOf[EventSource]
     }
   }
-
-  object EventSourceStateEnum {
-    val PENDING = "PENDING"
-    val ACTIVE  = "ACTIVE"
-    val DELETED = "DELETED"
+  @js.native
+  sealed trait EventSourceState extends js.Any
+  object EventSourceState extends js.Object {
+    val PENDING = "PENDING".asInstanceOf[EventSourceState]
+    val ACTIVE  = "ACTIVE".asInstanceOf[EventSourceState]
+    val DELETED = "DELETED".asInstanceOf[EventSourceState]
 
     val values = js.Object.freeze(js.Array(PENDING, ACTIVE, DELETED))
   }
@@ -865,10 +863,11 @@ package cloudwatchevents {
       __obj.asInstanceOf[KinesisParameters]
     }
   }
-
-  object LaunchTypeEnum {
-    val EC2     = "EC2"
-    val FARGATE = "FARGATE"
+  @js.native
+  sealed trait LaunchType extends js.Any
+  object LaunchType extends js.Object {
+    val EC2     = "EC2".asInstanceOf[LaunchType]
+    val FARGATE = "FARGATE".asInstanceOf[LaunchType]
 
     val values = js.Object.freeze(js.Array(EC2, FARGATE))
   }
@@ -1758,10 +1757,11 @@ package cloudwatchevents {
       __obj.asInstanceOf[Rule]
     }
   }
-
-  object RuleStateEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait RuleState extends js.Any
+  object RuleState extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[RuleState]
+    val DISABLED = "DISABLED".asInstanceOf[RuleState]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }

--- a/services/cloudwatchlogs/src/main/scala/facade/amazonaws/services/CloudWatchLogs.scala
+++ b/services/cloudwatchlogs/src/main/scala/facade/amazonaws/services/CloudWatchLogs.scala
@@ -17,7 +17,6 @@ package object cloudwatchlogs {
   type DestinationArn              = String
   type DestinationName             = String
   type Destinations                = js.Array[Destination]
-  type Distribution                = String
   type EventId                     = String
   type EventMessage                = String
   type EventNumber                 = Double
@@ -26,7 +25,6 @@ package object cloudwatchlogs {
   type ExportDestinationPrefix     = String
   type ExportTaskId                = String
   type ExportTaskName              = String
-  type ExportTaskStatusCode        = String
   type ExportTaskStatusMessage     = String
   type ExportTasks                 = js.Array[ExportTask]
   type ExtractedValues             = js.Dictionary[Value]
@@ -56,7 +54,6 @@ package object cloudwatchlogs {
   type MetricTransformations       = js.Array[MetricTransformation]
   type MetricValue                 = String
   type NextToken                   = String
-  type OrderBy                     = String
   type OutputLogEvents             = js.Array[OutputLogEvent]
   type Percentage                  = Int
   type PolicyDocument              = String
@@ -64,7 +61,6 @@ package object cloudwatchlogs {
   type QueryId                     = String
   type QueryInfoList               = js.Array[QueryInfo]
   type QueryResults                = js.Array[ResultRows]
-  type QueryStatus                 = String
   type QueryString                 = String
   type ResourcePolicies            = js.Array[ResourcePolicy]
   type ResultRows                  = js.Array[ResultField]
@@ -902,9 +898,11 @@ package cloudwatchlogs {
   /**
     * The method used to distribute log data to the destination, which can be either random or grouped by log stream.
     */
-  object DistributionEnum {
-    val Random      = "Random"
-    val ByLogStream = "ByLogStream"
+  @js.native
+  sealed trait Distribution extends js.Any
+  object Distribution extends js.Object {
+    val Random      = "Random".asInstanceOf[Distribution]
+    val ByLogStream = "ByLogStream".asInstanceOf[Distribution]
 
     val values = js.Object.freeze(js.Array(Random, ByLogStream))
   }
@@ -995,14 +993,15 @@ package cloudwatchlogs {
       __obj.asInstanceOf[ExportTaskStatus]
     }
   }
-
-  object ExportTaskStatusCodeEnum {
-    val CANCELLED      = "CANCELLED"
-    val COMPLETED      = "COMPLETED"
-    val FAILED         = "FAILED"
-    val PENDING        = "PENDING"
-    val PENDING_CANCEL = "PENDING_CANCEL"
-    val RUNNING        = "RUNNING"
+  @js.native
+  sealed trait ExportTaskStatusCode extends js.Any
+  object ExportTaskStatusCode extends js.Object {
+    val CANCELLED      = "CANCELLED".asInstanceOf[ExportTaskStatusCode]
+    val COMPLETED      = "COMPLETED".asInstanceOf[ExportTaskStatusCode]
+    val FAILED         = "FAILED".asInstanceOf[ExportTaskStatusCode]
+    val PENDING        = "PENDING".asInstanceOf[ExportTaskStatusCode]
+    val PENDING_CANCEL = "PENDING_CANCEL".asInstanceOf[ExportTaskStatusCode]
+    val RUNNING        = "RUNNING".asInstanceOf[ExportTaskStatusCode]
 
     val values = js.Object.freeze(js.Array(CANCELLED, COMPLETED, FAILED, PENDING, PENDING_CANCEL, RUNNING))
   }
@@ -1513,10 +1512,11 @@ package cloudwatchlogs {
       __obj.asInstanceOf[MetricTransformation]
     }
   }
-
-  object OrderByEnum {
-    val LogStreamName = "LogStreamName"
-    val LastEventTime = "LastEventTime"
+  @js.native
+  sealed trait OrderBy extends js.Any
+  object OrderBy extends js.Object {
+    val LogStreamName = "LogStreamName".asInstanceOf[OrderBy]
+    val LastEventTime = "LastEventTime".asInstanceOf[OrderBy]
 
     val values = js.Object.freeze(js.Array(LogStreamName, LastEventTime))
   }
@@ -1824,13 +1824,14 @@ package cloudwatchlogs {
       __obj.asInstanceOf[QueryStatistics]
     }
   }
-
-  object QueryStatusEnum {
-    val Scheduled = "Scheduled"
-    val Running   = "Running"
-    val Complete  = "Complete"
-    val Failed    = "Failed"
-    val Cancelled = "Cancelled"
+  @js.native
+  sealed trait QueryStatus extends js.Any
+  object QueryStatus extends js.Object {
+    val Scheduled = "Scheduled".asInstanceOf[QueryStatus]
+    val Running   = "Running".asInstanceOf[QueryStatus]
+    val Complete  = "Complete".asInstanceOf[QueryStatus]
+    val Failed    = "Failed".asInstanceOf[QueryStatus]
+    val Cancelled = "Cancelled".asInstanceOf[QueryStatus]
 
     val values = js.Object.freeze(js.Array(Scheduled, Running, Complete, Failed, Cancelled))
   }

--- a/services/codebuild/src/main/scala/facade/amazonaws/services/CodeBuild.scala
+++ b/services/codebuild/src/main/scala/facade/amazonaws/services/CodeBuild.scala
@@ -7,41 +7,25 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object codebuild {
-  type ArtifactNamespace              = String
-  type ArtifactPackaging              = String
-  type ArtifactsType                  = String
-  type AuthType                       = String
   type BuildArtifactsList             = js.Array[BuildArtifacts]
   type BuildIds                       = js.Array[NonEmptyString]
-  type BuildPhaseType                 = String
   type BuildPhases                    = js.Array[BuildPhase]
   type BuildReportArns                = js.Array[String]
   type Builds                         = js.Array[Build]
   type BuildsNotDeleted               = js.Array[BuildNotDeleted]
-  type CacheMode                      = String
-  type CacheType                      = String
-  type ComputeType                    = String
-  type CredentialProviderType         = String
   type EnvironmentImages              = js.Array[EnvironmentImage]
   type EnvironmentLanguages           = js.Array[EnvironmentLanguage]
   type EnvironmentPlatforms           = js.Array[EnvironmentPlatform]
-  type EnvironmentType                = String
-  type EnvironmentVariableType        = String
   type EnvironmentVariables           = js.Array[EnvironmentVariable]
   type ExportedEnvironmentVariables   = js.Array[ExportedEnvironmentVariable]
-  type FileSystemType                 = String
   type FilterGroup                    = js.Array[WebhookFilter]
   type FilterGroups                   = js.Array[FilterGroup]
   type GitCloneDepth                  = Int
-  type ImagePullCredentialsType       = String
   type ImageVersions                  = js.Array[String]
   type KeyInput                       = String
-  type LanguageType                   = String
-  type LogsConfigStatusType           = String
   type NonEmptyString                 = String
   type PageSize                       = Int
   type PhaseContexts                  = js.Array[PhaseContext]
-  type PlatformType                   = String
   type ProjectArns                    = js.Array[NonEmptyString]
   type ProjectArtifactsList           = js.Array[ProjectArtifacts]
   type ProjectCacheModes              = js.Array[CacheMode]
@@ -50,36 +34,23 @@ package object codebuild {
   type ProjectName                    = String
   type ProjectNames                   = js.Array[NonEmptyString]
   type ProjectSecondarySourceVersions = js.Array[ProjectSourceVersion]
-  type ProjectSortByType              = String
   type ProjectSources                 = js.Array[ProjectSource]
   type Projects                       = js.Array[Project]
   type ReportArns                     = js.Array[NonEmptyString]
-  type ReportExportConfigType         = String
   type ReportGroupArns                = js.Array[NonEmptyString]
   type ReportGroupName                = String
-  type ReportGroupSortByType          = String
   type ReportGroups                   = js.Array[ReportGroup]
-  type ReportPackagingType            = String
   type ReportStatusCounts             = js.Dictionary[WrapperInt]
-  type ReportStatusType               = String
-  type ReportType                     = String
   type Reports                        = js.Array[Report]
   type SecurityGroupIds               = js.Array[NonEmptyString]
   type SensitiveNonEmptyString        = String
-  type ServerType                     = String
-  type SharedResourceSortByType       = String
-  type SortOrderType                  = String
-  type SourceAuthType                 = String
   type SourceCredentialsInfos         = js.Array[SourceCredentialsInfo]
-  type SourceType                     = String
-  type StatusType                     = String
   type Subnets                        = js.Array[NonEmptyString]
   type TagList                        = js.Array[Tag]
   type TestCases                      = js.Array[TestCase]
   type TimeOut                        = Int
   type Timestamp                      = js.Date
   type ValueInput                     = String
-  type WebhookFilterType              = String
   type WrapperBoolean                 = Boolean
   type WrapperInt                     = Int
   type WrapperLong                    = Double
@@ -209,33 +180,37 @@ package codebuild {
     def updateReportGroup(params: UpdateReportGroupInput): Request[UpdateReportGroupOutput]                = js.native
     def updateWebhook(params: UpdateWebhookInput): Request[UpdateWebhookOutput]                            = js.native
   }
-
-  object ArtifactNamespaceEnum {
-    val NONE     = "NONE"
-    val BUILD_ID = "BUILD_ID"
+  @js.native
+  sealed trait ArtifactNamespace extends js.Any
+  object ArtifactNamespace extends js.Object {
+    val NONE     = "NONE".asInstanceOf[ArtifactNamespace]
+    val BUILD_ID = "BUILD_ID".asInstanceOf[ArtifactNamespace]
 
     val values = js.Object.freeze(js.Array(NONE, BUILD_ID))
   }
-
-  object ArtifactPackagingEnum {
-    val NONE = "NONE"
-    val ZIP  = "ZIP"
+  @js.native
+  sealed trait ArtifactPackaging extends js.Any
+  object ArtifactPackaging extends js.Object {
+    val NONE = "NONE".asInstanceOf[ArtifactPackaging]
+    val ZIP  = "ZIP".asInstanceOf[ArtifactPackaging]
 
     val values = js.Object.freeze(js.Array(NONE, ZIP))
   }
-
-  object ArtifactsTypeEnum {
-    val CODEPIPELINE = "CODEPIPELINE"
-    val S3           = "S3"
-    val NO_ARTIFACTS = "NO_ARTIFACTS"
+  @js.native
+  sealed trait ArtifactsType extends js.Any
+  object ArtifactsType extends js.Object {
+    val CODEPIPELINE = "CODEPIPELINE".asInstanceOf[ArtifactsType]
+    val S3           = "S3".asInstanceOf[ArtifactsType]
+    val NO_ARTIFACTS = "NO_ARTIFACTS".asInstanceOf[ArtifactsType]
 
     val values = js.Object.freeze(js.Array(CODEPIPELINE, S3, NO_ARTIFACTS))
   }
-
-  object AuthTypeEnum {
-    val OAUTH                 = "OAUTH"
-    val BASIC_AUTH            = "BASIC_AUTH"
-    val PERSONAL_ACCESS_TOKEN = "PERSONAL_ACCESS_TOKEN"
+  @js.native
+  sealed trait AuthType extends js.Any
+  object AuthType extends js.Object {
+    val OAUTH                 = "OAUTH".asInstanceOf[AuthType]
+    val BASIC_AUTH            = "BASIC_AUTH".asInstanceOf[AuthType]
+    val PERSONAL_ACCESS_TOKEN = "PERSONAL_ACCESS_TOKEN".asInstanceOf[AuthType]
 
     val values = js.Object.freeze(js.Array(OAUTH, BASIC_AUTH, PERSONAL_ACCESS_TOKEN))
   }
@@ -622,19 +597,20 @@ package codebuild {
       __obj.asInstanceOf[BuildPhase]
     }
   }
-
-  object BuildPhaseTypeEnum {
-    val SUBMITTED        = "SUBMITTED"
-    val QUEUED           = "QUEUED"
-    val PROVISIONING     = "PROVISIONING"
-    val DOWNLOAD_SOURCE  = "DOWNLOAD_SOURCE"
-    val INSTALL          = "INSTALL"
-    val PRE_BUILD        = "PRE_BUILD"
-    val BUILD            = "BUILD"
-    val POST_BUILD       = "POST_BUILD"
-    val UPLOAD_ARTIFACTS = "UPLOAD_ARTIFACTS"
-    val FINALIZING       = "FINALIZING"
-    val COMPLETED        = "COMPLETED"
+  @js.native
+  sealed trait BuildPhaseType extends js.Any
+  object BuildPhaseType extends js.Object {
+    val SUBMITTED        = "SUBMITTED".asInstanceOf[BuildPhaseType]
+    val QUEUED           = "QUEUED".asInstanceOf[BuildPhaseType]
+    val PROVISIONING     = "PROVISIONING".asInstanceOf[BuildPhaseType]
+    val DOWNLOAD_SOURCE  = "DOWNLOAD_SOURCE".asInstanceOf[BuildPhaseType]
+    val INSTALL          = "INSTALL".asInstanceOf[BuildPhaseType]
+    val PRE_BUILD        = "PRE_BUILD".asInstanceOf[BuildPhaseType]
+    val BUILD            = "BUILD".asInstanceOf[BuildPhaseType]
+    val POST_BUILD       = "POST_BUILD".asInstanceOf[BuildPhaseType]
+    val UPLOAD_ARTIFACTS = "UPLOAD_ARTIFACTS".asInstanceOf[BuildPhaseType]
+    val FINALIZING       = "FINALIZING".asInstanceOf[BuildPhaseType]
+    val COMPLETED        = "COMPLETED".asInstanceOf[BuildPhaseType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -652,19 +628,21 @@ package codebuild {
       )
     )
   }
-
-  object CacheModeEnum {
-    val LOCAL_DOCKER_LAYER_CACHE = "LOCAL_DOCKER_LAYER_CACHE"
-    val LOCAL_SOURCE_CACHE       = "LOCAL_SOURCE_CACHE"
-    val LOCAL_CUSTOM_CACHE       = "LOCAL_CUSTOM_CACHE"
+  @js.native
+  sealed trait CacheMode extends js.Any
+  object CacheMode extends js.Object {
+    val LOCAL_DOCKER_LAYER_CACHE = "LOCAL_DOCKER_LAYER_CACHE".asInstanceOf[CacheMode]
+    val LOCAL_SOURCE_CACHE       = "LOCAL_SOURCE_CACHE".asInstanceOf[CacheMode]
+    val LOCAL_CUSTOM_CACHE       = "LOCAL_CUSTOM_CACHE".asInstanceOf[CacheMode]
 
     val values = js.Object.freeze(js.Array(LOCAL_DOCKER_LAYER_CACHE, LOCAL_SOURCE_CACHE, LOCAL_CUSTOM_CACHE))
   }
-
-  object CacheTypeEnum {
-    val NO_CACHE = "NO_CACHE"
-    val S3       = "S3"
-    val LOCAL    = "LOCAL"
+  @js.native
+  sealed trait CacheType extends js.Any
+  object CacheType extends js.Object {
+    val NO_CACHE = "NO_CACHE".asInstanceOf[CacheType]
+    val S3       = "S3".asInstanceOf[CacheType]
+    val LOCAL    = "LOCAL".asInstanceOf[CacheType]
 
     val values = js.Object.freeze(js.Array(NO_CACHE, S3, LOCAL))
   }
@@ -695,12 +673,13 @@ package codebuild {
       __obj.asInstanceOf[CloudWatchLogsConfig]
     }
   }
-
-  object ComputeTypeEnum {
-    val BUILD_GENERAL1_SMALL   = "BUILD_GENERAL1_SMALL"
-    val BUILD_GENERAL1_MEDIUM  = "BUILD_GENERAL1_MEDIUM"
-    val BUILD_GENERAL1_LARGE   = "BUILD_GENERAL1_LARGE"
-    val BUILD_GENERAL1_2XLARGE = "BUILD_GENERAL1_2XLARGE"
+  @js.native
+  sealed trait ComputeType extends js.Any
+  object ComputeType extends js.Object {
+    val BUILD_GENERAL1_SMALL   = "BUILD_GENERAL1_SMALL".asInstanceOf[ComputeType]
+    val BUILD_GENERAL1_MEDIUM  = "BUILD_GENERAL1_MEDIUM".asInstanceOf[ComputeType]
+    val BUILD_GENERAL1_LARGE   = "BUILD_GENERAL1_LARGE".asInstanceOf[ComputeType]
+    val BUILD_GENERAL1_2XLARGE = "BUILD_GENERAL1_2XLARGE".asInstanceOf[ComputeType]
 
     val values = js.Object.freeze(
       js.Array(BUILD_GENERAL1_SMALL, BUILD_GENERAL1_MEDIUM, BUILD_GENERAL1_LARGE, BUILD_GENERAL1_2XLARGE)
@@ -874,9 +853,10 @@ package codebuild {
       __obj.asInstanceOf[CreateWebhookOutput]
     }
   }
-
-  object CredentialProviderTypeEnum {
-    val SECRETS_MANAGER = "SECRETS_MANAGER"
+  @js.native
+  sealed trait CredentialProviderType extends js.Any
+  object CredentialProviderType extends js.Object {
+    val SECRETS_MANAGER = "SECRETS_MANAGER".asInstanceOf[CredentialProviderType]
 
     val values = js.Object.freeze(js.Array(SECRETS_MANAGER))
   }
@@ -1184,12 +1164,13 @@ package codebuild {
       __obj.asInstanceOf[EnvironmentPlatform]
     }
   }
-
-  object EnvironmentTypeEnum {
-    val WINDOWS_CONTAINER   = "WINDOWS_CONTAINER"
-    val LINUX_CONTAINER     = "LINUX_CONTAINER"
-    val LINUX_GPU_CONTAINER = "LINUX_GPU_CONTAINER"
-    val ARM_CONTAINER       = "ARM_CONTAINER"
+  @js.native
+  sealed trait EnvironmentType extends js.Any
+  object EnvironmentType extends js.Object {
+    val WINDOWS_CONTAINER   = "WINDOWS_CONTAINER".asInstanceOf[EnvironmentType]
+    val LINUX_CONTAINER     = "LINUX_CONTAINER".asInstanceOf[EnvironmentType]
+    val LINUX_GPU_CONTAINER = "LINUX_GPU_CONTAINER".asInstanceOf[EnvironmentType]
+    val ARM_CONTAINER       = "ARM_CONTAINER".asInstanceOf[EnvironmentType]
 
     val values = js.Object.freeze(js.Array(WINDOWS_CONTAINER, LINUX_CONTAINER, LINUX_GPU_CONTAINER, ARM_CONTAINER))
   }
@@ -1220,11 +1201,12 @@ package codebuild {
       __obj.asInstanceOf[EnvironmentVariable]
     }
   }
-
-  object EnvironmentVariableTypeEnum {
-    val PLAINTEXT       = "PLAINTEXT"
-    val PARAMETER_STORE = "PARAMETER_STORE"
-    val SECRETS_MANAGER = "SECRETS_MANAGER"
+  @js.native
+  sealed trait EnvironmentVariableType extends js.Any
+  object EnvironmentVariableType extends js.Object {
+    val PLAINTEXT       = "PLAINTEXT".asInstanceOf[EnvironmentVariableType]
+    val PARAMETER_STORE = "PARAMETER_STORE".asInstanceOf[EnvironmentVariableType]
+    val SECRETS_MANAGER = "SECRETS_MANAGER".asInstanceOf[EnvironmentVariableType]
 
     val values = js.Object.freeze(js.Array(PLAINTEXT, PARAMETER_STORE, SECRETS_MANAGER))
   }
@@ -1250,9 +1232,10 @@ package codebuild {
       __obj.asInstanceOf[ExportedEnvironmentVariable]
     }
   }
-
-  object FileSystemTypeEnum {
-    val EFS = "EFS"
+  @js.native
+  sealed trait FileSystemType extends js.Any
+  object FileSystemType extends js.Object {
+    val EFS = "EFS".asInstanceOf[FileSystemType]
 
     val values = js.Object.freeze(js.Array(EFS))
   }
@@ -1311,10 +1294,11 @@ package codebuild {
       __obj.asInstanceOf[GitSubmodulesConfig]
     }
   }
-
-  object ImagePullCredentialsTypeEnum {
-    val CODEBUILD    = "CODEBUILD"
-    val SERVICE_ROLE = "SERVICE_ROLE"
+  @js.native
+  sealed trait ImagePullCredentialsType extends js.Any
+  object ImagePullCredentialsType extends js.Object {
+    val CODEBUILD    = "CODEBUILD".asInstanceOf[ImagePullCredentialsType]
+    val SERVICE_ROLE = "SERVICE_ROLE".asInstanceOf[ImagePullCredentialsType]
 
     val values = js.Object.freeze(js.Array(CODEBUILD, SERVICE_ROLE))
   }
@@ -1395,18 +1379,19 @@ package codebuild {
       __obj.asInstanceOf[InvalidateProjectCacheOutput]
     }
   }
-
-  object LanguageTypeEnum {
-    val JAVA    = "JAVA"
-    val PYTHON  = "PYTHON"
-    val NODE_JS = "NODE_JS"
-    val RUBY    = "RUBY"
-    val GOLANG  = "GOLANG"
-    val DOCKER  = "DOCKER"
-    val ANDROID = "ANDROID"
-    val DOTNET  = "DOTNET"
-    val BASE    = "BASE"
-    val PHP     = "PHP"
+  @js.native
+  sealed trait LanguageType extends js.Any
+  object LanguageType extends js.Object {
+    val JAVA    = "JAVA".asInstanceOf[LanguageType]
+    val PYTHON  = "PYTHON".asInstanceOf[LanguageType]
+    val NODE_JS = "NODE_JS".asInstanceOf[LanguageType]
+    val RUBY    = "RUBY".asInstanceOf[LanguageType]
+    val GOLANG  = "GOLANG".asInstanceOf[LanguageType]
+    val DOCKER  = "DOCKER".asInstanceOf[LanguageType]
+    val ANDROID = "ANDROID".asInstanceOf[LanguageType]
+    val DOTNET  = "DOTNET".asInstanceOf[LanguageType]
+    val BASE    = "BASE".asInstanceOf[LanguageType]
+    val PHP     = "PHP".asInstanceOf[LanguageType]
 
     val values = js.Object.freeze(js.Array(JAVA, PYTHON, NODE_JS, RUBY, GOLANG, DOCKER, ANDROID, DOTNET, BASE, PHP))
   }
@@ -1837,10 +1822,11 @@ package codebuild {
       __obj.asInstanceOf[LogsConfig]
     }
   }
-
-  object LogsConfigStatusTypeEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait LogsConfigStatusType extends js.Any
+  object LogsConfigStatusType extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[LogsConfigStatusType]
+    val DISABLED = "DISABLED".asInstanceOf[LogsConfigStatusType]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -1928,12 +1914,13 @@ package codebuild {
       __obj.asInstanceOf[PhaseContext]
     }
   }
-
-  object PlatformTypeEnum {
-    val DEBIAN         = "DEBIAN"
-    val AMAZON_LINUX   = "AMAZON_LINUX"
-    val UBUNTU         = "UBUNTU"
-    val WINDOWS_SERVER = "WINDOWS_SERVER"
+  @js.native
+  sealed trait PlatformType extends js.Any
+  object PlatformType extends js.Object {
+    val DEBIAN         = "DEBIAN".asInstanceOf[PlatformType]
+    val AMAZON_LINUX   = "AMAZON_LINUX".asInstanceOf[PlatformType]
+    val UBUNTU         = "UBUNTU".asInstanceOf[PlatformType]
+    val WINDOWS_SERVER = "WINDOWS_SERVER".asInstanceOf[PlatformType]
 
     val values = js.Object.freeze(js.Array(DEBIAN, AMAZON_LINUX, UBUNTU, WINDOWS_SERVER))
   }
@@ -2189,11 +2176,12 @@ package codebuild {
       __obj.asInstanceOf[ProjectFileSystemLocation]
     }
   }
-
-  object ProjectSortByTypeEnum {
-    val NAME               = "NAME"
-    val CREATED_TIME       = "CREATED_TIME"
-    val LAST_MODIFIED_TIME = "LAST_MODIFIED_TIME"
+  @js.native
+  sealed trait ProjectSortByType extends js.Any
+  object ProjectSortByType extends js.Object {
+    val NAME               = "NAME".asInstanceOf[ProjectSortByType]
+    val CREATED_TIME       = "CREATED_TIME".asInstanceOf[ProjectSortByType]
+    val LAST_MODIFIED_TIME = "LAST_MODIFIED_TIME".asInstanceOf[ProjectSortByType]
 
     val values = js.Object.freeze(js.Array(NAME, CREATED_TIME, LAST_MODIFIED_TIME))
   }
@@ -2401,10 +2389,11 @@ package codebuild {
       __obj.asInstanceOf[ReportExportConfig]
     }
   }
-
-  object ReportExportConfigTypeEnum {
-    val S3        = "S3"
-    val NO_EXPORT = "NO_EXPORT"
+  @js.native
+  sealed trait ReportExportConfigType extends js.Any
+  object ReportExportConfigType extends js.Object {
+    val S3        = "S3".asInstanceOf[ReportExportConfigType]
+    val NO_EXPORT = "NO_EXPORT".asInstanceOf[ReportExportConfigType]
 
     val values = js.Object.freeze(js.Array(S3, NO_EXPORT))
   }
@@ -2461,34 +2450,38 @@ package codebuild {
       __obj.asInstanceOf[ReportGroup]
     }
   }
-
-  object ReportGroupSortByTypeEnum {
-    val NAME               = "NAME"
-    val CREATED_TIME       = "CREATED_TIME"
-    val LAST_MODIFIED_TIME = "LAST_MODIFIED_TIME"
+  @js.native
+  sealed trait ReportGroupSortByType extends js.Any
+  object ReportGroupSortByType extends js.Object {
+    val NAME               = "NAME".asInstanceOf[ReportGroupSortByType]
+    val CREATED_TIME       = "CREATED_TIME".asInstanceOf[ReportGroupSortByType]
+    val LAST_MODIFIED_TIME = "LAST_MODIFIED_TIME".asInstanceOf[ReportGroupSortByType]
 
     val values = js.Object.freeze(js.Array(NAME, CREATED_TIME, LAST_MODIFIED_TIME))
   }
-
-  object ReportPackagingTypeEnum {
-    val ZIP  = "ZIP"
-    val NONE = "NONE"
+  @js.native
+  sealed trait ReportPackagingType extends js.Any
+  object ReportPackagingType extends js.Object {
+    val ZIP  = "ZIP".asInstanceOf[ReportPackagingType]
+    val NONE = "NONE".asInstanceOf[ReportPackagingType]
 
     val values = js.Object.freeze(js.Array(ZIP, NONE))
   }
-
-  object ReportStatusTypeEnum {
-    val GENERATING = "GENERATING"
-    val SUCCEEDED  = "SUCCEEDED"
-    val FAILED     = "FAILED"
-    val INCOMPLETE = "INCOMPLETE"
-    val DELETING   = "DELETING"
+  @js.native
+  sealed trait ReportStatusType extends js.Any
+  object ReportStatusType extends js.Object {
+    val GENERATING = "GENERATING".asInstanceOf[ReportStatusType]
+    val SUCCEEDED  = "SUCCEEDED".asInstanceOf[ReportStatusType]
+    val FAILED     = "FAILED".asInstanceOf[ReportStatusType]
+    val INCOMPLETE = "INCOMPLETE".asInstanceOf[ReportStatusType]
+    val DELETING   = "DELETING".asInstanceOf[ReportStatusType]
 
     val values = js.Object.freeze(js.Array(GENERATING, SUCCEEDED, FAILED, INCOMPLETE, DELETING))
   }
-
-  object ReportTypeEnum {
-    val TEST = "TEST"
+  @js.native
+  sealed trait ReportType extends js.Any
+  object ReportType extends js.Object {
+    val TEST = "TEST".asInstanceOf[ReportType]
 
     val values = js.Object.freeze(js.Array(TEST))
   }
@@ -2550,25 +2543,28 @@ package codebuild {
       __obj.asInstanceOf[S3ReportExportConfig]
     }
   }
-
-  object ServerTypeEnum {
-    val GITHUB            = "GITHUB"
-    val BITBUCKET         = "BITBUCKET"
-    val GITHUB_ENTERPRISE = "GITHUB_ENTERPRISE"
+  @js.native
+  sealed trait ServerType extends js.Any
+  object ServerType extends js.Object {
+    val GITHUB            = "GITHUB".asInstanceOf[ServerType]
+    val BITBUCKET         = "BITBUCKET".asInstanceOf[ServerType]
+    val GITHUB_ENTERPRISE = "GITHUB_ENTERPRISE".asInstanceOf[ServerType]
 
     val values = js.Object.freeze(js.Array(GITHUB, BITBUCKET, GITHUB_ENTERPRISE))
   }
-
-  object SharedResourceSortByTypeEnum {
-    val ARN           = "ARN"
-    val MODIFIED_TIME = "MODIFIED_TIME"
+  @js.native
+  sealed trait SharedResourceSortByType extends js.Any
+  object SharedResourceSortByType extends js.Object {
+    val ARN           = "ARN".asInstanceOf[SharedResourceSortByType]
+    val MODIFIED_TIME = "MODIFIED_TIME".asInstanceOf[SharedResourceSortByType]
 
     val values = js.Object.freeze(js.Array(ARN, MODIFIED_TIME))
   }
-
-  object SortOrderTypeEnum {
-    val ASCENDING  = "ASCENDING"
-    val DESCENDING = "DESCENDING"
+  @js.native
+  sealed trait SortOrderType extends js.Any
+  object SortOrderType extends js.Object {
+    val ASCENDING  = "ASCENDING".asInstanceOf[SortOrderType]
+    val DESCENDING = "DESCENDING".asInstanceOf[SortOrderType]
 
     val values = js.Object.freeze(js.Array(ASCENDING, DESCENDING))
   }
@@ -2597,9 +2593,10 @@ package codebuild {
       __obj.asInstanceOf[SourceAuth]
     }
   }
-
-  object SourceAuthTypeEnum {
-    val OAUTH = "OAUTH"
+  @js.native
+  sealed trait SourceAuthType extends js.Any
+  object SourceAuthType extends js.Object {
+    val OAUTH = "OAUTH".asInstanceOf[SourceAuthType]
 
     val values = js.Object.freeze(js.Array(OAUTH))
   }
@@ -2628,15 +2625,16 @@ package codebuild {
       __obj.asInstanceOf[SourceCredentialsInfo]
     }
   }
-
-  object SourceTypeEnum {
-    val CODECOMMIT        = "CODECOMMIT"
-    val CODEPIPELINE      = "CODEPIPELINE"
-    val GITHUB            = "GITHUB"
-    val S3                = "S3"
-    val BITBUCKET         = "BITBUCKET"
-    val GITHUB_ENTERPRISE = "GITHUB_ENTERPRISE"
-    val NO_SOURCE         = "NO_SOURCE"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val CODECOMMIT        = "CODECOMMIT".asInstanceOf[SourceType]
+    val CODEPIPELINE      = "CODEPIPELINE".asInstanceOf[SourceType]
+    val GITHUB            = "GITHUB".asInstanceOf[SourceType]
+    val S3                = "S3".asInstanceOf[SourceType]
+    val BITBUCKET         = "BITBUCKET".asInstanceOf[SourceType]
+    val GITHUB_ENTERPRISE = "GITHUB_ENTERPRISE".asInstanceOf[SourceType]
+    val NO_SOURCE         = "NO_SOURCE".asInstanceOf[SourceType]
 
     val values =
       js.Object.freeze(js.Array(CODECOMMIT, CODEPIPELINE, GITHUB, S3, BITBUCKET, GITHUB_ENTERPRISE, NO_SOURCE))
@@ -2775,14 +2773,15 @@ package codebuild {
       __obj.asInstanceOf[StartBuildOutput]
     }
   }
-
-  object StatusTypeEnum {
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
-    val FAULT       = "FAULT"
-    val TIMED_OUT   = "TIMED_OUT"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val STOPPED     = "STOPPED"
+  @js.native
+  sealed trait StatusType extends js.Any
+  object StatusType extends js.Object {
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[StatusType]
+    val FAILED      = "FAILED".asInstanceOf[StatusType]
+    val FAULT       = "FAULT".asInstanceOf[StatusType]
+    val TIMED_OUT   = "TIMED_OUT".asInstanceOf[StatusType]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[StatusType]
+    val STOPPED     = "STOPPED".asInstanceOf[StatusType]
 
     val values = js.Object.freeze(js.Array(SUCCEEDED, FAILED, FAULT, TIMED_OUT, IN_PROGRESS, STOPPED))
   }
@@ -3183,13 +3182,14 @@ package codebuild {
       __obj.asInstanceOf[WebhookFilter]
     }
   }
-
-  object WebhookFilterTypeEnum {
-    val EVENT            = "EVENT"
-    val BASE_REF         = "BASE_REF"
-    val HEAD_REF         = "HEAD_REF"
-    val ACTOR_ACCOUNT_ID = "ACTOR_ACCOUNT_ID"
-    val FILE_PATH        = "FILE_PATH"
+  @js.native
+  sealed trait WebhookFilterType extends js.Any
+  object WebhookFilterType extends js.Object {
+    val EVENT            = "EVENT".asInstanceOf[WebhookFilterType]
+    val BASE_REF         = "BASE_REF".asInstanceOf[WebhookFilterType]
+    val HEAD_REF         = "HEAD_REF".asInstanceOf[WebhookFilterType]
+    val ACTOR_ACCOUNT_ID = "ACTOR_ACCOUNT_ID".asInstanceOf[WebhookFilterType]
+    val FILE_PATH        = "FILE_PATH".asInstanceOf[WebhookFilterType]
 
     val values = js.Object.freeze(js.Array(EVENT, BASE_REF, HEAD_REF, ACTOR_ACCOUNT_ID, FILE_PATH))
   }

--- a/services/codecommit/src/main/scala/facade/amazonaws/services/CodeCommit.scala
+++ b/services/codecommit/src/main/scala/facade/amazonaws/services/CodeCommit.scala
@@ -21,7 +21,6 @@ package object codecommit {
   type ApprovalRulesList               = js.Array[ApprovalRule]
   type ApprovalRulesNotSatisfiedList   = js.Array[ApprovalRuleName]
   type ApprovalRulesSatisfiedList      = js.Array[ApprovalRuleName]
-  type ApprovalState                   = String
   type Approved                        = Boolean
   type Arn                             = String
   type BatchAssociateApprovalRuleTemplateWithRepositoriesErrorsList =
@@ -33,7 +32,6 @@ package object codecommit {
   type BranchName                               = String
   type BranchNameList                           = js.Array[BranchName]
   type CapitalBoolean                           = Boolean
-  type ChangeTypeEnum                           = String
   type ClientRequestToken                       = String
   type CloneUrlHttp                             = String
   type CloneUrlSsh                              = String
@@ -45,9 +43,7 @@ package object codecommit {
   type CommitIdsInputList                       = js.Array[ObjectId]
   type CommitName                               = String
   type CommitObjectsList                        = js.Array[Commit]
-  type ConflictDetailLevelTypeEnum              = String
   type ConflictMetadataList                     = js.Array[ConflictMetadata]
-  type ConflictResolutionStrategyTypeEnum       = String
   type Conflicts                                = js.Array[Conflict]
   type Content                                  = String
   type CreationDate                             = js.Date
@@ -62,7 +58,6 @@ package object codecommit {
   type ExceptionName                            = String
   type FileContent                              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type FileList                                 = js.Array[File]
-  type FileModeTypeEnum                         = String
   type FilePaths                                = js.Array[Path]
   type FileSize                                 = Double
   type FilesMetadata                            = js.Array[FileMetadata]
@@ -82,7 +77,6 @@ package object codecommit {
   type LineNumber                               = Int
   type MaxResults                               = Int
   type MergeHunks                               = js.Array[MergeHunk]
-  type MergeOptionTypeEnum                      = String
   type MergeOptions                             = js.Array[MergeOptionTypeEnum]
   type Message                                  = String
   type Mode                                     = String
@@ -91,24 +85,17 @@ package object codecommit {
   type NumberOfConflicts                        = Int
   type ObjectId                                 = String
   type ObjectSize                               = Double
-  type ObjectTypeEnum                           = String
-  type OrderEnum                                = String
   type Overridden                               = Boolean
-  type OverrideStatus                           = String
   type ParentList                               = js.Array[ObjectId]
   type Path                                     = String
   type Position                                 = Double
   type PullRequestEventList                     = js.Array[PullRequestEvent]
-  type PullRequestEventType                     = String
   type PullRequestId                            = String
   type PullRequestIdList                        = js.Array[PullRequestId]
-  type PullRequestStatusEnum                    = String
   type PullRequestTargetList                    = js.Array[PullRequestTarget]
   type PutFileEntries                           = js.Array[PutFileEntry]
   type ReferenceName                            = String
-  type RelativeFileVersionEnum                  = String
   type ReplaceContentEntries                    = js.Array[ReplaceContentEntry]
-  type ReplacementTypeEnum                      = String
   type RepositoryDescription                    = String
   type RepositoryId                             = String
   type RepositoryMetadataList                   = js.Array[RepositoryMetadata]
@@ -117,7 +104,6 @@ package object codecommit {
   type RepositoryNameList                       = js.Array[RepositoryName]
   type RepositoryNotFoundList                   = js.Array[RepositoryName]
   type RepositoryTriggerCustomData              = String
-  type RepositoryTriggerEventEnum               = String
   type RepositoryTriggerEventList               = js.Array[RepositoryTriggerEventEnum]
   type RepositoryTriggerExecutionFailureList    = js.Array[RepositoryTriggerExecutionFailure]
   type RepositoryTriggerExecutionFailureMessage = String
@@ -129,7 +115,6 @@ package object codecommit {
   type RevisionId                               = String
   type RuleContentSha256                        = String
   type SetFileModeEntries                       = js.Array[SetFileModeEntry]
-  type SortByEnum                               = String
   type SubModuleList                            = js.Array[SubModule]
   type SymbolicLinkList                         = js.Array[SymbolicLink]
   type TagKey                                   = String
@@ -628,10 +613,11 @@ package codecommit {
       __obj.asInstanceOf[ApprovalRuleTemplate]
     }
   }
-
-  object ApprovalStateEnum {
-    val APPROVE = "APPROVE"
-    val REVOKE  = "REVOKE"
+  @js.native
+  sealed trait ApprovalState extends js.Any
+  object ApprovalState extends js.Object {
+    val APPROVE = "APPROVE".asInstanceOf[ApprovalState]
+    val REVOKE  = "REVOKE".asInstanceOf[ApprovalState]
 
     val values = js.Object.freeze(js.Array(APPROVE, REVOKE))
   }
@@ -1074,11 +1060,12 @@ package codecommit {
       __obj.asInstanceOf[BranchInfo]
     }
   }
-
-  object ChangeTypeEnumEnum {
-    val A = "A"
-    val M = "M"
-    val D = "D"
+  @js.native
+  sealed trait ChangeTypeEnum extends js.Any
+  object ChangeTypeEnum extends js.Object {
+    val A = "A".asInstanceOf[ChangeTypeEnum]
+    val M = "M".asInstanceOf[ChangeTypeEnum]
+    val D = "D".asInstanceOf[ChangeTypeEnum]
 
     val values = js.Object.freeze(js.Array(A, M, D))
   }
@@ -1258,10 +1245,11 @@ package codecommit {
       __obj.asInstanceOf[Conflict]
     }
   }
-
-  object ConflictDetailLevelTypeEnumEnum {
-    val FILE_LEVEL = "FILE_LEVEL"
-    val LINE_LEVEL = "LINE_LEVEL"
+  @js.native
+  sealed trait ConflictDetailLevelTypeEnum extends js.Any
+  object ConflictDetailLevelTypeEnum extends js.Object {
+    val FILE_LEVEL = "FILE_LEVEL".asInstanceOf[ConflictDetailLevelTypeEnum]
+    val LINE_LEVEL = "LINE_LEVEL".asInstanceOf[ConflictDetailLevelTypeEnum]
 
     val values = js.Object.freeze(js.Array(FILE_LEVEL, LINE_LEVEL))
   }
@@ -1336,12 +1324,13 @@ package codecommit {
       __obj.asInstanceOf[ConflictResolution]
     }
   }
-
-  object ConflictResolutionStrategyTypeEnumEnum {
-    val NONE               = "NONE"
-    val ACCEPT_SOURCE      = "ACCEPT_SOURCE"
-    val ACCEPT_DESTINATION = "ACCEPT_DESTINATION"
-    val AUTOMERGE          = "AUTOMERGE"
+  @js.native
+  sealed trait ConflictResolutionStrategyTypeEnum extends js.Any
+  object ConflictResolutionStrategyTypeEnum extends js.Object {
+    val NONE               = "NONE".asInstanceOf[ConflictResolutionStrategyTypeEnum]
+    val ACCEPT_SOURCE      = "ACCEPT_SOURCE".asInstanceOf[ConflictResolutionStrategyTypeEnum]
+    val ACCEPT_DESTINATION = "ACCEPT_DESTINATION".asInstanceOf[ConflictResolutionStrategyTypeEnum]
+    val AUTOMERGE          = "AUTOMERGE".asInstanceOf[ConflictResolutionStrategyTypeEnum]
 
     val values = js.Object.freeze(js.Array(NONE, ACCEPT_SOURCE, ACCEPT_DESTINATION, AUTOMERGE))
   }
@@ -2266,11 +2255,12 @@ package codecommit {
       __obj.asInstanceOf[FileMetadata]
     }
   }
-
-  object FileModeTypeEnumEnum {
-    val EXECUTABLE = "EXECUTABLE"
-    val NORMAL     = "NORMAL"
-    val SYMLINK    = "SYMLINK"
+  @js.native
+  sealed trait FileModeTypeEnum extends js.Any
+  object FileModeTypeEnum extends js.Object {
+    val EXECUTABLE = "EXECUTABLE".asInstanceOf[FileModeTypeEnum]
+    val NORMAL     = "NORMAL".asInstanceOf[FileModeTypeEnum]
+    val SYMLINK    = "SYMLINK".asInstanceOf[FileModeTypeEnum]
 
     val values = js.Object.freeze(js.Array(EXECUTABLE, NORMAL, SYMLINK))
   }
@@ -3862,11 +3852,12 @@ package codecommit {
       __obj.asInstanceOf[MergeOperations]
     }
   }
-
-  object MergeOptionTypeEnumEnum {
-    val FAST_FORWARD_MERGE = "FAST_FORWARD_MERGE"
-    val SQUASH_MERGE       = "SQUASH_MERGE"
-    val THREE_WAY_MERGE    = "THREE_WAY_MERGE"
+  @js.native
+  sealed trait MergeOptionTypeEnum extends js.Any
+  object MergeOptionTypeEnum extends js.Object {
+    val FAST_FORWARD_MERGE = "FAST_FORWARD_MERGE".asInstanceOf[MergeOptionTypeEnum]
+    val SQUASH_MERGE       = "SQUASH_MERGE".asInstanceOf[MergeOptionTypeEnum]
+    val THREE_WAY_MERGE    = "THREE_WAY_MERGE".asInstanceOf[MergeOptionTypeEnum]
 
     val values = js.Object.freeze(js.Array(FAST_FORWARD_MERGE, SQUASH_MERGE, THREE_WAY_MERGE))
   }
@@ -4036,12 +4027,13 @@ package codecommit {
       __obj.asInstanceOf[MergePullRequestByThreeWayOutput]
     }
   }
-
-  object ObjectTypeEnumEnum {
-    val FILE          = "FILE"
-    val DIRECTORY     = "DIRECTORY"
-    val GIT_LINK      = "GIT_LINK"
-    val SYMBOLIC_LINK = "SYMBOLIC_LINK"
+  @js.native
+  sealed trait ObjectTypeEnum extends js.Any
+  object ObjectTypeEnum extends js.Object {
+    val FILE          = "FILE".asInstanceOf[ObjectTypeEnum]
+    val DIRECTORY     = "DIRECTORY".asInstanceOf[ObjectTypeEnum]
+    val GIT_LINK      = "GIT_LINK".asInstanceOf[ObjectTypeEnum]
+    val SYMBOLIC_LINK = "SYMBOLIC_LINK".asInstanceOf[ObjectTypeEnum]
 
     val values = js.Object.freeze(js.Array(FILE, DIRECTORY, GIT_LINK, SYMBOLIC_LINK))
   }
@@ -4070,10 +4062,11 @@ package codecommit {
       __obj.asInstanceOf[ObjectTypes]
     }
   }
-
-  object OrderEnumEnum {
-    val ascending  = "ascending"
-    val descending = "descending"
+  @js.native
+  sealed trait OrderEnum extends js.Any
+  object OrderEnum extends js.Object {
+    val ascending  = "ascending".asInstanceOf[OrderEnum]
+    val descending = "descending".asInstanceOf[OrderEnum]
 
     val values = js.Object.freeze(js.Array(ascending, descending))
   }
@@ -4123,10 +4116,11 @@ package codecommit {
       __obj.asInstanceOf[OverridePullRequestApprovalRulesInput]
     }
   }
-
-  object OverrideStatusEnum {
-    val OVERRIDE = "OVERRIDE"
-    val REVOKE   = "REVOKE"
+  @js.native
+  sealed trait OverrideStatus extends js.Any
+  object OverrideStatus extends js.Object {
+    val OVERRIDE = "OVERRIDE".asInstanceOf[OverrideStatus]
+    val REVOKE   = "REVOKE".asInstanceOf[OverrideStatus]
 
     val values = js.Object.freeze(js.Array(OVERRIDE, REVOKE))
   }
@@ -4452,17 +4446,20 @@ package codecommit {
       __obj.asInstanceOf[PullRequestEvent]
     }
   }
-
-  object PullRequestEventTypeEnum {
-    val PULL_REQUEST_CREATED                  = "PULL_REQUEST_CREATED"
-    val PULL_REQUEST_STATUS_CHANGED           = "PULL_REQUEST_STATUS_CHANGED"
-    val PULL_REQUEST_SOURCE_REFERENCE_UPDATED = "PULL_REQUEST_SOURCE_REFERENCE_UPDATED"
-    val PULL_REQUEST_MERGE_STATE_CHANGED      = "PULL_REQUEST_MERGE_STATE_CHANGED"
-    val PULL_REQUEST_APPROVAL_RULE_CREATED    = "PULL_REQUEST_APPROVAL_RULE_CREATED"
-    val PULL_REQUEST_APPROVAL_RULE_UPDATED    = "PULL_REQUEST_APPROVAL_RULE_UPDATED"
-    val PULL_REQUEST_APPROVAL_RULE_DELETED    = "PULL_REQUEST_APPROVAL_RULE_DELETED"
-    val PULL_REQUEST_APPROVAL_RULE_OVERRIDDEN = "PULL_REQUEST_APPROVAL_RULE_OVERRIDDEN"
-    val PULL_REQUEST_APPROVAL_STATE_CHANGED   = "PULL_REQUEST_APPROVAL_STATE_CHANGED"
+  @js.native
+  sealed trait PullRequestEventType extends js.Any
+  object PullRequestEventType extends js.Object {
+    val PULL_REQUEST_CREATED        = "PULL_REQUEST_CREATED".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_STATUS_CHANGED = "PULL_REQUEST_STATUS_CHANGED".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_SOURCE_REFERENCE_UPDATED =
+      "PULL_REQUEST_SOURCE_REFERENCE_UPDATED".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_MERGE_STATE_CHANGED   = "PULL_REQUEST_MERGE_STATE_CHANGED".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_APPROVAL_RULE_CREATED = "PULL_REQUEST_APPROVAL_RULE_CREATED".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_APPROVAL_RULE_UPDATED = "PULL_REQUEST_APPROVAL_RULE_UPDATED".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_APPROVAL_RULE_DELETED = "PULL_REQUEST_APPROVAL_RULE_DELETED".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_APPROVAL_RULE_OVERRIDDEN =
+      "PULL_REQUEST_APPROVAL_RULE_OVERRIDDEN".asInstanceOf[PullRequestEventType]
+    val PULL_REQUEST_APPROVAL_STATE_CHANGED = "PULL_REQUEST_APPROVAL_STATE_CHANGED".asInstanceOf[PullRequestEventType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4550,10 +4547,11 @@ package codecommit {
       __obj.asInstanceOf[PullRequestStatusChangedEventMetadata]
     }
   }
-
-  object PullRequestStatusEnumEnum {
-    val OPEN   = "OPEN"
-    val CLOSED = "CLOSED"
+  @js.native
+  sealed trait PullRequestStatusEnum extends js.Any
+  object PullRequestStatusEnum extends js.Object {
+    val OPEN   = "OPEN".asInstanceOf[PullRequestStatusEnum]
+    val CLOSED = "CLOSED".asInstanceOf[PullRequestStatusEnum]
 
     val values = js.Object.freeze(js.Array(OPEN, CLOSED))
   }
@@ -4733,10 +4731,11 @@ package codecommit {
       __obj.asInstanceOf[PutRepositoryTriggersOutput]
     }
   }
-
-  object RelativeFileVersionEnumEnum {
-    val BEFORE = "BEFORE"
-    val AFTER  = "AFTER"
+  @js.native
+  sealed trait RelativeFileVersionEnum extends js.Any
+  object RelativeFileVersionEnum extends js.Object {
+    val BEFORE = "BEFORE".asInstanceOf[RelativeFileVersionEnum]
+    val AFTER  = "AFTER".asInstanceOf[RelativeFileVersionEnum]
 
     val values = js.Object.freeze(js.Array(BEFORE, AFTER))
   }
@@ -4770,12 +4769,13 @@ package codecommit {
       __obj.asInstanceOf[ReplaceContentEntry]
     }
   }
-
-  object ReplacementTypeEnumEnum {
-    val KEEP_BASE        = "KEEP_BASE"
-    val KEEP_SOURCE      = "KEEP_SOURCE"
-    val KEEP_DESTINATION = "KEEP_DESTINATION"
-    val USE_NEW_CONTENT  = "USE_NEW_CONTENT"
+  @js.native
+  sealed trait ReplacementTypeEnum extends js.Any
+  object ReplacementTypeEnum extends js.Object {
+    val KEEP_BASE        = "KEEP_BASE".asInstanceOf[ReplacementTypeEnum]
+    val KEEP_SOURCE      = "KEEP_SOURCE".asInstanceOf[ReplacementTypeEnum]
+    val KEEP_DESTINATION = "KEEP_DESTINATION".asInstanceOf[ReplacementTypeEnum]
+    val USE_NEW_CONTENT  = "USE_NEW_CONTENT".asInstanceOf[ReplacementTypeEnum]
 
     val values = js.Object.freeze(js.Array(KEEP_BASE, KEEP_SOURCE, KEEP_DESTINATION, USE_NEW_CONTENT))
   }
@@ -4880,12 +4880,13 @@ package codecommit {
       __obj.asInstanceOf[RepositoryTrigger]
     }
   }
-
-  object RepositoryTriggerEventEnumEnum {
-    val all             = "all"
-    val updateReference = "updateReference"
-    val createReference = "createReference"
-    val deleteReference = "deleteReference"
+  @js.native
+  sealed trait RepositoryTriggerEventEnum extends js.Any
+  object RepositoryTriggerEventEnum extends js.Object {
+    val all             = "all".asInstanceOf[RepositoryTriggerEventEnum]
+    val updateReference = "updateReference".asInstanceOf[RepositoryTriggerEventEnum]
+    val createReference = "createReference".asInstanceOf[RepositoryTriggerEventEnum]
+    val deleteReference = "deleteReference".asInstanceOf[RepositoryTriggerEventEnum]
 
     val values = js.Object.freeze(js.Array(all, updateReference, createReference, deleteReference))
   }
@@ -4935,10 +4936,11 @@ package codecommit {
       __obj.asInstanceOf[SetFileModeEntry]
     }
   }
-
-  object SortByEnumEnum {
-    val repositoryName   = "repositoryName"
-    val lastModifiedDate = "lastModifiedDate"
+  @js.native
+  sealed trait SortByEnum extends js.Any
+  object SortByEnum extends js.Object {
+    val repositoryName   = "repositoryName".asInstanceOf[SortByEnum]
+    val lastModifiedDate = "lastModifiedDate".asInstanceOf[SortByEnum]
 
     val values = js.Object.freeze(js.Array(repositoryName, lastModifiedDate))
   }

--- a/services/codedeploy/src/main/scala/facade/amazonaws/services/CodeDeploy.scala
+++ b/services/codedeploy/src/main/scala/facade/amazonaws/services/CodeDeploy.scala
@@ -13,43 +13,31 @@ package object codedeploy {
   type AlarmName                      = String
   type ApplicationId                  = String
   type ApplicationName                = String
-  type ApplicationRevisionSortBy      = String
   type ApplicationsInfoList           = js.Array[ApplicationInfo]
   type ApplicationsList               = js.Array[ApplicationName]
   type Arn                            = String
-  type AutoRollbackEvent              = String
   type AutoRollbackEventsList         = js.Array[AutoRollbackEvent]
   type AutoScalingGroupHook           = String
   type AutoScalingGroupList           = js.Array[AutoScalingGroup]
   type AutoScalingGroupName           = String
   type AutoScalingGroupNameList       = js.Array[AutoScalingGroupName]
-  type BundleType                     = String
   type CommitId                       = String
-  type ComputePlatform                = String
   type DeploymentConfigId             = String
   type DeploymentConfigName           = String
   type DeploymentConfigsList          = js.Array[DeploymentConfigName]
-  type DeploymentCreator              = String
   type DeploymentGroupId              = String
   type DeploymentGroupInfoList        = js.Array[DeploymentGroupInfo]
   type DeploymentGroupName            = String
   type DeploymentGroupsList           = js.Array[DeploymentGroupName]
   type DeploymentId                   = String
-  type DeploymentOption               = String
-  type DeploymentReadyAction          = String
-  type DeploymentStatus               = String
   type DeploymentStatusList           = js.Array[DeploymentStatus]
   type DeploymentStatusMessageList    = js.Array[ErrorMessage]
   type DeploymentTargetList           = js.Array[DeploymentTarget]
-  type DeploymentTargetType           = String
-  type DeploymentType                 = String
-  type DeploymentWaitType             = String
   type DeploymentsInfoList            = js.Array[DeploymentInfo]
   type DeploymentsList                = js.Array[DeploymentId]
   type Description                    = String
   type Duration                       = Int
   type EC2TagFilterList               = js.Array[EC2TagFilter]
-  type EC2TagFilterType               = String
   type EC2TagSetList                  = js.Array[EC2TagFilterList]
   type ECSClusterName                 = String
   type ECSServiceList                 = js.Array[ECSService]
@@ -61,90 +49,69 @@ package object codedeploy {
   type ELBInfoList                    = js.Array[ELBInfo]
   type ELBName                        = String
   type ETag                           = String
-  type ErrorCode                      = String
   type ErrorMessage                   = String
-  type FileExistsBehavior             = String
   type FilterValue                    = String
   type FilterValueList                = js.Array[FilterValue]
   type GitHubAccountTokenName         = String
   type GitHubAccountTokenNameList     = js.Array[GitHubAccountTokenName]
-  type GreenFleetProvisioningAction   = String
   type IamSessionArn                  = String
   type IamUserArn                     = String
-  type InstanceAction                 = String
   type InstanceArn                    = String
   type InstanceCount                  = Double
   type InstanceId                     = String
   type InstanceInfoList               = js.Array[InstanceInfo]
   type InstanceName                   = String
   type InstanceNameList               = js.Array[InstanceName]
-  @deprecated("InstanceStatus is deprecated, use TargetStatus instead.", "forever")
-  type InstanceStatus                = String
-  type InstanceStatusList            = js.Array[InstanceStatus]
-  type InstanceSummaryList           = js.Array[InstanceSummary]
-  type InstanceType                  = String
-  type InstanceTypeList              = js.Array[InstanceType]
-  type InstancesList                 = js.Array[InstanceId]
-  type Key                           = String
-  type LambdaFunctionAlias           = String
-  type LambdaFunctionName            = String
-  type LifecycleErrorCode            = String
-  type LifecycleEventHookExecutionId = String
-  type LifecycleEventList            = js.Array[LifecycleEvent]
-  type LifecycleEventName            = String
-  type LifecycleEventStatus          = String
-  type LifecycleMessage              = String
-  type ListStateFilterAction         = String
-  type ListenerArn                   = String
-  type ListenerArnList               = js.Array[ListenerArn]
-  type LogTail                       = String
-  type Message                       = String
-  type MinimumHealthyHostsType       = String
-  type MinimumHealthyHostsValue      = Int
-  type NextToken                     = String
-  type NullableBoolean               = Boolean
-  type OnPremisesTagSetList          = js.Array[TagFilterList]
-  type Percentage                    = Int
-  type RawStringContent              = String
-  type RawStringSha256               = String
-  type RegistrationStatus            = String
-  type Repository                    = String
-  type RevisionInfoList              = js.Array[RevisionInfo]
-  type RevisionLocationList          = js.Array[RevisionLocation]
-  type RevisionLocationType          = String
-  type Role                          = String
-  type S3Bucket                      = String
-  type S3Key                         = String
-  type ScriptName                    = String
-  type SortOrder                     = String
-  type StopStatus                    = String
-  type TagFilterList                 = js.Array[TagFilter]
-  type TagFilterType                 = String
-  type TagKeyList                    = js.Array[Key]
-  type TagList                       = js.Array[Tag]
-  type TargetArn                     = String
-  type TargetFilterName              = String
-  type TargetFilters                 = js.Dictionary[FilterValueList]
-  type TargetGroupInfoList           = js.Array[TargetGroupInfo]
-  type TargetGroupName               = String
-  type TargetGroupPairInfoList       = js.Array[TargetGroupPairInfo]
-  type TargetId                      = String
-  type TargetIdList                  = js.Array[TargetId]
-  type TargetLabel                   = String
-  type TargetStatus                  = String
-  type Time                          = js.Date
-  type Timestamp                     = js.Date
-  type TrafficRoutingType            = String
-  type TrafficWeight                 = Double
-  type TriggerConfigList             = js.Array[TriggerConfig]
-  type TriggerEventType              = String
-  type TriggerEventTypeList          = js.Array[TriggerEventType]
-  type TriggerName                   = String
-  type TriggerTargetArn              = String
-  type Value                         = String
-  type Version                       = String
-  type VersionId                     = String
-  type WaitTimeInMins                = Int
+  type InstanceStatusList             = js.Array[InstanceStatus]
+  type InstanceSummaryList            = js.Array[InstanceSummary]
+  type InstanceTypeList               = js.Array[InstanceType]
+  type InstancesList                  = js.Array[InstanceId]
+  type Key                            = String
+  type LambdaFunctionAlias            = String
+  type LambdaFunctionName             = String
+  type LifecycleEventHookExecutionId  = String
+  type LifecycleEventList             = js.Array[LifecycleEvent]
+  type LifecycleEventName             = String
+  type LifecycleMessage               = String
+  type ListenerArn                    = String
+  type ListenerArnList                = js.Array[ListenerArn]
+  type LogTail                        = String
+  type Message                        = String
+  type MinimumHealthyHostsValue       = Int
+  type NextToken                      = String
+  type NullableBoolean                = Boolean
+  type OnPremisesTagSetList           = js.Array[TagFilterList]
+  type Percentage                     = Int
+  type RawStringContent               = String
+  type RawStringSha256                = String
+  type Repository                     = String
+  type RevisionInfoList               = js.Array[RevisionInfo]
+  type RevisionLocationList           = js.Array[RevisionLocation]
+  type Role                           = String
+  type S3Bucket                       = String
+  type S3Key                          = String
+  type ScriptName                     = String
+  type TagFilterList                  = js.Array[TagFilter]
+  type TagKeyList                     = js.Array[Key]
+  type TagList                        = js.Array[Tag]
+  type TargetArn                      = String
+  type TargetFilters                  = js.Dictionary[FilterValueList]
+  type TargetGroupInfoList            = js.Array[TargetGroupInfo]
+  type TargetGroupName                = String
+  type TargetGroupPairInfoList        = js.Array[TargetGroupPairInfo]
+  type TargetId                       = String
+  type TargetIdList                   = js.Array[TargetId]
+  type Time                           = js.Date
+  type Timestamp                      = js.Date
+  type TrafficWeight                  = Double
+  type TriggerConfigList              = js.Array[TriggerConfig]
+  type TriggerEventTypeList           = js.Array[TriggerEventType]
+  type TriggerName                    = String
+  type TriggerTargetArn               = String
+  type Value                          = String
+  type Version                        = String
+  type VersionId                      = String
+  type WaitTimeInMins                 = Int
 
   implicit final class CodeDeployOps(private val service: CodeDeploy) extends AnyVal {
 
@@ -447,11 +414,12 @@ package codedeploy {
       __obj.asInstanceOf[ApplicationInfo]
     }
   }
-
-  object ApplicationRevisionSortByEnum {
-    val registerTime  = "registerTime"
-    val firstUsedTime = "firstUsedTime"
-    val lastUsedTime  = "lastUsedTime"
+  @js.native
+  sealed trait ApplicationRevisionSortBy extends js.Any
+  object ApplicationRevisionSortBy extends js.Object {
+    val registerTime  = "registerTime".asInstanceOf[ApplicationRevisionSortBy]
+    val firstUsedTime = "firstUsedTime".asInstanceOf[ApplicationRevisionSortBy]
+    val lastUsedTime  = "lastUsedTime".asInstanceOf[ApplicationRevisionSortBy]
 
     val values = js.Object.freeze(js.Array(registerTime, firstUsedTime, lastUsedTime))
   }
@@ -477,11 +445,12 @@ package codedeploy {
       __obj.asInstanceOf[AutoRollbackConfiguration]
     }
   }
-
-  object AutoRollbackEventEnum {
-    val DEPLOYMENT_FAILURE         = "DEPLOYMENT_FAILURE"
-    val DEPLOYMENT_STOP_ON_ALARM   = "DEPLOYMENT_STOP_ON_ALARM"
-    val DEPLOYMENT_STOP_ON_REQUEST = "DEPLOYMENT_STOP_ON_REQUEST"
+  @js.native
+  sealed trait AutoRollbackEvent extends js.Any
+  object AutoRollbackEvent extends js.Object {
+    val DEPLOYMENT_FAILURE         = "DEPLOYMENT_FAILURE".asInstanceOf[AutoRollbackEvent]
+    val DEPLOYMENT_STOP_ON_ALARM   = "DEPLOYMENT_STOP_ON_ALARM".asInstanceOf[AutoRollbackEvent]
+    val DEPLOYMENT_STOP_ON_REQUEST = "DEPLOYMENT_STOP_ON_REQUEST".asInstanceOf[AutoRollbackEvent]
 
     val values = js.Object.freeze(js.Array(DEPLOYMENT_FAILURE, DEPLOYMENT_STOP_ON_ALARM, DEPLOYMENT_STOP_ON_REQUEST))
   }
@@ -856,21 +825,23 @@ package codedeploy {
       __obj.asInstanceOf[BlueInstanceTerminationOption]
     }
   }
-
-  object BundleTypeEnum {
-    val tar  = "tar"
-    val tgz  = "tgz"
-    val zip  = "zip"
-    val YAML = "YAML"
-    val JSON = "JSON"
+  @js.native
+  sealed trait BundleType extends js.Any
+  object BundleType extends js.Object {
+    val tar  = "tar".asInstanceOf[BundleType]
+    val tgz  = "tgz".asInstanceOf[BundleType]
+    val zip  = "zip".asInstanceOf[BundleType]
+    val YAML = "YAML".asInstanceOf[BundleType]
+    val JSON = "JSON".asInstanceOf[BundleType]
 
     val values = js.Object.freeze(js.Array(tar, tgz, zip, YAML, JSON))
   }
-
-  object ComputePlatformEnum {
-    val Server = "Server"
-    val Lambda = "Lambda"
-    val ECS    = "ECS"
+  @js.native
+  sealed trait ComputePlatform extends js.Any
+  object ComputePlatform extends js.Object {
+    val Server = "Server".asInstanceOf[ComputePlatform]
+    val Lambda = "Lambda".asInstanceOf[ComputePlatform]
+    val ECS    = "ECS".asInstanceOf[ComputePlatform]
 
     val values = js.Object.freeze(js.Array(Server, Lambda, ECS))
   }
@@ -1312,11 +1283,12 @@ package codedeploy {
       __obj.asInstanceOf[DeploymentConfigInfo]
     }
   }
-
-  object DeploymentCreatorEnum {
-    val user               = "user"
-    val autoscaling        = "autoscaling"
-    val codeDeployRollback = "codeDeployRollback"
+  @js.native
+  sealed trait DeploymentCreator extends js.Any
+  object DeploymentCreator extends js.Object {
+    val user               = "user".asInstanceOf[DeploymentCreator]
+    val autoscaling        = "autoscaling".asInstanceOf[DeploymentCreator]
+    val codeDeployRollback = "codeDeployRollback".asInstanceOf[DeploymentCreator]
 
     val values = js.Object.freeze(js.Array(user, autoscaling, codeDeployRollback))
   }
@@ -1514,10 +1486,11 @@ package codedeploy {
       __obj.asInstanceOf[DeploymentInfo]
     }
   }
-
-  object DeploymentOptionEnum {
-    val WITH_TRAFFIC_CONTROL    = "WITH_TRAFFIC_CONTROL"
-    val WITHOUT_TRAFFIC_CONTROL = "WITHOUT_TRAFFIC_CONTROL"
+  @js.native
+  sealed trait DeploymentOption extends js.Any
+  object DeploymentOption extends js.Object {
+    val WITH_TRAFFIC_CONTROL    = "WITH_TRAFFIC_CONTROL".asInstanceOf[DeploymentOption]
+    val WITHOUT_TRAFFIC_CONTROL = "WITHOUT_TRAFFIC_CONTROL".asInstanceOf[DeploymentOption]
 
     val values = js.Object.freeze(js.Array(WITH_TRAFFIC_CONTROL, WITHOUT_TRAFFIC_CONTROL))
   }
@@ -1555,10 +1528,11 @@ package codedeploy {
       __obj.asInstanceOf[DeploymentOverview]
     }
   }
-
-  object DeploymentReadyActionEnum {
-    val CONTINUE_DEPLOYMENT = "CONTINUE_DEPLOYMENT"
-    val STOP_DEPLOYMENT     = "STOP_DEPLOYMENT"
+  @js.native
+  sealed trait DeploymentReadyAction extends js.Any
+  object DeploymentReadyAction extends js.Object {
+    val CONTINUE_DEPLOYMENT = "CONTINUE_DEPLOYMENT".asInstanceOf[DeploymentReadyAction]
+    val STOP_DEPLOYMENT     = "STOP_DEPLOYMENT".asInstanceOf[DeploymentReadyAction]
 
     val values = js.Object.freeze(js.Array(CONTINUE_DEPLOYMENT, STOP_DEPLOYMENT))
   }
@@ -1584,15 +1558,16 @@ package codedeploy {
       __obj.asInstanceOf[DeploymentReadyOption]
     }
   }
-
-  object DeploymentStatusEnum {
-    val Created    = "Created"
-    val Queued     = "Queued"
-    val InProgress = "InProgress"
-    val Succeeded  = "Succeeded"
-    val Failed     = "Failed"
-    val Stopped    = "Stopped"
-    val Ready      = "Ready"
+  @js.native
+  sealed trait DeploymentStatus extends js.Any
+  object DeploymentStatus extends js.Object {
+    val Created    = "Created".asInstanceOf[DeploymentStatus]
+    val Queued     = "Queued".asInstanceOf[DeploymentStatus]
+    val InProgress = "InProgress".asInstanceOf[DeploymentStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[DeploymentStatus]
+    val Failed     = "Failed".asInstanceOf[DeploymentStatus]
+    val Stopped    = "Stopped".asInstanceOf[DeploymentStatus]
+    val Ready      = "Ready".asInstanceOf[DeploymentStatus]
 
     val values = js.Object.freeze(js.Array(Created, Queued, InProgress, Succeeded, Failed, Stopped, Ready))
   }
@@ -1646,25 +1621,28 @@ package codedeploy {
       __obj.asInstanceOf[DeploymentTarget]
     }
   }
-
-  object DeploymentTargetTypeEnum {
-    val InstanceTarget = "InstanceTarget"
-    val LambdaTarget   = "LambdaTarget"
-    val ECSTarget      = "ECSTarget"
+  @js.native
+  sealed trait DeploymentTargetType extends js.Any
+  object DeploymentTargetType extends js.Object {
+    val InstanceTarget = "InstanceTarget".asInstanceOf[DeploymentTargetType]
+    val LambdaTarget   = "LambdaTarget".asInstanceOf[DeploymentTargetType]
+    val ECSTarget      = "ECSTarget".asInstanceOf[DeploymentTargetType]
 
     val values = js.Object.freeze(js.Array(InstanceTarget, LambdaTarget, ECSTarget))
   }
-
-  object DeploymentTypeEnum {
-    val IN_PLACE   = "IN_PLACE"
-    val BLUE_GREEN = "BLUE_GREEN"
+  @js.native
+  sealed trait DeploymentType extends js.Any
+  object DeploymentType extends js.Object {
+    val IN_PLACE   = "IN_PLACE".asInstanceOf[DeploymentType]
+    val BLUE_GREEN = "BLUE_GREEN".asInstanceOf[DeploymentType]
 
     val values = js.Object.freeze(js.Array(IN_PLACE, BLUE_GREEN))
   }
-
-  object DeploymentWaitTypeEnum {
-    val READY_WAIT       = "READY_WAIT"
-    val TERMINATION_WAIT = "TERMINATION_WAIT"
+  @js.native
+  sealed trait DeploymentWaitType extends js.Any
+  object DeploymentWaitType extends js.Object {
+    val READY_WAIT       = "READY_WAIT".asInstanceOf[DeploymentWaitType]
+    val TERMINATION_WAIT = "TERMINATION_WAIT".asInstanceOf[DeploymentWaitType]
 
     val values = js.Object.freeze(js.Array(READY_WAIT, TERMINATION_WAIT))
   }
@@ -1742,11 +1720,12 @@ package codedeploy {
       __obj.asInstanceOf[EC2TagFilter]
     }
   }
-
-  object EC2TagFilterTypeEnum {
-    val KEY_ONLY      = "KEY_ONLY"
-    val VALUE_ONLY    = "VALUE_ONLY"
-    val KEY_AND_VALUE = "KEY_AND_VALUE"
+  @js.native
+  sealed trait EC2TagFilterType extends js.Any
+  object EC2TagFilterType extends js.Object {
+    val KEY_ONLY      = "KEY_ONLY".asInstanceOf[EC2TagFilterType]
+    val VALUE_ONLY    = "VALUE_ONLY".asInstanceOf[EC2TagFilterType]
+    val KEY_AND_VALUE = "KEY_AND_VALUE".asInstanceOf[EC2TagFilterType]
 
     val values = js.Object.freeze(js.Array(KEY_ONLY, VALUE_ONLY, KEY_AND_VALUE))
   }
@@ -1887,41 +1866,43 @@ package codedeploy {
       __obj.asInstanceOf[ELBInfo]
     }
   }
-
-  object ErrorCodeEnum {
-    val AGENT_ISSUE                                 = "AGENT_ISSUE"
-    val ALARM_ACTIVE                                = "ALARM_ACTIVE"
-    val APPLICATION_MISSING                         = "APPLICATION_MISSING"
-    val AUTOSCALING_VALIDATION_ERROR                = "AUTOSCALING_VALIDATION_ERROR"
-    val AUTO_SCALING_CONFIGURATION                  = "AUTO_SCALING_CONFIGURATION"
-    val AUTO_SCALING_IAM_ROLE_PERMISSIONS           = "AUTO_SCALING_IAM_ROLE_PERMISSIONS"
-    val CODEDEPLOY_RESOURCE_CANNOT_BE_FOUND         = "CODEDEPLOY_RESOURCE_CANNOT_BE_FOUND"
-    val CUSTOMER_APPLICATION_UNHEALTHY              = "CUSTOMER_APPLICATION_UNHEALTHY"
-    val DEPLOYMENT_GROUP_MISSING                    = "DEPLOYMENT_GROUP_MISSING"
-    val ECS_UPDATE_ERROR                            = "ECS_UPDATE_ERROR"
-    val ELASTIC_LOAD_BALANCING_INVALID              = "ELASTIC_LOAD_BALANCING_INVALID"
-    val ELB_INVALID_INSTANCE                        = "ELB_INVALID_INSTANCE"
-    val HEALTH_CONSTRAINTS                          = "HEALTH_CONSTRAINTS"
-    val HEALTH_CONSTRAINTS_INVALID                  = "HEALTH_CONSTRAINTS_INVALID"
-    val HOOK_EXECUTION_FAILURE                      = "HOOK_EXECUTION_FAILURE"
-    val IAM_ROLE_MISSING                            = "IAM_ROLE_MISSING"
-    val IAM_ROLE_PERMISSIONS                        = "IAM_ROLE_PERMISSIONS"
-    val INTERNAL_ERROR                              = "INTERNAL_ERROR"
-    val INVALID_ECS_SERVICE                         = "INVALID_ECS_SERVICE"
-    val INVALID_LAMBDA_CONFIGURATION                = "INVALID_LAMBDA_CONFIGURATION"
-    val INVALID_LAMBDA_FUNCTION                     = "INVALID_LAMBDA_FUNCTION"
-    val INVALID_REVISION                            = "INVALID_REVISION"
-    val MANUAL_STOP                                 = "MANUAL_STOP"
-    val MISSING_BLUE_GREEN_DEPLOYMENT_CONFIGURATION = "MISSING_BLUE_GREEN_DEPLOYMENT_CONFIGURATION"
-    val MISSING_ELB_INFORMATION                     = "MISSING_ELB_INFORMATION"
-    val MISSING_GITHUB_TOKEN                        = "MISSING_GITHUB_TOKEN"
-    val NO_EC2_SUBSCRIPTION                         = "NO_EC2_SUBSCRIPTION"
-    val NO_INSTANCES                                = "NO_INSTANCES"
-    val OVER_MAX_INSTANCES                          = "OVER_MAX_INSTANCES"
-    val RESOURCE_LIMIT_EXCEEDED                     = "RESOURCE_LIMIT_EXCEEDED"
-    val REVISION_MISSING                            = "REVISION_MISSING"
-    val THROTTLED                                   = "THROTTLED"
-    val TIMEOUT                                     = "TIMEOUT"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val AGENT_ISSUE                         = "AGENT_ISSUE".asInstanceOf[ErrorCode]
+    val ALARM_ACTIVE                        = "ALARM_ACTIVE".asInstanceOf[ErrorCode]
+    val APPLICATION_MISSING                 = "APPLICATION_MISSING".asInstanceOf[ErrorCode]
+    val AUTOSCALING_VALIDATION_ERROR        = "AUTOSCALING_VALIDATION_ERROR".asInstanceOf[ErrorCode]
+    val AUTO_SCALING_CONFIGURATION          = "AUTO_SCALING_CONFIGURATION".asInstanceOf[ErrorCode]
+    val AUTO_SCALING_IAM_ROLE_PERMISSIONS   = "AUTO_SCALING_IAM_ROLE_PERMISSIONS".asInstanceOf[ErrorCode]
+    val CODEDEPLOY_RESOURCE_CANNOT_BE_FOUND = "CODEDEPLOY_RESOURCE_CANNOT_BE_FOUND".asInstanceOf[ErrorCode]
+    val CUSTOMER_APPLICATION_UNHEALTHY      = "CUSTOMER_APPLICATION_UNHEALTHY".asInstanceOf[ErrorCode]
+    val DEPLOYMENT_GROUP_MISSING            = "DEPLOYMENT_GROUP_MISSING".asInstanceOf[ErrorCode]
+    val ECS_UPDATE_ERROR                    = "ECS_UPDATE_ERROR".asInstanceOf[ErrorCode]
+    val ELASTIC_LOAD_BALANCING_INVALID      = "ELASTIC_LOAD_BALANCING_INVALID".asInstanceOf[ErrorCode]
+    val ELB_INVALID_INSTANCE                = "ELB_INVALID_INSTANCE".asInstanceOf[ErrorCode]
+    val HEALTH_CONSTRAINTS                  = "HEALTH_CONSTRAINTS".asInstanceOf[ErrorCode]
+    val HEALTH_CONSTRAINTS_INVALID          = "HEALTH_CONSTRAINTS_INVALID".asInstanceOf[ErrorCode]
+    val HOOK_EXECUTION_FAILURE              = "HOOK_EXECUTION_FAILURE".asInstanceOf[ErrorCode]
+    val IAM_ROLE_MISSING                    = "IAM_ROLE_MISSING".asInstanceOf[ErrorCode]
+    val IAM_ROLE_PERMISSIONS                = "IAM_ROLE_PERMISSIONS".asInstanceOf[ErrorCode]
+    val INTERNAL_ERROR                      = "INTERNAL_ERROR".asInstanceOf[ErrorCode]
+    val INVALID_ECS_SERVICE                 = "INVALID_ECS_SERVICE".asInstanceOf[ErrorCode]
+    val INVALID_LAMBDA_CONFIGURATION        = "INVALID_LAMBDA_CONFIGURATION".asInstanceOf[ErrorCode]
+    val INVALID_LAMBDA_FUNCTION             = "INVALID_LAMBDA_FUNCTION".asInstanceOf[ErrorCode]
+    val INVALID_REVISION                    = "INVALID_REVISION".asInstanceOf[ErrorCode]
+    val MANUAL_STOP                         = "MANUAL_STOP".asInstanceOf[ErrorCode]
+    val MISSING_BLUE_GREEN_DEPLOYMENT_CONFIGURATION =
+      "MISSING_BLUE_GREEN_DEPLOYMENT_CONFIGURATION".asInstanceOf[ErrorCode]
+    val MISSING_ELB_INFORMATION = "MISSING_ELB_INFORMATION".asInstanceOf[ErrorCode]
+    val MISSING_GITHUB_TOKEN    = "MISSING_GITHUB_TOKEN".asInstanceOf[ErrorCode]
+    val NO_EC2_SUBSCRIPTION     = "NO_EC2_SUBSCRIPTION".asInstanceOf[ErrorCode]
+    val NO_INSTANCES            = "NO_INSTANCES".asInstanceOf[ErrorCode]
+    val OVER_MAX_INSTANCES      = "OVER_MAX_INSTANCES".asInstanceOf[ErrorCode]
+    val RESOURCE_LIMIT_EXCEEDED = "RESOURCE_LIMIT_EXCEEDED".asInstanceOf[ErrorCode]
+    val REVISION_MISSING        = "REVISION_MISSING".asInstanceOf[ErrorCode]
+    val THROTTLED               = "THROTTLED".asInstanceOf[ErrorCode]
+    val TIMEOUT                 = "TIMEOUT".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1983,11 +1964,12 @@ package codedeploy {
       __obj.asInstanceOf[ErrorInformation]
     }
   }
-
-  object FileExistsBehaviorEnum {
-    val DISALLOW  = "DISALLOW"
-    val OVERWRITE = "OVERWRITE"
-    val RETAIN    = "RETAIN"
+  @js.native
+  sealed trait FileExistsBehavior extends js.Any
+  object FileExistsBehavior extends js.Object {
+    val DISALLOW  = "DISALLOW".asInstanceOf[FileExistsBehavior]
+    val OVERWRITE = "OVERWRITE".asInstanceOf[FileExistsBehavior]
+    val RETAIN    = "RETAIN".asInstanceOf[FileExistsBehavior]
 
     val values = js.Object.freeze(js.Array(DISALLOW, OVERWRITE, RETAIN))
   }
@@ -2374,10 +2356,11 @@ package codedeploy {
       __obj.asInstanceOf[GitHubLocation]
     }
   }
-
-  object GreenFleetProvisioningActionEnum {
-    val DISCOVER_EXISTING       = "DISCOVER_EXISTING"
-    val COPY_AUTO_SCALING_GROUP = "COPY_AUTO_SCALING_GROUP"
+  @js.native
+  sealed trait GreenFleetProvisioningAction extends js.Any
+  object GreenFleetProvisioningAction extends js.Object {
+    val DISCOVER_EXISTING       = "DISCOVER_EXISTING".asInstanceOf[GreenFleetProvisioningAction]
+    val COPY_AUTO_SCALING_GROUP = "COPY_AUTO_SCALING_GROUP".asInstanceOf[GreenFleetProvisioningAction]
 
     val values = js.Object.freeze(js.Array(DISCOVER_EXISTING, COPY_AUTO_SCALING_GROUP))
   }
@@ -2400,10 +2383,11 @@ package codedeploy {
       __obj.asInstanceOf[GreenFleetProvisioningOption]
     }
   }
-
-  object InstanceActionEnum {
-    val TERMINATE  = "TERMINATE"
-    val KEEP_ALIVE = "KEEP_ALIVE"
+  @js.native
+  sealed trait InstanceAction extends js.Any
+  object InstanceAction extends js.Object {
+    val TERMINATE  = "TERMINATE".asInstanceOf[InstanceAction]
+    val KEEP_ALIVE = "KEEP_ALIVE".asInstanceOf[InstanceAction]
 
     val values = js.Object.freeze(js.Array(TERMINATE, KEEP_ALIVE))
   }
@@ -2446,14 +2430,16 @@ package codedeploy {
   }
 
   @deprecated("InstanceStatus is deprecated, use TargetStatus instead.", "forever")
-  object InstanceStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Succeeded  = "Succeeded"
-    val Failed     = "Failed"
-    val Skipped    = "Skipped"
-    val Unknown    = "Unknown"
-    val Ready      = "Ready"
+  @js.native
+  sealed trait InstanceStatus extends js.Any
+  object InstanceStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[InstanceStatus]
+    val InProgress = "InProgress".asInstanceOf[InstanceStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[InstanceStatus]
+    val Failed     = "Failed".asInstanceOf[InstanceStatus]
+    val Skipped    = "Skipped".asInstanceOf[InstanceStatus]
+    val Unknown    = "Unknown".asInstanceOf[InstanceStatus]
+    val Ready      = "Ready".asInstanceOf[InstanceStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Succeeded, Failed, Skipped, Unknown, Ready))
   }
@@ -2529,10 +2515,11 @@ package codedeploy {
       __obj.asInstanceOf[InstanceTarget]
     }
   }
-
-  object InstanceTypeEnum {
-    val Blue  = "Blue"
-    val Green = "Green"
+  @js.native
+  sealed trait InstanceType extends js.Any
+  object InstanceType extends js.Object {
+    val Blue  = "Blue".asInstanceOf[InstanceType]
+    val Green = "Green".asInstanceOf[InstanceType]
 
     val values = js.Object.freeze(js.Array(Blue, Green))
   }
@@ -2632,14 +2619,15 @@ package codedeploy {
       __obj.asInstanceOf[LastDeploymentInfo]
     }
   }
-
-  object LifecycleErrorCodeEnum {
-    val Success             = "Success"
-    val ScriptMissing       = "ScriptMissing"
-    val ScriptNotExecutable = "ScriptNotExecutable"
-    val ScriptTimedOut      = "ScriptTimedOut"
-    val ScriptFailed        = "ScriptFailed"
-    val UnknownError        = "UnknownError"
+  @js.native
+  sealed trait LifecycleErrorCode extends js.Any
+  object LifecycleErrorCode extends js.Object {
+    val Success             = "Success".asInstanceOf[LifecycleErrorCode]
+    val ScriptMissing       = "ScriptMissing".asInstanceOf[LifecycleErrorCode]
+    val ScriptNotExecutable = "ScriptNotExecutable".asInstanceOf[LifecycleErrorCode]
+    val ScriptTimedOut      = "ScriptTimedOut".asInstanceOf[LifecycleErrorCode]
+    val ScriptFailed        = "ScriptFailed".asInstanceOf[LifecycleErrorCode]
+    val UnknownError        = "UnknownError".asInstanceOf[LifecycleErrorCode]
 
     val values = js.Object.freeze(
       js.Array(Success, ScriptMissing, ScriptNotExecutable, ScriptTimedOut, ScriptFailed, UnknownError)
@@ -2676,14 +2664,15 @@ package codedeploy {
       __obj.asInstanceOf[LifecycleEvent]
     }
   }
-
-  object LifecycleEventStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Succeeded  = "Succeeded"
-    val Failed     = "Failed"
-    val Skipped    = "Skipped"
-    val Unknown    = "Unknown"
+  @js.native
+  sealed trait LifecycleEventStatus extends js.Any
+  object LifecycleEventStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[LifecycleEventStatus]
+    val InProgress = "InProgress".asInstanceOf[LifecycleEventStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[LifecycleEventStatus]
+    val Failed     = "Failed".asInstanceOf[LifecycleEventStatus]
+    val Skipped    = "Skipped".asInstanceOf[LifecycleEventStatus]
+    val Unknown    = "Unknown".asInstanceOf[LifecycleEventStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Succeeded, Failed, Skipped, Unknown))
   }
@@ -3113,11 +3102,12 @@ package codedeploy {
       __obj.asInstanceOf[ListOnPremisesInstancesOutput]
     }
   }
-
-  object ListStateFilterActionEnum {
-    val include = "include"
-    val exclude = "exclude"
-    val ignore  = "ignore"
+  @js.native
+  sealed trait ListStateFilterAction extends js.Any
+  object ListStateFilterAction extends js.Object {
+    val include = "include".asInstanceOf[ListStateFilterAction]
+    val exclude = "exclude".asInstanceOf[ListStateFilterAction]
+    val ignore  = "ignore".asInstanceOf[ListStateFilterAction]
 
     val values = js.Object.freeze(js.Array(include, exclude, ignore))
   }
@@ -3208,10 +3198,11 @@ package codedeploy {
       __obj.asInstanceOf[MinimumHealthyHosts]
     }
   }
-
-  object MinimumHealthyHostsTypeEnum {
-    val HOST_COUNT    = "HOST_COUNT"
-    val FLEET_PERCENT = "FLEET_PERCENT"
+  @js.native
+  sealed trait MinimumHealthyHostsType extends js.Any
+  object MinimumHealthyHostsType extends js.Object {
+    val HOST_COUNT    = "HOST_COUNT".asInstanceOf[MinimumHealthyHostsType]
+    val FLEET_PERCENT = "FLEET_PERCENT".asInstanceOf[MinimumHealthyHostsType]
 
     val values = js.Object.freeze(js.Array(HOST_COUNT, FLEET_PERCENT))
   }
@@ -3353,10 +3344,11 @@ package codedeploy {
       __obj.asInstanceOf[RegisterOnPremisesInstanceInput]
     }
   }
-
-  object RegistrationStatusEnum {
-    val Registered   = "Registered"
-    val Deregistered = "Deregistered"
+  @js.native
+  sealed trait RegistrationStatus extends js.Any
+  object RegistrationStatus extends js.Object {
+    val Registered   = "Registered".asInstanceOf[RegistrationStatus]
+    val Deregistered = "Deregistered".asInstanceOf[RegistrationStatus]
 
     val values = js.Object.freeze(js.Array(Registered, Deregistered))
   }
@@ -3437,12 +3429,13 @@ package codedeploy {
       __obj.asInstanceOf[RevisionLocation]
     }
   }
-
-  object RevisionLocationTypeEnum {
-    val S3             = "S3"
-    val GitHub         = "GitHub"
-    val String         = "String"
-    val AppSpecContent = "AppSpecContent"
+  @js.native
+  sealed trait RevisionLocationType extends js.Any
+  object RevisionLocationType extends js.Object {
+    val S3             = "S3".asInstanceOf[RevisionLocationType]
+    val GitHub         = "GitHub".asInstanceOf[RevisionLocationType]
+    val String         = "String".asInstanceOf[RevisionLocationType]
+    val AppSpecContent = "AppSpecContent".asInstanceOf[RevisionLocationType]
 
     val values = js.Object.freeze(js.Array(S3, GitHub, String, AppSpecContent))
   }
@@ -3520,10 +3513,11 @@ package codedeploy {
       __obj.asInstanceOf[SkipWaitTimeForInstanceTerminationInput]
     }
   }
-
-  object SortOrderEnum {
-    val ascending  = "ascending"
-    val descending = "descending"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val ascending  = "ascending".asInstanceOf[SortOrder]
+    val descending = "descending".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(ascending, descending))
   }
@@ -3573,10 +3567,11 @@ package codedeploy {
       __obj.asInstanceOf[StopDeploymentOutput]
     }
   }
-
-  object StopStatusEnum {
-    val Pending   = "Pending"
-    val Succeeded = "Succeeded"
+  @js.native
+  sealed trait StopStatus extends js.Any
+  object StopStatus extends js.Object {
+    val Pending   = "Pending".asInstanceOf[StopStatus]
+    val Succeeded = "Succeeded".asInstanceOf[StopStatus]
 
     val values = js.Object.freeze(js.Array(Pending, Succeeded))
   }
@@ -3627,11 +3622,12 @@ package codedeploy {
       __obj.asInstanceOf[TagFilter]
     }
   }
-
-  object TagFilterTypeEnum {
-    val KEY_ONLY      = "KEY_ONLY"
-    val VALUE_ONLY    = "VALUE_ONLY"
-    val KEY_AND_VALUE = "KEY_AND_VALUE"
+  @js.native
+  sealed trait TagFilterType extends js.Any
+  object TagFilterType extends js.Object {
+    val KEY_ONLY      = "KEY_ONLY".asInstanceOf[TagFilterType]
+    val VALUE_ONLY    = "VALUE_ONLY".asInstanceOf[TagFilterType]
+    val KEY_AND_VALUE = "KEY_AND_VALUE".asInstanceOf[TagFilterType]
 
     val values = js.Object.freeze(js.Array(KEY_ONLY, VALUE_ONLY, KEY_AND_VALUE))
   }
@@ -3669,10 +3665,11 @@ package codedeploy {
       __obj.asInstanceOf[TagResourceOutput]
     }
   }
-
-  object TargetFilterNameEnum {
-    val TargetStatus        = "TargetStatus"
-    val ServerInstanceLabel = "ServerInstanceLabel"
+  @js.native
+  sealed trait TargetFilterName extends js.Any
+  object TargetFilterName extends js.Object {
+    val TargetStatus        = "TargetStatus".asInstanceOf[TargetFilterName]
+    val ServerInstanceLabel = "ServerInstanceLabel".asInstanceOf[TargetFilterName]
 
     val values = js.Object.freeze(js.Array(TargetStatus, ServerInstanceLabel))
   }
@@ -3745,22 +3742,24 @@ package codedeploy {
       __obj.asInstanceOf[TargetInstances]
     }
   }
-
-  object TargetLabelEnum {
-    val Blue  = "Blue"
-    val Green = "Green"
+  @js.native
+  sealed trait TargetLabel extends js.Any
+  object TargetLabel extends js.Object {
+    val Blue  = "Blue".asInstanceOf[TargetLabel]
+    val Green = "Green".asInstanceOf[TargetLabel]
 
     val values = js.Object.freeze(js.Array(Blue, Green))
   }
-
-  object TargetStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Succeeded  = "Succeeded"
-    val Failed     = "Failed"
-    val Skipped    = "Skipped"
-    val Unknown    = "Unknown"
-    val Ready      = "Ready"
+  @js.native
+  sealed trait TargetStatus extends js.Any
+  object TargetStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[TargetStatus]
+    val InProgress = "InProgress".asInstanceOf[TargetStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[TargetStatus]
+    val Failed     = "Failed".asInstanceOf[TargetStatus]
+    val Skipped    = "Skipped".asInstanceOf[TargetStatus]
+    val Unknown    = "Unknown".asInstanceOf[TargetStatus]
+    val Ready      = "Ready".asInstanceOf[TargetStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Succeeded, Failed, Skipped, Unknown, Ready))
   }
@@ -3874,11 +3873,12 @@ package codedeploy {
       __obj.asInstanceOf[TrafficRoutingConfig]
     }
   }
-
-  object TrafficRoutingTypeEnum {
-    val TimeBasedCanary = "TimeBasedCanary"
-    val TimeBasedLinear = "TimeBasedLinear"
-    val AllAtOnce       = "AllAtOnce"
+  @js.native
+  sealed trait TrafficRoutingType extends js.Any
+  object TrafficRoutingType extends js.Object {
+    val TimeBasedCanary = "TimeBasedCanary".asInstanceOf[TrafficRoutingType]
+    val TimeBasedLinear = "TimeBasedLinear".asInstanceOf[TrafficRoutingType]
+    val AllAtOnce       = "AllAtOnce".asInstanceOf[TrafficRoutingType]
 
     val values = js.Object.freeze(js.Array(TimeBasedCanary, TimeBasedLinear, AllAtOnce))
   }
@@ -3907,18 +3907,19 @@ package codedeploy {
       __obj.asInstanceOf[TriggerConfig]
     }
   }
-
-  object TriggerEventTypeEnum {
-    val DeploymentStart    = "DeploymentStart"
-    val DeploymentSuccess  = "DeploymentSuccess"
-    val DeploymentFailure  = "DeploymentFailure"
-    val DeploymentStop     = "DeploymentStop"
-    val DeploymentRollback = "DeploymentRollback"
-    val DeploymentReady    = "DeploymentReady"
-    val InstanceStart      = "InstanceStart"
-    val InstanceSuccess    = "InstanceSuccess"
-    val InstanceFailure    = "InstanceFailure"
-    val InstanceReady      = "InstanceReady"
+  @js.native
+  sealed trait TriggerEventType extends js.Any
+  object TriggerEventType extends js.Object {
+    val DeploymentStart    = "DeploymentStart".asInstanceOf[TriggerEventType]
+    val DeploymentSuccess  = "DeploymentSuccess".asInstanceOf[TriggerEventType]
+    val DeploymentFailure  = "DeploymentFailure".asInstanceOf[TriggerEventType]
+    val DeploymentStop     = "DeploymentStop".asInstanceOf[TriggerEventType]
+    val DeploymentRollback = "DeploymentRollback".asInstanceOf[TriggerEventType]
+    val DeploymentReady    = "DeploymentReady".asInstanceOf[TriggerEventType]
+    val InstanceStart      = "InstanceStart".asInstanceOf[TriggerEventType]
+    val InstanceSuccess    = "InstanceSuccess".asInstanceOf[TriggerEventType]
+    val InstanceFailure    = "InstanceFailure".asInstanceOf[TriggerEventType]
+    val InstanceReady      = "InstanceReady".asInstanceOf[TriggerEventType]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/codeguruprofiler/src/main/scala/facade/amazonaws/services/CodeGuruProfiler.scala
+++ b/services/codeguruprofiler/src/main/scala/facade/amazonaws/services/CodeGuruProfiler.scala
@@ -9,12 +9,10 @@ import facade.amazonaws._
 package object codeguruprofiler {
   type AgentProfile               = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type AggregatedProfile          = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type AggregationPeriod          = String
   type ClientToken                = String
   type FleetInstanceId            = String
   type MaxDepth                   = Int
   type MaxResults                 = Int
-  type OrderBy                    = String
   type PaginationToken            = String
   type Period                     = String
   type ProfileTimes               = js.Array[ProfileTime]
@@ -136,10 +134,12 @@ package codeguruprofiler {
   /**
     * Periods of time used for aggregation of profiles, represented using ISO 8601 format.
     */
-  object AggregationPeriodEnum {
-    val P1D  = "P1D"
-    val PT1H = "PT1H"
-    val PT5M = "PT5M"
+  @js.native
+  sealed trait AggregationPeriod extends js.Any
+  object AggregationPeriod extends js.Object {
+    val P1D  = "P1D".asInstanceOf[AggregationPeriod]
+    val PT1H = "PT1H".asInstanceOf[AggregationPeriod]
+    val PT5M = "PT5M".asInstanceOf[AggregationPeriod]
 
     val values = js.Object.freeze(js.Array(P1D, PT1H, PT5M))
   }
@@ -493,10 +493,11 @@ package codeguruprofiler {
       __obj.asInstanceOf[ListProfilingGroupsResponse]
     }
   }
-
-  object OrderByEnum {
-    val TimestampAscending  = "TimestampAscending"
-    val TimestampDescending = "TimestampDescending"
+  @js.native
+  sealed trait OrderBy extends js.Any
+  object OrderBy extends js.Object {
+    val TimestampAscending  = "TimestampAscending".asInstanceOf[OrderBy]
+    val TimestampDescending = "TimestampDescending".asInstanceOf[OrderBy]
 
     val values = js.Object.freeze(js.Array(TimestampAscending, TimestampDescending))
   }

--- a/services/codegurureviewer/src/main/scala/facade/amazonaws/services/CodeGuruReviewer.scala
+++ b/services/codegurureviewer/src/main/scala/facade/amazonaws/services/CodeGuruReviewer.scala
@@ -16,9 +16,7 @@ package object codegurureviewer {
   type NextToken                      = String
   type Owner                          = String
   type Owners                         = js.Array[Owner]
-  type ProviderType                   = String
   type ProviderTypes                  = js.Array[ProviderType]
-  type RepositoryAssociationState     = String
   type RepositoryAssociationStates    = js.Array[RepositoryAssociationState]
   type RepositoryAssociationSummaries = js.Array[RepositoryAssociationSummary]
   type StateReason                    = String
@@ -234,10 +232,11 @@ package codegurureviewer {
       __obj.asInstanceOf[ListRepositoryAssociationsResponse]
     }
   }
-
-  object ProviderTypeEnum {
-    val CodeCommit = "CodeCommit"
-    val GitHub     = "GitHub"
+  @js.native
+  sealed trait ProviderType extends js.Any
+  object ProviderType extends js.Object {
+    val CodeCommit = "CodeCommit".asInstanceOf[ProviderType]
+    val GitHub     = "GitHub".asInstanceOf[ProviderType]
 
     val values = js.Object.freeze(js.Array(CodeCommit, GitHub))
   }
@@ -303,12 +302,13 @@ package codegurureviewer {
       __obj.asInstanceOf[RepositoryAssociation]
     }
   }
-
-  object RepositoryAssociationStateEnum {
-    val Associated     = "Associated"
-    val Associating    = "Associating"
-    val Failed         = "Failed"
-    val Disassociating = "Disassociating"
+  @js.native
+  sealed trait RepositoryAssociationState extends js.Any
+  object RepositoryAssociationState extends js.Object {
+    val Associated     = "Associated".asInstanceOf[RepositoryAssociationState]
+    val Associating    = "Associating".asInstanceOf[RepositoryAssociationState]
+    val Failed         = "Failed".asInstanceOf[RepositoryAssociationState]
+    val Disassociating = "Disassociating".asInstanceOf[RepositoryAssociationState]
 
     val values = js.Object.freeze(js.Array(Associated, Associating, Failed, Disassociating))
   }

--- a/services/codepipeline/src/main/scala/facade/amazonaws/services/CodePipeline.scala
+++ b/services/codepipeline/src/main/scala/facade/amazonaws/services/CodePipeline.scala
@@ -10,37 +10,29 @@ package object codepipeline {
   type AWSRegionName                          = String
   type AccessKeyId                            = String
   type AccountId                              = String
-  type ActionCategory                         = String
   type ActionConfigurationKey                 = String
   type ActionConfigurationMap                 = js.Dictionary[ActionConfigurationValue]
   type ActionConfigurationPropertyList        = js.Array[ActionConfigurationProperty]
-  type ActionConfigurationPropertyType        = String
   type ActionConfigurationQueryableValue      = String
   type ActionConfigurationValue               = String
   type ActionExecutionDetailList              = js.Array[ActionExecutionDetail]
   type ActionExecutionId                      = String
-  type ActionExecutionStatus                  = String
   type ActionExecutionToken                   = String
   type ActionName                             = String
   type ActionNamespace                        = String
-  type ActionOwner                            = String
   type ActionProvider                         = String
   type ActionRunOrder                         = Int
   type ActionStateList                        = js.Array[ActionState]
   type ActionTypeList                         = js.Array[ActionType]
-  type ApprovalStatus                         = String
   type ApprovalSummary                        = String
   type ApprovalToken                          = String
   type ArtifactDetailList                     = js.Array[ArtifactDetail]
   type ArtifactList                           = js.Array[Artifact]
-  type ArtifactLocationType                   = String
   type ArtifactName                           = String
   type ArtifactRevisionList                   = js.Array[ArtifactRevision]
   type ArtifactStoreLocation                  = String
   type ArtifactStoreMap                       = js.Dictionary[ArtifactStore]
-  type ArtifactStoreType                      = String
   type BlockerName                            = String
-  type BlockerType                            = String
   type ClientId                               = String
   type ClientRequestToken                     = String
   type ClientToken                            = String
@@ -50,16 +42,13 @@ package object codepipeline {
   type DisabledReason                         = String
   type Enabled                                = Boolean
   type EncryptionKeyId                        = String
-  type EncryptionKeyType                      = String
   type ExecutionId                            = String
   type ExecutionSummary                       = String
   type ExternalExecutionId                    = String
   type ExternalExecutionSummary               = String
-  type FailureType                            = String
   type InputArtifactList                      = js.Array[InputArtifact]
   type JobId                                  = String
   type JobList                                = js.Array[Job]
-  type JobStatus                              = String
   type JsonPath                               = String
   type LastChangedAt                          = js.Date
   type LastChangedBy                          = String
@@ -79,7 +68,6 @@ package object codepipeline {
   type Percentage                             = Int
   type PipelineArn                            = String
   type PipelineExecutionId                    = String
-  type PipelineExecutionStatus                = String
   type PipelineExecutionSummaryList           = js.Array[PipelineExecutionSummary]
   type PipelineList                           = js.Array[PipelineSummary]
   type PipelineName                           = String
@@ -101,11 +89,8 @@ package object codepipeline {
   type SourceRevisionList                     = js.Array[SourceRevision]
   type StageActionDeclarationList             = js.Array[ActionDeclaration]
   type StageBlockerDeclarationList            = js.Array[BlockerDeclaration]
-  type StageExecutionStatus                   = String
   type StageName                              = String
-  type StageRetryMode                         = String
   type StageStateList                         = js.Array[StageState]
-  type StageTransitionType                    = String
   type StopPipelineExecutionReason            = String
   type TagKey                                 = String
   type TagKeyList                             = js.Array[TagKey]
@@ -116,14 +101,12 @@ package object codepipeline {
   type Time                                   = js.Date
   type Timestamp                              = js.Date
   type TriggerDetail                          = String
-  type TriggerType                            = String
   type Url                                    = String
   type UrlTemplate                            = String
   type Version                                = String
   type WebhookArn                             = String
   type WebhookAuthConfigurationAllowedIPRange = String
   type WebhookAuthConfigurationSecretToken    = String
-  type WebhookAuthenticationType              = String
   type WebhookErrorCode                       = String
   type WebhookErrorMessage                    = String
   type WebhookFilters                         = js.Array[WebhookFilterRule]
@@ -384,14 +367,15 @@ package codepipeline {
       __obj.asInstanceOf[AcknowledgeThirdPartyJobOutput]
     }
   }
-
-  object ActionCategoryEnum {
-    val Source   = "Source"
-    val Build    = "Build"
-    val Deploy   = "Deploy"
-    val Test     = "Test"
-    val Invoke   = "Invoke"
-    val Approval = "Approval"
+  @js.native
+  sealed trait ActionCategory extends js.Any
+  object ActionCategory extends js.Object {
+    val Source   = "Source".asInstanceOf[ActionCategory]
+    val Build    = "Build".asInstanceOf[ActionCategory]
+    val Deploy   = "Deploy".asInstanceOf[ActionCategory]
+    val Test     = "Test".asInstanceOf[ActionCategory]
+    val Invoke   = "Invoke".asInstanceOf[ActionCategory]
+    val Approval = "Approval".asInstanceOf[ActionCategory]
 
     val values = js.Object.freeze(js.Array(Source, Build, Deploy, Test, Invoke, Approval))
   }
@@ -453,11 +437,12 @@ package codepipeline {
       __obj.asInstanceOf[ActionConfigurationProperty]
     }
   }
-
-  object ActionConfigurationPropertyTypeEnum {
-    val String  = "String"
-    val Number  = "Number"
-    val Boolean = "Boolean"
+  @js.native
+  sealed trait ActionConfigurationPropertyType extends js.Any
+  object ActionConfigurationPropertyType extends js.Object {
+    val String  = "String".asInstanceOf[ActionConfigurationPropertyType]
+    val Number  = "Number".asInstanceOf[ActionConfigurationPropertyType]
+    val Boolean = "Boolean".asInstanceOf[ActionConfigurationPropertyType]
 
     val values = js.Object.freeze(js.Array(String, Number, Boolean))
   }
@@ -723,20 +708,22 @@ package codepipeline {
       __obj.asInstanceOf[ActionExecutionResult]
     }
   }
-
-  object ActionExecutionStatusEnum {
-    val InProgress = "InProgress"
-    val Abandoned  = "Abandoned"
-    val Succeeded  = "Succeeded"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait ActionExecutionStatus extends js.Any
+  object ActionExecutionStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[ActionExecutionStatus]
+    val Abandoned  = "Abandoned".asInstanceOf[ActionExecutionStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[ActionExecutionStatus]
+    val Failed     = "Failed".asInstanceOf[ActionExecutionStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Abandoned, Succeeded, Failed))
   }
-
-  object ActionOwnerEnum {
-    val AWS        = "AWS"
-    val ThirdParty = "ThirdParty"
-    val Custom     = "Custom"
+  @js.native
+  sealed trait ActionOwner extends js.Any
+  object ActionOwner extends js.Object {
+    val AWS        = "AWS".asInstanceOf[ActionOwner]
+    val ThirdParty = "ThirdParty".asInstanceOf[ActionOwner]
+    val Custom     = "Custom".asInstanceOf[ActionOwner]
 
     val values = js.Object.freeze(js.Array(AWS, ThirdParty, Custom))
   }
@@ -917,10 +904,11 @@ package codepipeline {
       __obj.asInstanceOf[ApprovalResult]
     }
   }
-
-  object ApprovalStatusEnum {
-    val Approved = "Approved"
-    val Rejected = "Rejected"
+  @js.native
+  sealed trait ApprovalStatus extends js.Any
+  object ApprovalStatus extends js.Object {
+    val Approved = "Approved".asInstanceOf[ApprovalStatus]
+    val Rejected = "Rejected".asInstanceOf[ApprovalStatus]
 
     val values = js.Object.freeze(js.Array(Approved, Rejected))
   }
@@ -1017,9 +1005,10 @@ package codepipeline {
       __obj.asInstanceOf[ArtifactLocation]
     }
   }
-
-  object ArtifactLocationTypeEnum {
-    val S3 = "S3"
+  @js.native
+  sealed trait ArtifactLocationType extends js.Any
+  object ArtifactLocationType extends js.Object {
+    val S3 = "S3".asInstanceOf[ArtifactLocationType]
 
     val values = js.Object.freeze(js.Array(S3))
   }
@@ -1086,9 +1075,10 @@ package codepipeline {
       __obj.asInstanceOf[ArtifactStore]
     }
   }
-
-  object ArtifactStoreTypeEnum {
-    val S3 = "S3"
+  @js.native
+  sealed trait ArtifactStoreType extends js.Any
+  object ArtifactStoreType extends js.Object {
+    val S3 = "S3".asInstanceOf[ArtifactStoreType]
 
     val values = js.Object.freeze(js.Array(S3))
   }
@@ -1116,9 +1106,10 @@ package codepipeline {
       __obj.asInstanceOf[BlockerDeclaration]
     }
   }
-
-  object BlockerTypeEnum {
-    val Schedule = "Schedule"
+  @js.native
+  sealed trait BlockerType extends js.Any
+  object BlockerType extends js.Object {
+    val Schedule = "Schedule".asInstanceOf[BlockerType]
 
     val values = js.Object.freeze(js.Array(Schedule))
   }
@@ -1453,9 +1444,10 @@ package codepipeline {
       __obj.asInstanceOf[EncryptionKey]
     }
   }
-
-  object EncryptionKeyTypeEnum {
-    val KMS = "KMS"
+  @js.native
+  sealed trait EncryptionKeyType extends js.Any
+  object EncryptionKeyType extends js.Object {
+    val KMS = "KMS".asInstanceOf[EncryptionKeyType]
 
     val values = js.Object.freeze(js.Array(KMS))
   }
@@ -1555,14 +1547,15 @@ package codepipeline {
       __obj.asInstanceOf[FailureDetails]
     }
   }
-
-  object FailureTypeEnum {
-    val JobFailed           = "JobFailed"
-    val ConfigurationError  = "ConfigurationError"
-    val PermissionError     = "PermissionError"
-    val RevisionOutOfSync   = "RevisionOutOfSync"
-    val RevisionUnavailable = "RevisionUnavailable"
-    val SystemUnavailable   = "SystemUnavailable"
+  @js.native
+  sealed trait FailureType extends js.Any
+  object FailureType extends js.Object {
+    val JobFailed           = "JobFailed".asInstanceOf[FailureType]
+    val ConfigurationError  = "ConfigurationError".asInstanceOf[FailureType]
+    val PermissionError     = "PermissionError".asInstanceOf[FailureType]
+    val RevisionOutOfSync   = "RevisionOutOfSync".asInstanceOf[FailureType]
+    val RevisionUnavailable = "RevisionUnavailable".asInstanceOf[FailureType]
+    val SystemUnavailable   = "SystemUnavailable".asInstanceOf[FailureType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1913,15 +1906,16 @@ package codepipeline {
       __obj.asInstanceOf[JobDetails]
     }
   }
-
-  object JobStatusEnum {
-    val Created    = "Created"
-    val Queued     = "Queued"
-    val Dispatched = "Dispatched"
-    val InProgress = "InProgress"
-    val TimedOut   = "TimedOut"
-    val Succeeded  = "Succeeded"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val Created    = "Created".asInstanceOf[JobStatus]
+    val Queued     = "Queued".asInstanceOf[JobStatus]
+    val Dispatched = "Dispatched".asInstanceOf[JobStatus]
+    val InProgress = "InProgress".asInstanceOf[JobStatus]
+    val TimedOut   = "TimedOut".asInstanceOf[JobStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[JobStatus]
+    val Failed     = "Failed".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(js.Array(Created, Queued, Dispatched, InProgress, TimedOut, Succeeded, Failed))
   }
@@ -2350,14 +2344,15 @@ package codepipeline {
       __obj.asInstanceOf[PipelineExecution]
     }
   }
-
-  object PipelineExecutionStatusEnum {
-    val InProgress = "InProgress"
-    val Stopped    = "Stopped"
-    val Stopping   = "Stopping"
-    val Succeeded  = "Succeeded"
-    val Superseded = "Superseded"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait PipelineExecutionStatus extends js.Any
+  object PipelineExecutionStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[PipelineExecutionStatus]
+    val Stopped    = "Stopped".asInstanceOf[PipelineExecutionStatus]
+    val Stopping   = "Stopping".asInstanceOf[PipelineExecutionStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[PipelineExecutionStatus]
+    val Superseded = "Superseded".asInstanceOf[PipelineExecutionStatus]
+    val Failed     = "Failed".asInstanceOf[PipelineExecutionStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Stopped, Stopping, Succeeded, Superseded, Failed))
   }
@@ -3022,19 +3017,21 @@ package codepipeline {
       __obj.asInstanceOf[StageExecution]
     }
   }
-
-  object StageExecutionStatusEnum {
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Stopped    = "Stopped"
-    val Stopping   = "Stopping"
-    val Succeeded  = "Succeeded"
+  @js.native
+  sealed trait StageExecutionStatus extends js.Any
+  object StageExecutionStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[StageExecutionStatus]
+    val Failed     = "Failed".asInstanceOf[StageExecutionStatus]
+    val Stopped    = "Stopped".asInstanceOf[StageExecutionStatus]
+    val Stopping   = "Stopping".asInstanceOf[StageExecutionStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[StageExecutionStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Failed, Stopped, Stopping, Succeeded))
   }
-
-  object StageRetryModeEnum {
-    val FAILED_ACTIONS = "FAILED_ACTIONS"
+  @js.native
+  sealed trait StageRetryMode extends js.Any
+  object StageRetryMode extends js.Object {
+    val FAILED_ACTIONS = "FAILED_ACTIONS".asInstanceOf[StageRetryMode]
 
     val values = js.Object.freeze(js.Array(FAILED_ACTIONS))
   }
@@ -3066,10 +3063,11 @@ package codepipeline {
       __obj.asInstanceOf[StageState]
     }
   }
-
-  object StageTransitionTypeEnum {
-    val Inbound  = "Inbound"
-    val Outbound = "Outbound"
+  @js.native
+  sealed trait StageTransitionType extends js.Any
+  object StageTransitionType extends js.Object {
+    val Inbound  = "Inbound".asInstanceOf[StageTransitionType]
+    val Outbound = "Outbound".asInstanceOf[StageTransitionType]
 
     val values = js.Object.freeze(js.Array(Inbound, Outbound))
   }
@@ -3351,14 +3349,15 @@ package codepipeline {
       __obj.asInstanceOf[TransitionState]
     }
   }
-
-  object TriggerTypeEnum {
-    val CreatePipeline         = "CreatePipeline"
-    val StartPipelineExecution = "StartPipelineExecution"
-    val PollForSourceChanges   = "PollForSourceChanges"
-    val Webhook                = "Webhook"
-    val CloudWatchEvent        = "CloudWatchEvent"
-    val PutActionRevision      = "PutActionRevision"
+  @js.native
+  sealed trait TriggerType extends js.Any
+  object TriggerType extends js.Object {
+    val CreatePipeline         = "CreatePipeline".asInstanceOf[TriggerType]
+    val StartPipelineExecution = "StartPipelineExecution".asInstanceOf[TriggerType]
+    val PollForSourceChanges   = "PollForSourceChanges".asInstanceOf[TriggerType]
+    val Webhook                = "Webhook".asInstanceOf[TriggerType]
+    val CloudWatchEvent        = "CloudWatchEvent".asInstanceOf[TriggerType]
+    val PutActionRevision      = "PutActionRevision".asInstanceOf[TriggerType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3467,11 +3466,12 @@ package codepipeline {
       __obj.asInstanceOf[WebhookAuthConfiguration]
     }
   }
-
-  object WebhookAuthenticationTypeEnum {
-    val GITHUB_HMAC     = "GITHUB_HMAC"
-    val IP              = "IP"
-    val UNAUTHENTICATED = "UNAUTHENTICATED"
+  @js.native
+  sealed trait WebhookAuthenticationType extends js.Any
+  object WebhookAuthenticationType extends js.Object {
+    val GITHUB_HMAC     = "GITHUB_HMAC".asInstanceOf[WebhookAuthenticationType]
+    val IP              = "IP".asInstanceOf[WebhookAuthenticationType]
+    val UNAUTHENTICATED = "UNAUTHENTICATED".asInstanceOf[WebhookAuthenticationType]
 
     val values = js.Object.freeze(js.Array(GITHUB_HMAC, IP, UNAUTHENTICATED))
   }

--- a/services/codestarconnections/src/main/scala/facade/amazonaws/services/CodeStarconnections.scala
+++ b/services/codestarconnections/src/main/scala/facade/amazonaws/services/CodeStarconnections.scala
@@ -7,14 +7,12 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object codestarconnections {
-  type AccountId        = String
-  type ConnectionArn    = String
-  type ConnectionList   = js.Array[Connection]
-  type ConnectionName   = String
-  type ConnectionStatus = String
-  type MaxResults       = Int
-  type NextToken        = String
-  type ProviderType     = String
+  type AccountId      = String
+  type ConnectionArn  = String
+  type ConnectionList = js.Array[Connection]
+  type ConnectionName = String
+  type MaxResults     = Int
+  type NextToken      = String
 
   implicit final class CodeStarconnectionsOps(private val service: CodeStarconnections) extends AnyVal {
 
@@ -71,11 +69,12 @@ package codestarconnections {
       __obj.asInstanceOf[Connection]
     }
   }
-
-  object ConnectionStatusEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val ERROR     = "ERROR"
+  @js.native
+  sealed trait ConnectionStatus extends js.Any
+  object ConnectionStatus extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[ConnectionStatus]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[ConnectionStatus]
+    val ERROR     = "ERROR".asInstanceOf[ConnectionStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, ERROR))
   }
@@ -224,9 +223,10 @@ package codestarconnections {
       __obj.asInstanceOf[ListConnectionsOutput]
     }
   }
-
-  object ProviderTypeEnum {
-    val Bitbucket = "Bitbucket"
+  @js.native
+  sealed trait ProviderType extends js.Any
+  object ProviderType extends js.Object {
+    val Bitbucket = "Bitbucket".asInstanceOf[ProviderType]
 
     val values = js.Object.freeze(js.Array(Bitbucket))
   }

--- a/services/codestarnotifications/src/main/scala/facade/amazonaws/services/CodeStarNotifications.scala
+++ b/services/codestarnotifications/src/main/scala/facade/amazonaws/services/CodeStarNotifications.scala
@@ -9,20 +9,16 @@ import facade.amazonaws._
 package object codestarnotifications {
   type ClientRequestToken               = String
   type CreatedTimestamp                 = js.Date
-  type DetailType                       = String
   type EventTypeBatch                   = js.Array[EventTypeSummary]
   type EventTypeId                      = String
   type EventTypeIds                     = js.Array[EventTypeId]
   type EventTypeName                    = String
   type ForceUnsubscribeAll              = Boolean
   type LastModifiedTimestamp            = js.Date
-  type ListEventTypesFilterName         = String
   type ListEventTypesFilterValue        = String
   type ListEventTypesFilters            = js.Array[ListEventTypesFilter]
-  type ListNotificationRulesFilterName  = String
   type ListNotificationRulesFilterValue = String
   type ListNotificationRulesFilters     = js.Array[ListNotificationRulesFilter]
-  type ListTargetsFilterName            = String
   type ListTargetsFilterValue           = String
   type ListTargetsFilters               = js.Array[ListTargetsFilter]
   type MaxResults                       = Int
@@ -33,7 +29,6 @@ package object codestarnotifications {
   type NotificationRuleId               = String
   type NotificationRuleName             = String
   type NotificationRuleResource         = String
-  type NotificationRuleStatus           = String
   type ResourceType                     = String
   type ServiceName                      = String
   type TagKey                           = String
@@ -41,7 +36,6 @@ package object codestarnotifications {
   type TagValue                         = String
   type Tags                             = js.Dictionary[TagValue]
   type TargetAddress                    = String
-  type TargetStatus                     = String
   type TargetType                       = String
   type Targets                          = js.Array[Target]
   type TargetsBatch                     = js.Array[TargetSummary]
@@ -291,10 +285,11 @@ package codestarnotifications {
       __obj.asInstanceOf[DescribeNotificationRuleResult]
     }
   }
-
-  object DetailTypeEnum {
-    val BASIC = "BASIC"
-    val FULL  = "FULL"
+  @js.native
+  sealed trait DetailType extends js.Any
+  object DetailType extends js.Object {
+    val BASIC = "BASIC".asInstanceOf[DetailType]
+    val FULL  = "FULL".asInstanceOf[DetailType]
 
     val values = js.Object.freeze(js.Array(BASIC, FULL))
   }
@@ -350,10 +345,11 @@ package codestarnotifications {
       __obj.asInstanceOf[ListEventTypesFilter]
     }
   }
-
-  object ListEventTypesFilterNameEnum {
-    val RESOURCE_TYPE = "RESOURCE_TYPE"
-    val SERVICE_NAME  = "SERVICE_NAME"
+  @js.native
+  sealed trait ListEventTypesFilterName extends js.Any
+  object ListEventTypesFilterName extends js.Object {
+    val RESOURCE_TYPE = "RESOURCE_TYPE".asInstanceOf[ListEventTypesFilterName]
+    val SERVICE_NAME  = "SERVICE_NAME".asInstanceOf[ListEventTypesFilterName]
 
     val values = js.Object.freeze(js.Array(RESOURCE_TYPE, SERVICE_NAME))
   }
@@ -422,12 +418,13 @@ package codestarnotifications {
       __obj.asInstanceOf[ListNotificationRulesFilter]
     }
   }
-
-  object ListNotificationRulesFilterNameEnum {
-    val EVENT_TYPE_ID  = "EVENT_TYPE_ID"
-    val CREATED_BY     = "CREATED_BY"
-    val RESOURCE       = "RESOURCE"
-    val TARGET_ADDRESS = "TARGET_ADDRESS"
+  @js.native
+  sealed trait ListNotificationRulesFilterName extends js.Any
+  object ListNotificationRulesFilterName extends js.Object {
+    val EVENT_TYPE_ID  = "EVENT_TYPE_ID".asInstanceOf[ListNotificationRulesFilterName]
+    val CREATED_BY     = "CREATED_BY".asInstanceOf[ListNotificationRulesFilterName]
+    val RESOURCE       = "RESOURCE".asInstanceOf[ListNotificationRulesFilterName]
+    val TARGET_ADDRESS = "TARGET_ADDRESS".asInstanceOf[ListNotificationRulesFilterName]
 
     val values = js.Object.freeze(js.Array(EVENT_TYPE_ID, CREATED_BY, RESOURCE, TARGET_ADDRESS))
   }
@@ -530,11 +527,12 @@ package codestarnotifications {
       __obj.asInstanceOf[ListTargetsFilter]
     }
   }
-
-  object ListTargetsFilterNameEnum {
-    val TARGET_TYPE    = "TARGET_TYPE"
-    val TARGET_ADDRESS = "TARGET_ADDRESS"
-    val TARGET_STATUS  = "TARGET_STATUS"
+  @js.native
+  sealed trait ListTargetsFilterName extends js.Any
+  object ListTargetsFilterName extends js.Object {
+    val TARGET_TYPE    = "TARGET_TYPE".asInstanceOf[ListTargetsFilterName]
+    val TARGET_ADDRESS = "TARGET_ADDRESS".asInstanceOf[ListTargetsFilterName]
+    val TARGET_STATUS  = "TARGET_STATUS".asInstanceOf[ListTargetsFilterName]
 
     val values = js.Object.freeze(js.Array(TARGET_TYPE, TARGET_ADDRESS, TARGET_STATUS))
   }
@@ -579,10 +577,11 @@ package codestarnotifications {
       __obj.asInstanceOf[ListTargetsResult]
     }
   }
-
-  object NotificationRuleStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait NotificationRuleStatus extends js.Any
+  object NotificationRuleStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[NotificationRuleStatus]
+    val DISABLED = "DISABLED".asInstanceOf[NotificationRuleStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -707,13 +706,14 @@ package codestarnotifications {
       __obj.asInstanceOf[Target]
     }
   }
-
-  object TargetStatusEnum {
-    val PENDING     = "PENDING"
-    val ACTIVE      = "ACTIVE"
-    val UNREACHABLE = "UNREACHABLE"
-    val INACTIVE    = "INACTIVE"
-    val DEACTIVATED = "DEACTIVATED"
+  @js.native
+  sealed trait TargetStatus extends js.Any
+  object TargetStatus extends js.Object {
+    val PENDING     = "PENDING".asInstanceOf[TargetStatus]
+    val ACTIVE      = "ACTIVE".asInstanceOf[TargetStatus]
+    val UNREACHABLE = "UNREACHABLE".asInstanceOf[TargetStatus]
+    val INACTIVE    = "INACTIVE".asInstanceOf[TargetStatus]
+    val DEACTIVATED = "DEACTIVATED".asInstanceOf[TargetStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, ACTIVE, UNREACHABLE, INACTIVE, DEACTIVATED))
   }

--- a/services/cognitoidentity/src/main/scala/facade/amazonaws/services/CognitoIdentity.scala
+++ b/services/cognitoidentity/src/main/scala/facade/amazonaws/services/CognitoIdentity.scala
@@ -10,7 +10,6 @@ package object cognitoidentity {
   type ARNString                         = String
   type AccessKeyString                   = String
   type AccountId                         = String
-  type AmbiguousRoleResolutionType       = String
   type ClaimName                         = String
   type ClaimValue                        = String
   type ClassicFlow                       = Boolean
@@ -22,7 +21,6 @@ package object cognitoidentity {
   type DeveloperProviderName             = String
   type DeveloperUserIdentifier           = String
   type DeveloperUserIdentifierList       = js.Array[DeveloperUserIdentifier]
-  type ErrorCode                         = String
   type HideDisabled                      = Boolean
   type IdentitiesList                    = js.Array[IdentityDescription]
   type IdentityId                        = String
@@ -39,14 +37,12 @@ package object cognitoidentity {
   type IdentityProviders                 = js.Dictionary[IdentityProviderId]
   type LoginsList                        = js.Array[IdentityProviderName]
   type LoginsMap                         = js.Dictionary[IdentityProviderToken]
-  type MappingRuleMatchType              = String
   type MappingRulesList                  = js.Array[MappingRule]
   type OIDCProviderList                  = js.Array[ARNString]
   type OIDCToken                         = String
   type PaginationKey                     = String
   type QueryLimit                        = Int
   type RoleMappingMap                    = js.Dictionary[RoleMapping]
-  type RoleMappingType                   = String
   type RoleType                          = String
   type RolesMap                          = js.Dictionary[ARNString]
   type SAMLProviderList                  = js.Array[ARNString]
@@ -141,10 +137,11 @@ package cognitoidentity {
     def untagResource(params: UntagResourceInput): Request[UntagResourceResponse]         = js.native
     def updateIdentityPool(params: IdentityPool): Request[IdentityPool]                   = js.native
   }
-
-  object AmbiguousRoleResolutionTypeEnum {
-    val AuthenticatedRole = "AuthenticatedRole"
-    val Deny              = "Deny"
+  @js.native
+  sealed trait AmbiguousRoleResolutionType extends js.Any
+  object AmbiguousRoleResolutionType extends js.Object {
+    val AuthenticatedRole = "AuthenticatedRole".asInstanceOf[AmbiguousRoleResolutionType]
+    val Deny              = "Deny".asInstanceOf[AmbiguousRoleResolutionType]
 
     val values = js.Object.freeze(js.Array(AuthenticatedRole, Deny))
   }
@@ -351,10 +348,11 @@ package cognitoidentity {
       __obj.asInstanceOf[DescribeIdentityPoolInput]
     }
   }
-
-  object ErrorCodeEnum {
-    val AccessDenied        = "AccessDenied"
-    val InternalServerError = "InternalServerError"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val AccessDenied        = "AccessDenied".asInstanceOf[ErrorCode]
+    val InternalServerError = "InternalServerError".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(js.Array(AccessDenied, InternalServerError))
   }
@@ -922,12 +920,13 @@ package cognitoidentity {
       __obj.asInstanceOf[MappingRule]
     }
   }
-
-  object MappingRuleMatchTypeEnum {
-    val Equals     = "Equals"
-    val Contains   = "Contains"
-    val StartsWith = "StartsWith"
-    val NotEqual   = "NotEqual"
+  @js.native
+  sealed trait MappingRuleMatchType extends js.Any
+  object MappingRuleMatchType extends js.Object {
+    val Equals     = "Equals".asInstanceOf[MappingRuleMatchType]
+    val Contains   = "Contains".asInstanceOf[MappingRuleMatchType]
+    val StartsWith = "StartsWith".asInstanceOf[MappingRuleMatchType]
+    val NotEqual   = "NotEqual".asInstanceOf[MappingRuleMatchType]
 
     val values = js.Object.freeze(js.Array(Equals, Contains, StartsWith, NotEqual))
   }
@@ -1007,10 +1006,11 @@ package cognitoidentity {
       __obj.asInstanceOf[RoleMapping]
     }
   }
-
-  object RoleMappingTypeEnum {
-    val Token = "Token"
-    val Rules = "Rules"
+  @js.native
+  sealed trait RoleMappingType extends js.Any
+  object RoleMappingType extends js.Object {
+    val Token = "Token".asInstanceOf[RoleMappingType]
+    val Rules = "Rules".asInstanceOf[RoleMappingType]
 
     val values = js.Object.freeze(js.Array(Token, Rules))
   }

--- a/services/cognitoidentityprovider/src/main/scala/facade/amazonaws/services/CognitoIdentityProvider.scala
+++ b/services/cognitoidentityprovider/src/main/scala/facade/amazonaws/services/CognitoIdentityProvider.scala
@@ -9,13 +9,9 @@ import facade.amazonaws._
 package object cognitoidentityprovider {
   type AWSAccountIdType                             = String
   type AccountTakeoverActionNotifyType              = Boolean
-  type AccountTakeoverEventActionType               = String
   type AdminCreateUserUnusedAccountValidityDaysType = Int
-  type AdvancedSecurityModeType                     = String
-  type AliasAttributeType                           = String
   type AliasAttributesListType                      = js.Array[AliasAttributeType]
   type ArnType                                      = String
-  type AttributeDataType                            = String
   type AttributeListType                            = js.Array[AttributeType]
   type AttributeMappingKeyType                      = String
   type AttributeMappingType                         = js.Dictionary[StringType]
@@ -23,7 +19,6 @@ package object cognitoidentityprovider {
   type AttributeNameType                            = String
   type AttributeValueType                           = String
   type AuthEventsType                               = js.Array[AuthEventType]
-  type AuthFlowType                                 = String
   type AuthParametersType                           = js.Dictionary[AuthParametersValueType]
   type AuthParametersValueType                      = String
   type BlockedIPRangeListType                       = js.Array[StringType]
@@ -31,10 +26,7 @@ package object cognitoidentityprovider {
   type CSSType                                      = String
   type CSSVersionType                               = String
   type CallbackURLsListType                         = js.Array[RedirectUrlType]
-  type ChallengeName                                = String
-  type ChallengeNameType                            = String
   type ChallengeParametersType                      = js.Dictionary[StringType]
-  type ChallengeResponse                            = String
   type ChallengeResponseListType                    = js.Array[ChallengeResponseType]
   type ChallengeResponsesType                       = js.Dictionary[StringType]
   type ClientIdType                                 = String
@@ -45,45 +37,33 @@ package object cognitoidentityprovider {
   type ClientSecretType                             = String
   type CodeDeliveryDetailsListType                  = js.Array[CodeDeliveryDetailsType]
   type CompletionMessageType                        = String
-  type CompromisedCredentialsEventActionType        = String
   type ConfirmationCodeType                         = String
   type CustomAttributeNameType                      = String
   type CustomAttributesListType                     = js.Array[SchemaAttributeType]
   type DateType                                     = js.Date
-  type DefaultEmailOptionType                       = String
   type DeliveryMediumListType                       = js.Array[DeliveryMediumType]
-  type DeliveryMediumType                           = String
   type DescriptionType                              = String
   type DeviceKeyType                                = String
   type DeviceListType                               = js.Array[DeviceType]
   type DeviceNameType                               = String
-  type DeviceRememberedStatusType                   = String
-  type DomainStatusType                             = String
   type DomainType                                   = String
   type DomainVersionType                            = String
   type EmailAddressType                             = String
   type EmailNotificationBodyType                    = String
   type EmailNotificationSubjectType                 = String
-  type EmailSendingAccountType                      = String
   type EmailVerificationMessageByLinkType           = String
   type EmailVerificationMessageType                 = String
   type EmailVerificationSubjectByLinkType           = String
   type EmailVerificationSubjectType                 = String
-  type EventFilterType                              = String
   type EventFiltersType                             = js.Array[EventFilterType]
   type EventIdType                                  = String
-  type EventResponseType                            = String
-  type EventType                                    = String
   type ExplicitAuthFlowsListType                    = js.Array[ExplicitAuthFlowsType]
-  type ExplicitAuthFlowsType                        = String
-  type FeedbackValueType                            = String
   type ForceAliasCreation                           = Boolean
   type GenerateSecret                               = Boolean
   type GroupListType                                = js.Array[GroupType]
   type GroupNameType                                = String
   type HexStringType                                = String
   type HttpHeaderList                               = js.Array[HttpHeader]
-  type IdentityProviderTypeType                     = String
   type IdpIdentifierType                            = String
   type IdpIdentifiersListType                       = js.Array[IdpIdentifierType]
   type ImageFileType                                = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
@@ -95,8 +75,6 @@ package object cognitoidentityprovider {
   type LogoutURLsListType                           = js.Array[RedirectUrlType]
   type LongType                                     = Double
   type MFAOptionListType                            = js.Array[MFAOptionType]
-  type MessageActionType                            = String
-  type OAuthFlowType                                = String
   type OAuthFlowsType                               = js.Array[OAuthFlowType]
   type PaginationKey                                = String
   type PaginationKeyType                            = String
@@ -105,7 +83,6 @@ package object cognitoidentityprovider {
   type PoolQueryLimitType                           = Int
   type PreSignedUrlType                             = String
   type PrecedenceType                               = Int
-  type PreventUserExistenceErrorTypes               = String
   type PriorityType                                 = Int
   type ProviderDetailsType                          = js.Dictionary[StringType]
   type ProviderNameType                             = String
@@ -114,7 +91,6 @@ package object cognitoidentityprovider {
   type QueryLimit                                   = Int
   type QueryLimitType                               = Int
   type RecoveryMechanismsType                       = js.Array[RecoveryOptionType]
-  type RecoveryOptionNameType                       = String
   type RedirectUrlType                              = String
   type RefreshTokenValidityType                     = Int
   type ResourceServerIdentifierType                 = String
@@ -123,8 +99,6 @@ package object cognitoidentityprovider {
   type ResourceServerScopeListType                  = js.Array[ResourceServerScopeType]
   type ResourceServerScopeNameType                  = String
   type ResourceServersListType                      = js.Array[ResourceServerType]
-  type RiskDecisionType                             = String
-  type RiskLevelType                                = String
   type S3BucketType                                 = String
   type SESConfigurationSet                          = String
   type SchemaAttributesListType                     = js.Array[SchemaAttributeType]
@@ -138,7 +112,6 @@ package object cognitoidentityprovider {
   type SkippedIPRangeListType                       = js.Array[StringType]
   type SmsVerificationMessageType                   = String
   type SoftwareTokenMFAUserCodeType                 = String
-  type StatusType                                   = String
   type StringType                                   = String
   type SupportedIdentityProvidersListType           = js.Array[ProviderNameType]
   type TagKeysType                                  = String
@@ -148,24 +121,18 @@ package object cognitoidentityprovider {
   type UserFilterType                               = String
   type UserImportJobIdType                          = String
   type UserImportJobNameType                        = String
-  type UserImportJobStatusType                      = String
   type UserImportJobsListType                       = js.Array[UserImportJobType]
   type UserMFASettingListType                       = js.Array[StringType]
   type UserPoolClientListType                       = js.Array[UserPoolClientDescription]
   type UserPoolIdType                               = String
   type UserPoolListType                             = js.Array[UserPoolDescriptionType]
-  type UserPoolMfaType                              = String
   type UserPoolNameType                             = String
   type UserPoolTagsListType                         = js.Array[TagKeysType]
   type UserPoolTagsType                             = js.Dictionary[TagValueType]
-  type UserStatusType                               = String
-  type UsernameAttributeType                        = String
   type UsernameAttributesListType                   = js.Array[UsernameAttributeType]
   type UsernameType                                 = String
   type UsersListType                                = js.Array[UserType]
-  type VerifiedAttributeType                        = String
   type VerifiedAttributesListType                   = js.Array[VerifiedAttributeType]
-  type VerifySoftwareTokenResponseType              = String
   type WrappedBooleanType                           = Boolean
 
   implicit final class CognitoIdentityProviderOps(private val service: CognitoIdentityProvider) extends AnyVal {
@@ -612,12 +579,13 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[AccountTakeoverActionsType]
     }
   }
-
-  object AccountTakeoverEventActionTypeEnum {
-    val BLOCK             = "BLOCK"
-    val MFA_IF_CONFIGURED = "MFA_IF_CONFIGURED"
-    val MFA_REQUIRED      = "MFA_REQUIRED"
-    val NO_ACTION         = "NO_ACTION"
+  @js.native
+  sealed trait AccountTakeoverEventActionType extends js.Any
+  object AccountTakeoverEventActionType extends js.Object {
+    val BLOCK             = "BLOCK".asInstanceOf[AccountTakeoverEventActionType]
+    val MFA_IF_CONFIGURED = "MFA_IF_CONFIGURED".asInstanceOf[AccountTakeoverEventActionType]
+    val MFA_REQUIRED      = "MFA_REQUIRED".asInstanceOf[AccountTakeoverEventActionType]
+    val NO_ACTION         = "NO_ACTION".asInstanceOf[AccountTakeoverEventActionType]
 
     val values = js.Object.freeze(js.Array(BLOCK, MFA_IF_CONFIGURED, MFA_REQUIRED, NO_ACTION))
   }
@@ -1848,19 +1816,21 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[AdminUserGlobalSignOutResponse]
     }
   }
-
-  object AdvancedSecurityModeTypeEnum {
-    val OFF      = "OFF"
-    val AUDIT    = "AUDIT"
-    val ENFORCED = "ENFORCED"
+  @js.native
+  sealed trait AdvancedSecurityModeType extends js.Any
+  object AdvancedSecurityModeType extends js.Object {
+    val OFF      = "OFF".asInstanceOf[AdvancedSecurityModeType]
+    val AUDIT    = "AUDIT".asInstanceOf[AdvancedSecurityModeType]
+    val ENFORCED = "ENFORCED".asInstanceOf[AdvancedSecurityModeType]
 
     val values = js.Object.freeze(js.Array(OFF, AUDIT, ENFORCED))
   }
-
-  object AliasAttributeTypeEnum {
-    val phone_number       = "phone_number"
-    val email              = "email"
-    val preferred_username = "preferred_username"
+  @js.native
+  sealed trait AliasAttributeType extends js.Any
+  object AliasAttributeType extends js.Object {
+    val phone_number       = "phone_number".asInstanceOf[AliasAttributeType]
+    val email              = "email".asInstanceOf[AliasAttributeType]
+    val preferred_username = "preferred_username".asInstanceOf[AliasAttributeType]
 
     val values = js.Object.freeze(js.Array(phone_number, email, preferred_username))
   }
@@ -1952,12 +1922,13 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[AssociateSoftwareTokenResponse]
     }
   }
-
-  object AttributeDataTypeEnum {
-    val String   = "String"
-    val Number   = "Number"
-    val DateTime = "DateTime"
-    val Boolean  = "Boolean"
+  @js.native
+  sealed trait AttributeDataType extends js.Any
+  object AttributeDataType extends js.Object {
+    val String   = "String".asInstanceOf[AttributeDataType]
+    val Number   = "Number".asInstanceOf[AttributeDataType]
+    val DateTime = "DateTime".asInstanceOf[AttributeDataType]
+    val Boolean  = "Boolean".asInstanceOf[AttributeDataType]
 
     val values = js.Object.freeze(js.Array(String, Number, DateTime, Boolean))
   }
@@ -2025,15 +1996,16 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[AuthEventType]
     }
   }
-
-  object AuthFlowTypeEnum {
-    val USER_SRP_AUTH            = "USER_SRP_AUTH"
-    val REFRESH_TOKEN_AUTH       = "REFRESH_TOKEN_AUTH"
-    val REFRESH_TOKEN            = "REFRESH_TOKEN"
-    val CUSTOM_AUTH              = "CUSTOM_AUTH"
-    val ADMIN_NO_SRP_AUTH        = "ADMIN_NO_SRP_AUTH"
-    val USER_PASSWORD_AUTH       = "USER_PASSWORD_AUTH"
-    val ADMIN_USER_PASSWORD_AUTH = "ADMIN_USER_PASSWORD_AUTH"
+  @js.native
+  sealed trait AuthFlowType extends js.Any
+  object AuthFlowType extends js.Object {
+    val USER_SRP_AUTH            = "USER_SRP_AUTH".asInstanceOf[AuthFlowType]
+    val REFRESH_TOKEN_AUTH       = "REFRESH_TOKEN_AUTH".asInstanceOf[AuthFlowType]
+    val REFRESH_TOKEN            = "REFRESH_TOKEN".asInstanceOf[AuthFlowType]
+    val CUSTOM_AUTH              = "CUSTOM_AUTH".asInstanceOf[AuthFlowType]
+    val ADMIN_NO_SRP_AUTH        = "ADMIN_NO_SRP_AUTH".asInstanceOf[AuthFlowType]
+    val USER_PASSWORD_AUTH       = "USER_PASSWORD_AUTH".asInstanceOf[AuthFlowType]
+    val ADMIN_USER_PASSWORD_AUTH = "ADMIN_USER_PASSWORD_AUTH".asInstanceOf[AuthFlowType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2081,25 +2053,27 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[AuthenticationResultType]
     }
   }
-
-  object ChallengeNameEnum {
-    val Password = "Password"
-    val Mfa      = "Mfa"
+  @js.native
+  sealed trait ChallengeName extends js.Any
+  object ChallengeName extends js.Object {
+    val Password = "Password".asInstanceOf[ChallengeName]
+    val Mfa      = "Mfa".asInstanceOf[ChallengeName]
 
     val values = js.Object.freeze(js.Array(Password, Mfa))
   }
-
-  object ChallengeNameTypeEnum {
-    val SMS_MFA                  = "SMS_MFA"
-    val SOFTWARE_TOKEN_MFA       = "SOFTWARE_TOKEN_MFA"
-    val SELECT_MFA_TYPE          = "SELECT_MFA_TYPE"
-    val MFA_SETUP                = "MFA_SETUP"
-    val PASSWORD_VERIFIER        = "PASSWORD_VERIFIER"
-    val CUSTOM_CHALLENGE         = "CUSTOM_CHALLENGE"
-    val DEVICE_SRP_AUTH          = "DEVICE_SRP_AUTH"
-    val DEVICE_PASSWORD_VERIFIER = "DEVICE_PASSWORD_VERIFIER"
-    val ADMIN_NO_SRP_AUTH        = "ADMIN_NO_SRP_AUTH"
-    val NEW_PASSWORD_REQUIRED    = "NEW_PASSWORD_REQUIRED"
+  @js.native
+  sealed trait ChallengeNameType extends js.Any
+  object ChallengeNameType extends js.Object {
+    val SMS_MFA                  = "SMS_MFA".asInstanceOf[ChallengeNameType]
+    val SOFTWARE_TOKEN_MFA       = "SOFTWARE_TOKEN_MFA".asInstanceOf[ChallengeNameType]
+    val SELECT_MFA_TYPE          = "SELECT_MFA_TYPE".asInstanceOf[ChallengeNameType]
+    val MFA_SETUP                = "MFA_SETUP".asInstanceOf[ChallengeNameType]
+    val PASSWORD_VERIFIER        = "PASSWORD_VERIFIER".asInstanceOf[ChallengeNameType]
+    val CUSTOM_CHALLENGE         = "CUSTOM_CHALLENGE".asInstanceOf[ChallengeNameType]
+    val DEVICE_SRP_AUTH          = "DEVICE_SRP_AUTH".asInstanceOf[ChallengeNameType]
+    val DEVICE_PASSWORD_VERIFIER = "DEVICE_PASSWORD_VERIFIER".asInstanceOf[ChallengeNameType]
+    val ADMIN_NO_SRP_AUTH        = "ADMIN_NO_SRP_AUTH".asInstanceOf[ChallengeNameType]
+    val NEW_PASSWORD_REQUIRED    = "NEW_PASSWORD_REQUIRED".asInstanceOf[ChallengeNameType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2116,10 +2090,11 @@ package cognitoidentityprovider {
       )
     )
   }
-
-  object ChallengeResponseEnum {
-    val Success = "Success"
-    val Failure = "Failure"
+  @js.native
+  sealed trait ChallengeResponse extends js.Any
+  object ChallengeResponse extends js.Object {
+    val Success = "Success".asInstanceOf[ChallengeResponse]
+    val Failure = "Failure".asInstanceOf[ChallengeResponse]
 
     val values = js.Object.freeze(js.Array(Success, Failure))
   }
@@ -2234,10 +2209,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[CompromisedCredentialsActionsType]
     }
   }
-
-  object CompromisedCredentialsEventActionTypeEnum {
-    val BLOCK     = "BLOCK"
-    val NO_ACTION = "NO_ACTION"
+  @js.native
+  sealed trait CompromisedCredentialsEventActionType extends js.Any
+  object CompromisedCredentialsEventActionType extends js.Object {
+    val BLOCK     = "BLOCK".asInstanceOf[CompromisedCredentialsEventActionType]
+    val NO_ACTION = "NO_ACTION".asInstanceOf[CompromisedCredentialsEventActionType]
 
     val values = js.Object.freeze(js.Array(BLOCK, NO_ACTION))
   }
@@ -2909,10 +2885,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[CustomDomainConfigType]
     }
   }
-
-  object DefaultEmailOptionTypeEnum {
-    val CONFIRM_WITH_LINK = "CONFIRM_WITH_LINK"
-    val CONFIRM_WITH_CODE = "CONFIRM_WITH_CODE"
+  @js.native
+  sealed trait DefaultEmailOptionType extends js.Any
+  object DefaultEmailOptionType extends js.Object {
+    val CONFIRM_WITH_LINK = "CONFIRM_WITH_LINK".asInstanceOf[DefaultEmailOptionType]
+    val CONFIRM_WITH_CODE = "CONFIRM_WITH_CODE".asInstanceOf[DefaultEmailOptionType]
 
     val values = js.Object.freeze(js.Array(CONFIRM_WITH_LINK, CONFIRM_WITH_CODE))
   }
@@ -3119,10 +3096,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[DeleteUserRequest]
     }
   }
-
-  object DeliveryMediumTypeEnum {
-    val SMS   = "SMS"
-    val EMAIL = "EMAIL"
+  @js.native
+  sealed trait DeliveryMediumType extends js.Any
+  object DeliveryMediumType extends js.Object {
+    val SMS   = "SMS".asInstanceOf[DeliveryMediumType]
+    val EMAIL = "EMAIL".asInstanceOf[DeliveryMediumType]
 
     val values = js.Object.freeze(js.Array(SMS, EMAIL))
   }
@@ -3429,10 +3407,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[DeviceConfigurationType]
     }
   }
-
-  object DeviceRememberedStatusTypeEnum {
-    val remembered     = "remembered"
-    val not_remembered = "not_remembered"
+  @js.native
+  sealed trait DeviceRememberedStatusType extends js.Any
+  object DeviceRememberedStatusType extends js.Object {
+    val remembered     = "remembered".asInstanceOf[DeviceRememberedStatusType]
+    val not_remembered = "not_remembered".asInstanceOf[DeviceRememberedStatusType]
 
     val values = js.Object.freeze(js.Array(remembered, not_remembered))
   }
@@ -3531,13 +3510,14 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[DomainDescriptionType]
     }
   }
-
-  object DomainStatusTypeEnum {
-    val CREATING = "CREATING"
-    val DELETING = "DELETING"
-    val UPDATING = "UPDATING"
-    val ACTIVE   = "ACTIVE"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait DomainStatusType extends js.Any
+  object DomainStatusType extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[DomainStatusType]
+    val DELETING = "DELETING".asInstanceOf[DomainStatusType]
+    val UPDATING = "UPDATING".asInstanceOf[DomainStatusType]
+    val ACTIVE   = "ACTIVE".asInstanceOf[DomainStatusType]
+    val FAILED   = "FAILED".asInstanceOf[DomainStatusType]
 
     val values = js.Object.freeze(js.Array(CREATING, DELETING, UPDATING, ACTIVE, FAILED))
   }
@@ -3572,10 +3552,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[EmailConfigurationType]
     }
   }
-
-  object EmailSendingAccountTypeEnum {
-    val COGNITO_DEFAULT = "COGNITO_DEFAULT"
-    val DEVELOPER       = "DEVELOPER"
+  @js.native
+  sealed trait EmailSendingAccountType extends js.Any
+  object EmailSendingAccountType extends js.Object {
+    val COGNITO_DEFAULT = "COGNITO_DEFAULT".asInstanceOf[EmailSendingAccountType]
+    val DEVELOPER       = "DEVELOPER".asInstanceOf[EmailSendingAccountType]
 
     val values = js.Object.freeze(js.Array(COGNITO_DEFAULT, DEVELOPER))
   }
@@ -3637,18 +3618,20 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[EventFeedbackType]
     }
   }
-
-  object EventFilterTypeEnum {
-    val SIGN_IN         = "SIGN_IN"
-    val PASSWORD_CHANGE = "PASSWORD_CHANGE"
-    val SIGN_UP         = "SIGN_UP"
+  @js.native
+  sealed trait EventFilterType extends js.Any
+  object EventFilterType extends js.Object {
+    val SIGN_IN         = "SIGN_IN".asInstanceOf[EventFilterType]
+    val PASSWORD_CHANGE = "PASSWORD_CHANGE".asInstanceOf[EventFilterType]
+    val SIGN_UP         = "SIGN_UP".asInstanceOf[EventFilterType]
 
     val values = js.Object.freeze(js.Array(SIGN_IN, PASSWORD_CHANGE, SIGN_UP))
   }
-
-  object EventResponseTypeEnum {
-    val Success = "Success"
-    val Failure = "Failure"
+  @js.native
+  sealed trait EventResponseType extends js.Any
+  object EventResponseType extends js.Object {
+    val Success = "Success".asInstanceOf[EventResponseType]
+    val Failure = "Failure".asInstanceOf[EventResponseType]
 
     val values = js.Object.freeze(js.Array(Success, Failure))
   }
@@ -3674,24 +3657,26 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[EventRiskType]
     }
   }
-
-  object EventTypeEnum {
-    val SignIn         = "SignIn"
-    val SignUp         = "SignUp"
-    val ForgotPassword = "ForgotPassword"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val SignIn         = "SignIn".asInstanceOf[EventType]
+    val SignUp         = "SignUp".asInstanceOf[EventType]
+    val ForgotPassword = "ForgotPassword".asInstanceOf[EventType]
 
     val values = js.Object.freeze(js.Array(SignIn, SignUp, ForgotPassword))
   }
-
-  object ExplicitAuthFlowsTypeEnum {
-    val ADMIN_NO_SRP_AUTH              = "ADMIN_NO_SRP_AUTH"
-    val CUSTOM_AUTH_FLOW_ONLY          = "CUSTOM_AUTH_FLOW_ONLY"
-    val USER_PASSWORD_AUTH             = "USER_PASSWORD_AUTH"
-    val ALLOW_ADMIN_USER_PASSWORD_AUTH = "ALLOW_ADMIN_USER_PASSWORD_AUTH"
-    val ALLOW_CUSTOM_AUTH              = "ALLOW_CUSTOM_AUTH"
-    val ALLOW_USER_PASSWORD_AUTH       = "ALLOW_USER_PASSWORD_AUTH"
-    val ALLOW_USER_SRP_AUTH            = "ALLOW_USER_SRP_AUTH"
-    val ALLOW_REFRESH_TOKEN_AUTH       = "ALLOW_REFRESH_TOKEN_AUTH"
+  @js.native
+  sealed trait ExplicitAuthFlowsType extends js.Any
+  object ExplicitAuthFlowsType extends js.Object {
+    val ADMIN_NO_SRP_AUTH              = "ADMIN_NO_SRP_AUTH".asInstanceOf[ExplicitAuthFlowsType]
+    val CUSTOM_AUTH_FLOW_ONLY          = "CUSTOM_AUTH_FLOW_ONLY".asInstanceOf[ExplicitAuthFlowsType]
+    val USER_PASSWORD_AUTH             = "USER_PASSWORD_AUTH".asInstanceOf[ExplicitAuthFlowsType]
+    val ALLOW_ADMIN_USER_PASSWORD_AUTH = "ALLOW_ADMIN_USER_PASSWORD_AUTH".asInstanceOf[ExplicitAuthFlowsType]
+    val ALLOW_CUSTOM_AUTH              = "ALLOW_CUSTOM_AUTH".asInstanceOf[ExplicitAuthFlowsType]
+    val ALLOW_USER_PASSWORD_AUTH       = "ALLOW_USER_PASSWORD_AUTH".asInstanceOf[ExplicitAuthFlowsType]
+    val ALLOW_USER_SRP_AUTH            = "ALLOW_USER_SRP_AUTH".asInstanceOf[ExplicitAuthFlowsType]
+    val ALLOW_REFRESH_TOKEN_AUTH       = "ALLOW_REFRESH_TOKEN_AUTH".asInstanceOf[ExplicitAuthFlowsType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3706,10 +3691,11 @@ package cognitoidentityprovider {
       )
     )
   }
-
-  object FeedbackValueTypeEnum {
-    val Valid   = "Valid"
-    val Invalid = "Invalid"
+  @js.native
+  sealed trait FeedbackValueType extends js.Any
+  object FeedbackValueType extends js.Object {
+    val Valid   = "Valid".asInstanceOf[FeedbackValueType]
+    val Invalid = "Invalid".asInstanceOf[FeedbackValueType]
 
     val values = js.Object.freeze(js.Array(Valid, Invalid))
   }
@@ -4313,14 +4299,15 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[IdentityProviderType]
     }
   }
-
-  object IdentityProviderTypeTypeEnum {
-    val SAML            = "SAML"
-    val Facebook        = "Facebook"
-    val Google          = "Google"
-    val LoginWithAmazon = "LoginWithAmazon"
-    val SignInWithApple = "SignInWithApple"
-    val OIDC            = "OIDC"
+  @js.native
+  sealed trait IdentityProviderTypeType extends js.Any
+  object IdentityProviderTypeType extends js.Object {
+    val SAML            = "SAML".asInstanceOf[IdentityProviderTypeType]
+    val Facebook        = "Facebook".asInstanceOf[IdentityProviderTypeType]
+    val Google          = "Google".asInstanceOf[IdentityProviderTypeType]
+    val LoginWithAmazon = "LoginWithAmazon".asInstanceOf[IdentityProviderTypeType]
+    val SignInWithApple = "SignInWithApple".asInstanceOf[IdentityProviderTypeType]
+    val OIDC            = "OIDC".asInstanceOf[IdentityProviderTypeType]
 
     val values = js.Object.freeze(js.Array(SAML, Facebook, Google, LoginWithAmazon, SignInWithApple, OIDC))
   }
@@ -4921,10 +4908,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[MFAOptionType]
     }
   }
-
-  object MessageActionTypeEnum {
-    val RESEND   = "RESEND"
-    val SUPPRESS = "SUPPRESS"
+  @js.native
+  sealed trait MessageActionType extends js.Any
+  object MessageActionType extends js.Object {
+    val RESEND   = "RESEND".asInstanceOf[MessageActionType]
+    val SUPPRESS = "SUPPRESS".asInstanceOf[MessageActionType]
 
     val values = js.Object.freeze(js.Array(RESEND, SUPPRESS))
   }
@@ -5060,11 +5048,12 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[NumberAttributeConstraintsType]
     }
   }
-
-  object OAuthFlowTypeEnum {
-    val code               = "code"
-    val `implicit`         = "implicit"
-    val client_credentials = "client_credentials"
+  @js.native
+  sealed trait OAuthFlowType extends js.Any
+  object OAuthFlowType extends js.Object {
+    val code               = "code".asInstanceOf[OAuthFlowType]
+    val `implicit`         = "implicit".asInstanceOf[OAuthFlowType]
+    val client_credentials = "client_credentials".asInstanceOf[OAuthFlowType]
 
     val values = js.Object.freeze(js.Array(code, `implicit`, client_credentials))
   }
@@ -5104,10 +5093,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[PasswordPolicyType]
     }
   }
-
-  object PreventUserExistenceErrorTypesEnum {
-    val LEGACY  = "LEGACY"
-    val ENABLED = "ENABLED"
+  @js.native
+  sealed trait PreventUserExistenceErrorTypes extends js.Any
+  object PreventUserExistenceErrorTypes extends js.Object {
+    val LEGACY  = "LEGACY".asInstanceOf[PreventUserExistenceErrorTypes]
+    val ENABLED = "ENABLED".asInstanceOf[PreventUserExistenceErrorTypes]
 
     val values = js.Object.freeze(js.Array(LEGACY, ENABLED))
   }
@@ -5164,11 +5154,12 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[ProviderUserIdentifierType]
     }
   }
-
-  object RecoveryOptionNameTypeEnum {
-    val verified_email        = "verified_email"
-    val verified_phone_number = "verified_phone_number"
-    val admin_only            = "admin_only"
+  @js.native
+  sealed trait RecoveryOptionNameType extends js.Any
+  object RecoveryOptionNameType extends js.Object {
+    val verified_email        = "verified_email".asInstanceOf[RecoveryOptionNameType]
+    val verified_phone_number = "verified_phone_number".asInstanceOf[RecoveryOptionNameType]
+    val admin_only            = "admin_only".asInstanceOf[RecoveryOptionNameType]
 
     val values = js.Object.freeze(js.Array(verified_email, verified_phone_number, admin_only))
   }
@@ -5410,11 +5401,12 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[RiskConfigurationType]
     }
   }
-
-  object RiskDecisionTypeEnum {
-    val NoRisk          = "NoRisk"
-    val AccountTakeover = "AccountTakeover"
-    val Block           = "Block"
+  @js.native
+  sealed trait RiskDecisionType extends js.Any
+  object RiskDecisionType extends js.Object {
+    val NoRisk          = "NoRisk".asInstanceOf[RiskDecisionType]
+    val AccountTakeover = "AccountTakeover".asInstanceOf[RiskDecisionType]
+    val Block           = "Block".asInstanceOf[RiskDecisionType]
 
     val values = js.Object.freeze(js.Array(NoRisk, AccountTakeover, Block))
   }
@@ -5440,11 +5432,12 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[RiskExceptionConfigurationType]
     }
   }
-
-  object RiskLevelTypeEnum {
-    val Low    = "Low"
-    val Medium = "Medium"
-    val High   = "High"
+  @js.native
+  sealed trait RiskLevelType extends js.Any
+  object RiskLevelType extends js.Object {
+    val Low    = "Low".asInstanceOf[RiskLevelType]
+    val Medium = "Medium".asInstanceOf[RiskLevelType]
+    val High   = "High".asInstanceOf[RiskLevelType]
 
     val values = js.Object.freeze(js.Array(Low, Medium, High))
   }
@@ -5942,10 +5935,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[StartUserImportJobResponse]
     }
   }
-
-  object StatusTypeEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait StatusType extends js.Any
+  object StatusType extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[StatusType]
+    val Disabled = "Disabled".asInstanceOf[StatusType]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
@@ -6633,16 +6627,17 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[UserContextDataType]
     }
   }
-
-  object UserImportJobStatusTypeEnum {
-    val Created    = "Created"
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Stopping   = "Stopping"
-    val Expired    = "Expired"
-    val Stopped    = "Stopped"
-    val Failed     = "Failed"
-    val Succeeded  = "Succeeded"
+  @js.native
+  sealed trait UserImportJobStatusType extends js.Any
+  object UserImportJobStatusType extends js.Object {
+    val Created    = "Created".asInstanceOf[UserImportJobStatusType]
+    val Pending    = "Pending".asInstanceOf[UserImportJobStatusType]
+    val InProgress = "InProgress".asInstanceOf[UserImportJobStatusType]
+    val Stopping   = "Stopping".asInstanceOf[UserImportJobStatusType]
+    val Expired    = "Expired".asInstanceOf[UserImportJobStatusType]
+    val Stopped    = "Stopped".asInstanceOf[UserImportJobStatusType]
+    val Failed     = "Failed".asInstanceOf[UserImportJobStatusType]
+    val Succeeded  = "Succeeded".asInstanceOf[UserImportJobStatusType]
 
     val values = js.Object.freeze(js.Array(Created, Pending, InProgress, Stopping, Expired, Stopped, Failed, Succeeded))
   }
@@ -6860,11 +6855,12 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[UserPoolDescriptionType]
     }
   }
-
-  object UserPoolMfaTypeEnum {
-    val OFF      = "OFF"
-    val ON       = "ON"
-    val OPTIONAL = "OPTIONAL"
+  @js.native
+  sealed trait UserPoolMfaType extends js.Any
+  object UserPoolMfaType extends js.Object {
+    val OFF      = "OFF".asInstanceOf[UserPoolMfaType]
+    val ON       = "ON".asInstanceOf[UserPoolMfaType]
+    val OPTIONAL = "OPTIONAL".asInstanceOf[UserPoolMfaType]
 
     val values = js.Object.freeze(js.Array(OFF, ON, OPTIONAL))
   }
@@ -7000,15 +6996,16 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[UserPoolType]
     }
   }
-
-  object UserStatusTypeEnum {
-    val UNCONFIRMED           = "UNCONFIRMED"
-    val CONFIRMED             = "CONFIRMED"
-    val ARCHIVED              = "ARCHIVED"
-    val COMPROMISED           = "COMPROMISED"
-    val UNKNOWN               = "UNKNOWN"
-    val RESET_REQUIRED        = "RESET_REQUIRED"
-    val FORCE_CHANGE_PASSWORD = "FORCE_CHANGE_PASSWORD"
+  @js.native
+  sealed trait UserStatusType extends js.Any
+  object UserStatusType extends js.Object {
+    val UNCONFIRMED           = "UNCONFIRMED".asInstanceOf[UserStatusType]
+    val CONFIRMED             = "CONFIRMED".asInstanceOf[UserStatusType]
+    val ARCHIVED              = "ARCHIVED".asInstanceOf[UserStatusType]
+    val COMPROMISED           = "COMPROMISED".asInstanceOf[UserStatusType]
+    val UNKNOWN               = "UNKNOWN".asInstanceOf[UserStatusType]
+    val RESET_REQUIRED        = "RESET_REQUIRED".asInstanceOf[UserStatusType]
+    val FORCE_CHANGE_PASSWORD = "FORCE_CHANGE_PASSWORD".asInstanceOf[UserStatusType]
 
     val values = js.Object.freeze(
       js.Array(UNCONFIRMED, CONFIRMED, ARCHIVED, COMPROMISED, UNKNOWN, RESET_REQUIRED, FORCE_CHANGE_PASSWORD)
@@ -7051,10 +7048,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[UserType]
     }
   }
-
-  object UsernameAttributeTypeEnum {
-    val phone_number = "phone_number"
-    val email        = "email"
+  @js.native
+  sealed trait UsernameAttributeType extends js.Any
+  object UsernameAttributeType extends js.Object {
+    val phone_number = "phone_number".asInstanceOf[UsernameAttributeType]
+    val email        = "email".asInstanceOf[UsernameAttributeType]
 
     val values = js.Object.freeze(js.Array(phone_number, email))
   }
@@ -7113,10 +7111,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[VerificationMessageTemplateType]
     }
   }
-
-  object VerifiedAttributeTypeEnum {
-    val phone_number = "phone_number"
-    val email        = "email"
+  @js.native
+  sealed trait VerifiedAttributeType extends js.Any
+  object VerifiedAttributeType extends js.Object {
+    val phone_number = "phone_number".asInstanceOf[VerifiedAttributeType]
+    val email        = "email".asInstanceOf[VerifiedAttributeType]
 
     val values = js.Object.freeze(js.Array(phone_number, email))
   }
@@ -7166,10 +7165,11 @@ package cognitoidentityprovider {
       __obj.asInstanceOf[VerifySoftwareTokenResponse]
     }
   }
-
-  object VerifySoftwareTokenResponseTypeEnum {
-    val SUCCESS = "SUCCESS"
-    val ERROR   = "ERROR"
+  @js.native
+  sealed trait VerifySoftwareTokenResponseType extends js.Any
+  object VerifySoftwareTokenResponseType extends js.Object {
+    val SUCCESS = "SUCCESS".asInstanceOf[VerifySoftwareTokenResponseType]
+    val ERROR   = "ERROR".asInstanceOf[VerifySoftwareTokenResponseType]
 
     val values = js.Object.freeze(js.Array(SUCCESS, ERROR))
   }

--- a/services/cognitosync/src/main/scala/facade/amazonaws/services/CognitoSync.scala
+++ b/services/cognitosync/src/main/scala/facade/amazonaws/services/CognitoSync.scala
@@ -10,7 +10,6 @@ package object cognitosync {
   type ApplicationArn        = String
   type ApplicationArnList    = js.Array[ApplicationArn]
   type AssumeRoleArn         = String
-  type BulkPublishStatus     = String
   type ClientContext         = String
   type CognitoEventType      = String
   type DatasetList           = js.Array[Dataset]
@@ -25,15 +24,12 @@ package object cognitosync {
   type IntegerString         = Int
   type LambdaFunctionArn     = String
   type MergedDatasetNameList = js.Array[String]
-  type Operation             = String
-  type Platform              = String
   type PushToken             = String
   type RecordKey             = String
   type RecordList            = js.Array[Record]
   type RecordPatchList       = js.Array[RecordPatch]
   type RecordValue           = String
   type StreamName            = String
-  type StreamingStatus       = String
   type SyncSessionToken      = String
 
   implicit final class CognitoSyncOps(private val service: CognitoSync) extends AnyVal {
@@ -161,12 +157,13 @@ package cognitosync {
       __obj.asInstanceOf[BulkPublishResponse]
     }
   }
-
-  object BulkPublishStatusEnum {
-    val NOT_STARTED = "NOT_STARTED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val FAILED      = "FAILED"
-    val SUCCEEDED   = "SUCCEEDED"
+  @js.native
+  sealed trait BulkPublishStatus extends js.Any
+  object BulkPublishStatus extends js.Object {
+    val NOT_STARTED = "NOT_STARTED".asInstanceOf[BulkPublishStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[BulkPublishStatus]
+    val FAILED      = "FAILED".asInstanceOf[BulkPublishStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[BulkPublishStatus]
 
     val values = js.Object.freeze(js.Array(NOT_STARTED, IN_PROGRESS, FAILED, SUCCEEDED))
   }
@@ -862,19 +859,21 @@ package cognitosync {
   trait NotAuthorizedExceptionException extends js.Object {
     val message: ExceptionMessage
   }
-
-  object OperationEnum {
-    val replace = "replace"
-    val remove  = "remove"
+  @js.native
+  sealed trait Operation extends js.Any
+  object Operation extends js.Object {
+    val replace = "replace".asInstanceOf[Operation]
+    val remove  = "remove".asInstanceOf[Operation]
 
     val values = js.Object.freeze(js.Array(replace, remove))
   }
-
-  object PlatformEnum {
-    val APNS         = "APNS"
-    val APNS_SANDBOX = "APNS_SANDBOX"
-    val GCM          = "GCM"
-    val ADM          = "ADM"
+  @js.native
+  sealed trait Platform extends js.Any
+  object Platform extends js.Object {
+    val APNS         = "APNS".asInstanceOf[Platform]
+    val APNS_SANDBOX = "APNS_SANDBOX".asInstanceOf[Platform]
+    val GCM          = "GCM".asInstanceOf[Platform]
+    val ADM          = "ADM".asInstanceOf[Platform]
 
     val values = js.Object.freeze(js.Array(APNS, APNS_SANDBOX, GCM, ADM))
   }
@@ -1109,10 +1108,11 @@ package cognitosync {
       __obj.asInstanceOf[SetIdentityPoolConfigurationResponse]
     }
   }
-
-  object StreamingStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait StreamingStatus extends js.Any
+  object StreamingStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[StreamingStatus]
+    val DISABLED = "DISABLED".asInstanceOf[StreamingStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }

--- a/services/comprehend/src/main/scala/facade/amazonaws/services/Comprehend.scala
+++ b/services/comprehend/src/main/scala/facade/amazonaws/services/Comprehend.scala
@@ -18,28 +18,22 @@ package object comprehend {
   type DocumentClassificationJobPropertiesList    = js.Array[DocumentClassificationJobProperties]
   type DocumentClassifierArn                      = String
   type DocumentClassifierEndpointArn              = String
-  type DocumentClassifierMode                     = String
   type DocumentClassifierPropertiesList           = js.Array[DocumentClassifierProperties]
   type DominantLanguageDetectionJobPropertiesList = js.Array[DominantLanguageDetectionJobProperties]
   type EndpointPropertiesList                     = js.Array[EndpointProperties]
-  type EndpointStatus                             = String
   type EntitiesDetectionJobPropertiesList         = js.Array[EntitiesDetectionJobProperties]
   type EntityRecognizerArn                        = String
   type EntityRecognizerMetadataEntityTypesList    = js.Array[EntityRecognizerMetadataEntityTypesListItem]
   type EntityRecognizerPropertiesList             = js.Array[EntityRecognizerProperties]
-  type EntityType                                 = String
   type EntityTypeName                             = String
   type EntityTypesList                            = js.Array[EntityTypesListItem]
   type IamRoleArn                                 = String
   type InferenceUnitsInteger                      = Int
-  type InputFormat                                = String
   type JobId                                      = String
   type JobName                                    = String
-  type JobStatus                                  = String
   type KeyPhrasesDetectionJobPropertiesList       = js.Array[KeyPhrasesDetectionJobProperties]
   type KmsKeyId                                   = String
   type LabelDelimiter                             = String
-  type LanguageCode                               = String
   type ListOfClasses                              = js.Array[DocumentClass]
   type ListOfDetectDominantLanguageResult         = js.Array[BatchDetectDominantLanguageItemResult]
   type ListOfDetectEntitiesResult                 = js.Array[BatchDetectEntitiesItemResult]
@@ -52,18 +46,14 @@ package object comprehend {
   type ListOfLabels                               = js.Array[DocumentLabel]
   type ListOfSyntaxTokens                         = js.Array[SyntaxToken]
   type MaxResultsInteger                          = Int
-  type ModelStatus                                = String
   type NumberOfTopicsInteger                      = Int
-  type PartOfSpeechTagType                        = String
   type S3Uri                                      = String
   type SecurityGroupId                            = String
   type SecurityGroupIds                           = js.Array[SecurityGroupId]
   type SentimentDetectionJobPropertiesList        = js.Array[SentimentDetectionJobProperties]
-  type SentimentType                              = String
   type StringList                                 = js.Array[String]
   type SubnetId                                   = String
   type Subnets                                    = js.Array[SubnetId]
-  type SyntaxLanguageCode                         = String
   type TagKey                                     = String
   type TagKeyList                                 = js.Array[TagKey]
   type TagList                                    = js.Array[Tag]
@@ -1699,10 +1689,11 @@ package comprehend {
       __obj.asInstanceOf[DocumentClassifierInputDataConfig]
     }
   }
-
-  object DocumentClassifierModeEnum {
-    val MULTI_CLASS = "MULTI_CLASS"
-    val MULTI_LABEL = "MULTI_LABEL"
+  @js.native
+  sealed trait DocumentClassifierMode extends js.Any
+  object DocumentClassifierMode extends js.Object {
+    val MULTI_CLASS = "MULTI_CLASS".asInstanceOf[DocumentClassifierMode]
+    val MULTI_LABEL = "MULTI_LABEL".asInstanceOf[DocumentClassifierMode]
 
     val values = js.Object.freeze(js.Array(MULTI_CLASS, MULTI_LABEL))
   }
@@ -1978,13 +1969,14 @@ package comprehend {
       __obj.asInstanceOf[EndpointProperties]
     }
   }
-
-  object EndpointStatusEnum {
-    val CREATING   = "CREATING"
-    val DELETING   = "DELETING"
-    val FAILED     = "FAILED"
-    val IN_SERVICE = "IN_SERVICE"
-    val UPDATING   = "UPDATING"
+  @js.native
+  sealed trait EndpointStatus extends js.Any
+  object EndpointStatus extends js.Object {
+    val CREATING   = "CREATING".asInstanceOf[EndpointStatus]
+    val DELETING   = "DELETING".asInstanceOf[EndpointStatus]
+    val FAILED     = "FAILED".asInstanceOf[EndpointStatus]
+    val IN_SERVICE = "IN_SERVICE".asInstanceOf[EndpointStatus]
+    val UPDATING   = "UPDATING".asInstanceOf[EndpointStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, DELETING, FAILED, IN_SERVICE, UPDATING))
   }
@@ -2354,17 +2346,18 @@ package comprehend {
       __obj.asInstanceOf[EntityRecognizerProperties]
     }
   }
-
-  object EntityTypeEnum {
-    val PERSON          = "PERSON"
-    val LOCATION        = "LOCATION"
-    val ORGANIZATION    = "ORGANIZATION"
-    val COMMERCIAL_ITEM = "COMMERCIAL_ITEM"
-    val EVENT           = "EVENT"
-    val DATE            = "DATE"
-    val QUANTITY        = "QUANTITY"
-    val TITLE           = "TITLE"
-    val OTHER           = "OTHER"
+  @js.native
+  sealed trait EntityType extends js.Any
+  object EntityType extends js.Object {
+    val PERSON          = "PERSON".asInstanceOf[EntityType]
+    val LOCATION        = "LOCATION".asInstanceOf[EntityType]
+    val ORGANIZATION    = "ORGANIZATION".asInstanceOf[EntityType]
+    val COMMERCIAL_ITEM = "COMMERCIAL_ITEM".asInstanceOf[EntityType]
+    val EVENT           = "EVENT".asInstanceOf[EntityType]
+    val DATE            = "DATE".asInstanceOf[EntityType]
+    val QUANTITY        = "QUANTITY".asInstanceOf[EntityType]
+    val TITLE           = "TITLE".asInstanceOf[EntityType]
+    val OTHER           = "OTHER".asInstanceOf[EntityType]
 
     val values =
       js.Object.freeze(js.Array(PERSON, LOCATION, ORGANIZATION, COMMERCIAL_ITEM, EVENT, DATE, QUANTITY, TITLE, OTHER))
@@ -2439,21 +2432,23 @@ package comprehend {
       __obj.asInstanceOf[InputDataConfig]
     }
   }
-
-  object InputFormatEnum {
-    val ONE_DOC_PER_FILE = "ONE_DOC_PER_FILE"
-    val ONE_DOC_PER_LINE = "ONE_DOC_PER_LINE"
+  @js.native
+  sealed trait InputFormat extends js.Any
+  object InputFormat extends js.Object {
+    val ONE_DOC_PER_FILE = "ONE_DOC_PER_FILE".asInstanceOf[InputFormat]
+    val ONE_DOC_PER_LINE = "ONE_DOC_PER_LINE".asInstanceOf[InputFormat]
 
     val values = js.Object.freeze(js.Array(ONE_DOC_PER_FILE, ONE_DOC_PER_LINE))
   }
-
-  object JobStatusEnum {
-    val SUBMITTED      = "SUBMITTED"
-    val IN_PROGRESS    = "IN_PROGRESS"
-    val COMPLETED      = "COMPLETED"
-    val FAILED         = "FAILED"
-    val STOP_REQUESTED = "STOP_REQUESTED"
-    val STOPPED        = "STOPPED"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val SUBMITTED      = "SUBMITTED".asInstanceOf[JobStatus]
+    val IN_PROGRESS    = "IN_PROGRESS".asInstanceOf[JobStatus]
+    val COMPLETED      = "COMPLETED".asInstanceOf[JobStatus]
+    val FAILED         = "FAILED".asInstanceOf[JobStatus]
+    val STOP_REQUESTED = "STOP_REQUESTED".asInstanceOf[JobStatus]
+    val STOPPED        = "STOPPED".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(js.Array(SUBMITTED, IN_PROGRESS, COMPLETED, FAILED, STOP_REQUESTED, STOPPED))
   }
@@ -2565,20 +2560,21 @@ package comprehend {
       __obj.asInstanceOf[KeyPhrasesDetectionJobProperties]
     }
   }
-
-  object LanguageCodeEnum {
-    val en      = "en"
-    val es      = "es"
-    val fr      = "fr"
-    val de      = "de"
-    val it      = "it"
-    val pt      = "pt"
-    val ar      = "ar"
-    val hi      = "hi"
-    val ja      = "ja"
-    val ko      = "ko"
-    val zh      = "zh"
-    val `zh-TW` = "zh-TW"
+  @js.native
+  sealed trait LanguageCode extends js.Any
+  object LanguageCode extends js.Object {
+    val en      = "en".asInstanceOf[LanguageCode]
+    val es      = "es".asInstanceOf[LanguageCode]
+    val fr      = "fr".asInstanceOf[LanguageCode]
+    val de      = "de".asInstanceOf[LanguageCode]
+    val it      = "it".asInstanceOf[LanguageCode]
+    val pt      = "pt".asInstanceOf[LanguageCode]
+    val ar      = "ar".asInstanceOf[LanguageCode]
+    val hi      = "hi".asInstanceOf[LanguageCode]
+    val ja      = "ja".asInstanceOf[LanguageCode]
+    val ko      = "ko".asInstanceOf[LanguageCode]
+    val zh      = "zh".asInstanceOf[LanguageCode]
+    val `zh-TW` = "zh-TW".asInstanceOf[LanguageCode]
 
     val values = js.Object.freeze(js.Array(en, es, fr, de, it, pt, ar, hi, ja, ko, zh, `zh-TW`))
   }
@@ -3005,15 +3001,16 @@ package comprehend {
       __obj.asInstanceOf[ListTopicsDetectionJobsResponse]
     }
   }
-
-  object ModelStatusEnum {
-    val SUBMITTED      = "SUBMITTED"
-    val TRAINING       = "TRAINING"
-    val DELETING       = "DELETING"
-    val STOP_REQUESTED = "STOP_REQUESTED"
-    val STOPPED        = "STOPPED"
-    val IN_ERROR       = "IN_ERROR"
-    val TRAINED        = "TRAINED"
+  @js.native
+  sealed trait ModelStatus extends js.Any
+  object ModelStatus extends js.Object {
+    val SUBMITTED      = "SUBMITTED".asInstanceOf[ModelStatus]
+    val TRAINING       = "TRAINING".asInstanceOf[ModelStatus]
+    val DELETING       = "DELETING".asInstanceOf[ModelStatus]
+    val STOP_REQUESTED = "STOP_REQUESTED".asInstanceOf[ModelStatus]
+    val STOPPED        = "STOPPED".asInstanceOf[ModelStatus]
+    val IN_ERROR       = "IN_ERROR".asInstanceOf[ModelStatus]
+    val TRAINED        = "TRAINED".asInstanceOf[ModelStatus]
 
     val values = js.Object.freeze(js.Array(SUBMITTED, TRAINING, DELETING, STOP_REQUESTED, STOPPED, IN_ERROR, TRAINED))
   }
@@ -3064,26 +3061,27 @@ package comprehend {
       __obj.asInstanceOf[PartOfSpeechTag]
     }
   }
-
-  object PartOfSpeechTagTypeEnum {
-    val ADJ   = "ADJ"
-    val ADP   = "ADP"
-    val ADV   = "ADV"
-    val AUX   = "AUX"
-    val CONJ  = "CONJ"
-    val CCONJ = "CCONJ"
-    val DET   = "DET"
-    val INTJ  = "INTJ"
-    val NOUN  = "NOUN"
-    val NUM   = "NUM"
-    val O     = "O"
-    val PART  = "PART"
-    val PRON  = "PRON"
-    val PROPN = "PROPN"
-    val PUNCT = "PUNCT"
-    val SCONJ = "SCONJ"
-    val SYM   = "SYM"
-    val VERB  = "VERB"
+  @js.native
+  sealed trait PartOfSpeechTagType extends js.Any
+  object PartOfSpeechTagType extends js.Object {
+    val ADJ   = "ADJ".asInstanceOf[PartOfSpeechTagType]
+    val ADP   = "ADP".asInstanceOf[PartOfSpeechTagType]
+    val ADV   = "ADV".asInstanceOf[PartOfSpeechTagType]
+    val AUX   = "AUX".asInstanceOf[PartOfSpeechTagType]
+    val CONJ  = "CONJ".asInstanceOf[PartOfSpeechTagType]
+    val CCONJ = "CCONJ".asInstanceOf[PartOfSpeechTagType]
+    val DET   = "DET".asInstanceOf[PartOfSpeechTagType]
+    val INTJ  = "INTJ".asInstanceOf[PartOfSpeechTagType]
+    val NOUN  = "NOUN".asInstanceOf[PartOfSpeechTagType]
+    val NUM   = "NUM".asInstanceOf[PartOfSpeechTagType]
+    val O     = "O".asInstanceOf[PartOfSpeechTagType]
+    val PART  = "PART".asInstanceOf[PartOfSpeechTagType]
+    val PRON  = "PRON".asInstanceOf[PartOfSpeechTagType]
+    val PROPN = "PROPN".asInstanceOf[PartOfSpeechTagType]
+    val PUNCT = "PUNCT".asInstanceOf[PartOfSpeechTagType]
+    val SCONJ = "SCONJ".asInstanceOf[PartOfSpeechTagType]
+    val SYM   = "SYM".asInstanceOf[PartOfSpeechTagType]
+    val VERB  = "VERB".asInstanceOf[PartOfSpeechTagType]
 
     val values = js.Object.freeze(
       js.Array(ADJ, ADP, ADV, AUX, CONJ, CCONJ, DET, INTJ, NOUN, NUM, O, PART, PRON, PROPN, PUNCT, SCONJ, SYM, VERB)
@@ -3197,12 +3195,13 @@ package comprehend {
       __obj.asInstanceOf[SentimentScore]
     }
   }
-
-  object SentimentTypeEnum {
-    val POSITIVE = "POSITIVE"
-    val NEGATIVE = "NEGATIVE"
-    val NEUTRAL  = "NEUTRAL"
-    val MIXED    = "MIXED"
+  @js.native
+  sealed trait SentimentType extends js.Any
+  object SentimentType extends js.Object {
+    val POSITIVE = "POSITIVE".asInstanceOf[SentimentType]
+    val NEGATIVE = "NEGATIVE".asInstanceOf[SentimentType]
+    val NEUTRAL  = "NEUTRAL".asInstanceOf[SentimentType]
+    val MIXED    = "MIXED".asInstanceOf[SentimentType]
 
     val values = js.Object.freeze(js.Array(POSITIVE, NEGATIVE, NEUTRAL, MIXED))
   }
@@ -3764,14 +3763,15 @@ package comprehend {
       __obj.asInstanceOf[StopTrainingEntityRecognizerResponse]
     }
   }
-
-  object SyntaxLanguageCodeEnum {
-    val en = "en"
-    val es = "es"
-    val fr = "fr"
-    val de = "de"
-    val it = "it"
-    val pt = "pt"
+  @js.native
+  sealed trait SyntaxLanguageCode extends js.Any
+  object SyntaxLanguageCode extends js.Object {
+    val en = "en".asInstanceOf[SyntaxLanguageCode]
+    val es = "es".asInstanceOf[SyntaxLanguageCode]
+    val fr = "fr".asInstanceOf[SyntaxLanguageCode]
+    val de = "de".asInstanceOf[SyntaxLanguageCode]
+    val it = "it".asInstanceOf[SyntaxLanguageCode]
+    val pt = "pt".asInstanceOf[SyntaxLanguageCode]
 
     val values = js.Object.freeze(js.Array(en, es, fr, de, it, pt))
   }

--- a/services/comprehendmedical/src/main/scala/facade/amazonaws/services/ComprehendMedical.scala
+++ b/services/comprehendmedical/src/main/scala/facade/amazonaws/services/ComprehendMedical.scala
@@ -9,39 +9,26 @@ import facade.amazonaws._
 package object comprehendmedical {
   type AnyLengthString                         = String
   type AttributeList                           = js.Array[Attribute]
-  type AttributeName                           = String
   type BoundedLengthString                     = String
   type ClientRequestTokenString                = String
   type ComprehendMedicalAsyncJobPropertiesList = js.Array[ComprehendMedicalAsyncJobProperties]
   type EntityList                              = js.Array[Entity]
-  type EntitySubType                           = String
-  type EntityType                              = String
   type ICD10CMAttributeList                    = js.Array[ICD10CMAttribute]
-  type ICD10CMAttributeType                    = String
   type ICD10CMConceptList                      = js.Array[ICD10CMConcept]
-  type ICD10CMEntityCategory                   = String
   type ICD10CMEntityList                       = js.Array[ICD10CMEntity]
-  type ICD10CMEntityType                       = String
   type ICD10CMTraitList                        = js.Array[ICD10CMTrait]
-  type ICD10CMTraitName                        = String
   type IamRoleArn                              = String
   type JobId                                   = String
   type JobName                                 = String
-  type JobStatus                               = String
   type KMSKey                                  = String
-  type LanguageCode                            = String
   type ManifestFilePath                        = String
   type MaxResultsInteger                       = Int
   type ModelVersion                            = String
   type OntologyLinkingBoundedLengthString      = String
   type RxNormAttributeList                     = js.Array[RxNormAttribute]
-  type RxNormAttributeType                     = String
   type RxNormConceptList                       = js.Array[RxNormConcept]
-  type RxNormEntityCategory                    = String
   type RxNormEntityList                        = js.Array[RxNormEntity]
-  type RxNormEntityType                        = String
   type RxNormTraitList                         = js.Array[RxNormTrait]
-  type RxNormTraitName                         = String
   type S3Bucket                                = String
   type S3Key                                   = String
   type Timestamp                               = js.Date
@@ -153,12 +140,13 @@ package comprehendmedical {
       __obj.asInstanceOf[Attribute]
     }
   }
-
-  object AttributeNameEnum {
-    val SIGN      = "SIGN"
-    val SYMPTOM   = "SYMPTOM"
-    val DIAGNOSIS = "DIAGNOSIS"
-    val NEGATION  = "NEGATION"
+  @js.native
+  sealed trait AttributeName extends js.Any
+  object AttributeName extends js.Object {
+    val SIGN      = "SIGN".asInstanceOf[AttributeName]
+    val SYMPTOM   = "SYMPTOM".asInstanceOf[AttributeName]
+    val DIAGNOSIS = "DIAGNOSIS".asInstanceOf[AttributeName]
+    val NEGATION  = "NEGATION".asInstanceOf[AttributeName]
 
     val values = js.Object.freeze(js.Array(SIGN, SYMPTOM, DIAGNOSIS, NEGATION))
   }
@@ -495,36 +483,37 @@ package comprehendmedical {
       __obj.asInstanceOf[Entity]
     }
   }
-
-  object EntitySubTypeEnum {
-    val NAME              = "NAME"
-    val DOSAGE            = "DOSAGE"
-    val ROUTE_OR_MODE     = "ROUTE_OR_MODE"
-    val FORM              = "FORM"
-    val FREQUENCY         = "FREQUENCY"
-    val DURATION          = "DURATION"
-    val GENERIC_NAME      = "GENERIC_NAME"
-    val BRAND_NAME        = "BRAND_NAME"
-    val STRENGTH          = "STRENGTH"
-    val RATE              = "RATE"
-    val ACUITY            = "ACUITY"
-    val TEST_NAME         = "TEST_NAME"
-    val TEST_VALUE        = "TEST_VALUE"
-    val TEST_UNITS        = "TEST_UNITS"
-    val PROCEDURE_NAME    = "PROCEDURE_NAME"
-    val TREATMENT_NAME    = "TREATMENT_NAME"
-    val DATE              = "DATE"
-    val AGE               = "AGE"
-    val CONTACT_POINT     = "CONTACT_POINT"
-    val EMAIL             = "EMAIL"
-    val IDENTIFIER        = "IDENTIFIER"
-    val URL               = "URL"
-    val ADDRESS           = "ADDRESS"
-    val PROFESSION        = "PROFESSION"
-    val SYSTEM_ORGAN_SITE = "SYSTEM_ORGAN_SITE"
-    val DIRECTION         = "DIRECTION"
-    val QUALITY           = "QUALITY"
-    val QUANTITY          = "QUANTITY"
+  @js.native
+  sealed trait EntitySubType extends js.Any
+  object EntitySubType extends js.Object {
+    val NAME              = "NAME".asInstanceOf[EntitySubType]
+    val DOSAGE            = "DOSAGE".asInstanceOf[EntitySubType]
+    val ROUTE_OR_MODE     = "ROUTE_OR_MODE".asInstanceOf[EntitySubType]
+    val FORM              = "FORM".asInstanceOf[EntitySubType]
+    val FREQUENCY         = "FREQUENCY".asInstanceOf[EntitySubType]
+    val DURATION          = "DURATION".asInstanceOf[EntitySubType]
+    val GENERIC_NAME      = "GENERIC_NAME".asInstanceOf[EntitySubType]
+    val BRAND_NAME        = "BRAND_NAME".asInstanceOf[EntitySubType]
+    val STRENGTH          = "STRENGTH".asInstanceOf[EntitySubType]
+    val RATE              = "RATE".asInstanceOf[EntitySubType]
+    val ACUITY            = "ACUITY".asInstanceOf[EntitySubType]
+    val TEST_NAME         = "TEST_NAME".asInstanceOf[EntitySubType]
+    val TEST_VALUE        = "TEST_VALUE".asInstanceOf[EntitySubType]
+    val TEST_UNITS        = "TEST_UNITS".asInstanceOf[EntitySubType]
+    val PROCEDURE_NAME    = "PROCEDURE_NAME".asInstanceOf[EntitySubType]
+    val TREATMENT_NAME    = "TREATMENT_NAME".asInstanceOf[EntitySubType]
+    val DATE              = "DATE".asInstanceOf[EntitySubType]
+    val AGE               = "AGE".asInstanceOf[EntitySubType]
+    val CONTACT_POINT     = "CONTACT_POINT".asInstanceOf[EntitySubType]
+    val EMAIL             = "EMAIL".asInstanceOf[EntitySubType]
+    val IDENTIFIER        = "IDENTIFIER".asInstanceOf[EntitySubType]
+    val URL               = "URL".asInstanceOf[EntitySubType]
+    val ADDRESS           = "ADDRESS".asInstanceOf[EntitySubType]
+    val PROFESSION        = "PROFESSION".asInstanceOf[EntitySubType]
+    val SYSTEM_ORGAN_SITE = "SYSTEM_ORGAN_SITE".asInstanceOf[EntitySubType]
+    val DIRECTION         = "DIRECTION".asInstanceOf[EntitySubType]
+    val QUALITY           = "QUALITY".asInstanceOf[EntitySubType]
+    val QUANTITY          = "QUANTITY".asInstanceOf[EntitySubType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -559,13 +548,14 @@ package comprehendmedical {
       )
     )
   }
-
-  object EntityTypeEnum {
-    val MEDICATION                   = "MEDICATION"
-    val MEDICAL_CONDITION            = "MEDICAL_CONDITION"
-    val PROTECTED_HEALTH_INFORMATION = "PROTECTED_HEALTH_INFORMATION"
-    val TEST_TREATMENT_PROCEDURE     = "TEST_TREATMENT_PROCEDURE"
-    val ANATOMY                      = "ANATOMY"
+  @js.native
+  sealed trait EntityType extends js.Any
+  object EntityType extends js.Object {
+    val MEDICATION                   = "MEDICATION".asInstanceOf[EntityType]
+    val MEDICAL_CONDITION            = "MEDICAL_CONDITION".asInstanceOf[EntityType]
+    val PROTECTED_HEALTH_INFORMATION = "PROTECTED_HEALTH_INFORMATION".asInstanceOf[EntityType]
+    val TEST_TREATMENT_PROCEDURE     = "TEST_TREATMENT_PROCEDURE".asInstanceOf[EntityType]
+    val ANATOMY                      = "ANATOMY".asInstanceOf[EntityType]
 
     val values = js.Object.freeze(
       js.Array(MEDICATION, MEDICAL_CONDITION, PROTECTED_HEALTH_INFORMATION, TEST_TREATMENT_PROCEDURE, ANATOMY)
@@ -611,13 +601,14 @@ package comprehendmedical {
       __obj.asInstanceOf[ICD10CMAttribute]
     }
   }
-
-  object ICD10CMAttributeTypeEnum {
-    val ACUITY            = "ACUITY"
-    val DIRECTION         = "DIRECTION"
-    val SYSTEM_ORGAN_SITE = "SYSTEM_ORGAN_SITE"
-    val QUALITY           = "QUALITY"
-    val QUANTITY          = "QUANTITY"
+  @js.native
+  sealed trait ICD10CMAttributeType extends js.Any
+  object ICD10CMAttributeType extends js.Object {
+    val ACUITY            = "ACUITY".asInstanceOf[ICD10CMAttributeType]
+    val DIRECTION         = "DIRECTION".asInstanceOf[ICD10CMAttributeType]
+    val SYSTEM_ORGAN_SITE = "SYSTEM_ORGAN_SITE".asInstanceOf[ICD10CMAttributeType]
+    val QUALITY           = "QUALITY".asInstanceOf[ICD10CMAttributeType]
+    val QUANTITY          = "QUANTITY".asInstanceOf[ICD10CMAttributeType]
 
     val values = js.Object.freeze(js.Array(ACUITY, DIRECTION, SYSTEM_ORGAN_SITE, QUALITY, QUANTITY))
   }
@@ -692,15 +683,17 @@ package comprehendmedical {
       __obj.asInstanceOf[ICD10CMEntity]
     }
   }
-
-  object ICD10CMEntityCategoryEnum {
-    val MEDICAL_CONDITION = "MEDICAL_CONDITION"
+  @js.native
+  sealed trait ICD10CMEntityCategory extends js.Any
+  object ICD10CMEntityCategory extends js.Object {
+    val MEDICAL_CONDITION = "MEDICAL_CONDITION".asInstanceOf[ICD10CMEntityCategory]
 
     val values = js.Object.freeze(js.Array(MEDICAL_CONDITION))
   }
-
-  object ICD10CMEntityTypeEnum {
-    val DX_NAME = "DX_NAME"
+  @js.native
+  sealed trait ICD10CMEntityType extends js.Any
+  object ICD10CMEntityType extends js.Object {
+    val DX_NAME = "DX_NAME".asInstanceOf[ICD10CMEntityType]
 
     val values = js.Object.freeze(js.Array(DX_NAME))
   }
@@ -726,12 +719,13 @@ package comprehendmedical {
       __obj.asInstanceOf[ICD10CMTrait]
     }
   }
-
-  object ICD10CMTraitNameEnum {
-    val NEGATION  = "NEGATION"
-    val DIAGNOSIS = "DIAGNOSIS"
-    val SIGN      = "SIGN"
-    val SYMPTOM   = "SYMPTOM"
+  @js.native
+  sealed trait ICD10CMTraitName extends js.Any
+  object ICD10CMTraitName extends js.Object {
+    val NEGATION  = "NEGATION".asInstanceOf[ICD10CMTraitName]
+    val DIAGNOSIS = "DIAGNOSIS".asInstanceOf[ICD10CMTraitName]
+    val SIGN      = "SIGN".asInstanceOf[ICD10CMTraitName]
+    val SYMPTOM   = "SYMPTOM".asInstanceOf[ICD10CMTraitName]
 
     val values = js.Object.freeze(js.Array(NEGATION, DIAGNOSIS, SIGN, SYMPTOM))
   }
@@ -843,22 +837,24 @@ package comprehendmedical {
       __obj.asInstanceOf[InputDataConfig]
     }
   }
-
-  object JobStatusEnum {
-    val SUBMITTED       = "SUBMITTED"
-    val IN_PROGRESS     = "IN_PROGRESS"
-    val COMPLETED       = "COMPLETED"
-    val PARTIAL_SUCCESS = "PARTIAL_SUCCESS"
-    val FAILED          = "FAILED"
-    val STOP_REQUESTED  = "STOP_REQUESTED"
-    val STOPPED         = "STOPPED"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val SUBMITTED       = "SUBMITTED".asInstanceOf[JobStatus]
+    val IN_PROGRESS     = "IN_PROGRESS".asInstanceOf[JobStatus]
+    val COMPLETED       = "COMPLETED".asInstanceOf[JobStatus]
+    val PARTIAL_SUCCESS = "PARTIAL_SUCCESS".asInstanceOf[JobStatus]
+    val FAILED          = "FAILED".asInstanceOf[JobStatus]
+    val STOP_REQUESTED  = "STOP_REQUESTED".asInstanceOf[JobStatus]
+    val STOPPED         = "STOPPED".asInstanceOf[JobStatus]
 
     val values =
       js.Object.freeze(js.Array(SUBMITTED, IN_PROGRESS, COMPLETED, PARTIAL_SUCCESS, FAILED, STOP_REQUESTED, STOPPED))
   }
-
-  object LanguageCodeEnum {
-    val en = "en"
+  @js.native
+  sealed trait LanguageCode extends js.Any
+  object LanguageCode extends js.Object {
+    val en = "en".asInstanceOf[LanguageCode]
 
     val values = js.Object.freeze(js.Array(en))
   }
@@ -1012,15 +1008,16 @@ package comprehendmedical {
       __obj.asInstanceOf[RxNormAttribute]
     }
   }
-
-  object RxNormAttributeTypeEnum {
-    val DOSAGE        = "DOSAGE"
-    val DURATION      = "DURATION"
-    val FORM          = "FORM"
-    val FREQUENCY     = "FREQUENCY"
-    val RATE          = "RATE"
-    val ROUTE_OR_MODE = "ROUTE_OR_MODE"
-    val STRENGTH      = "STRENGTH"
+  @js.native
+  sealed trait RxNormAttributeType extends js.Any
+  object RxNormAttributeType extends js.Object {
+    val DOSAGE        = "DOSAGE".asInstanceOf[RxNormAttributeType]
+    val DURATION      = "DURATION".asInstanceOf[RxNormAttributeType]
+    val FORM          = "FORM".asInstanceOf[RxNormAttributeType]
+    val FREQUENCY     = "FREQUENCY".asInstanceOf[RxNormAttributeType]
+    val RATE          = "RATE".asInstanceOf[RxNormAttributeType]
+    val ROUTE_OR_MODE = "ROUTE_OR_MODE".asInstanceOf[RxNormAttributeType]
+    val STRENGTH      = "STRENGTH".asInstanceOf[RxNormAttributeType]
 
     val values = js.Object.freeze(js.Array(DOSAGE, DURATION, FORM, FREQUENCY, RATE, ROUTE_OR_MODE, STRENGTH))
   }
@@ -1095,16 +1092,18 @@ package comprehendmedical {
       __obj.asInstanceOf[RxNormEntity]
     }
   }
-
-  object RxNormEntityCategoryEnum {
-    val MEDICATION = "MEDICATION"
+  @js.native
+  sealed trait RxNormEntityCategory extends js.Any
+  object RxNormEntityCategory extends js.Object {
+    val MEDICATION = "MEDICATION".asInstanceOf[RxNormEntityCategory]
 
     val values = js.Object.freeze(js.Array(MEDICATION))
   }
-
-  object RxNormEntityTypeEnum {
-    val BRAND_NAME   = "BRAND_NAME"
-    val GENERIC_NAME = "GENERIC_NAME"
+  @js.native
+  sealed trait RxNormEntityType extends js.Any
+  object RxNormEntityType extends js.Object {
+    val BRAND_NAME   = "BRAND_NAME".asInstanceOf[RxNormEntityType]
+    val GENERIC_NAME = "GENERIC_NAME".asInstanceOf[RxNormEntityType]
 
     val values = js.Object.freeze(js.Array(BRAND_NAME, GENERIC_NAME))
   }
@@ -1130,9 +1129,10 @@ package comprehendmedical {
       __obj.asInstanceOf[RxNormTrait]
     }
   }
-
-  object RxNormTraitNameEnum {
-    val NEGATION = "NEGATION"
+  @js.native
+  sealed trait RxNormTraitName extends js.Any
+  object RxNormTraitName extends js.Object {
+    val NEGATION = "NEGATION".asInstanceOf[RxNormTraitName]
 
     val values = js.Object.freeze(js.Array(NEGATION))
   }

--- a/services/computeoptimizer/src/main/scala/facade/amazonaws/services/ComputeOptimizer.scala
+++ b/services/computeoptimizer/src/main/scala/facade/amazonaws/services/ComputeOptimizer.scala
@@ -17,11 +17,9 @@ package object computeoptimizer {
   type Code                                  = String
   type CurrentInstanceType                   = String
   type DesiredCapacity                       = Int
-  type FilterName                            = String
   type FilterValue                           = String
   type FilterValues                          = js.Array[FilterValue]
   type Filters                               = js.Array[Filter]
-  type Finding                               = String
   type GetRecommendationErrors               = js.Array[GetRecommendationError]
   type Identifier                            = String
   type IncludeMemberAccounts                 = Boolean
@@ -36,8 +34,6 @@ package object computeoptimizer {
   type MaxSize                               = Int
   type MemberAccountsEnrolled                = Boolean
   type Message                               = String
-  type MetricName                            = String
-  type MetricStatistic                       = String
   type MetricValue                           = Double
   type MetricValues                          = js.Array[MetricValue]
   type MinSize                               = Int
@@ -49,12 +45,10 @@ package object computeoptimizer {
   type Rank                                  = Int
   type RecommendationOptions                 = js.Array[InstanceRecommendationOption]
   type RecommendationSourceArn               = String
-  type RecommendationSourceType              = String
   type RecommendationSources                 = js.Array[RecommendationSource]
   type RecommendationSummaries               = js.Array[RecommendationSummary]
   type RecommendedInstanceType               = String
   type RecommendedOptionProjectedMetrics     = js.Array[RecommendedOptionProjectedMetric]
-  type Status                                = String
   type StatusReason                          = String
   type Summaries                             = js.Array[Summary]
   type SummaryValue                          = Double
@@ -231,19 +225,21 @@ package computeoptimizer {
       __obj.asInstanceOf[Filter]
     }
   }
-
-  object FilterNameEnum {
-    val Finding                  = "Finding"
-    val RecommendationSourceType = "RecommendationSourceType"
+  @js.native
+  sealed trait FilterName extends js.Any
+  object FilterName extends js.Object {
+    val Finding                  = "Finding".asInstanceOf[FilterName]
+    val RecommendationSourceType = "RecommendationSourceType".asInstanceOf[FilterName]
 
     val values = js.Object.freeze(js.Array(Finding, RecommendationSourceType))
   }
-
-  object FindingEnum {
-    val Underprovisioned = "Underprovisioned"
-    val Overprovisioned  = "Overprovisioned"
-    val Optimized        = "Optimized"
-    val NotOptimized     = "NotOptimized"
+  @js.native
+  sealed trait Finding extends js.Any
+  object Finding extends js.Object {
+    val Underprovisioned = "Underprovisioned".asInstanceOf[Finding]
+    val Overprovisioned  = "Overprovisioned".asInstanceOf[Finding]
+    val Optimized        = "Optimized".asInstanceOf[Finding]
+    val NotOptimized     = "NotOptimized".asInstanceOf[Finding]
 
     val values = js.Object.freeze(js.Array(Underprovisioned, Overprovisioned, Optimized, NotOptimized))
   }
@@ -575,17 +571,19 @@ package computeoptimizer {
       __obj.asInstanceOf[InstanceRecommendationOption]
     }
   }
-
-  object MetricNameEnum {
-    val Cpu    = "Cpu"
-    val Memory = "Memory"
+  @js.native
+  sealed trait MetricName extends js.Any
+  object MetricName extends js.Object {
+    val Cpu    = "Cpu".asInstanceOf[MetricName]
+    val Memory = "Memory".asInstanceOf[MetricName]
 
     val values = js.Object.freeze(js.Array(Cpu, Memory))
   }
-
-  object MetricStatisticEnum {
-    val Maximum = "Maximum"
-    val Average = "Average"
+  @js.native
+  sealed trait MetricStatistic extends js.Any
+  object MetricStatistic extends js.Object {
+    val Maximum = "Maximum".asInstanceOf[MetricStatistic]
+    val Average = "Average".asInstanceOf[MetricStatistic]
 
     val values = js.Object.freeze(js.Array(Maximum, Average))
   }
@@ -636,10 +634,11 @@ package computeoptimizer {
       __obj.asInstanceOf[RecommendationSource]
     }
   }
-
-  object RecommendationSourceTypeEnum {
-    val Ec2Instance      = "Ec2Instance"
-    val AutoScalingGroup = "AutoScalingGroup"
+  @js.native
+  sealed trait RecommendationSourceType extends js.Any
+  object RecommendationSourceType extends js.Object {
+    val Ec2Instance      = "Ec2Instance".asInstanceOf[RecommendationSourceType]
+    val AutoScalingGroup = "AutoScalingGroup".asInstanceOf[RecommendationSourceType]
 
     val values = js.Object.freeze(js.Array(Ec2Instance, AutoScalingGroup))
   }
@@ -695,12 +694,13 @@ package computeoptimizer {
       __obj.asInstanceOf[RecommendedOptionProjectedMetric]
     }
   }
-
-  object StatusEnum {
-    val Active   = "Active"
-    val Inactive = "Inactive"
-    val Pending  = "Pending"
-    val Failed   = "Failed"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val Active   = "Active".asInstanceOf[Status]
+    val Inactive = "Inactive".asInstanceOf[Status]
+    val Pending  = "Pending".asInstanceOf[Status]
+    val Failed   = "Failed".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(Active, Inactive, Pending, Failed))
   }

--- a/services/configservice/src/main/scala/facade/amazonaws/services/ConfigService.scala
+++ b/services/configservice/src/main/scala/facade/amazonaws/services/ConfigService.scala
@@ -15,9 +15,7 @@ package object configservice {
   type AggregateComplianceCountList                = js.Array[AggregateComplianceCount]
   type AggregateEvaluationResultList               = js.Array[AggregateEvaluationResult]
   type AggregatedSourceStatusList                  = js.Array[AggregatedSourceStatus]
-  type AggregatedSourceStatusType                  = String
   type AggregatedSourceStatusTypeList              = js.Array[AggregatedSourceStatusType]
-  type AggregatedSourceType                        = String
   type AggregationAuthorizationList                = js.Array[AggregationAuthorization]
   type AggregatorRegionList                        = js.Array[String]
   type AllSupported                                = Boolean
@@ -30,18 +28,14 @@ package object configservice {
   type BaseConfigurationItems                      = js.Array[BaseConfigurationItem]
   type BaseResourceId                              = String
   type ChannelName                                 = String
-  type ChronologicalOrder                          = String
   type ComplianceByConfigRules                     = js.Array[ComplianceByConfigRule]
   type ComplianceByResources                       = js.Array[ComplianceByResource]
   type ComplianceResourceTypes                     = js.Array[StringWithCharLimit256]
   type ComplianceSummariesByResourceType           = js.Array[ComplianceSummaryByResourceType]
-  type ComplianceType                              = String
   type ComplianceTypes                             = js.Array[ComplianceType]
-  type ConfigRuleComplianceSummaryGroupKey         = String
   type ConfigRuleEvaluationStatusList              = js.Array[ConfigRuleEvaluationStatus]
   type ConfigRuleName                              = String
   type ConfigRuleNames                             = js.Array[ConfigRuleName]
-  type ConfigRuleState                             = String
   type ConfigRules                                 = js.Array[ConfigRule]
   type Configuration                               = String
   type ConfigurationAggregatorArn                  = String
@@ -51,7 +45,6 @@ package object configservice {
   type ConfigurationItemCaptureTime                = js.Date
   type ConfigurationItemList                       = js.Array[ConfigurationItem]
   type ConfigurationItemMD5Hash                    = String
-  type ConfigurationItemStatus                     = String
   type ConfigurationRecorderList                   = js.Array[ConfigurationRecorder]
   type ConfigurationRecorderNameList               = js.Array[RecorderName]
   type ConfigurationRecorderStatusList             = js.Array[ConfigurationRecorderStatus]
@@ -59,7 +52,6 @@ package object configservice {
   type ConformancePackArn                          = String
   type ConformancePackComplianceResourceIds        = js.Array[StringWithCharLimit256]
   type ConformancePackComplianceSummaryList        = js.Array[ConformancePackComplianceSummary]
-  type ConformancePackComplianceType               = String
   type ConformancePackConfigRuleNames              = js.Array[StringWithCharLimit64]
   type ConformancePackDetailList                   = js.Array[ConformancePackDetail]
   type ConformancePackId                           = String
@@ -69,7 +61,6 @@ package object configservice {
   type ConformancePackNamesToSummarizeList         = js.Array[ConformancePackName]
   type ConformancePackRuleComplianceList           = js.Array[ConformancePackRuleCompliance]
   type ConformancePackRuleEvaluationResultsList    = js.Array[ConformancePackEvaluationResult]
-  type ConformancePackState                        = String
   type ConformancePackStatusDetailsList            = js.Array[ConformancePackStatusDetail]
   type ConformancePackStatusReason                 = String
   type CosmosPageLimit                             = Int
@@ -79,7 +70,6 @@ package object configservice {
   type DeliveryChannelStatusList                   = js.Array[DeliveryChannelStatus]
   type DeliveryS3Bucket                            = String
   type DeliveryS3KeyPrefix                         = String
-  type DeliveryStatus                              = String
   type DescribeConformancePackComplianceLimit      = Int
   type DescribePendingAggregationRequestsLimit     = Int
   type DiscoveredResourceIdentifierList            = js.Array[AggregateResourceIdentifier]
@@ -87,7 +77,6 @@ package object configservice {
   type EmptiableStringWithCharLimit256             = String
   type EvaluationResults                           = js.Array[EvaluationResult]
   type Evaluations                                 = js.Array[Evaluation]
-  type EventSource                                 = String
   type ExcludedAccounts                            = js.Array[AccountId]
   type Expression                                  = String
   type FailedDeleteRemediationExceptionsBatches    = js.Array[FailedDeleteRemediationExceptionsBatch]
@@ -101,9 +90,6 @@ package object configservice {
   type IncludeGlobalResourceTypes                  = Boolean
   type LaterTime                                   = js.Date
   type Limit                                       = Int
-  type MaximumExecutionFrequency                   = String
-  type MemberAccountRuleStatus                     = String
-  type MessageType                                 = String
   type Name                                        = String
   type NextToken                                   = String
   type OrderingTimestamp                           = js.Date
@@ -111,7 +97,6 @@ package object configservice {
   type OrganizationConfigRuleName                  = String
   type OrganizationConfigRuleNames                 = js.Array[StringWithCharLimit64]
   type OrganizationConfigRuleStatuses              = js.Array[OrganizationConfigRuleStatus]
-  type OrganizationConfigRuleTriggerType           = String
   type OrganizationConfigRuleTriggerTypes          = js.Array[OrganizationConfigRuleTriggerType]
   type OrganizationConfigRules                     = js.Array[OrganizationConfigRule]
   type OrganizationConformancePackDetailedStatuses = js.Array[OrganizationConformancePackDetailedStatus]
@@ -119,17 +104,12 @@ package object configservice {
   type OrganizationConformancePackNames            = js.Array[OrganizationConformancePackName]
   type OrganizationConformancePackStatuses         = js.Array[OrganizationConformancePackStatus]
   type OrganizationConformancePacks                = js.Array[OrganizationConformancePack]
-  type OrganizationResourceDetailedStatus          = String
-  type OrganizationResourceStatus                  = String
-  type OrganizationRuleStatus                      = String
-  type Owner                                       = String
   type PageSizeLimit                               = Int
   type ParameterName                               = String
   type ParameterValue                              = String
   type PendingAggregationRequestList               = js.Array[PendingAggregationRequest]
   type Percentage                                  = Int
   type RecorderName                                = String
-  type RecorderStatus                              = String
   type ReevaluateConfigRuleNames                   = js.Array[StringWithCharLimit64]
   type RelatedEvent                                = String
   type RelatedEventList                            = js.Array[RelatedEvent]
@@ -138,13 +118,9 @@ package object configservice {
   type RemediationConfigurations                   = js.Array[RemediationConfiguration]
   type RemediationExceptionResourceKeys            = js.Array[RemediationExceptionResourceKey]
   type RemediationExceptions                       = js.Array[RemediationException]
-  type RemediationExecutionState                   = String
   type RemediationExecutionStatuses                = js.Array[RemediationExecutionStatus]
-  type RemediationExecutionStepState               = String
   type RemediationExecutionSteps                   = js.Array[RemediationExecutionStep]
   type RemediationParameters                       = js.Dictionary[RemediationParameterValue]
-  type RemediationTargetType                       = String
-  type ResourceCountGroupKey                       = String
   type ResourceCounts                              = js.Array[ResourceCount]
   type ResourceCreationTime                        = js.Date
   type ResourceDeletionTime                        = js.Date
@@ -154,12 +130,10 @@ package object configservice {
   type ResourceIdentifiersList                     = js.Array[AggregateResourceIdentifier]
   type ResourceKeys                                = js.Array[ResourceKey]
   type ResourceName                                = String
-  type ResourceType                                = String
   type ResourceTypeList                            = js.Array[ResourceType]
   type ResourceTypeString                          = String
   type ResourceTypes                               = js.Array[StringWithCharLimit256]
   type ResourceTypesScope                          = js.Array[StringWithCharLimit256]
-  type ResourceValueType                           = String
   type Results                                     = js.Array[String]
   type RetentionConfigurationList                  = js.Array[RetentionConfiguration]
   type RetentionConfigurationName                  = String
@@ -804,18 +778,20 @@ package configservice {
       __obj.asInstanceOf[AggregatedSourceStatus]
     }
   }
-
-  object AggregatedSourceStatusTypeEnum {
-    val FAILED    = "FAILED"
-    val SUCCEEDED = "SUCCEEDED"
-    val OUTDATED  = "OUTDATED"
+  @js.native
+  sealed trait AggregatedSourceStatusType extends js.Any
+  object AggregatedSourceStatusType extends js.Object {
+    val FAILED    = "FAILED".asInstanceOf[AggregatedSourceStatusType]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[AggregatedSourceStatusType]
+    val OUTDATED  = "OUTDATED".asInstanceOf[AggregatedSourceStatusType]
 
     val values = js.Object.freeze(js.Array(FAILED, SUCCEEDED, OUTDATED))
   }
-
-  object AggregatedSourceTypeEnum {
-    val ACCOUNT      = "ACCOUNT"
-    val ORGANIZATION = "ORGANIZATION"
+  @js.native
+  sealed trait AggregatedSourceType extends js.Any
+  object AggregatedSourceType extends js.Object {
+    val ACCOUNT      = "ACCOUNT".asInstanceOf[AggregatedSourceType]
+    val ORGANIZATION = "ORGANIZATION".asInstanceOf[AggregatedSourceType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT, ORGANIZATION))
   }
@@ -990,10 +966,11 @@ package configservice {
       __obj.asInstanceOf[BatchGetResourceConfigResponse]
     }
   }
-
-  object ChronologicalOrderEnum {
-    val Reverse = "Reverse"
-    val Forward = "Forward"
+  @js.native
+  sealed trait ChronologicalOrder extends js.Any
+  object ChronologicalOrder extends js.Object {
+    val Reverse = "Reverse".asInstanceOf[ChronologicalOrder]
+    val Forward = "Forward".asInstanceOf[ChronologicalOrder]
 
     val values = js.Object.freeze(js.Array(Reverse, Forward))
   }
@@ -1141,12 +1118,13 @@ package configservice {
       __obj.asInstanceOf[ComplianceSummaryByResourceType]
     }
   }
-
-  object ComplianceTypeEnum {
-    val COMPLIANT         = "COMPLIANT"
-    val NON_COMPLIANT     = "NON_COMPLIANT"
-    val NOT_APPLICABLE    = "NOT_APPLICABLE"
-    val INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+  @js.native
+  sealed trait ComplianceType extends js.Any
+  object ComplianceType extends js.Object {
+    val COMPLIANT         = "COMPLIANT".asInstanceOf[ComplianceType]
+    val NON_COMPLIANT     = "NON_COMPLIANT".asInstanceOf[ComplianceType]
+    val NOT_APPLICABLE    = "NOT_APPLICABLE".asInstanceOf[ComplianceType]
+    val INSUFFICIENT_DATA = "INSUFFICIENT_DATA".asInstanceOf[ComplianceType]
 
     val values = js.Object.freeze(js.Array(COMPLIANT, NON_COMPLIANT, NOT_APPLICABLE, INSUFFICIENT_DATA))
   }
@@ -1287,10 +1265,11 @@ package configservice {
       __obj.asInstanceOf[ConfigRuleComplianceSummaryFilters]
     }
   }
-
-  object ConfigRuleComplianceSummaryGroupKeyEnum {
-    val ACCOUNT_ID = "ACCOUNT_ID"
-    val AWS_REGION = "AWS_REGION"
+  @js.native
+  sealed trait ConfigRuleComplianceSummaryGroupKey extends js.Any
+  object ConfigRuleComplianceSummaryGroupKey extends js.Object {
+    val ACCOUNT_ID = "ACCOUNT_ID".asInstanceOf[ConfigRuleComplianceSummaryGroupKey]
+    val AWS_REGION = "AWS_REGION".asInstanceOf[ConfigRuleComplianceSummaryGroupKey]
 
     val values = js.Object.freeze(js.Array(ACCOUNT_ID, AWS_REGION))
   }
@@ -1348,12 +1327,13 @@ package configservice {
       __obj.asInstanceOf[ConfigRuleEvaluationStatus]
     }
   }
-
-  object ConfigRuleStateEnum {
-    val ACTIVE           = "ACTIVE"
-    val DELETING         = "DELETING"
-    val DELETING_RESULTS = "DELETING_RESULTS"
-    val EVALUATING       = "EVALUATING"
+  @js.native
+  sealed trait ConfigRuleState extends js.Any
+  object ConfigRuleState extends js.Object {
+    val ACTIVE           = "ACTIVE".asInstanceOf[ConfigRuleState]
+    val DELETING         = "DELETING".asInstanceOf[ConfigRuleState]
+    val DELETING_RESULTS = "DELETING_RESULTS".asInstanceOf[ConfigRuleState]
+    val EVALUATING       = "EVALUATING".asInstanceOf[ConfigRuleState]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETING, DELETING_RESULTS, EVALUATING))
   }
@@ -1530,13 +1510,14 @@ package configservice {
       __obj.asInstanceOf[ConfigurationItem]
     }
   }
-
-  object ConfigurationItemStatusEnum {
-    val OK                         = "OK"
-    val ResourceDiscovered         = "ResourceDiscovered"
-    val ResourceNotRecorded        = "ResourceNotRecorded"
-    val ResourceDeleted            = "ResourceDeleted"
-    val ResourceDeletedNotRecorded = "ResourceDeletedNotRecorded"
+  @js.native
+  sealed trait ConfigurationItemStatus extends js.Any
+  object ConfigurationItemStatus extends js.Object {
+    val OK                         = "OK".asInstanceOf[ConfigurationItemStatus]
+    val ResourceDiscovered         = "ResourceDiscovered".asInstanceOf[ConfigurationItemStatus]
+    val ResourceNotRecorded        = "ResourceNotRecorded".asInstanceOf[ConfigurationItemStatus]
+    val ResourceDeleted            = "ResourceDeleted".asInstanceOf[ConfigurationItemStatus]
+    val ResourceDeletedNotRecorded = "ResourceDeletedNotRecorded".asInstanceOf[ConfigurationItemStatus]
 
     val values = js.Object.freeze(
       js.Array(OK, ResourceDiscovered, ResourceNotRecorded, ResourceDeleted, ResourceDeletedNotRecorded)
@@ -1653,10 +1634,11 @@ package configservice {
       __obj.asInstanceOf[ConformancePackComplianceSummary]
     }
   }
-
-  object ConformancePackComplianceTypeEnum {
-    val COMPLIANT     = "COMPLIANT"
-    val NON_COMPLIANT = "NON_COMPLIANT"
+  @js.native
+  sealed trait ConformancePackComplianceType extends js.Any
+  object ConformancePackComplianceType extends js.Object {
+    val COMPLIANT     = "COMPLIANT".asInstanceOf[ConformancePackComplianceType]
+    val NON_COMPLIANT = "NON_COMPLIANT".asInstanceOf[ConformancePackComplianceType]
 
     val values = js.Object.freeze(js.Array(COMPLIANT, NON_COMPLIANT))
   }
@@ -1811,13 +1793,14 @@ package configservice {
       __obj.asInstanceOf[ConformancePackRuleCompliance]
     }
   }
-
-  object ConformancePackStateEnum {
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_COMPLETE    = "CREATE_COMPLETE"
-    val CREATE_FAILED      = "CREATE_FAILED"
-    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
-    val DELETE_FAILED      = "DELETE_FAILED"
+  @js.native
+  sealed trait ConformancePackState extends js.Any
+  object ConformancePackState extends js.Object {
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[ConformancePackState]
+    val CREATE_COMPLETE    = "CREATE_COMPLETE".asInstanceOf[ConformancePackState]
+    val CREATE_FAILED      = "CREATE_FAILED".asInstanceOf[ConformancePackState]
+    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS".asInstanceOf[ConformancePackState]
+    val DELETE_FAILED      = "DELETE_FAILED".asInstanceOf[ConformancePackState]
 
     val values =
       js.Object.freeze(js.Array(CREATE_IN_PROGRESS, CREATE_COMPLETE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETE_FAILED))
@@ -2296,11 +2279,12 @@ package configservice {
       __obj.asInstanceOf[DeliveryChannelStatus]
     }
   }
-
-  object DeliveryStatusEnum {
-    val Success        = "Success"
-    val Failure        = "Failure"
-    val Not_Applicable = "Not_Applicable"
+  @js.native
+  sealed trait DeliveryStatus extends js.Any
+  object DeliveryStatus extends js.Object {
+    val Success        = "Success".asInstanceOf[DeliveryStatus]
+    val Failure        = "Failure".asInstanceOf[DeliveryStatus]
+    val Not_Applicable = "Not_Applicable".asInstanceOf[DeliveryStatus]
 
     val values = js.Object.freeze(js.Array(Success, Failure, Not_Applicable))
   }
@@ -3475,9 +3459,10 @@ package configservice {
       __obj.asInstanceOf[EvaluationResultQualifier]
     }
   }
-
-  object EventSourceEnum {
-    val `aws.config` = "aws.config"
+  @js.native
+  sealed trait EventSource extends js.Any
+  object EventSource extends js.Object {
+    val `aws.config` = "aws.config".asInstanceOf[EventSource]
 
     val values = js.Object.freeze(js.Array(`aws.config`))
   }
@@ -4427,27 +4412,29 @@ package configservice {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object MaximumExecutionFrequencyEnum {
-    val One_Hour         = "One_Hour"
-    val Three_Hours      = "Three_Hours"
-    val Six_Hours        = "Six_Hours"
-    val Twelve_Hours     = "Twelve_Hours"
-    val TwentyFour_Hours = "TwentyFour_Hours"
+  @js.native
+  sealed trait MaximumExecutionFrequency extends js.Any
+  object MaximumExecutionFrequency extends js.Object {
+    val One_Hour         = "One_Hour".asInstanceOf[MaximumExecutionFrequency]
+    val Three_Hours      = "Three_Hours".asInstanceOf[MaximumExecutionFrequency]
+    val Six_Hours        = "Six_Hours".asInstanceOf[MaximumExecutionFrequency]
+    val Twelve_Hours     = "Twelve_Hours".asInstanceOf[MaximumExecutionFrequency]
+    val TwentyFour_Hours = "TwentyFour_Hours".asInstanceOf[MaximumExecutionFrequency]
 
     val values = js.Object.freeze(js.Array(One_Hour, Three_Hours, Six_Hours, Twelve_Hours, TwentyFour_Hours))
   }
-
-  object MemberAccountRuleStatusEnum {
-    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL"
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_FAILED      = "CREATE_FAILED"
-    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL"
-    val DELETE_FAILED      = "DELETE_FAILED"
-    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
-    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL"
-    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS"
-    val UPDATE_FAILED      = "UPDATE_FAILED"
+  @js.native
+  sealed trait MemberAccountRuleStatus extends js.Any
+  object MemberAccountRuleStatus extends js.Object {
+    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL".asInstanceOf[MemberAccountRuleStatus]
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[MemberAccountRuleStatus]
+    val CREATE_FAILED      = "CREATE_FAILED".asInstanceOf[MemberAccountRuleStatus]
+    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL".asInstanceOf[MemberAccountRuleStatus]
+    val DELETE_FAILED      = "DELETE_FAILED".asInstanceOf[MemberAccountRuleStatus]
+    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS".asInstanceOf[MemberAccountRuleStatus]
+    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL".asInstanceOf[MemberAccountRuleStatus]
+    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS".asInstanceOf[MemberAccountRuleStatus]
+    val UPDATE_FAILED      = "UPDATE_FAILED".asInstanceOf[MemberAccountRuleStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4499,12 +4486,14 @@ package configservice {
       __obj.asInstanceOf[MemberAccountStatus]
     }
   }
-
-  object MessageTypeEnum {
-    val ConfigurationItemChangeNotification          = "ConfigurationItemChangeNotification"
-    val ConfigurationSnapshotDeliveryCompleted       = "ConfigurationSnapshotDeliveryCompleted"
-    val ScheduledNotification                        = "ScheduledNotification"
-    val OversizedConfigurationItemChangeNotification = "OversizedConfigurationItemChangeNotification"
+  @js.native
+  sealed trait MessageType extends js.Any
+  object MessageType extends js.Object {
+    val ConfigurationItemChangeNotification    = "ConfigurationItemChangeNotification".asInstanceOf[MessageType]
+    val ConfigurationSnapshotDeliveryCompleted = "ConfigurationSnapshotDeliveryCompleted".asInstanceOf[MessageType]
+    val ScheduledNotification                  = "ScheduledNotification".asInstanceOf[MessageType]
+    val OversizedConfigurationItemChangeNotification =
+      "OversizedConfigurationItemChangeNotification".asInstanceOf[MessageType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4615,11 +4604,14 @@ package configservice {
       __obj.asInstanceOf[OrganizationConfigRuleStatus]
     }
   }
-
-  object OrganizationConfigRuleTriggerTypeEnum {
-    val ConfigurationItemChangeNotification          = "ConfigurationItemChangeNotification"
-    val OversizedConfigurationItemChangeNotification = "OversizedConfigurationItemChangeNotification"
-    val ScheduledNotification                        = "ScheduledNotification"
+  @js.native
+  sealed trait OrganizationConfigRuleTriggerType extends js.Any
+  object OrganizationConfigRuleTriggerType extends js.Object {
+    val ConfigurationItemChangeNotification =
+      "ConfigurationItemChangeNotification".asInstanceOf[OrganizationConfigRuleTriggerType]
+    val OversizedConfigurationItemChangeNotification =
+      "OversizedConfigurationItemChangeNotification".asInstanceOf[OrganizationConfigRuleTriggerType]
+    val ScheduledNotification = "ScheduledNotification".asInstanceOf[OrganizationConfigRuleTriggerType]
 
     val values = js.Object.freeze(
       js.Array(ConfigurationItemChangeNotification, OversizedConfigurationItemChangeNotification, ScheduledNotification)
@@ -4826,17 +4818,18 @@ package configservice {
       __obj.asInstanceOf[OrganizationManagedRuleMetadata]
     }
   }
-
-  object OrganizationResourceDetailedStatusEnum {
-    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL"
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_FAILED      = "CREATE_FAILED"
-    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL"
-    val DELETE_FAILED      = "DELETE_FAILED"
-    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
-    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL"
-    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS"
-    val UPDATE_FAILED      = "UPDATE_FAILED"
+  @js.native
+  sealed trait OrganizationResourceDetailedStatus extends js.Any
+  object OrganizationResourceDetailedStatus extends js.Object {
+    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL".asInstanceOf[OrganizationResourceDetailedStatus]
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[OrganizationResourceDetailedStatus]
+    val CREATE_FAILED      = "CREATE_FAILED".asInstanceOf[OrganizationResourceDetailedStatus]
+    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL".asInstanceOf[OrganizationResourceDetailedStatus]
+    val DELETE_FAILED      = "DELETE_FAILED".asInstanceOf[OrganizationResourceDetailedStatus]
+    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS".asInstanceOf[OrganizationResourceDetailedStatus]
+    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL".asInstanceOf[OrganizationResourceDetailedStatus]
+    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS".asInstanceOf[OrganizationResourceDetailedStatus]
+    val UPDATE_FAILED      = "UPDATE_FAILED".asInstanceOf[OrganizationResourceDetailedStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4874,43 +4867,18 @@ package configservice {
       __obj.asInstanceOf[OrganizationResourceDetailedStatusFilters]
     }
   }
-
-  object OrganizationResourceStatusEnum {
-    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL"
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_FAILED      = "CREATE_FAILED"
-    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL"
-    val DELETE_FAILED      = "DELETE_FAILED"
-    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
-    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL"
-    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS"
-    val UPDATE_FAILED      = "UPDATE_FAILED"
-
-    val values = js.Object.freeze(
-      js.Array(
-        CREATE_SUCCESSFUL,
-        CREATE_IN_PROGRESS,
-        CREATE_FAILED,
-        DELETE_SUCCESSFUL,
-        DELETE_FAILED,
-        DELETE_IN_PROGRESS,
-        UPDATE_SUCCESSFUL,
-        UPDATE_IN_PROGRESS,
-        UPDATE_FAILED
-      )
-    )
-  }
-
-  object OrganizationRuleStatusEnum {
-    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL"
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_FAILED      = "CREATE_FAILED"
-    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL"
-    val DELETE_FAILED      = "DELETE_FAILED"
-    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS"
-    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL"
-    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS"
-    val UPDATE_FAILED      = "UPDATE_FAILED"
+  @js.native
+  sealed trait OrganizationResourceStatus extends js.Any
+  object OrganizationResourceStatus extends js.Object {
+    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL".asInstanceOf[OrganizationResourceStatus]
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[OrganizationResourceStatus]
+    val CREATE_FAILED      = "CREATE_FAILED".asInstanceOf[OrganizationResourceStatus]
+    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL".asInstanceOf[OrganizationResourceStatus]
+    val DELETE_FAILED      = "DELETE_FAILED".asInstanceOf[OrganizationResourceStatus]
+    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS".asInstanceOf[OrganizationResourceStatus]
+    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL".asInstanceOf[OrganizationResourceStatus]
+    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS".asInstanceOf[OrganizationResourceStatus]
+    val UPDATE_FAILED      = "UPDATE_FAILED".asInstanceOf[OrganizationResourceStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4926,10 +4894,38 @@ package configservice {
       )
     )
   }
+  @js.native
+  sealed trait OrganizationRuleStatus extends js.Any
+  object OrganizationRuleStatus extends js.Object {
+    val CREATE_SUCCESSFUL  = "CREATE_SUCCESSFUL".asInstanceOf[OrganizationRuleStatus]
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[OrganizationRuleStatus]
+    val CREATE_FAILED      = "CREATE_FAILED".asInstanceOf[OrganizationRuleStatus]
+    val DELETE_SUCCESSFUL  = "DELETE_SUCCESSFUL".asInstanceOf[OrganizationRuleStatus]
+    val DELETE_FAILED      = "DELETE_FAILED".asInstanceOf[OrganizationRuleStatus]
+    val DELETE_IN_PROGRESS = "DELETE_IN_PROGRESS".asInstanceOf[OrganizationRuleStatus]
+    val UPDATE_SUCCESSFUL  = "UPDATE_SUCCESSFUL".asInstanceOf[OrganizationRuleStatus]
+    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS".asInstanceOf[OrganizationRuleStatus]
+    val UPDATE_FAILED      = "UPDATE_FAILED".asInstanceOf[OrganizationRuleStatus]
 
-  object OwnerEnum {
-    val CUSTOM_LAMBDA = "CUSTOM_LAMBDA"
-    val AWS           = "AWS"
+    val values = js.Object.freeze(
+      js.Array(
+        CREATE_SUCCESSFUL,
+        CREATE_IN_PROGRESS,
+        CREATE_FAILED,
+        DELETE_SUCCESSFUL,
+        DELETE_FAILED,
+        DELETE_IN_PROGRESS,
+        UPDATE_SUCCESSFUL,
+        UPDATE_IN_PROGRESS,
+        UPDATE_FAILED
+      )
+    )
+  }
+  @js.native
+  sealed trait Owner extends js.Any
+  object Owner extends js.Object {
+    val CUSTOM_LAMBDA = "CUSTOM_LAMBDA".asInstanceOf[Owner]
+    val AWS           = "AWS".asInstanceOf[Owner]
 
     val values = js.Object.freeze(js.Array(CUSTOM_LAMBDA, AWS))
   }
@@ -5470,11 +5466,12 @@ package configservice {
       __obj.asInstanceOf[QueryInfo]
     }
   }
-
-  object RecorderStatusEnum {
-    val Pending = "Pending"
-    val Success = "Success"
-    val Failure = "Failure"
+  @js.native
+  sealed trait RecorderStatus extends js.Any
+  object RecorderStatus extends js.Object {
+    val Pending = "Pending".asInstanceOf[RecorderStatus]
+    val Success = "Success".asInstanceOf[RecorderStatus]
+    val Failure = "Failure".asInstanceOf[RecorderStatus]
 
     val values = js.Object.freeze(js.Array(Pending, Success, Failure))
   }
@@ -5649,12 +5646,13 @@ package configservice {
       __obj.asInstanceOf[RemediationExceptionResourceKey]
     }
   }
-
-  object RemediationExecutionStateEnum {
-    val QUEUED      = "QUEUED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait RemediationExecutionState extends js.Any
+  object RemediationExecutionState extends js.Object {
+    val QUEUED      = "QUEUED".asInstanceOf[RemediationExecutionState]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[RemediationExecutionState]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[RemediationExecutionState]
+    val FAILED      = "FAILED".asInstanceOf[RemediationExecutionState]
 
     val values = js.Object.freeze(js.Array(QUEUED, IN_PROGRESS, SUCCEEDED, FAILED))
   }
@@ -5720,11 +5718,12 @@ package configservice {
       __obj.asInstanceOf[RemediationExecutionStep]
     }
   }
-
-  object RemediationExecutionStepStateEnum {
-    val SUCCEEDED = "SUCCEEDED"
-    val PENDING   = "PENDING"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait RemediationExecutionStepState extends js.Any
+  object RemediationExecutionStepState extends js.Object {
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[RemediationExecutionStepState]
+    val PENDING   = "PENDING".asInstanceOf[RemediationExecutionStepState]
+    val FAILED    = "FAILED".asInstanceOf[RemediationExecutionStepState]
 
     val values = js.Object.freeze(js.Array(SUCCEEDED, PENDING, FAILED))
   }
@@ -5750,9 +5749,10 @@ package configservice {
       __obj.asInstanceOf[RemediationParameterValue]
     }
   }
-
-  object RemediationTargetTypeEnum {
-    val SSM_DOCUMENT = "SSM_DOCUMENT"
+  @js.native
+  sealed trait RemediationTargetType extends js.Any
+  object RemediationTargetType extends js.Object {
+    val SSM_DOCUMENT = "SSM_DOCUMENT".asInstanceOf[RemediationTargetType]
 
     val values = js.Object.freeze(js.Array(SSM_DOCUMENT))
   }
@@ -5803,11 +5803,12 @@ package configservice {
       __obj.asInstanceOf[ResourceCountFilters]
     }
   }
-
-  object ResourceCountGroupKeyEnum {
-    val RESOURCE_TYPE = "RESOURCE_TYPE"
-    val ACCOUNT_ID    = "ACCOUNT_ID"
-    val AWS_REGION    = "AWS_REGION"
+  @js.native
+  sealed trait ResourceCountGroupKey extends js.Any
+  object ResourceCountGroupKey extends js.Object {
+    val RESOURCE_TYPE = "RESOURCE_TYPE".asInstanceOf[ResourceCountGroupKey]
+    val ACCOUNT_ID    = "ACCOUNT_ID".asInstanceOf[ResourceCountGroupKey]
+    val AWS_REGION    = "AWS_REGION".asInstanceOf[ResourceCountGroupKey]
 
     val values = js.Object.freeze(js.Array(RESOURCE_TYPE, ACCOUNT_ID, AWS_REGION))
   }
@@ -5891,99 +5892,104 @@ package configservice {
       __obj.asInstanceOf[ResourceKey]
     }
   }
-
-  object ResourceTypeEnum {
-    val `AWS::EC2::CustomerGateway`                 = "AWS::EC2::CustomerGateway"
-    val `AWS::EC2::EIP`                             = "AWS::EC2::EIP"
-    val `AWS::EC2::Host`                            = "AWS::EC2::Host"
-    val `AWS::EC2::Instance`                        = "AWS::EC2::Instance"
-    val `AWS::EC2::InternetGateway`                 = "AWS::EC2::InternetGateway"
-    val `AWS::EC2::NetworkAcl`                      = "AWS::EC2::NetworkAcl"
-    val `AWS::EC2::NetworkInterface`                = "AWS::EC2::NetworkInterface"
-    val `AWS::EC2::RouteTable`                      = "AWS::EC2::RouteTable"
-    val `AWS::EC2::SecurityGroup`                   = "AWS::EC2::SecurityGroup"
-    val `AWS::EC2::Subnet`                          = "AWS::EC2::Subnet"
-    val `AWS::CloudTrail::Trail`                    = "AWS::CloudTrail::Trail"
-    val `AWS::EC2::Volume`                          = "AWS::EC2::Volume"
-    val `AWS::EC2::VPC`                             = "AWS::EC2::VPC"
-    val `AWS::EC2::VPNConnection`                   = "AWS::EC2::VPNConnection"
-    val `AWS::EC2::VPNGateway`                      = "AWS::EC2::VPNGateway"
-    val `AWS::EC2::RegisteredHAInstance`            = "AWS::EC2::RegisteredHAInstance"
-    val `AWS::EC2::NatGateway`                      = "AWS::EC2::NatGateway"
-    val `AWS::EC2::EgressOnlyInternetGateway`       = "AWS::EC2::EgressOnlyInternetGateway"
-    val `AWS::EC2::VPCEndpoint`                     = "AWS::EC2::VPCEndpoint"
-    val `AWS::EC2::VPCEndpointService`              = "AWS::EC2::VPCEndpointService"
-    val `AWS::EC2::FlowLog`                         = "AWS::EC2::FlowLog"
-    val `AWS::EC2::VPCPeeringConnection`            = "AWS::EC2::VPCPeeringConnection"
-    val `AWS::IAM::Group`                           = "AWS::IAM::Group"
-    val `AWS::IAM::Policy`                          = "AWS::IAM::Policy"
-    val `AWS::IAM::Role`                            = "AWS::IAM::Role"
-    val `AWS::IAM::User`                            = "AWS::IAM::User"
-    val `AWS::ElasticLoadBalancingV2::LoadBalancer` = "AWS::ElasticLoadBalancingV2::LoadBalancer"
-    val `AWS::ACM::Certificate`                     = "AWS::ACM::Certificate"
-    val `AWS::RDS::DBInstance`                      = "AWS::RDS::DBInstance"
-    val `AWS::RDS::DBParameterGroup`                = "AWS::RDS::DBParameterGroup"
-    val `AWS::RDS::DBOptionGroup`                   = "AWS::RDS::DBOptionGroup"
-    val `AWS::RDS::DBSubnetGroup`                   = "AWS::RDS::DBSubnetGroup"
-    val `AWS::RDS::DBSecurityGroup`                 = "AWS::RDS::DBSecurityGroup"
-    val `AWS::RDS::DBSnapshot`                      = "AWS::RDS::DBSnapshot"
-    val `AWS::RDS::DBCluster`                       = "AWS::RDS::DBCluster"
-    val `AWS::RDS::DBClusterParameterGroup`         = "AWS::RDS::DBClusterParameterGroup"
-    val `AWS::RDS::DBClusterSnapshot`               = "AWS::RDS::DBClusterSnapshot"
-    val `AWS::RDS::EventSubscription`               = "AWS::RDS::EventSubscription"
-    val `AWS::S3::Bucket`                           = "AWS::S3::Bucket"
-    val `AWS::S3::AccountPublicAccessBlock`         = "AWS::S3::AccountPublicAccessBlock"
-    val `AWS::Redshift::Cluster`                    = "AWS::Redshift::Cluster"
-    val `AWS::Redshift::ClusterSnapshot`            = "AWS::Redshift::ClusterSnapshot"
-    val `AWS::Redshift::ClusterParameterGroup`      = "AWS::Redshift::ClusterParameterGroup"
-    val `AWS::Redshift::ClusterSecurityGroup`       = "AWS::Redshift::ClusterSecurityGroup"
-    val `AWS::Redshift::ClusterSubnetGroup`         = "AWS::Redshift::ClusterSubnetGroup"
-    val `AWS::Redshift::EventSubscription`          = "AWS::Redshift::EventSubscription"
-    val `AWS::SSM::ManagedInstanceInventory`        = "AWS::SSM::ManagedInstanceInventory"
-    val `AWS::CloudWatch::Alarm`                    = "AWS::CloudWatch::Alarm"
-    val `AWS::CloudFormation::Stack`                = "AWS::CloudFormation::Stack"
-    val `AWS::ElasticLoadBalancing::LoadBalancer`   = "AWS::ElasticLoadBalancing::LoadBalancer"
-    val `AWS::AutoScaling::AutoScalingGroup`        = "AWS::AutoScaling::AutoScalingGroup"
-    val `AWS::AutoScaling::LaunchConfiguration`     = "AWS::AutoScaling::LaunchConfiguration"
-    val `AWS::AutoScaling::ScalingPolicy`           = "AWS::AutoScaling::ScalingPolicy"
-    val `AWS::AutoScaling::ScheduledAction`         = "AWS::AutoScaling::ScheduledAction"
-    val `AWS::DynamoDB::Table`                      = "AWS::DynamoDB::Table"
-    val `AWS::CodeBuild::Project`                   = "AWS::CodeBuild::Project"
-    val `AWS::WAF::RateBasedRule`                   = "AWS::WAF::RateBasedRule"
-    val `AWS::WAF::Rule`                            = "AWS::WAF::Rule"
-    val `AWS::WAF::RuleGroup`                       = "AWS::WAF::RuleGroup"
-    val `AWS::WAF::WebACL`                          = "AWS::WAF::WebACL"
-    val `AWS::WAFRegional::RateBasedRule`           = "AWS::WAFRegional::RateBasedRule"
-    val `AWS::WAFRegional::Rule`                    = "AWS::WAFRegional::Rule"
-    val `AWS::WAFRegional::RuleGroup`               = "AWS::WAFRegional::RuleGroup"
-    val `AWS::WAFRegional::WebACL`                  = "AWS::WAFRegional::WebACL"
-    val `AWS::CloudFront::Distribution`             = "AWS::CloudFront::Distribution"
-    val `AWS::CloudFront::StreamingDistribution`    = "AWS::CloudFront::StreamingDistribution"
-    val `AWS::Lambda::Alias`                        = "AWS::Lambda::Alias"
-    val `AWS::Lambda::Function`                     = "AWS::Lambda::Function"
-    val `AWS::ElasticBeanstalk::Application`        = "AWS::ElasticBeanstalk::Application"
-    val `AWS::ElasticBeanstalk::ApplicationVersion` = "AWS::ElasticBeanstalk::ApplicationVersion"
-    val `AWS::ElasticBeanstalk::Environment`        = "AWS::ElasticBeanstalk::Environment"
-    val `AWS::MobileHub::Project`                   = "AWS::MobileHub::Project"
-    val `AWS::XRay::EncryptionConfig`               = "AWS::XRay::EncryptionConfig"
-    val `AWS::SSM::AssociationCompliance`           = "AWS::SSM::AssociationCompliance"
-    val `AWS::SSM::PatchCompliance`                 = "AWS::SSM::PatchCompliance"
-    val `AWS::Shield::Protection`                   = "AWS::Shield::Protection"
-    val `AWS::ShieldRegional::Protection`           = "AWS::ShieldRegional::Protection"
-    val `AWS::Config::ResourceCompliance`           = "AWS::Config::ResourceCompliance"
-    val `AWS::LicenseManager::LicenseConfiguration` = "AWS::LicenseManager::LicenseConfiguration"
-    val `AWS::ApiGateway::DomainName`               = "AWS::ApiGateway::DomainName"
-    val `AWS::ApiGateway::Method`                   = "AWS::ApiGateway::Method"
-    val `AWS::ApiGateway::Stage`                    = "AWS::ApiGateway::Stage"
-    val `AWS::ApiGateway::RestApi`                  = "AWS::ApiGateway::RestApi"
-    val `AWS::ApiGatewayV2::DomainName`             = "AWS::ApiGatewayV2::DomainName"
-    val `AWS::ApiGatewayV2::Stage`                  = "AWS::ApiGatewayV2::Stage"
-    val `AWS::ApiGatewayV2::Api`                    = "AWS::ApiGatewayV2::Api"
-    val `AWS::CodePipeline::Pipeline`               = "AWS::CodePipeline::Pipeline"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val `AWS::EC2::CustomerGateway`           = "AWS::EC2::CustomerGateway".asInstanceOf[ResourceType]
+    val `AWS::EC2::EIP`                       = "AWS::EC2::EIP".asInstanceOf[ResourceType]
+    val `AWS::EC2::Host`                      = "AWS::EC2::Host".asInstanceOf[ResourceType]
+    val `AWS::EC2::Instance`                  = "AWS::EC2::Instance".asInstanceOf[ResourceType]
+    val `AWS::EC2::InternetGateway`           = "AWS::EC2::InternetGateway".asInstanceOf[ResourceType]
+    val `AWS::EC2::NetworkAcl`                = "AWS::EC2::NetworkAcl".asInstanceOf[ResourceType]
+    val `AWS::EC2::NetworkInterface`          = "AWS::EC2::NetworkInterface".asInstanceOf[ResourceType]
+    val `AWS::EC2::RouteTable`                = "AWS::EC2::RouteTable".asInstanceOf[ResourceType]
+    val `AWS::EC2::SecurityGroup`             = "AWS::EC2::SecurityGroup".asInstanceOf[ResourceType]
+    val `AWS::EC2::Subnet`                    = "AWS::EC2::Subnet".asInstanceOf[ResourceType]
+    val `AWS::CloudTrail::Trail`              = "AWS::CloudTrail::Trail".asInstanceOf[ResourceType]
+    val `AWS::EC2::Volume`                    = "AWS::EC2::Volume".asInstanceOf[ResourceType]
+    val `AWS::EC2::VPC`                       = "AWS::EC2::VPC".asInstanceOf[ResourceType]
+    val `AWS::EC2::VPNConnection`             = "AWS::EC2::VPNConnection".asInstanceOf[ResourceType]
+    val `AWS::EC2::VPNGateway`                = "AWS::EC2::VPNGateway".asInstanceOf[ResourceType]
+    val `AWS::EC2::RegisteredHAInstance`      = "AWS::EC2::RegisteredHAInstance".asInstanceOf[ResourceType]
+    val `AWS::EC2::NatGateway`                = "AWS::EC2::NatGateway".asInstanceOf[ResourceType]
+    val `AWS::EC2::EgressOnlyInternetGateway` = "AWS::EC2::EgressOnlyInternetGateway".asInstanceOf[ResourceType]
+    val `AWS::EC2::VPCEndpoint`               = "AWS::EC2::VPCEndpoint".asInstanceOf[ResourceType]
+    val `AWS::EC2::VPCEndpointService`        = "AWS::EC2::VPCEndpointService".asInstanceOf[ResourceType]
+    val `AWS::EC2::FlowLog`                   = "AWS::EC2::FlowLog".asInstanceOf[ResourceType]
+    val `AWS::EC2::VPCPeeringConnection`      = "AWS::EC2::VPCPeeringConnection".asInstanceOf[ResourceType]
+    val `AWS::IAM::Group`                     = "AWS::IAM::Group".asInstanceOf[ResourceType]
+    val `AWS::IAM::Policy`                    = "AWS::IAM::Policy".asInstanceOf[ResourceType]
+    val `AWS::IAM::Role`                      = "AWS::IAM::Role".asInstanceOf[ResourceType]
+    val `AWS::IAM::User`                      = "AWS::IAM::User".asInstanceOf[ResourceType]
+    val `AWS::ElasticLoadBalancingV2::LoadBalancer` =
+      "AWS::ElasticLoadBalancingV2::LoadBalancer".asInstanceOf[ResourceType]
+    val `AWS::ACM::Certificate`                   = "AWS::ACM::Certificate".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBInstance`                    = "AWS::RDS::DBInstance".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBParameterGroup`              = "AWS::RDS::DBParameterGroup".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBOptionGroup`                 = "AWS::RDS::DBOptionGroup".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBSubnetGroup`                 = "AWS::RDS::DBSubnetGroup".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBSecurityGroup`               = "AWS::RDS::DBSecurityGroup".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBSnapshot`                    = "AWS::RDS::DBSnapshot".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBCluster`                     = "AWS::RDS::DBCluster".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBClusterParameterGroup`       = "AWS::RDS::DBClusterParameterGroup".asInstanceOf[ResourceType]
+    val `AWS::RDS::DBClusterSnapshot`             = "AWS::RDS::DBClusterSnapshot".asInstanceOf[ResourceType]
+    val `AWS::RDS::EventSubscription`             = "AWS::RDS::EventSubscription".asInstanceOf[ResourceType]
+    val `AWS::S3::Bucket`                         = "AWS::S3::Bucket".asInstanceOf[ResourceType]
+    val `AWS::S3::AccountPublicAccessBlock`       = "AWS::S3::AccountPublicAccessBlock".asInstanceOf[ResourceType]
+    val `AWS::Redshift::Cluster`                  = "AWS::Redshift::Cluster".asInstanceOf[ResourceType]
+    val `AWS::Redshift::ClusterSnapshot`          = "AWS::Redshift::ClusterSnapshot".asInstanceOf[ResourceType]
+    val `AWS::Redshift::ClusterParameterGroup`    = "AWS::Redshift::ClusterParameterGroup".asInstanceOf[ResourceType]
+    val `AWS::Redshift::ClusterSecurityGroup`     = "AWS::Redshift::ClusterSecurityGroup".asInstanceOf[ResourceType]
+    val `AWS::Redshift::ClusterSubnetGroup`       = "AWS::Redshift::ClusterSubnetGroup".asInstanceOf[ResourceType]
+    val `AWS::Redshift::EventSubscription`        = "AWS::Redshift::EventSubscription".asInstanceOf[ResourceType]
+    val `AWS::SSM::ManagedInstanceInventory`      = "AWS::SSM::ManagedInstanceInventory".asInstanceOf[ResourceType]
+    val `AWS::CloudWatch::Alarm`                  = "AWS::CloudWatch::Alarm".asInstanceOf[ResourceType]
+    val `AWS::CloudFormation::Stack`              = "AWS::CloudFormation::Stack".asInstanceOf[ResourceType]
+    val `AWS::ElasticLoadBalancing::LoadBalancer` = "AWS::ElasticLoadBalancing::LoadBalancer".asInstanceOf[ResourceType]
+    val `AWS::AutoScaling::AutoScalingGroup`      = "AWS::AutoScaling::AutoScalingGroup".asInstanceOf[ResourceType]
+    val `AWS::AutoScaling::LaunchConfiguration`   = "AWS::AutoScaling::LaunchConfiguration".asInstanceOf[ResourceType]
+    val `AWS::AutoScaling::ScalingPolicy`         = "AWS::AutoScaling::ScalingPolicy".asInstanceOf[ResourceType]
+    val `AWS::AutoScaling::ScheduledAction`       = "AWS::AutoScaling::ScheduledAction".asInstanceOf[ResourceType]
+    val `AWS::DynamoDB::Table`                    = "AWS::DynamoDB::Table".asInstanceOf[ResourceType]
+    val `AWS::CodeBuild::Project`                 = "AWS::CodeBuild::Project".asInstanceOf[ResourceType]
+    val `AWS::WAF::RateBasedRule`                 = "AWS::WAF::RateBasedRule".asInstanceOf[ResourceType]
+    val `AWS::WAF::Rule`                          = "AWS::WAF::Rule".asInstanceOf[ResourceType]
+    val `AWS::WAF::RuleGroup`                     = "AWS::WAF::RuleGroup".asInstanceOf[ResourceType]
+    val `AWS::WAF::WebACL`                        = "AWS::WAF::WebACL".asInstanceOf[ResourceType]
+    val `AWS::WAFRegional::RateBasedRule`         = "AWS::WAFRegional::RateBasedRule".asInstanceOf[ResourceType]
+    val `AWS::WAFRegional::Rule`                  = "AWS::WAFRegional::Rule".asInstanceOf[ResourceType]
+    val `AWS::WAFRegional::RuleGroup`             = "AWS::WAFRegional::RuleGroup".asInstanceOf[ResourceType]
+    val `AWS::WAFRegional::WebACL`                = "AWS::WAFRegional::WebACL".asInstanceOf[ResourceType]
+    val `AWS::CloudFront::Distribution`           = "AWS::CloudFront::Distribution".asInstanceOf[ResourceType]
+    val `AWS::CloudFront::StreamingDistribution`  = "AWS::CloudFront::StreamingDistribution".asInstanceOf[ResourceType]
+    val `AWS::Lambda::Alias`                      = "AWS::Lambda::Alias".asInstanceOf[ResourceType]
+    val `AWS::Lambda::Function`                   = "AWS::Lambda::Function".asInstanceOf[ResourceType]
+    val `AWS::ElasticBeanstalk::Application`      = "AWS::ElasticBeanstalk::Application".asInstanceOf[ResourceType]
+    val `AWS::ElasticBeanstalk::ApplicationVersion` =
+      "AWS::ElasticBeanstalk::ApplicationVersion".asInstanceOf[ResourceType]
+    val `AWS::ElasticBeanstalk::Environment` = "AWS::ElasticBeanstalk::Environment".asInstanceOf[ResourceType]
+    val `AWS::MobileHub::Project`            = "AWS::MobileHub::Project".asInstanceOf[ResourceType]
+    val `AWS::XRay::EncryptionConfig`        = "AWS::XRay::EncryptionConfig".asInstanceOf[ResourceType]
+    val `AWS::SSM::AssociationCompliance`    = "AWS::SSM::AssociationCompliance".asInstanceOf[ResourceType]
+    val `AWS::SSM::PatchCompliance`          = "AWS::SSM::PatchCompliance".asInstanceOf[ResourceType]
+    val `AWS::Shield::Protection`            = "AWS::Shield::Protection".asInstanceOf[ResourceType]
+    val `AWS::ShieldRegional::Protection`    = "AWS::ShieldRegional::Protection".asInstanceOf[ResourceType]
+    val `AWS::Config::ResourceCompliance`    = "AWS::Config::ResourceCompliance".asInstanceOf[ResourceType]
+    val `AWS::LicenseManager::LicenseConfiguration` =
+      "AWS::LicenseManager::LicenseConfiguration".asInstanceOf[ResourceType]
+    val `AWS::ApiGateway::DomainName`   = "AWS::ApiGateway::DomainName".asInstanceOf[ResourceType]
+    val `AWS::ApiGateway::Method`       = "AWS::ApiGateway::Method".asInstanceOf[ResourceType]
+    val `AWS::ApiGateway::Stage`        = "AWS::ApiGateway::Stage".asInstanceOf[ResourceType]
+    val `AWS::ApiGateway::RestApi`      = "AWS::ApiGateway::RestApi".asInstanceOf[ResourceType]
+    val `AWS::ApiGatewayV2::DomainName` = "AWS::ApiGatewayV2::DomainName".asInstanceOf[ResourceType]
+    val `AWS::ApiGatewayV2::Stage`      = "AWS::ApiGatewayV2::Stage".asInstanceOf[ResourceType]
+    val `AWS::ApiGatewayV2::Api`        = "AWS::ApiGatewayV2::Api".asInstanceOf[ResourceType]
+    val `AWS::CodePipeline::Pipeline`   = "AWS::CodePipeline::Pipeline".asInstanceOf[ResourceType]
     val `AWS::ServiceCatalog::CloudFormationProvisionedProduct` =
-      "AWS::ServiceCatalog::CloudFormationProvisionedProduct"
-    val `AWS::ServiceCatalog::CloudFormationProduct` = "AWS::ServiceCatalog::CloudFormationProduct"
-    val `AWS::ServiceCatalog::Portfolio`             = "AWS::ServiceCatalog::Portfolio"
+      "AWS::ServiceCatalog::CloudFormationProvisionedProduct".asInstanceOf[ResourceType]
+    val `AWS::ServiceCatalog::CloudFormationProduct` =
+      "AWS::ServiceCatalog::CloudFormationProduct".asInstanceOf[ResourceType]
+    val `AWS::ServiceCatalog::Portfolio` = "AWS::ServiceCatalog::Portfolio".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -6101,9 +6107,10 @@ package configservice {
       __obj.asInstanceOf[ResourceValue]
     }
   }
-
-  object ResourceValueTypeEnum {
-    val RESOURCE_ID = "RESOURCE_ID"
+  @js.native
+  sealed trait ResourceValueType extends js.Any
+  object ResourceValueType extends js.Object {
+    val RESOURCE_ID = "RESOURCE_ID".asInstanceOf[ResourceValueType]
 
     val values = js.Object.freeze(js.Array(RESOURCE_ID))
   }

--- a/services/connect/src/main/scala/facade/amazonaws/services/Connect.scala
+++ b/services/connect/src/main/scala/facade/amazonaws/services/Connect.scala
@@ -16,26 +16,21 @@ package object connect {
   type AttributeValue                  = String
   type Attributes                      = js.Dictionary[AttributeValue]
   type AutoAccept                      = Boolean
-  type Channel                         = String
   type Channels                        = js.Array[Channel]
   type ChatContent                     = String
   type ChatContentType                 = String
   type ClientToken                     = String
-  type Comparison                      = String
   type ContactFlowId                   = String
   type ContactFlowName                 = String
   type ContactFlowSummaryList          = js.Array[ContactFlowSummary]
-  type ContactFlowType                 = String
   type ContactFlowTypes                = js.Array[ContactFlowType]
   type ContactId                       = String
   type CurrentMetricDataCollections    = js.Array[CurrentMetricData]
-  type CurrentMetricName               = String
   type CurrentMetricResults            = js.Array[CurrentMetricResult]
   type CurrentMetrics                  = js.Array[CurrentMetric]
   type DirectoryUserId                 = String
   type DisplayName                     = String
   type Email                           = String
-  type Grouping                        = String
   type Groupings                       = js.Array[Grouping]
   type HierarchyGroupId                = String
   type HierarchyGroupName              = String
@@ -43,7 +38,6 @@ package object connect {
   type HierarchyLevelId                = String
   type HierarchyLevelName              = String
   type HistoricalMetricDataCollections = js.Array[HistoricalMetricData]
-  type HistoricalMetricName            = String
   type HistoricalMetricResults         = js.Array[HistoricalMetricResult]
   type HistoricalMetrics               = js.Array[HistoricalMetric]
   type HoursOfOperationId              = String
@@ -57,17 +51,13 @@ package object connect {
   type ParticipantToken                = String
   type Password                        = String
   type PhoneNumber                     = String
-  type PhoneNumberCountryCode          = String
   type PhoneNumberCountryCodes         = js.Array[PhoneNumberCountryCode]
   type PhoneNumberId                   = String
   type PhoneNumberSummaryList          = js.Array[PhoneNumberSummary]
-  type PhoneNumberType                 = String
   type PhoneNumberTypes                = js.Array[PhoneNumberType]
-  type PhoneType                       = String
   type QueueId                         = String
   type QueueName                       = String
   type QueueSummaryList                = js.Array[QueueSummary]
-  type QueueType                       = String
   type QueueTypes                      = js.Array[QueueType]
   type Queues                          = js.Array[QueueId]
   type RoutingProfileId                = String
@@ -78,13 +68,11 @@ package object connect {
   type SecurityProfileName             = String
   type SecurityProfileSummaryList      = js.Array[SecurityProfileSummary]
   type SecurityToken                   = String
-  type Statistic                       = String
   type TagKey                          = String
   type TagKeyList                      = js.Array[TagKey]
   type TagMap                          = js.Dictionary[TagValue]
   type TagValue                        = String
   type ThresholdValue                  = Double
-  type Unit                            = String
   type UserId                          = String
   type UserSummaryList                 = js.Array[UserSummary]
   type Value                           = Double
@@ -203,10 +191,11 @@ package connect {
     def updateUserRoutingProfile(params: UpdateUserRoutingProfileRequest): Request[js.Object]     = js.native
     def updateUserSecurityProfiles(params: UpdateUserSecurityProfilesRequest): Request[js.Object] = js.native
   }
-
-  object ChannelEnum {
-    val VOICE = "VOICE"
-    val CHAT  = "CHAT"
+  @js.native
+  sealed trait Channel extends js.Any
+  object Channel extends js.Object {
+    val VOICE = "VOICE".asInstanceOf[Channel]
+    val CHAT  = "CHAT".asInstanceOf[Channel]
 
     val values = js.Object.freeze(js.Array(VOICE, CHAT))
   }
@@ -234,9 +223,10 @@ package connect {
       __obj.asInstanceOf[ChatMessage]
     }
   }
-
-  object ComparisonEnum {
-    val LT = "LT"
+  @js.native
+  sealed trait Comparison extends js.Any
+  object Comparison extends js.Object {
+    val LT = "LT".asInstanceOf[Comparison]
 
     val values = js.Object.freeze(js.Array(LT))
   }
@@ -268,17 +258,18 @@ package connect {
       __obj.asInstanceOf[ContactFlowSummary]
     }
   }
-
-  object ContactFlowTypeEnum {
-    val CONTACT_FLOW     = "CONTACT_FLOW"
-    val CUSTOMER_QUEUE   = "CUSTOMER_QUEUE"
-    val CUSTOMER_HOLD    = "CUSTOMER_HOLD"
-    val CUSTOMER_WHISPER = "CUSTOMER_WHISPER"
-    val AGENT_HOLD       = "AGENT_HOLD"
-    val AGENT_WHISPER    = "AGENT_WHISPER"
-    val OUTBOUND_WHISPER = "OUTBOUND_WHISPER"
-    val AGENT_TRANSFER   = "AGENT_TRANSFER"
-    val QUEUE_TRANSFER   = "QUEUE_TRANSFER"
+  @js.native
+  sealed trait ContactFlowType extends js.Any
+  object ContactFlowType extends js.Object {
+    val CONTACT_FLOW     = "CONTACT_FLOW".asInstanceOf[ContactFlowType]
+    val CUSTOMER_QUEUE   = "CUSTOMER_QUEUE".asInstanceOf[ContactFlowType]
+    val CUSTOMER_HOLD    = "CUSTOMER_HOLD".asInstanceOf[ContactFlowType]
+    val CUSTOMER_WHISPER = "CUSTOMER_WHISPER".asInstanceOf[ContactFlowType]
+    val AGENT_HOLD       = "AGENT_HOLD".asInstanceOf[ContactFlowType]
+    val AGENT_WHISPER    = "AGENT_WHISPER".asInstanceOf[ContactFlowType]
+    val OUTBOUND_WHISPER = "OUTBOUND_WHISPER".asInstanceOf[ContactFlowType]
+    val AGENT_TRANSFER   = "AGENT_TRANSFER".asInstanceOf[ContactFlowType]
+    val QUEUE_TRANSFER   = "QUEUE_TRANSFER".asInstanceOf[ContactFlowType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -434,20 +425,22 @@ package connect {
   /**
     * The current metric names.
     */
-  object CurrentMetricNameEnum {
-    val AGENTS_ONLINE             = "AGENTS_ONLINE"
-    val AGENTS_AVAILABLE          = "AGENTS_AVAILABLE"
-    val AGENTS_ON_CALL            = "AGENTS_ON_CALL"
-    val AGENTS_NON_PRODUCTIVE     = "AGENTS_NON_PRODUCTIVE"
-    val AGENTS_AFTER_CONTACT_WORK = "AGENTS_AFTER_CONTACT_WORK"
-    val AGENTS_ERROR              = "AGENTS_ERROR"
-    val AGENTS_STAFFED            = "AGENTS_STAFFED"
-    val CONTACTS_IN_QUEUE         = "CONTACTS_IN_QUEUE"
-    val OLDEST_CONTACT_AGE        = "OLDEST_CONTACT_AGE"
-    val CONTACTS_SCHEDULED        = "CONTACTS_SCHEDULED"
-    val AGENTS_ON_CONTACT         = "AGENTS_ON_CONTACT"
-    val SLOTS_ACTIVE              = "SLOTS_ACTIVE"
-    val SLOTS_AVAILABLE           = "SLOTS_AVAILABLE"
+  @js.native
+  sealed trait CurrentMetricName extends js.Any
+  object CurrentMetricName extends js.Object {
+    val AGENTS_ONLINE             = "AGENTS_ONLINE".asInstanceOf[CurrentMetricName]
+    val AGENTS_AVAILABLE          = "AGENTS_AVAILABLE".asInstanceOf[CurrentMetricName]
+    val AGENTS_ON_CALL            = "AGENTS_ON_CALL".asInstanceOf[CurrentMetricName]
+    val AGENTS_NON_PRODUCTIVE     = "AGENTS_NON_PRODUCTIVE".asInstanceOf[CurrentMetricName]
+    val AGENTS_AFTER_CONTACT_WORK = "AGENTS_AFTER_CONTACT_WORK".asInstanceOf[CurrentMetricName]
+    val AGENTS_ERROR              = "AGENTS_ERROR".asInstanceOf[CurrentMetricName]
+    val AGENTS_STAFFED            = "AGENTS_STAFFED".asInstanceOf[CurrentMetricName]
+    val CONTACTS_IN_QUEUE         = "CONTACTS_IN_QUEUE".asInstanceOf[CurrentMetricName]
+    val OLDEST_CONTACT_AGE        = "OLDEST_CONTACT_AGE".asInstanceOf[CurrentMetricName]
+    val CONTACTS_SCHEDULED        = "CONTACTS_SCHEDULED".asInstanceOf[CurrentMetricName]
+    val AGENTS_ON_CONTACT         = "AGENTS_ON_CONTACT".asInstanceOf[CurrentMetricName]
+    val SLOTS_ACTIVE              = "SLOTS_ACTIVE".asInstanceOf[CurrentMetricName]
+    val SLOTS_AVAILABLE           = "SLOTS_AVAILABLE".asInstanceOf[CurrentMetricName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -846,10 +839,11 @@ package connect {
       __obj.asInstanceOf[GetMetricDataResponse]
     }
   }
-
-  object GroupingEnum {
-    val QUEUE   = "QUEUE"
-    val CHANNEL = "CHANNEL"
+  @js.native
+  sealed trait Grouping extends js.Any
+  object Grouping extends js.Object {
+    val QUEUE   = "QUEUE".asInstanceOf[Grouping]
+    val CHANNEL = "CHANNEL".asInstanceOf[Grouping]
 
     val values = js.Object.freeze(js.Array(QUEUE, CHANNEL))
   }
@@ -1050,32 +1044,34 @@ package connect {
   /**
     * The historical metric names.
     */
-  object HistoricalMetricNameEnum {
-    val CONTACTS_QUEUED                     = "CONTACTS_QUEUED"
-    val CONTACTS_HANDLED                    = "CONTACTS_HANDLED"
-    val CONTACTS_ABANDONED                  = "CONTACTS_ABANDONED"
-    val CONTACTS_CONSULTED                  = "CONTACTS_CONSULTED"
-    val CONTACTS_AGENT_HUNG_UP_FIRST        = "CONTACTS_AGENT_HUNG_UP_FIRST"
-    val CONTACTS_HANDLED_INCOMING           = "CONTACTS_HANDLED_INCOMING"
-    val CONTACTS_HANDLED_OUTBOUND           = "CONTACTS_HANDLED_OUTBOUND"
-    val CONTACTS_HOLD_ABANDONS              = "CONTACTS_HOLD_ABANDONS"
-    val CONTACTS_TRANSFERRED_IN             = "CONTACTS_TRANSFERRED_IN"
-    val CONTACTS_TRANSFERRED_OUT            = "CONTACTS_TRANSFERRED_OUT"
-    val CONTACTS_TRANSFERRED_IN_FROM_QUEUE  = "CONTACTS_TRANSFERRED_IN_FROM_QUEUE"
-    val CONTACTS_TRANSFERRED_OUT_FROM_QUEUE = "CONTACTS_TRANSFERRED_OUT_FROM_QUEUE"
-    val CONTACTS_MISSED                     = "CONTACTS_MISSED"
-    val CALLBACK_CONTACTS_HANDLED           = "CALLBACK_CONTACTS_HANDLED"
-    val API_CONTACTS_HANDLED                = "API_CONTACTS_HANDLED"
-    val OCCUPANCY                           = "OCCUPANCY"
-    val HANDLE_TIME                         = "HANDLE_TIME"
-    val AFTER_CONTACT_WORK_TIME             = "AFTER_CONTACT_WORK_TIME"
-    val QUEUED_TIME                         = "QUEUED_TIME"
-    val ABANDON_TIME                        = "ABANDON_TIME"
-    val QUEUE_ANSWER_TIME                   = "QUEUE_ANSWER_TIME"
-    val HOLD_TIME                           = "HOLD_TIME"
-    val INTERACTION_TIME                    = "INTERACTION_TIME"
-    val INTERACTION_AND_HOLD_TIME           = "INTERACTION_AND_HOLD_TIME"
-    val SERVICE_LEVEL                       = "SERVICE_LEVEL"
+  @js.native
+  sealed trait HistoricalMetricName extends js.Any
+  object HistoricalMetricName extends js.Object {
+    val CONTACTS_QUEUED                     = "CONTACTS_QUEUED".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_HANDLED                    = "CONTACTS_HANDLED".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_ABANDONED                  = "CONTACTS_ABANDONED".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_CONSULTED                  = "CONTACTS_CONSULTED".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_AGENT_HUNG_UP_FIRST        = "CONTACTS_AGENT_HUNG_UP_FIRST".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_HANDLED_INCOMING           = "CONTACTS_HANDLED_INCOMING".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_HANDLED_OUTBOUND           = "CONTACTS_HANDLED_OUTBOUND".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_HOLD_ABANDONS              = "CONTACTS_HOLD_ABANDONS".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_TRANSFERRED_IN             = "CONTACTS_TRANSFERRED_IN".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_TRANSFERRED_OUT            = "CONTACTS_TRANSFERRED_OUT".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_TRANSFERRED_IN_FROM_QUEUE  = "CONTACTS_TRANSFERRED_IN_FROM_QUEUE".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_TRANSFERRED_OUT_FROM_QUEUE = "CONTACTS_TRANSFERRED_OUT_FROM_QUEUE".asInstanceOf[HistoricalMetricName]
+    val CONTACTS_MISSED                     = "CONTACTS_MISSED".asInstanceOf[HistoricalMetricName]
+    val CALLBACK_CONTACTS_HANDLED           = "CALLBACK_CONTACTS_HANDLED".asInstanceOf[HistoricalMetricName]
+    val API_CONTACTS_HANDLED                = "API_CONTACTS_HANDLED".asInstanceOf[HistoricalMetricName]
+    val OCCUPANCY                           = "OCCUPANCY".asInstanceOf[HistoricalMetricName]
+    val HANDLE_TIME                         = "HANDLE_TIME".asInstanceOf[HistoricalMetricName]
+    val AFTER_CONTACT_WORK_TIME             = "AFTER_CONTACT_WORK_TIME".asInstanceOf[HistoricalMetricName]
+    val QUEUED_TIME                         = "QUEUED_TIME".asInstanceOf[HistoricalMetricName]
+    val ABANDON_TIME                        = "ABANDON_TIME".asInstanceOf[HistoricalMetricName]
+    val QUEUE_ANSWER_TIME                   = "QUEUE_ANSWER_TIME".asInstanceOf[HistoricalMetricName]
+    val HOLD_TIME                           = "HOLD_TIME".asInstanceOf[HistoricalMetricName]
+    val INTERACTION_TIME                    = "INTERACTION_TIME".asInstanceOf[HistoricalMetricName]
+    val INTERACTION_AND_HOLD_TIME           = "INTERACTION_AND_HOLD_TIME".asInstanceOf[HistoricalMetricName]
+    val SERVICE_LEVEL                       = "SERVICE_LEVEL".asInstanceOf[HistoricalMetricName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1573,245 +1569,246 @@ package connect {
       __obj.asInstanceOf[ParticipantDetails]
     }
   }
-
-  object PhoneNumberCountryCodeEnum {
-    val AF = "AF"
-    val AL = "AL"
-    val DZ = "DZ"
-    val AS = "AS"
-    val AD = "AD"
-    val AO = "AO"
-    val AI = "AI"
-    val AQ = "AQ"
-    val AG = "AG"
-    val AR = "AR"
-    val AM = "AM"
-    val AW = "AW"
-    val AU = "AU"
-    val AT = "AT"
-    val AZ = "AZ"
-    val BS = "BS"
-    val BH = "BH"
-    val BD = "BD"
-    val BB = "BB"
-    val BY = "BY"
-    val BE = "BE"
-    val BZ = "BZ"
-    val BJ = "BJ"
-    val BM = "BM"
-    val BT = "BT"
-    val BO = "BO"
-    val BA = "BA"
-    val BW = "BW"
-    val BR = "BR"
-    val IO = "IO"
-    val VG = "VG"
-    val BN = "BN"
-    val BG = "BG"
-    val BF = "BF"
-    val BI = "BI"
-    val KH = "KH"
-    val CM = "CM"
-    val CA = "CA"
-    val CV = "CV"
-    val KY = "KY"
-    val CF = "CF"
-    val TD = "TD"
-    val CL = "CL"
-    val CN = "CN"
-    val CX = "CX"
-    val CC = "CC"
-    val CO = "CO"
-    val KM = "KM"
-    val CK = "CK"
-    val CR = "CR"
-    val HR = "HR"
-    val CU = "CU"
-    val CW = "CW"
-    val CY = "CY"
-    val CZ = "CZ"
-    val CD = "CD"
-    val DK = "DK"
-    val DJ = "DJ"
-    val DM = "DM"
-    val DO = "DO"
-    val TL = "TL"
-    val EC = "EC"
-    val EG = "EG"
-    val SV = "SV"
-    val GQ = "GQ"
-    val ER = "ER"
-    val EE = "EE"
-    val ET = "ET"
-    val FK = "FK"
-    val FO = "FO"
-    val FJ = "FJ"
-    val FI = "FI"
-    val FR = "FR"
-    val PF = "PF"
-    val GA = "GA"
-    val GM = "GM"
-    val GE = "GE"
-    val DE = "DE"
-    val GH = "GH"
-    val GI = "GI"
-    val GR = "GR"
-    val GL = "GL"
-    val GD = "GD"
-    val GU = "GU"
-    val GT = "GT"
-    val GG = "GG"
-    val GN = "GN"
-    val GW = "GW"
-    val GY = "GY"
-    val HT = "HT"
-    val HN = "HN"
-    val HK = "HK"
-    val HU = "HU"
-    val IS = "IS"
-    val IN = "IN"
-    val ID = "ID"
-    val IR = "IR"
-    val IQ = "IQ"
-    val IE = "IE"
-    val IM = "IM"
-    val IL = "IL"
-    val IT = "IT"
-    val CI = "CI"
-    val JM = "JM"
-    val JP = "JP"
-    val JE = "JE"
-    val JO = "JO"
-    val KZ = "KZ"
-    val KE = "KE"
-    val KI = "KI"
-    val KW = "KW"
-    val KG = "KG"
-    val LA = "LA"
-    val LV = "LV"
-    val LB = "LB"
-    val LS = "LS"
-    val LR = "LR"
-    val LY = "LY"
-    val LI = "LI"
-    val LT = "LT"
-    val LU = "LU"
-    val MO = "MO"
-    val MK = "MK"
-    val MG = "MG"
-    val MW = "MW"
-    val MY = "MY"
-    val MV = "MV"
-    val ML = "ML"
-    val MT = "MT"
-    val MH = "MH"
-    val MR = "MR"
-    val MU = "MU"
-    val YT = "YT"
-    val MX = "MX"
-    val FM = "FM"
-    val MD = "MD"
-    val MC = "MC"
-    val MN = "MN"
-    val ME = "ME"
-    val MS = "MS"
-    val MA = "MA"
-    val MZ = "MZ"
-    val MM = "MM"
-    val NA = "NA"
-    val NR = "NR"
-    val NP = "NP"
-    val NL = "NL"
-    val AN = "AN"
-    val NC = "NC"
-    val NZ = "NZ"
-    val NI = "NI"
-    val NE = "NE"
-    val NG = "NG"
-    val NU = "NU"
-    val KP = "KP"
-    val MP = "MP"
-    val NO = "NO"
-    val OM = "OM"
-    val PK = "PK"
-    val PW = "PW"
-    val PA = "PA"
-    val PG = "PG"
-    val PY = "PY"
-    val PE = "PE"
-    val PH = "PH"
-    val PN = "PN"
-    val PL = "PL"
-    val PT = "PT"
-    val PR = "PR"
-    val QA = "QA"
-    val CG = "CG"
-    val RE = "RE"
-    val RO = "RO"
-    val RU = "RU"
-    val RW = "RW"
-    val BL = "BL"
-    val SH = "SH"
-    val KN = "KN"
-    val LC = "LC"
-    val MF = "MF"
-    val PM = "PM"
-    val VC = "VC"
-    val WS = "WS"
-    val SM = "SM"
-    val ST = "ST"
-    val SA = "SA"
-    val SN = "SN"
-    val RS = "RS"
-    val SC = "SC"
-    val SL = "SL"
-    val SG = "SG"
-    val SX = "SX"
-    val SK = "SK"
-    val SI = "SI"
-    val SB = "SB"
-    val SO = "SO"
-    val ZA = "ZA"
-    val KR = "KR"
-    val ES = "ES"
-    val LK = "LK"
-    val SD = "SD"
-    val SR = "SR"
-    val SJ = "SJ"
-    val SZ = "SZ"
-    val SE = "SE"
-    val CH = "CH"
-    val SY = "SY"
-    val TW = "TW"
-    val TJ = "TJ"
-    val TZ = "TZ"
-    val TH = "TH"
-    val TG = "TG"
-    val TK = "TK"
-    val TO = "TO"
-    val TT = "TT"
-    val TN = "TN"
-    val TR = "TR"
-    val TM = "TM"
-    val TC = "TC"
-    val TV = "TV"
-    val VI = "VI"
-    val UG = "UG"
-    val UA = "UA"
-    val AE = "AE"
-    val GB = "GB"
-    val US = "US"
-    val UY = "UY"
-    val UZ = "UZ"
-    val VU = "VU"
-    val VA = "VA"
-    val VE = "VE"
-    val VN = "VN"
-    val WF = "WF"
-    val EH = "EH"
-    val YE = "YE"
-    val ZM = "ZM"
-    val ZW = "ZW"
+  @js.native
+  sealed trait PhoneNumberCountryCode extends js.Any
+  object PhoneNumberCountryCode extends js.Object {
+    val AF = "AF".asInstanceOf[PhoneNumberCountryCode]
+    val AL = "AL".asInstanceOf[PhoneNumberCountryCode]
+    val DZ = "DZ".asInstanceOf[PhoneNumberCountryCode]
+    val AS = "AS".asInstanceOf[PhoneNumberCountryCode]
+    val AD = "AD".asInstanceOf[PhoneNumberCountryCode]
+    val AO = "AO".asInstanceOf[PhoneNumberCountryCode]
+    val AI = "AI".asInstanceOf[PhoneNumberCountryCode]
+    val AQ = "AQ".asInstanceOf[PhoneNumberCountryCode]
+    val AG = "AG".asInstanceOf[PhoneNumberCountryCode]
+    val AR = "AR".asInstanceOf[PhoneNumberCountryCode]
+    val AM = "AM".asInstanceOf[PhoneNumberCountryCode]
+    val AW = "AW".asInstanceOf[PhoneNumberCountryCode]
+    val AU = "AU".asInstanceOf[PhoneNumberCountryCode]
+    val AT = "AT".asInstanceOf[PhoneNumberCountryCode]
+    val AZ = "AZ".asInstanceOf[PhoneNumberCountryCode]
+    val BS = "BS".asInstanceOf[PhoneNumberCountryCode]
+    val BH = "BH".asInstanceOf[PhoneNumberCountryCode]
+    val BD = "BD".asInstanceOf[PhoneNumberCountryCode]
+    val BB = "BB".asInstanceOf[PhoneNumberCountryCode]
+    val BY = "BY".asInstanceOf[PhoneNumberCountryCode]
+    val BE = "BE".asInstanceOf[PhoneNumberCountryCode]
+    val BZ = "BZ".asInstanceOf[PhoneNumberCountryCode]
+    val BJ = "BJ".asInstanceOf[PhoneNumberCountryCode]
+    val BM = "BM".asInstanceOf[PhoneNumberCountryCode]
+    val BT = "BT".asInstanceOf[PhoneNumberCountryCode]
+    val BO = "BO".asInstanceOf[PhoneNumberCountryCode]
+    val BA = "BA".asInstanceOf[PhoneNumberCountryCode]
+    val BW = "BW".asInstanceOf[PhoneNumberCountryCode]
+    val BR = "BR".asInstanceOf[PhoneNumberCountryCode]
+    val IO = "IO".asInstanceOf[PhoneNumberCountryCode]
+    val VG = "VG".asInstanceOf[PhoneNumberCountryCode]
+    val BN = "BN".asInstanceOf[PhoneNumberCountryCode]
+    val BG = "BG".asInstanceOf[PhoneNumberCountryCode]
+    val BF = "BF".asInstanceOf[PhoneNumberCountryCode]
+    val BI = "BI".asInstanceOf[PhoneNumberCountryCode]
+    val KH = "KH".asInstanceOf[PhoneNumberCountryCode]
+    val CM = "CM".asInstanceOf[PhoneNumberCountryCode]
+    val CA = "CA".asInstanceOf[PhoneNumberCountryCode]
+    val CV = "CV".asInstanceOf[PhoneNumberCountryCode]
+    val KY = "KY".asInstanceOf[PhoneNumberCountryCode]
+    val CF = "CF".asInstanceOf[PhoneNumberCountryCode]
+    val TD = "TD".asInstanceOf[PhoneNumberCountryCode]
+    val CL = "CL".asInstanceOf[PhoneNumberCountryCode]
+    val CN = "CN".asInstanceOf[PhoneNumberCountryCode]
+    val CX = "CX".asInstanceOf[PhoneNumberCountryCode]
+    val CC = "CC".asInstanceOf[PhoneNumberCountryCode]
+    val CO = "CO".asInstanceOf[PhoneNumberCountryCode]
+    val KM = "KM".asInstanceOf[PhoneNumberCountryCode]
+    val CK = "CK".asInstanceOf[PhoneNumberCountryCode]
+    val CR = "CR".asInstanceOf[PhoneNumberCountryCode]
+    val HR = "HR".asInstanceOf[PhoneNumberCountryCode]
+    val CU = "CU".asInstanceOf[PhoneNumberCountryCode]
+    val CW = "CW".asInstanceOf[PhoneNumberCountryCode]
+    val CY = "CY".asInstanceOf[PhoneNumberCountryCode]
+    val CZ = "CZ".asInstanceOf[PhoneNumberCountryCode]
+    val CD = "CD".asInstanceOf[PhoneNumberCountryCode]
+    val DK = "DK".asInstanceOf[PhoneNumberCountryCode]
+    val DJ = "DJ".asInstanceOf[PhoneNumberCountryCode]
+    val DM = "DM".asInstanceOf[PhoneNumberCountryCode]
+    val DO = "DO".asInstanceOf[PhoneNumberCountryCode]
+    val TL = "TL".asInstanceOf[PhoneNumberCountryCode]
+    val EC = "EC".asInstanceOf[PhoneNumberCountryCode]
+    val EG = "EG".asInstanceOf[PhoneNumberCountryCode]
+    val SV = "SV".asInstanceOf[PhoneNumberCountryCode]
+    val GQ = "GQ".asInstanceOf[PhoneNumberCountryCode]
+    val ER = "ER".asInstanceOf[PhoneNumberCountryCode]
+    val EE = "EE".asInstanceOf[PhoneNumberCountryCode]
+    val ET = "ET".asInstanceOf[PhoneNumberCountryCode]
+    val FK = "FK".asInstanceOf[PhoneNumberCountryCode]
+    val FO = "FO".asInstanceOf[PhoneNumberCountryCode]
+    val FJ = "FJ".asInstanceOf[PhoneNumberCountryCode]
+    val FI = "FI".asInstanceOf[PhoneNumberCountryCode]
+    val FR = "FR".asInstanceOf[PhoneNumberCountryCode]
+    val PF = "PF".asInstanceOf[PhoneNumberCountryCode]
+    val GA = "GA".asInstanceOf[PhoneNumberCountryCode]
+    val GM = "GM".asInstanceOf[PhoneNumberCountryCode]
+    val GE = "GE".asInstanceOf[PhoneNumberCountryCode]
+    val DE = "DE".asInstanceOf[PhoneNumberCountryCode]
+    val GH = "GH".asInstanceOf[PhoneNumberCountryCode]
+    val GI = "GI".asInstanceOf[PhoneNumberCountryCode]
+    val GR = "GR".asInstanceOf[PhoneNumberCountryCode]
+    val GL = "GL".asInstanceOf[PhoneNumberCountryCode]
+    val GD = "GD".asInstanceOf[PhoneNumberCountryCode]
+    val GU = "GU".asInstanceOf[PhoneNumberCountryCode]
+    val GT = "GT".asInstanceOf[PhoneNumberCountryCode]
+    val GG = "GG".asInstanceOf[PhoneNumberCountryCode]
+    val GN = "GN".asInstanceOf[PhoneNumberCountryCode]
+    val GW = "GW".asInstanceOf[PhoneNumberCountryCode]
+    val GY = "GY".asInstanceOf[PhoneNumberCountryCode]
+    val HT = "HT".asInstanceOf[PhoneNumberCountryCode]
+    val HN = "HN".asInstanceOf[PhoneNumberCountryCode]
+    val HK = "HK".asInstanceOf[PhoneNumberCountryCode]
+    val HU = "HU".asInstanceOf[PhoneNumberCountryCode]
+    val IS = "IS".asInstanceOf[PhoneNumberCountryCode]
+    val IN = "IN".asInstanceOf[PhoneNumberCountryCode]
+    val ID = "ID".asInstanceOf[PhoneNumberCountryCode]
+    val IR = "IR".asInstanceOf[PhoneNumberCountryCode]
+    val IQ = "IQ".asInstanceOf[PhoneNumberCountryCode]
+    val IE = "IE".asInstanceOf[PhoneNumberCountryCode]
+    val IM = "IM".asInstanceOf[PhoneNumberCountryCode]
+    val IL = "IL".asInstanceOf[PhoneNumberCountryCode]
+    val IT = "IT".asInstanceOf[PhoneNumberCountryCode]
+    val CI = "CI".asInstanceOf[PhoneNumberCountryCode]
+    val JM = "JM".asInstanceOf[PhoneNumberCountryCode]
+    val JP = "JP".asInstanceOf[PhoneNumberCountryCode]
+    val JE = "JE".asInstanceOf[PhoneNumberCountryCode]
+    val JO = "JO".asInstanceOf[PhoneNumberCountryCode]
+    val KZ = "KZ".asInstanceOf[PhoneNumberCountryCode]
+    val KE = "KE".asInstanceOf[PhoneNumberCountryCode]
+    val KI = "KI".asInstanceOf[PhoneNumberCountryCode]
+    val KW = "KW".asInstanceOf[PhoneNumberCountryCode]
+    val KG = "KG".asInstanceOf[PhoneNumberCountryCode]
+    val LA = "LA".asInstanceOf[PhoneNumberCountryCode]
+    val LV = "LV".asInstanceOf[PhoneNumberCountryCode]
+    val LB = "LB".asInstanceOf[PhoneNumberCountryCode]
+    val LS = "LS".asInstanceOf[PhoneNumberCountryCode]
+    val LR = "LR".asInstanceOf[PhoneNumberCountryCode]
+    val LY = "LY".asInstanceOf[PhoneNumberCountryCode]
+    val LI = "LI".asInstanceOf[PhoneNumberCountryCode]
+    val LT = "LT".asInstanceOf[PhoneNumberCountryCode]
+    val LU = "LU".asInstanceOf[PhoneNumberCountryCode]
+    val MO = "MO".asInstanceOf[PhoneNumberCountryCode]
+    val MK = "MK".asInstanceOf[PhoneNumberCountryCode]
+    val MG = "MG".asInstanceOf[PhoneNumberCountryCode]
+    val MW = "MW".asInstanceOf[PhoneNumberCountryCode]
+    val MY = "MY".asInstanceOf[PhoneNumberCountryCode]
+    val MV = "MV".asInstanceOf[PhoneNumberCountryCode]
+    val ML = "ML".asInstanceOf[PhoneNumberCountryCode]
+    val MT = "MT".asInstanceOf[PhoneNumberCountryCode]
+    val MH = "MH".asInstanceOf[PhoneNumberCountryCode]
+    val MR = "MR".asInstanceOf[PhoneNumberCountryCode]
+    val MU = "MU".asInstanceOf[PhoneNumberCountryCode]
+    val YT = "YT".asInstanceOf[PhoneNumberCountryCode]
+    val MX = "MX".asInstanceOf[PhoneNumberCountryCode]
+    val FM = "FM".asInstanceOf[PhoneNumberCountryCode]
+    val MD = "MD".asInstanceOf[PhoneNumberCountryCode]
+    val MC = "MC".asInstanceOf[PhoneNumberCountryCode]
+    val MN = "MN".asInstanceOf[PhoneNumberCountryCode]
+    val ME = "ME".asInstanceOf[PhoneNumberCountryCode]
+    val MS = "MS".asInstanceOf[PhoneNumberCountryCode]
+    val MA = "MA".asInstanceOf[PhoneNumberCountryCode]
+    val MZ = "MZ".asInstanceOf[PhoneNumberCountryCode]
+    val MM = "MM".asInstanceOf[PhoneNumberCountryCode]
+    val NA = "NA".asInstanceOf[PhoneNumberCountryCode]
+    val NR = "NR".asInstanceOf[PhoneNumberCountryCode]
+    val NP = "NP".asInstanceOf[PhoneNumberCountryCode]
+    val NL = "NL".asInstanceOf[PhoneNumberCountryCode]
+    val AN = "AN".asInstanceOf[PhoneNumberCountryCode]
+    val NC = "NC".asInstanceOf[PhoneNumberCountryCode]
+    val NZ = "NZ".asInstanceOf[PhoneNumberCountryCode]
+    val NI = "NI".asInstanceOf[PhoneNumberCountryCode]
+    val NE = "NE".asInstanceOf[PhoneNumberCountryCode]
+    val NG = "NG".asInstanceOf[PhoneNumberCountryCode]
+    val NU = "NU".asInstanceOf[PhoneNumberCountryCode]
+    val KP = "KP".asInstanceOf[PhoneNumberCountryCode]
+    val MP = "MP".asInstanceOf[PhoneNumberCountryCode]
+    val NO = "NO".asInstanceOf[PhoneNumberCountryCode]
+    val OM = "OM".asInstanceOf[PhoneNumberCountryCode]
+    val PK = "PK".asInstanceOf[PhoneNumberCountryCode]
+    val PW = "PW".asInstanceOf[PhoneNumberCountryCode]
+    val PA = "PA".asInstanceOf[PhoneNumberCountryCode]
+    val PG = "PG".asInstanceOf[PhoneNumberCountryCode]
+    val PY = "PY".asInstanceOf[PhoneNumberCountryCode]
+    val PE = "PE".asInstanceOf[PhoneNumberCountryCode]
+    val PH = "PH".asInstanceOf[PhoneNumberCountryCode]
+    val PN = "PN".asInstanceOf[PhoneNumberCountryCode]
+    val PL = "PL".asInstanceOf[PhoneNumberCountryCode]
+    val PT = "PT".asInstanceOf[PhoneNumberCountryCode]
+    val PR = "PR".asInstanceOf[PhoneNumberCountryCode]
+    val QA = "QA".asInstanceOf[PhoneNumberCountryCode]
+    val CG = "CG".asInstanceOf[PhoneNumberCountryCode]
+    val RE = "RE".asInstanceOf[PhoneNumberCountryCode]
+    val RO = "RO".asInstanceOf[PhoneNumberCountryCode]
+    val RU = "RU".asInstanceOf[PhoneNumberCountryCode]
+    val RW = "RW".asInstanceOf[PhoneNumberCountryCode]
+    val BL = "BL".asInstanceOf[PhoneNumberCountryCode]
+    val SH = "SH".asInstanceOf[PhoneNumberCountryCode]
+    val KN = "KN".asInstanceOf[PhoneNumberCountryCode]
+    val LC = "LC".asInstanceOf[PhoneNumberCountryCode]
+    val MF = "MF".asInstanceOf[PhoneNumberCountryCode]
+    val PM = "PM".asInstanceOf[PhoneNumberCountryCode]
+    val VC = "VC".asInstanceOf[PhoneNumberCountryCode]
+    val WS = "WS".asInstanceOf[PhoneNumberCountryCode]
+    val SM = "SM".asInstanceOf[PhoneNumberCountryCode]
+    val ST = "ST".asInstanceOf[PhoneNumberCountryCode]
+    val SA = "SA".asInstanceOf[PhoneNumberCountryCode]
+    val SN = "SN".asInstanceOf[PhoneNumberCountryCode]
+    val RS = "RS".asInstanceOf[PhoneNumberCountryCode]
+    val SC = "SC".asInstanceOf[PhoneNumberCountryCode]
+    val SL = "SL".asInstanceOf[PhoneNumberCountryCode]
+    val SG = "SG".asInstanceOf[PhoneNumberCountryCode]
+    val SX = "SX".asInstanceOf[PhoneNumberCountryCode]
+    val SK = "SK".asInstanceOf[PhoneNumberCountryCode]
+    val SI = "SI".asInstanceOf[PhoneNumberCountryCode]
+    val SB = "SB".asInstanceOf[PhoneNumberCountryCode]
+    val SO = "SO".asInstanceOf[PhoneNumberCountryCode]
+    val ZA = "ZA".asInstanceOf[PhoneNumberCountryCode]
+    val KR = "KR".asInstanceOf[PhoneNumberCountryCode]
+    val ES = "ES".asInstanceOf[PhoneNumberCountryCode]
+    val LK = "LK".asInstanceOf[PhoneNumberCountryCode]
+    val SD = "SD".asInstanceOf[PhoneNumberCountryCode]
+    val SR = "SR".asInstanceOf[PhoneNumberCountryCode]
+    val SJ = "SJ".asInstanceOf[PhoneNumberCountryCode]
+    val SZ = "SZ".asInstanceOf[PhoneNumberCountryCode]
+    val SE = "SE".asInstanceOf[PhoneNumberCountryCode]
+    val CH = "CH".asInstanceOf[PhoneNumberCountryCode]
+    val SY = "SY".asInstanceOf[PhoneNumberCountryCode]
+    val TW = "TW".asInstanceOf[PhoneNumberCountryCode]
+    val TJ = "TJ".asInstanceOf[PhoneNumberCountryCode]
+    val TZ = "TZ".asInstanceOf[PhoneNumberCountryCode]
+    val TH = "TH".asInstanceOf[PhoneNumberCountryCode]
+    val TG = "TG".asInstanceOf[PhoneNumberCountryCode]
+    val TK = "TK".asInstanceOf[PhoneNumberCountryCode]
+    val TO = "TO".asInstanceOf[PhoneNumberCountryCode]
+    val TT = "TT".asInstanceOf[PhoneNumberCountryCode]
+    val TN = "TN".asInstanceOf[PhoneNumberCountryCode]
+    val TR = "TR".asInstanceOf[PhoneNumberCountryCode]
+    val TM = "TM".asInstanceOf[PhoneNumberCountryCode]
+    val TC = "TC".asInstanceOf[PhoneNumberCountryCode]
+    val TV = "TV".asInstanceOf[PhoneNumberCountryCode]
+    val VI = "VI".asInstanceOf[PhoneNumberCountryCode]
+    val UG = "UG".asInstanceOf[PhoneNumberCountryCode]
+    val UA = "UA".asInstanceOf[PhoneNumberCountryCode]
+    val AE = "AE".asInstanceOf[PhoneNumberCountryCode]
+    val GB = "GB".asInstanceOf[PhoneNumberCountryCode]
+    val US = "US".asInstanceOf[PhoneNumberCountryCode]
+    val UY = "UY".asInstanceOf[PhoneNumberCountryCode]
+    val UZ = "UZ".asInstanceOf[PhoneNumberCountryCode]
+    val VU = "VU".asInstanceOf[PhoneNumberCountryCode]
+    val VA = "VA".asInstanceOf[PhoneNumberCountryCode]
+    val VE = "VE".asInstanceOf[PhoneNumberCountryCode]
+    val VN = "VN".asInstanceOf[PhoneNumberCountryCode]
+    val WF = "WF".asInstanceOf[PhoneNumberCountryCode]
+    val EH = "EH".asInstanceOf[PhoneNumberCountryCode]
+    val YE = "YE".asInstanceOf[PhoneNumberCountryCode]
+    val ZM = "ZM".asInstanceOf[PhoneNumberCountryCode]
+    val ZW = "ZW".asInstanceOf[PhoneNumberCountryCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2086,17 +2083,19 @@ package connect {
       __obj.asInstanceOf[PhoneNumberSummary]
     }
   }
-
-  object PhoneNumberTypeEnum {
-    val TOLL_FREE = "TOLL_FREE"
-    val DID       = "DID"
+  @js.native
+  sealed trait PhoneNumberType extends js.Any
+  object PhoneNumberType extends js.Object {
+    val TOLL_FREE = "TOLL_FREE".asInstanceOf[PhoneNumberType]
+    val DID       = "DID".asInstanceOf[PhoneNumberType]
 
     val values = js.Object.freeze(js.Array(TOLL_FREE, DID))
   }
-
-  object PhoneTypeEnum {
-    val SOFT_PHONE = "SOFT_PHONE"
-    val DESK_PHONE = "DESK_PHONE"
+  @js.native
+  sealed trait PhoneType extends js.Any
+  object PhoneType extends js.Object {
+    val SOFT_PHONE = "SOFT_PHONE".asInstanceOf[PhoneType]
+    val DESK_PHONE = "DESK_PHONE".asInstanceOf[PhoneType]
 
     val values = js.Object.freeze(js.Array(SOFT_PHONE, DESK_PHONE))
   }
@@ -2150,10 +2149,11 @@ package connect {
       __obj.asInstanceOf[QueueSummary]
     }
   }
-
-  object QueueTypeEnum {
-    val STANDARD = "STANDARD"
-    val AGENT    = "AGENT"
+  @js.native
+  sealed trait QueueType extends js.Any
+  object QueueType extends js.Object {
+    val STANDARD = "STANDARD".asInstanceOf[QueueType]
+    val AGENT    = "AGENT".asInstanceOf[QueueType]
 
     val values = js.Object.freeze(js.Array(STANDARD, AGENT))
   }
@@ -2314,11 +2314,12 @@ package connect {
       __obj.asInstanceOf[StartOutboundVoiceContactResponse]
     }
   }
-
-  object StatisticEnum {
-    val SUM = "SUM"
-    val MAX = "MAX"
-    val AVG = "AVG"
+  @js.native
+  sealed trait Statistic extends js.Any
+  object Statistic extends js.Object {
+    val SUM = "SUM".asInstanceOf[Statistic]
+    val MAX = "MAX".asInstanceOf[Statistic]
+    val AVG = "AVG".asInstanceOf[Statistic]
 
     val values = js.Object.freeze(js.Array(SUM, MAX, AVG))
   }
@@ -2399,11 +2400,12 @@ package connect {
       __obj.asInstanceOf[Threshold]
     }
   }
-
-  object UnitEnum {
-    val SECONDS = "SECONDS"
-    val COUNT   = "COUNT"
-    val PERCENT = "PERCENT"
+  @js.native
+  sealed trait Unit extends js.Any
+  object Unit extends js.Object {
+    val SECONDS = "SECONDS".asInstanceOf[Unit]
+    val COUNT   = "COUNT".asInstanceOf[Unit]
+    val PERCENT = "PERCENT".asInstanceOf[Unit]
 
     val values = js.Object.freeze(js.Array(SECONDS, COUNT, PERCENT))
   }

--- a/services/connectparticipant/src/main/scala/facade/amazonaws/services/ConnectParticipant.scala
+++ b/services/connectparticipant/src/main/scala/facade/amazonaws/services/ConnectParticipant.scala
@@ -10,9 +10,7 @@ package object connectparticipant {
   type ChatContent            = String
   type ChatContentType        = String
   type ChatItemId             = String
-  type ChatItemType           = String
   type ClientToken            = String
-  type ConnectionType         = String
   type ConnectionTypeList     = js.Array[ConnectionType]
   type ContactId              = String
   type DisplayName            = String
@@ -22,11 +20,8 @@ package object connectparticipant {
   type MostRecent             = Int
   type NextToken              = String
   type ParticipantId          = String
-  type ParticipantRole        = String
   type ParticipantToken       = String
   type PreSignedConnectionUrl = String
-  type ScanDirection          = String
-  type SortKey                = String
   type Transcript             = js.Array[Item]
 
   implicit final class ConnectParticipantOps(private val service: ConnectParticipant) extends AnyVal {
@@ -60,11 +55,12 @@ package connectparticipant {
     def sendEvent(params: SendEventRequest): Request[SendEventResponse]                                     = js.native
     def sendMessage(params: SendMessageRequest): Request[SendMessageResponse]                               = js.native
   }
-
-  object ChatItemTypeEnum {
-    val MESSAGE        = "MESSAGE"
-    val EVENT          = "EVENT"
-    val CONNECTION_ACK = "CONNECTION_ACK"
+  @js.native
+  sealed trait ChatItemType extends js.Any
+  object ChatItemType extends js.Object {
+    val MESSAGE        = "MESSAGE".asInstanceOf[ChatItemType]
+    val EVENT          = "EVENT".asInstanceOf[ChatItemType]
+    val CONNECTION_ACK = "CONNECTION_ACK".asInstanceOf[ChatItemType]
 
     val values = js.Object.freeze(js.Array(MESSAGE, EVENT, CONNECTION_ACK))
   }
@@ -90,10 +86,11 @@ package connectparticipant {
       __obj.asInstanceOf[ConnectionCredentials]
     }
   }
-
-  object ConnectionTypeEnum {
-    val WEBSOCKET              = "WEBSOCKET"
-    val CONNECTION_CREDENTIALS = "CONNECTION_CREDENTIALS"
+  @js.native
+  sealed trait ConnectionType extends js.Any
+  object ConnectionType extends js.Object {
+    val WEBSOCKET              = "WEBSOCKET".asInstanceOf[ConnectionType]
+    val CONNECTION_CREDENTIALS = "CONNECTION_CREDENTIALS".asInstanceOf[ConnectionType]
 
     val values = js.Object.freeze(js.Array(WEBSOCKET, CONNECTION_CREDENTIALS))
   }
@@ -269,18 +266,20 @@ package connectparticipant {
       __obj.asInstanceOf[Item]
     }
   }
-
-  object ParticipantRoleEnum {
-    val AGENT    = "AGENT"
-    val CUSTOMER = "CUSTOMER"
-    val SYSTEM   = "SYSTEM"
+  @js.native
+  sealed trait ParticipantRole extends js.Any
+  object ParticipantRole extends js.Object {
+    val AGENT    = "AGENT".asInstanceOf[ParticipantRole]
+    val CUSTOMER = "CUSTOMER".asInstanceOf[ParticipantRole]
+    val SYSTEM   = "SYSTEM".asInstanceOf[ParticipantRole]
 
     val values = js.Object.freeze(js.Array(AGENT, CUSTOMER, SYSTEM))
   }
-
-  object ScanDirectionEnum {
-    val FORWARD  = "FORWARD"
-    val BACKWARD = "BACKWARD"
+  @js.native
+  sealed trait ScanDirection extends js.Any
+  object ScanDirection extends js.Object {
+    val FORWARD  = "FORWARD".asInstanceOf[ScanDirection]
+    val BACKWARD = "BACKWARD".asInstanceOf[ScanDirection]
 
     val values = js.Object.freeze(js.Array(FORWARD, BACKWARD))
   }
@@ -376,10 +375,11 @@ package connectparticipant {
       __obj.asInstanceOf[SendMessageResponse]
     }
   }
-
-  object SortKeyEnum {
-    val DESCENDING = "DESCENDING"
-    val ASCENDING  = "ASCENDING"
+  @js.native
+  sealed trait SortKey extends js.Any
+  object SortKey extends js.Object {
+    val DESCENDING = "DESCENDING".asInstanceOf[SortKey]
+    val ASCENDING  = "ASCENDING".asInstanceOf[SortKey]
 
     val values = js.Object.freeze(js.Array(DESCENDING, ASCENDING))
   }

--- a/services/costexplorer/src/main/scala/facade/amazonaws/services/CostExplorer.scala
+++ b/services/costexplorer/src/main/scala/facade/amazonaws/services/CostExplorer.scala
@@ -7,23 +7,19 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object costexplorer {
-  type AccountScope                                 = String
   type AmortizedRecurringFee                        = String
   type AmortizedUpfrontFee                          = String
   type Arn                                          = String
   type AttributeType                                = String
   type AttributeValue                               = String
   type Attributes                                   = js.Dictionary[AttributeValue]
-  type Context                                      = String
   type CostCategoryName                             = String
   type CostCategoryReferencesList                   = js.Array[CostCategoryReference]
-  type CostCategoryRuleVersion                      = String
   type CostCategoryRulesList                        = js.Array[CostCategoryRule]
   type CostCategoryValue                            = String
   type CoverageHoursPercentage                      = String
   type CoverageNormalizedUnitsPercentage            = String
   type CoveragesByTime                              = js.Array[CoverageByTime]
-  type Dimension                                    = String
   type DimensionValuesWithAttributesList            = js.Array[DimensionValuesWithAttributes]
   type Entity                                       = String
   type Estimated                                    = Boolean
@@ -31,16 +27,12 @@ package object costexplorer {
   type ForecastResultsByTime                        = js.Array[ForecastResult]
   type GenericBoolean                               = Boolean
   type GenericString                                = String
-  type Granularity                                  = String
   type GroupDefinitionKey                           = String
-  type GroupDefinitionType                          = String
   type GroupDefinitions                             = js.Array[GroupDefinition]
   type Groups                                       = js.Array[Group]
   type Key                                          = String
   type Keys                                         = js.Array[Key]
-  type LookbackPeriodInDays                         = String
   type MaxResults                                   = Int
-  type Metric                                       = String
   type MetricAmount                                 = String
   type MetricName                                   = String
   type MetricNames                                  = js.Array[MetricName]
@@ -49,13 +41,11 @@ package object costexplorer {
   type NetRISavings                                 = String
   type NextPageToken                                = String
   type NonNegativeInteger                           = Int
-  type OfferingClass                                = String
   type OnDemandCost                                 = String
   type OnDemandCostOfRIHoursUsed                    = String
   type OnDemandHours                                = String
   type OnDemandNormalizedUnits                      = String
   type PageSize                                     = Int
-  type PaymentOption                                = String
   type PredictionIntervalLevel                      = Int
   type PurchasedHours                               = String
   type PurchasedUnits                               = String
@@ -69,19 +59,16 @@ package object costexplorer {
   type ReservedNormalizedUnits                      = String
   type ResultsByTime                                = js.Array[ResultByTime]
   type RightsizingRecommendationList                = js.Array[RightsizingRecommendation]
-  type RightsizingType                              = String
   type SavingsPlanArn                               = String
   type SavingsPlansCoverages                        = js.Array[SavingsPlansCoverage]
   type SavingsPlansPurchaseRecommendationDetailList = js.Array[SavingsPlansPurchaseRecommendationDetail]
   type SavingsPlansUtilizationDetails               = js.Array[SavingsPlansUtilizationDetail]
   type SavingsPlansUtilizationsByTime               = js.Array[SavingsPlansUtilizationByTime]
   type SearchString                                 = String
-  type SupportedSavingsPlansType                    = String
   type TagKey                                       = String
   type TagList                                      = js.Array[Entity]
   type TagValuesList                                = js.Array[TagValues]
   type TargetInstancesList                          = js.Array[TargetInstance]
-  type TermInYears                                  = String
   type TotalActualHours                             = String
   type TotalActualUnits                             = String
   type TotalAmortizedFee                            = String
@@ -210,18 +197,20 @@ package costexplorer {
         params: UpdateCostCategoryDefinitionRequest
     ): Request[UpdateCostCategoryDefinitionResponse] = js.native
   }
-
-  object AccountScopeEnum {
-    val PAYER  = "PAYER"
-    val LINKED = "LINKED"
+  @js.native
+  sealed trait AccountScope extends js.Any
+  object AccountScope extends js.Object {
+    val PAYER  = "PAYER".asInstanceOf[AccountScope]
+    val LINKED = "LINKED".asInstanceOf[AccountScope]
 
     val values = js.Object.freeze(js.Array(PAYER, LINKED))
   }
-
-  object ContextEnum {
-    val COST_AND_USAGE = "COST_AND_USAGE"
-    val RESERVATIONS   = "RESERVATIONS"
-    val SAVINGS_PLANS  = "SAVINGS_PLANS"
+  @js.native
+  sealed trait Context extends js.Any
+  object Context extends js.Object {
+    val COST_AND_USAGE = "COST_AND_USAGE".asInstanceOf[Context]
+    val RESERVATIONS   = "RESERVATIONS".asInstanceOf[Context]
+    val SAVINGS_PLANS  = "SAVINGS_PLANS".asInstanceOf[Context]
 
     val values = js.Object.freeze(js.Array(COST_AND_USAGE, RESERVATIONS, SAVINGS_PLANS))
   }
@@ -321,8 +310,10 @@ package costexplorer {
   /**
     * The rule schema version in this particular Cost Category.
     */
-  object CostCategoryRuleVersionEnum {
-    val `CostCategoryExpression.v1` = "CostCategoryExpression.v1"
+  @js.native
+  sealed trait CostCategoryRuleVersion extends js.Any
+  object CostCategoryRuleVersion extends js.Object {
+    val `CostCategoryExpression.v1` = "CostCategoryExpression.v1".asInstanceOf[CostCategoryRuleVersion]
 
     val values = js.Object.freeze(js.Array(`CostCategoryExpression.v1`))
   }
@@ -674,35 +665,36 @@ package costexplorer {
       __obj.asInstanceOf[DescribeCostCategoryDefinitionResponse]
     }
   }
-
-  object DimensionEnum {
-    val AZ                   = "AZ"
-    val INSTANCE_TYPE        = "INSTANCE_TYPE"
-    val LINKED_ACCOUNT       = "LINKED_ACCOUNT"
-    val OPERATION            = "OPERATION"
-    val PURCHASE_TYPE        = "PURCHASE_TYPE"
-    val REGION               = "REGION"
-    val SERVICE              = "SERVICE"
-    val USAGE_TYPE           = "USAGE_TYPE"
-    val USAGE_TYPE_GROUP     = "USAGE_TYPE_GROUP"
-    val RECORD_TYPE          = "RECORD_TYPE"
-    val OPERATING_SYSTEM     = "OPERATING_SYSTEM"
-    val TENANCY              = "TENANCY"
-    val SCOPE                = "SCOPE"
-    val PLATFORM             = "PLATFORM"
-    val SUBSCRIPTION_ID      = "SUBSCRIPTION_ID"
-    val LEGAL_ENTITY_NAME    = "LEGAL_ENTITY_NAME"
-    val DEPLOYMENT_OPTION    = "DEPLOYMENT_OPTION"
-    val DATABASE_ENGINE      = "DATABASE_ENGINE"
-    val CACHE_ENGINE         = "CACHE_ENGINE"
-    val INSTANCE_TYPE_FAMILY = "INSTANCE_TYPE_FAMILY"
-    val BILLING_ENTITY       = "BILLING_ENTITY"
-    val RESERVATION_ID       = "RESERVATION_ID"
-    val RESOURCE_ID          = "RESOURCE_ID"
-    val RIGHTSIZING_TYPE     = "RIGHTSIZING_TYPE"
-    val SAVINGS_PLANS_TYPE   = "SAVINGS_PLANS_TYPE"
-    val SAVINGS_PLAN_ARN     = "SAVINGS_PLAN_ARN"
-    val PAYMENT_OPTION       = "PAYMENT_OPTION"
+  @js.native
+  sealed trait Dimension extends js.Any
+  object Dimension extends js.Object {
+    val AZ                   = "AZ".asInstanceOf[Dimension]
+    val INSTANCE_TYPE        = "INSTANCE_TYPE".asInstanceOf[Dimension]
+    val LINKED_ACCOUNT       = "LINKED_ACCOUNT".asInstanceOf[Dimension]
+    val OPERATION            = "OPERATION".asInstanceOf[Dimension]
+    val PURCHASE_TYPE        = "PURCHASE_TYPE".asInstanceOf[Dimension]
+    val REGION               = "REGION".asInstanceOf[Dimension]
+    val SERVICE              = "SERVICE".asInstanceOf[Dimension]
+    val USAGE_TYPE           = "USAGE_TYPE".asInstanceOf[Dimension]
+    val USAGE_TYPE_GROUP     = "USAGE_TYPE_GROUP".asInstanceOf[Dimension]
+    val RECORD_TYPE          = "RECORD_TYPE".asInstanceOf[Dimension]
+    val OPERATING_SYSTEM     = "OPERATING_SYSTEM".asInstanceOf[Dimension]
+    val TENANCY              = "TENANCY".asInstanceOf[Dimension]
+    val SCOPE                = "SCOPE".asInstanceOf[Dimension]
+    val PLATFORM             = "PLATFORM".asInstanceOf[Dimension]
+    val SUBSCRIPTION_ID      = "SUBSCRIPTION_ID".asInstanceOf[Dimension]
+    val LEGAL_ENTITY_NAME    = "LEGAL_ENTITY_NAME".asInstanceOf[Dimension]
+    val DEPLOYMENT_OPTION    = "DEPLOYMENT_OPTION".asInstanceOf[Dimension]
+    val DATABASE_ENGINE      = "DATABASE_ENGINE".asInstanceOf[Dimension]
+    val CACHE_ENGINE         = "CACHE_ENGINE".asInstanceOf[Dimension]
+    val INSTANCE_TYPE_FAMILY = "INSTANCE_TYPE_FAMILY".asInstanceOf[Dimension]
+    val BILLING_ENTITY       = "BILLING_ENTITY".asInstanceOf[Dimension]
+    val RESERVATION_ID       = "RESERVATION_ID".asInstanceOf[Dimension]
+    val RESOURCE_ID          = "RESOURCE_ID".asInstanceOf[Dimension]
+    val RIGHTSIZING_TYPE     = "RIGHTSIZING_TYPE".asInstanceOf[Dimension]
+    val SAVINGS_PLANS_TYPE   = "SAVINGS_PLANS_TYPE".asInstanceOf[Dimension]
+    val SAVINGS_PLAN_ARN     = "SAVINGS_PLAN_ARN".asInstanceOf[Dimension]
+    val PAYMENT_OPTION       = "PAYMENT_OPTION".asInstanceOf[Dimension]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1819,11 +1811,12 @@ package costexplorer {
       __obj.asInstanceOf[GetUsageForecastResponse]
     }
   }
-
-  object GranularityEnum {
-    val DAILY   = "DAILY"
-    val MONTHLY = "MONTHLY"
-    val HOURLY  = "HOURLY"
+  @js.native
+  sealed trait Granularity extends js.Any
+  object Granularity extends js.Object {
+    val DAILY   = "DAILY".asInstanceOf[Granularity]
+    val MONTHLY = "MONTHLY".asInstanceOf[Granularity]
+    val HOURLY  = "HOURLY".asInstanceOf[Granularity]
 
     val values = js.Object.freeze(js.Array(DAILY, MONTHLY, HOURLY))
   }
@@ -1871,11 +1864,12 @@ package costexplorer {
       __obj.asInstanceOf[GroupDefinition]
     }
   }
-
-  object GroupDefinitionTypeEnum {
-    val DIMENSION     = "DIMENSION"
-    val TAG           = "TAG"
-    val COST_CATEGORY = "COST_CATEGORY"
+  @js.native
+  sealed trait GroupDefinitionType extends js.Any
+  object GroupDefinitionType extends js.Object {
+    val DIMENSION     = "DIMENSION".asInstanceOf[GroupDefinitionType]
+    val TAG           = "TAG".asInstanceOf[GroupDefinitionType]
+    val COST_CATEGORY = "COST_CATEGORY".asInstanceOf[GroupDefinitionType]
 
     val values = js.Object.freeze(js.Array(DIMENSION, TAG, COST_CATEGORY))
   }
@@ -1950,23 +1944,25 @@ package costexplorer {
       __obj.asInstanceOf[ListCostCategoryDefinitionsResponse]
     }
   }
-
-  object LookbackPeriodInDaysEnum {
-    val SEVEN_DAYS  = "SEVEN_DAYS"
-    val THIRTY_DAYS = "THIRTY_DAYS"
-    val SIXTY_DAYS  = "SIXTY_DAYS"
+  @js.native
+  sealed trait LookbackPeriodInDays extends js.Any
+  object LookbackPeriodInDays extends js.Object {
+    val SEVEN_DAYS  = "SEVEN_DAYS".asInstanceOf[LookbackPeriodInDays]
+    val THIRTY_DAYS = "THIRTY_DAYS".asInstanceOf[LookbackPeriodInDays]
+    val SIXTY_DAYS  = "SIXTY_DAYS".asInstanceOf[LookbackPeriodInDays]
 
     val values = js.Object.freeze(js.Array(SEVEN_DAYS, THIRTY_DAYS, SIXTY_DAYS))
   }
-
-  object MetricEnum {
-    val BLENDED_COST            = "BLENDED_COST"
-    val UNBLENDED_COST          = "UNBLENDED_COST"
-    val AMORTIZED_COST          = "AMORTIZED_COST"
-    val NET_UNBLENDED_COST      = "NET_UNBLENDED_COST"
-    val NET_AMORTIZED_COST      = "NET_AMORTIZED_COST"
-    val USAGE_QUANTITY          = "USAGE_QUANTITY"
-    val NORMALIZED_USAGE_AMOUNT = "NORMALIZED_USAGE_AMOUNT"
+  @js.native
+  sealed trait Metric extends js.Any
+  object Metric extends js.Object {
+    val BLENDED_COST            = "BLENDED_COST".asInstanceOf[Metric]
+    val UNBLENDED_COST          = "UNBLENDED_COST".asInstanceOf[Metric]
+    val AMORTIZED_COST          = "AMORTIZED_COST".asInstanceOf[Metric]
+    val NET_UNBLENDED_COST      = "NET_UNBLENDED_COST".asInstanceOf[Metric]
+    val NET_AMORTIZED_COST      = "NET_AMORTIZED_COST".asInstanceOf[Metric]
+    val USAGE_QUANTITY          = "USAGE_QUANTITY".asInstanceOf[Metric]
+    val NORMALIZED_USAGE_AMOUNT = "NORMALIZED_USAGE_AMOUNT".asInstanceOf[Metric]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2021,21 +2017,23 @@ package costexplorer {
       __obj.asInstanceOf[ModifyRecommendationDetail]
     }
   }
-
-  object OfferingClassEnum {
-    val STANDARD    = "STANDARD"
-    val CONVERTIBLE = "CONVERTIBLE"
+  @js.native
+  sealed trait OfferingClass extends js.Any
+  object OfferingClass extends js.Object {
+    val STANDARD    = "STANDARD".asInstanceOf[OfferingClass]
+    val CONVERTIBLE = "CONVERTIBLE".asInstanceOf[OfferingClass]
 
     val values = js.Object.freeze(js.Array(STANDARD, CONVERTIBLE))
   }
-
-  object PaymentOptionEnum {
-    val NO_UPFRONT         = "NO_UPFRONT"
-    val PARTIAL_UPFRONT    = "PARTIAL_UPFRONT"
-    val ALL_UPFRONT        = "ALL_UPFRONT"
-    val LIGHT_UTILIZATION  = "LIGHT_UTILIZATION"
-    val MEDIUM_UTILIZATION = "MEDIUM_UTILIZATION"
-    val HEAVY_UTILIZATION  = "HEAVY_UTILIZATION"
+  @js.native
+  sealed trait PaymentOption extends js.Any
+  object PaymentOption extends js.Object {
+    val NO_UPFRONT         = "NO_UPFRONT".asInstanceOf[PaymentOption]
+    val PARTIAL_UPFRONT    = "PARTIAL_UPFRONT".asInstanceOf[PaymentOption]
+    val ALL_UPFRONT        = "ALL_UPFRONT".asInstanceOf[PaymentOption]
+    val LIGHT_UTILIZATION  = "LIGHT_UTILIZATION".asInstanceOf[PaymentOption]
+    val MEDIUM_UTILIZATION = "MEDIUM_UTILIZATION".asInstanceOf[PaymentOption]
+    val HEAVY_UTILIZATION  = "HEAVY_UTILIZATION".asInstanceOf[PaymentOption]
 
     val values = js.Object.freeze(
       js.Array(NO_UPFRONT, PARTIAL_UPFRONT, ALL_UPFRONT, LIGHT_UTILIZATION, MEDIUM_UTILIZATION, HEAVY_UTILIZATION)
@@ -2572,10 +2570,11 @@ package costexplorer {
       __obj.asInstanceOf[RightsizingRecommendationSummary]
     }
   }
-
-  object RightsizingTypeEnum {
-    val TERMINATE = "TERMINATE"
-    val MODIFY    = "MODIFY"
+  @js.native
+  sealed trait RightsizingType extends js.Any
+  object RightsizingType extends js.Object {
+    val TERMINATE = "TERMINATE".asInstanceOf[RightsizingType]
+    val MODIFY    = "MODIFY".asInstanceOf[RightsizingType]
 
     val values = js.Object.freeze(js.Array(TERMINATE, MODIFY))
   }
@@ -3045,10 +3044,11 @@ package costexplorer {
       __obj.asInstanceOf[ServiceSpecification]
     }
   }
-
-  object SupportedSavingsPlansTypeEnum {
-    val COMPUTE_SP      = "COMPUTE_SP"
-    val EC2_INSTANCE_SP = "EC2_INSTANCE_SP"
+  @js.native
+  sealed trait SupportedSavingsPlansType extends js.Any
+  object SupportedSavingsPlansType extends js.Object {
+    val COMPUTE_SP      = "COMPUTE_SP".asInstanceOf[SupportedSavingsPlansType]
+    val EC2_INSTANCE_SP = "EC2_INSTANCE_SP".asInstanceOf[SupportedSavingsPlansType]
 
     val values = js.Object.freeze(js.Array(COMPUTE_SP, EC2_INSTANCE_SP))
   }
@@ -3110,10 +3110,11 @@ package costexplorer {
       __obj.asInstanceOf[TargetInstance]
     }
   }
-
-  object TermInYearsEnum {
-    val ONE_YEAR    = "ONE_YEAR"
-    val THREE_YEARS = "THREE_YEARS"
+  @js.native
+  sealed trait TermInYears extends js.Any
+  object TermInYears extends js.Object {
+    val ONE_YEAR    = "ONE_YEAR".asInstanceOf[TermInYears]
+    val THREE_YEARS = "THREE_YEARS".asInstanceOf[TermInYears]
 
     val values = js.Object.freeze(js.Array(ONE_YEAR, THREE_YEARS))
   }

--- a/services/cur/src/main/scala/facade/amazonaws/services/CUR.scala
+++ b/services/cur/src/main/scala/facade/amazonaws/services/CUR.scala
@@ -7,23 +7,16 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object cur {
-  type AWSRegion              = String
-  type AdditionalArtifact     = String
   type AdditionalArtifactList = js.Array[AdditionalArtifact]
-  type CompressionFormat      = String
   type DeleteResponseMessage  = String
   type GenericString          = String
   type MaxResults             = Int
   type RefreshClosedReports   = Boolean
   type ReportDefinitionList   = js.Array[ReportDefinition]
-  type ReportFormat           = String
   type ReportName             = String
-  type ReportVersioning       = String
   type S3Bucket               = String
   type S3Prefix               = String
-  type SchemaElement          = String
   type SchemaElementList      = js.Array[SchemaElement]
-  type TimeUnit               = String
 
   implicit final class CUROps(private val service: CUR) extends AnyVal {
 
@@ -60,18 +53,20 @@ package cur {
   /**
     * The region of the S3 bucket that AWS delivers the report into.
     */
-  object AWSRegionEnum {
-    val `us-east-1`      = "us-east-1"
-    val `us-west-1`      = "us-west-1"
-    val `us-west-2`      = "us-west-2"
-    val `eu-central-1`   = "eu-central-1"
-    val `eu-west-1`      = "eu-west-1"
-    val `ap-southeast-1` = "ap-southeast-1"
-    val `ap-southeast-2` = "ap-southeast-2"
-    val `ap-northeast-1` = "ap-northeast-1"
-    val `eu-north-1`     = "eu-north-1"
-    val `ap-northeast-3` = "ap-northeast-3"
-    val `ap-east-1`      = "ap-east-1"
+  @js.native
+  sealed trait AWSRegion extends js.Any
+  object AWSRegion extends js.Object {
+    val `us-east-1`      = "us-east-1".asInstanceOf[AWSRegion]
+    val `us-west-1`      = "us-west-1".asInstanceOf[AWSRegion]
+    val `us-west-2`      = "us-west-2".asInstanceOf[AWSRegion]
+    val `eu-central-1`   = "eu-central-1".asInstanceOf[AWSRegion]
+    val `eu-west-1`      = "eu-west-1".asInstanceOf[AWSRegion]
+    val `ap-southeast-1` = "ap-southeast-1".asInstanceOf[AWSRegion]
+    val `ap-southeast-2` = "ap-southeast-2".asInstanceOf[AWSRegion]
+    val `ap-northeast-1` = "ap-northeast-1".asInstanceOf[AWSRegion]
+    val `eu-north-1`     = "eu-north-1".asInstanceOf[AWSRegion]
+    val `ap-northeast-3` = "ap-northeast-3".asInstanceOf[AWSRegion]
+    val `ap-east-1`      = "ap-east-1".asInstanceOf[AWSRegion]
 
     val values = js.Object.freeze(
       js.Array(
@@ -93,10 +88,12 @@ package cur {
   /**
     * The types of manifest that you want AWS to create for this report.
     */
-  object AdditionalArtifactEnum {
-    val REDSHIFT   = "REDSHIFT"
-    val QUICKSIGHT = "QUICKSIGHT"
-    val ATHENA     = "ATHENA"
+  @js.native
+  sealed trait AdditionalArtifact extends js.Any
+  object AdditionalArtifact extends js.Object {
+    val REDSHIFT   = "REDSHIFT".asInstanceOf[AdditionalArtifact]
+    val QUICKSIGHT = "QUICKSIGHT".asInstanceOf[AdditionalArtifact]
+    val ATHENA     = "ATHENA".asInstanceOf[AdditionalArtifact]
 
     val values = js.Object.freeze(js.Array(REDSHIFT, QUICKSIGHT, ATHENA))
   }
@@ -104,10 +101,12 @@ package cur {
   /**
     * The compression format that AWS uses for the report.
     */
-  object CompressionFormatEnum {
-    val ZIP     = "ZIP"
-    val GZIP    = "GZIP"
-    val Parquet = "Parquet"
+  @js.native
+  sealed trait CompressionFormat extends js.Any
+  object CompressionFormat extends js.Object {
+    val ZIP     = "ZIP".asInstanceOf[CompressionFormat]
+    val GZIP    = "GZIP".asInstanceOf[CompressionFormat]
+    val Parquet = "Parquet".asInstanceOf[CompressionFormat]
 
     val values = js.Object.freeze(js.Array(ZIP, GZIP, Parquet))
   }
@@ -319,16 +318,19 @@ package cur {
   /**
     * The format that AWS saves the report in.
     */
-  object ReportFormatEnum {
-    val textORcsv = "textORcsv"
-    val Parquet   = "Parquet"
+  @js.native
+  sealed trait ReportFormat extends js.Any
+  object ReportFormat extends js.Object {
+    val textORcsv = "textORcsv".asInstanceOf[ReportFormat]
+    val Parquet   = "Parquet".asInstanceOf[ReportFormat]
 
     val values = js.Object.freeze(js.Array(textORcsv, Parquet))
   }
-
-  object ReportVersioningEnum {
-    val CREATE_NEW_REPORT = "CREATE_NEW_REPORT"
-    val OVERWRITE_REPORT  = "OVERWRITE_REPORT"
+  @js.native
+  sealed trait ReportVersioning extends js.Any
+  object ReportVersioning extends js.Object {
+    val CREATE_NEW_REPORT = "CREATE_NEW_REPORT".asInstanceOf[ReportVersioning]
+    val OVERWRITE_REPORT  = "OVERWRITE_REPORT".asInstanceOf[ReportVersioning]
 
     val values = js.Object.freeze(js.Array(CREATE_NEW_REPORT, OVERWRITE_REPORT))
   }
@@ -336,8 +338,10 @@ package cur {
   /**
     * Whether or not AWS includes resource IDs in the report.
     */
-  object SchemaElementEnum {
-    val RESOURCES = "RESOURCES"
+  @js.native
+  sealed trait SchemaElement extends js.Any
+  object SchemaElement extends js.Object {
+    val RESOURCES = "RESOURCES".asInstanceOf[SchemaElement]
 
     val values = js.Object.freeze(js.Array(RESOURCES))
   }
@@ -345,9 +349,11 @@ package cur {
   /**
     * The length of time covered by the report.
     */
-  object TimeUnitEnum {
-    val HOURLY = "HOURLY"
-    val DAILY  = "DAILY"
+  @js.native
+  sealed trait TimeUnit extends js.Any
+  object TimeUnit extends js.Object {
+    val HOURLY = "HOURLY".asInstanceOf[TimeUnit]
+    val DAILY  = "DAILY".asInstanceOf[TimeUnit]
 
     val values = js.Object.freeze(js.Array(HOURLY, DAILY))
   }

--- a/services/dataexchange/src/main/scala/facade/amazonaws/services/DataExchange.scala
+++ b/services/dataexchange/src/main/scala/facade/amazonaws/services/DataExchange.scala
@@ -9,12 +9,8 @@ import facade.amazonaws._
 package object dataexchange {
   type Arn                                            = String
   type AssetName                                      = String
-  type AssetType                                      = String
-  type Code                                           = String
   type Description                                    = String
   type Id                                             = String
-  type JobErrorLimitName                              = String
-  type JobErrorResourceTypes                          = String
   type ListOfAssetDestinationEntry                    = js.Array[AssetDestinationEntry]
   type ListOfAssetEntry                               = js.Array[AssetEntry]
   type ListOfAssetSourceEntry                         = js.Array[AssetSourceEntry]
@@ -27,10 +23,7 @@ package object dataexchange {
   type MaxResults                                     = Int
   type Name                                           = String
   type NextToken                                      = String
-  type Origin                                         = String
-  type State                                          = String
   type Timestamp                                      = js.Date
-  type Type                                           = String
   type __boolean                                      = Boolean
   type __double                                       = Double
   type __doubleMin0                                   = Double
@@ -234,8 +227,10 @@ package dataexchange {
   /**
     * The type of file your data is stored in. Currently, the supported asset type is S3_SNAPSHOT.
     */
-  object AssetTypeEnum {
-    val S3_SNAPSHOT = "S3_SNAPSHOT"
+  @js.native
+  sealed trait AssetType extends js.Any
+  object AssetType extends js.Object {
+    val S3_SNAPSHOT = "S3_SNAPSHOT".asInstanceOf[AssetType]
 
     val values = js.Object.freeze(js.Array(S3_SNAPSHOT))
   }
@@ -257,15 +252,16 @@ package dataexchange {
       __obj.asInstanceOf[CancelJobRequest]
     }
   }
-
-  object CodeEnum {
-    val ACCESS_DENIED_EXCEPTION          = "ACCESS_DENIED_EXCEPTION"
-    val INTERNAL_SERVER_EXCEPTION        = "INTERNAL_SERVER_EXCEPTION"
-    val MALWARE_DETECTED                 = "MALWARE_DETECTED"
-    val RESOURCE_NOT_FOUND_EXCEPTION     = "RESOURCE_NOT_FOUND_EXCEPTION"
-    val SERVICE_QUOTA_EXCEEDED_EXCEPTION = "SERVICE_QUOTA_EXCEEDED_EXCEPTION"
-    val VALIDATION_EXCEPTION             = "VALIDATION_EXCEPTION"
-    val MALWARE_SCAN_ENCRYPTED_FILE      = "MALWARE_SCAN_ENCRYPTED_FILE"
+  @js.native
+  sealed trait Code extends js.Any
+  object Code extends js.Object {
+    val ACCESS_DENIED_EXCEPTION          = "ACCESS_DENIED_EXCEPTION".asInstanceOf[Code]
+    val INTERNAL_SERVER_EXCEPTION        = "INTERNAL_SERVER_EXCEPTION".asInstanceOf[Code]
+    val MALWARE_DETECTED                 = "MALWARE_DETECTED".asInstanceOf[Code]
+    val RESOURCE_NOT_FOUND_EXCEPTION     = "RESOURCE_NOT_FOUND_EXCEPTION".asInstanceOf[Code]
+    val SERVICE_QUOTA_EXCEEDED_EXCEPTION = "SERVICE_QUOTA_EXCEEDED_EXCEPTION".asInstanceOf[Code]
+    val VALIDATION_EXCEPTION             = "VALIDATION_EXCEPTION".asInstanceOf[Code]
+    val MALWARE_SCAN_ENCRYPTED_FILE      = "MALWARE_SCAN_ENCRYPTED_FILE".asInstanceOf[Code]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1201,9 +1197,11 @@ package dataexchange {
   /**
     * The name of the limit that was reached.
     */
-  object JobErrorLimitNameEnum {
-    val `Assets per revision` = "Assets per revision"
-    val `Asset size in GB`    = "Asset size in GB"
+  @js.native
+  sealed trait JobErrorLimitName extends js.Any
+  object JobErrorLimitName extends js.Object {
+    val `Assets per revision` = "Assets per revision".asInstanceOf[JobErrorLimitName]
+    val `Asset size in GB`    = "Asset size in GB".asInstanceOf[JobErrorLimitName]
 
     val values = js.Object.freeze(js.Array(`Assets per revision`, `Asset size in GB`))
   }
@@ -1211,9 +1209,11 @@ package dataexchange {
   /**
     * The types of resource which the job error can apply to.
     */
-  object JobErrorResourceTypesEnum {
-    val REVISION = "REVISION"
-    val ASSET    = "ASSET"
+  @js.native
+  sealed trait JobErrorResourceTypes extends js.Any
+  object JobErrorResourceTypes extends js.Object {
+    val REVISION = "REVISION".asInstanceOf[JobErrorResourceTypes]
+    val ASSET    = "ASSET".asInstanceOf[JobErrorResourceTypes]
 
     val values = js.Object.freeze(js.Array(REVISION, ASSET))
   }
@@ -1429,9 +1429,11 @@ package dataexchange {
   /**
     * A property that defines the data set as OWNED by the account (for providers) or ENTITLED to the account (for subscribers). When an owned data set is published in a product, AWS Data Exchange creates a copy of the data set. Subscribers can access that copy of the data set as an entitled data set.
     */
-  object OriginEnum {
-    val OWNED    = "OWNED"
-    val ENTITLED = "ENTITLED"
+  @js.native
+  sealed trait Origin extends js.Any
+  object Origin extends js.Object {
+    val OWNED    = "OWNED".asInstanceOf[Origin]
+    val ENTITLED = "ENTITLED".asInstanceOf[Origin]
 
     val values = js.Object.freeze(js.Array(OWNED, ENTITLED))
   }
@@ -1603,14 +1605,15 @@ package dataexchange {
       __obj.asInstanceOf[StartJobResponse]
     }
   }
-
-  object StateEnum {
-    val WAITING     = "WAITING"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val ERROR       = "ERROR"
-    val COMPLETED   = "COMPLETED"
-    val CANCELLED   = "CANCELLED"
-    val TIMED_OUT   = "TIMED_OUT"
+  @js.native
+  sealed trait State extends js.Any
+  object State extends js.Object {
+    val WAITING     = "WAITING".asInstanceOf[State]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[State]
+    val ERROR       = "ERROR".asInstanceOf[State]
+    val COMPLETED   = "COMPLETED".asInstanceOf[State]
+    val CANCELLED   = "CANCELLED".asInstanceOf[State]
+    val TIMED_OUT   = "TIMED_OUT".asInstanceOf[State]
 
     val values = js.Object.freeze(js.Array(WAITING, IN_PROGRESS, ERROR, COMPLETED, CANCELLED, TIMED_OUT))
   }
@@ -1638,12 +1641,13 @@ package dataexchange {
       __obj.asInstanceOf[TagResourceRequest]
     }
   }
-
-  object TypeEnum {
-    val IMPORT_ASSETS_FROM_S3        = "IMPORT_ASSETS_FROM_S3"
-    val IMPORT_ASSET_FROM_SIGNED_URL = "IMPORT_ASSET_FROM_SIGNED_URL"
-    val EXPORT_ASSETS_TO_S3          = "EXPORT_ASSETS_TO_S3"
-    val EXPORT_ASSET_TO_SIGNED_URL   = "EXPORT_ASSET_TO_SIGNED_URL"
+  @js.native
+  sealed trait Type extends js.Any
+  object Type extends js.Object {
+    val IMPORT_ASSETS_FROM_S3        = "IMPORT_ASSETS_FROM_S3".asInstanceOf[Type]
+    val IMPORT_ASSET_FROM_SIGNED_URL = "IMPORT_ASSET_FROM_SIGNED_URL".asInstanceOf[Type]
+    val EXPORT_ASSETS_TO_S3          = "EXPORT_ASSETS_TO_S3".asInstanceOf[Type]
+    val EXPORT_ASSET_TO_SIGNED_URL   = "EXPORT_ASSET_TO_SIGNED_URL".asInstanceOf[Type]
 
     val values = js.Object.freeze(
       js.Array(IMPORT_ASSETS_FROM_S3, IMPORT_ASSET_FROM_SIGNED_URL, EXPORT_ASSETS_TO_S3, EXPORT_ASSET_TO_SIGNED_URL)

--- a/services/datapipeline/src/main/scala/facade/amazonaws/services/DataPipeline.scala
+++ b/services/datapipeline/src/main/scala/facade/amazonaws/services/DataPipeline.scala
@@ -7,7 +7,6 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object datapipeline {
-  type OperatorType            = String
   type ParameterAttributeList  = js.Array[ParameterAttribute]
   type ParameterObjectList     = js.Array[ParameterObject]
   type ParameterValueList      = js.Array[ParameterValue]
@@ -15,7 +14,6 @@ package object datapipeline {
   type PipelineObjectList      = js.Array[PipelineObject]
   type PipelineObjectMap       = js.Dictionary[PipelineObject]
   type SelectorList            = js.Array[Selector]
-  type TaskStatus              = String
   type ValidationErrors        = js.Array[ValidationError]
   type ValidationWarnings      = js.Array[ValidationWarning]
   type attributeNameString     = String
@@ -634,13 +632,14 @@ package datapipeline {
       __obj.asInstanceOf[Operator]
     }
   }
-
-  object OperatorTypeEnum {
-    val EQ      = "EQ"
-    val REF_EQ  = "REF_EQ"
-    val LE      = "LE"
-    val GE      = "GE"
-    val BETWEEN = "BETWEEN"
+  @js.native
+  sealed trait OperatorType extends js.Any
+  object OperatorType extends js.Object {
+    val EQ      = "EQ".asInstanceOf[OperatorType]
+    val REF_EQ  = "REF_EQ".asInstanceOf[OperatorType]
+    val LE      = "LE".asInstanceOf[OperatorType]
+    val GE      = "GE".asInstanceOf[OperatorType]
+    val BETWEEN = "BETWEEN".asInstanceOf[OperatorType]
 
     val values = js.Object.freeze(js.Array(EQ, REF_EQ, LE, GE, BETWEEN))
   }
@@ -1285,11 +1284,12 @@ package datapipeline {
       __obj.asInstanceOf[TaskObject]
     }
   }
-
-  object TaskStatusEnum {
-    val FINISHED = "FINISHED"
-    val FAILED   = "FAILED"
-    val FALSE    = "FALSE"
+  @js.native
+  sealed trait TaskStatus extends js.Any
+  object TaskStatus extends js.Object {
+    val FINISHED = "FINISHED".asInstanceOf[TaskStatus]
+    val FAILED   = "FAILED".asInstanceOf[TaskStatus]
+    val FALSE    = "FALSE".asInstanceOf[TaskStatus]
 
     val values = js.Object.freeze(js.Array(FINISHED, FAILED, FALSE))
   }

--- a/services/datasync/src/main/scala/facade/amazonaws/services/DataSync.scala
+++ b/services/datasync/src/main/scala/facade/amazonaws/services/DataSync.scala
@@ -11,8 +11,6 @@ package object datasync {
   type AgentArn                        = String
   type AgentArnList                    = js.Array[AgentArn]
   type AgentList                       = js.Array[AgentListEntry]
-  type AgentStatus                     = String
-  type Atime                           = String
   type BytesPerSecond                  = Double
   type DestinationNetworkInterfaceArns = js.Array[NetworkInterfaceArn]
   type Duration                        = Double
@@ -22,34 +20,22 @@ package object datasync {
   type EfsFilesystemArn                = String
   type EfsSubdirectory                 = String
   type Endpoint                        = String
-  type EndpointType                    = String
   type FilterList                      = js.Array[FilterRule]
-  type FilterType                      = String
   type FilterValue                     = String
   type FsxFilesystemArn                = String
   type FsxWindowsSubdirectory          = String
-  type Gid                             = String
   type IamRoleArn                      = String
   type LocationArn                     = String
   type LocationList                    = js.Array[LocationListEntry]
   type LocationUri                     = String
   type LogGroupArn                     = String
-  type LogLevel                        = String
   type MaxResults                      = Int
-  type Mtime                           = String
   type NetworkInterfaceArn             = String
   type NextToken                       = String
   type NfsSubdirectory                 = String
-  type NfsVersion                      = String
-  type OverwriteMode                   = String
   type PLSecurityGroupArnList          = js.Array[Ec2SecurityGroupArn]
   type PLSubnetArnList                 = js.Array[Ec2SubnetArn]
-  type PhaseStatus                     = String
-  type PosixPermissions                = String
-  type PreserveDeletedFiles            = String
-  type PreserveDevices                 = String
   type S3BucketArn                     = String
-  type S3StorageClass                  = String
   type S3Subdirectory                  = String
   type ScheduleExpressionCron          = String
   type ServerHostname                  = String
@@ -57,7 +43,6 @@ package object datasync {
   type SmbPassword                     = String
   type SmbSubdirectory                 = String
   type SmbUser                         = String
-  type SmbVersion                      = String
   type SourceNetworkInterfaceArns      = js.Array[NetworkInterfaceArn]
   type TagKey                          = String
   type TagKeyList                      = js.Array[TagKey]
@@ -67,13 +52,8 @@ package object datasync {
   type TaskArn                         = String
   type TaskExecutionArn                = String
   type TaskExecutionList               = js.Array[TaskExecutionListEntry]
-  type TaskExecutionStatus             = String
   type TaskList                        = js.Array[TaskListEntry]
-  type TaskQueueing                    = String
-  type TaskStatus                      = String
   type Time                            = js.Date
-  type Uid                             = String
-  type VerifyMode                      = String
   type VpcEndpointId                   = String
 
   implicit final class DataSyncOps(private val service: DataSync) extends AnyVal {
@@ -206,17 +186,19 @@ package datasync {
       __obj.asInstanceOf[AgentListEntry]
     }
   }
-
-  object AgentStatusEnum {
-    val ONLINE  = "ONLINE"
-    val OFFLINE = "OFFLINE"
+  @js.native
+  sealed trait AgentStatus extends js.Any
+  object AgentStatus extends js.Object {
+    val ONLINE  = "ONLINE".asInstanceOf[AgentStatus]
+    val OFFLINE = "OFFLINE".asInstanceOf[AgentStatus]
 
     val values = js.Object.freeze(js.Array(ONLINE, OFFLINE))
   }
-
-  object AtimeEnum {
-    val NONE        = "NONE"
-    val BEST_EFFORT = "BEST_EFFORT"
+  @js.native
+  sealed trait Atime extends js.Any
+  object Atime extends js.Object {
+    val NONE        = "NONE".asInstanceOf[Atime]
+    val BEST_EFFORT = "BEST_EFFORT".asInstanceOf[Atime]
 
     val values = js.Object.freeze(js.Array(NONE, BEST_EFFORT))
   }
@@ -1161,11 +1143,12 @@ package datasync {
       __obj.asInstanceOf[Ec2Config]
     }
   }
-
-  object EndpointTypeEnum {
-    val PUBLIC       = "PUBLIC"
-    val PRIVATE_LINK = "PRIVATE_LINK"
-    val FIPS         = "FIPS"
+  @js.native
+  sealed trait EndpointType extends js.Any
+  object EndpointType extends js.Object {
+    val PUBLIC       = "PUBLIC".asInstanceOf[EndpointType]
+    val PRIVATE_LINK = "PRIVATE_LINK".asInstanceOf[EndpointType]
+    val FIPS         = "FIPS".asInstanceOf[EndpointType]
 
     val values = js.Object.freeze(js.Array(PUBLIC, PRIVATE_LINK, FIPS))
   }
@@ -1191,18 +1174,20 @@ package datasync {
       __obj.asInstanceOf[FilterRule]
     }
   }
-
-  object FilterTypeEnum {
-    val SIMPLE_PATTERN = "SIMPLE_PATTERN"
+  @js.native
+  sealed trait FilterType extends js.Any
+  object FilterType extends js.Object {
+    val SIMPLE_PATTERN = "SIMPLE_PATTERN".asInstanceOf[FilterType]
 
     val values = js.Object.freeze(js.Array(SIMPLE_PATTERN))
   }
-
-  object GidEnum {
-    val NONE      = "NONE"
-    val INT_VALUE = "INT_VALUE"
-    val NAME      = "NAME"
-    val BOTH      = "BOTH"
+  @js.native
+  sealed trait Gid extends js.Any
+  object Gid extends js.Object {
+    val NONE      = "NONE".asInstanceOf[Gid]
+    val INT_VALUE = "INT_VALUE".asInstanceOf[Gid]
+    val NAME      = "NAME".asInstanceOf[Gid]
+    val BOTH      = "BOTH".asInstanceOf[Gid]
 
     val values = js.Object.freeze(js.Array(NONE, INT_VALUE, NAME, BOTH))
   }
@@ -1429,18 +1414,20 @@ package datasync {
       __obj.asInstanceOf[LocationListEntry]
     }
   }
-
-  object LogLevelEnum {
-    val OFF      = "OFF"
-    val BASIC    = "BASIC"
-    val TRANSFER = "TRANSFER"
+  @js.native
+  sealed trait LogLevel extends js.Any
+  object LogLevel extends js.Object {
+    val OFF      = "OFF".asInstanceOf[LogLevel]
+    val BASIC    = "BASIC".asInstanceOf[LogLevel]
+    val TRANSFER = "TRANSFER".asInstanceOf[LogLevel]
 
     val values = js.Object.freeze(js.Array(OFF, BASIC, TRANSFER))
   }
-
-  object MtimeEnum {
-    val NONE     = "NONE"
-    val PRESERVE = "PRESERVE"
+  @js.native
+  sealed trait Mtime extends js.Any
+  object Mtime extends js.Object {
+    val NONE     = "NONE".asInstanceOf[Mtime]
+    val PRESERVE = "PRESERVE".asInstanceOf[Mtime]
 
     val values = js.Object.freeze(js.Array(NONE, PRESERVE))
   }
@@ -1463,12 +1450,13 @@ package datasync {
       __obj.asInstanceOf[NfsMountOptions]
     }
   }
-
-  object NfsVersionEnum {
-    val AUTOMATIC = "AUTOMATIC"
-    val NFS3      = "NFS3"
-    val NFS4_0    = "NFS4_0"
-    val NFS4_1    = "NFS4_1"
+  @js.native
+  sealed trait NfsVersion extends js.Any
+  object NfsVersion extends js.Object {
+    val AUTOMATIC = "AUTOMATIC".asInstanceOf[NfsVersion]
+    val NFS3      = "NFS3".asInstanceOf[NfsVersion]
+    val NFS4_0    = "NFS4_0".asInstanceOf[NfsVersion]
+    val NFS4_1    = "NFS4_1".asInstanceOf[NfsVersion]
 
     val values = js.Object.freeze(js.Array(AUTOMATIC, NFS3, NFS4_0, NFS4_1))
   }
@@ -1546,39 +1534,44 @@ package datasync {
       __obj.asInstanceOf[Options]
     }
   }
-
-  object OverwriteModeEnum {
-    val ALWAYS = "ALWAYS"
-    val NEVER  = "NEVER"
+  @js.native
+  sealed trait OverwriteMode extends js.Any
+  object OverwriteMode extends js.Object {
+    val ALWAYS = "ALWAYS".asInstanceOf[OverwriteMode]
+    val NEVER  = "NEVER".asInstanceOf[OverwriteMode]
 
     val values = js.Object.freeze(js.Array(ALWAYS, NEVER))
   }
-
-  object PhaseStatusEnum {
-    val PENDING = "PENDING"
-    val SUCCESS = "SUCCESS"
-    val ERROR   = "ERROR"
+  @js.native
+  sealed trait PhaseStatus extends js.Any
+  object PhaseStatus extends js.Object {
+    val PENDING = "PENDING".asInstanceOf[PhaseStatus]
+    val SUCCESS = "SUCCESS".asInstanceOf[PhaseStatus]
+    val ERROR   = "ERROR".asInstanceOf[PhaseStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, SUCCESS, ERROR))
   }
-
-  object PosixPermissionsEnum {
-    val NONE     = "NONE"
-    val PRESERVE = "PRESERVE"
+  @js.native
+  sealed trait PosixPermissions extends js.Any
+  object PosixPermissions extends js.Object {
+    val NONE     = "NONE".asInstanceOf[PosixPermissions]
+    val PRESERVE = "PRESERVE".asInstanceOf[PosixPermissions]
 
     val values = js.Object.freeze(js.Array(NONE, PRESERVE))
   }
-
-  object PreserveDeletedFilesEnum {
-    val PRESERVE = "PRESERVE"
-    val REMOVE   = "REMOVE"
+  @js.native
+  sealed trait PreserveDeletedFiles extends js.Any
+  object PreserveDeletedFiles extends js.Object {
+    val PRESERVE = "PRESERVE".asInstanceOf[PreserveDeletedFiles]
+    val REMOVE   = "REMOVE".asInstanceOf[PreserveDeletedFiles]
 
     val values = js.Object.freeze(js.Array(PRESERVE, REMOVE))
   }
-
-  object PreserveDevicesEnum {
-    val NONE     = "NONE"
-    val PRESERVE = "PRESERVE"
+  @js.native
+  sealed trait PreserveDevices extends js.Any
+  object PreserveDevices extends js.Object {
+    val NONE     = "NONE".asInstanceOf[PreserveDevices]
+    val PRESERVE = "PRESERVE".asInstanceOf[PreserveDevices]
 
     val values = js.Object.freeze(js.Array(NONE, PRESERVE))
   }
@@ -1632,14 +1625,15 @@ package datasync {
       __obj.asInstanceOf[S3Config]
     }
   }
-
-  object S3StorageClassEnum {
-    val STANDARD            = "STANDARD"
-    val STANDARD_IA         = "STANDARD_IA"
-    val ONEZONE_IA          = "ONEZONE_IA"
-    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING"
-    val GLACIER             = "GLACIER"
-    val DEEP_ARCHIVE        = "DEEP_ARCHIVE"
+  @js.native
+  sealed trait S3StorageClass extends js.Any
+  object S3StorageClass extends js.Object {
+    val STANDARD            = "STANDARD".asInstanceOf[S3StorageClass]
+    val STANDARD_IA         = "STANDARD_IA".asInstanceOf[S3StorageClass]
+    val ONEZONE_IA          = "ONEZONE_IA".asInstanceOf[S3StorageClass]
+    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING".asInstanceOf[S3StorageClass]
+    val GLACIER             = "GLACIER".asInstanceOf[S3StorageClass]
+    val DEEP_ARCHIVE        = "DEEP_ARCHIVE".asInstanceOf[S3StorageClass]
 
     val values =
       js.Object.freeze(js.Array(STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE))
@@ -1663,11 +1657,12 @@ package datasync {
       __obj.asInstanceOf[SmbMountOptions]
     }
   }
-
-  object SmbVersionEnum {
-    val AUTOMATIC = "AUTOMATIC"
-    val SMB2      = "SMB2"
-    val SMB3      = "SMB3"
+  @js.native
+  sealed trait SmbVersion extends js.Any
+  object SmbVersion extends js.Object {
+    val AUTOMATIC = "AUTOMATIC".asInstanceOf[SmbVersion]
+    val SMB2      = "SMB2".asInstanceOf[SmbVersion]
+    val SMB3      = "SMB3".asInstanceOf[SmbVersion]
 
     val values = js.Object.freeze(js.Array(AUTOMATIC, SMB2, SMB3))
   }
@@ -1834,15 +1829,16 @@ package datasync {
       __obj.asInstanceOf[TaskExecutionResultDetail]
     }
   }
-
-  object TaskExecutionStatusEnum {
-    val QUEUED       = "QUEUED"
-    val LAUNCHING    = "LAUNCHING"
-    val PREPARING    = "PREPARING"
-    val TRANSFERRING = "TRANSFERRING"
-    val VERIFYING    = "VERIFYING"
-    val SUCCESS      = "SUCCESS"
-    val ERROR        = "ERROR"
+  @js.native
+  sealed trait TaskExecutionStatus extends js.Any
+  object TaskExecutionStatus extends js.Object {
+    val QUEUED       = "QUEUED".asInstanceOf[TaskExecutionStatus]
+    val LAUNCHING    = "LAUNCHING".asInstanceOf[TaskExecutionStatus]
+    val PREPARING    = "PREPARING".asInstanceOf[TaskExecutionStatus]
+    val TRANSFERRING = "TRANSFERRING".asInstanceOf[TaskExecutionStatus]
+    val VERIFYING    = "VERIFYING".asInstanceOf[TaskExecutionStatus]
+    val SUCCESS      = "SUCCESS".asInstanceOf[TaskExecutionStatus]
+    val ERROR        = "ERROR".asInstanceOf[TaskExecutionStatus]
 
     val values = js.Object.freeze(js.Array(QUEUED, LAUNCHING, PREPARING, TRANSFERRING, VERIFYING, SUCCESS, ERROR))
   }
@@ -1871,10 +1867,11 @@ package datasync {
       __obj.asInstanceOf[TaskListEntry]
     }
   }
-
-  object TaskQueueingEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait TaskQueueing extends js.Any
+  object TaskQueueing extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[TaskQueueing]
+    val DISABLED = "DISABLED".asInstanceOf[TaskQueueing]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -1899,22 +1896,24 @@ package datasync {
       __obj.asInstanceOf[TaskSchedule]
     }
   }
-
-  object TaskStatusEnum {
-    val AVAILABLE   = "AVAILABLE"
-    val CREATING    = "CREATING"
-    val QUEUED      = "QUEUED"
-    val RUNNING     = "RUNNING"
-    val UNAVAILABLE = "UNAVAILABLE"
+  @js.native
+  sealed trait TaskStatus extends js.Any
+  object TaskStatus extends js.Object {
+    val AVAILABLE   = "AVAILABLE".asInstanceOf[TaskStatus]
+    val CREATING    = "CREATING".asInstanceOf[TaskStatus]
+    val QUEUED      = "QUEUED".asInstanceOf[TaskStatus]
+    val RUNNING     = "RUNNING".asInstanceOf[TaskStatus]
+    val UNAVAILABLE = "UNAVAILABLE".asInstanceOf[TaskStatus]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, CREATING, QUEUED, RUNNING, UNAVAILABLE))
   }
-
-  object UidEnum {
-    val NONE      = "NONE"
-    val INT_VALUE = "INT_VALUE"
-    val NAME      = "NAME"
-    val BOTH      = "BOTH"
+  @js.native
+  sealed trait Uid extends js.Any
+  object Uid extends js.Object {
+    val NONE      = "NONE".asInstanceOf[Uid]
+    val INT_VALUE = "INT_VALUE".asInstanceOf[Uid]
+    val NAME      = "NAME".asInstanceOf[Uid]
+    val BOTH      = "BOTH".asInstanceOf[Uid]
 
     val values = js.Object.freeze(js.Array(NONE, INT_VALUE, NAME, BOTH))
   }
@@ -2035,11 +2034,12 @@ package datasync {
       __obj.asInstanceOf[UpdateTaskResponse]
     }
   }
-
-  object VerifyModeEnum {
-    val POINT_IN_TIME_CONSISTENT = "POINT_IN_TIME_CONSISTENT"
-    val ONLY_FILES_TRANSFERRED   = "ONLY_FILES_TRANSFERRED"
-    val NONE                     = "NONE"
+  @js.native
+  sealed trait VerifyMode extends js.Any
+  object VerifyMode extends js.Object {
+    val POINT_IN_TIME_CONSISTENT = "POINT_IN_TIME_CONSISTENT".asInstanceOf[VerifyMode]
+    val ONLY_FILES_TRANSFERRED   = "ONLY_FILES_TRANSFERRED".asInstanceOf[VerifyMode]
+    val NONE                     = "NONE".asInstanceOf[VerifyMode]
 
     val values = js.Object.freeze(js.Array(POINT_IN_TIME_CONSISTENT, ONLY_FILES_TRANSFERRED, NONE))
   }

--- a/services/dax/src/main/scala/facade/amazonaws/services/DAX.scala
+++ b/services/dax/src/main/scala/facade/amazonaws/services/DAX.scala
@@ -8,12 +8,10 @@ import facade.amazonaws._
 
 package object dax {
   type AvailabilityZoneList        = js.Array[String]
-  type ChangeType                  = String
   type ClusterList                 = js.Array[Cluster]
   type ClusterNameList             = js.Array[String]
   type EventList                   = js.Array[Event]
   type IntegerOptional             = Int
-  type IsModifiable                = String
   type KeyList                     = js.Array[String]
   type NodeIdentifierList          = js.Array[String]
   type NodeList                    = js.Array[Node]
@@ -22,12 +20,9 @@ package object dax {
   type ParameterGroupNameList      = js.Array[String]
   type ParameterList               = js.Array[Parameter]
   type ParameterNameValueList      = js.Array[ParameterNameValue]
-  type ParameterType               = String
   type SSEEnabled                  = Boolean
-  type SSEStatus                   = String
   type SecurityGroupIdentifierList = js.Array[String]
   type SecurityGroupMembershipList = js.Array[SecurityGroupMembership]
-  type SourceType                  = String
   type SubnetGroupList             = js.Array[SubnetGroup]
   type SubnetGroupNameList         = js.Array[String]
   type SubnetIdentifierList        = js.Array[String]
@@ -121,10 +116,11 @@ package dax {
     def updateParameterGroup(params: UpdateParameterGroupRequest): Request[UpdateParameterGroupResponse] = js.native
     def updateSubnetGroup(params: UpdateSubnetGroupRequest): Request[UpdateSubnetGroupResponse]          = js.native
   }
-
-  object ChangeTypeEnum {
-    val IMMEDIATE       = "IMMEDIATE"
-    val REQUIRES_REBOOT = "REQUIRES_REBOOT"
+  @js.native
+  sealed trait ChangeType extends js.Any
+  object ChangeType extends js.Object {
+    val IMMEDIATE       = "IMMEDIATE".asInstanceOf[ChangeType]
+    val REQUIRES_REBOOT = "REQUIRES_REBOOT".asInstanceOf[ChangeType]
 
     val values = js.Object.freeze(js.Array(IMMEDIATE, REQUIRES_REBOOT))
   }
@@ -843,11 +839,12 @@ package dax {
       __obj.asInstanceOf[IncreaseReplicationFactorResponse]
     }
   }
-
-  object IsModifiableEnum {
-    val TRUE        = "TRUE"
-    val FALSE       = "FALSE"
-    val CONDITIONAL = "CONDITIONAL"
+  @js.native
+  sealed trait IsModifiable extends js.Any
+  object IsModifiable extends js.Object {
+    val TRUE        = "TRUE".asInstanceOf[IsModifiable]
+    val FALSE       = "FALSE".asInstanceOf[IsModifiable]
+    val CONDITIONAL = "CONDITIONAL".asInstanceOf[IsModifiable]
 
     val values = js.Object.freeze(js.Array(TRUE, FALSE, CONDITIONAL))
   }
@@ -1084,10 +1081,11 @@ package dax {
       __obj.asInstanceOf[ParameterNameValue]
     }
   }
-
-  object ParameterTypeEnum {
-    val DEFAULT            = "DEFAULT"
-    val NODE_TYPE_SPECIFIC = "NODE_TYPE_SPECIFIC"
+  @js.native
+  sealed trait ParameterType extends js.Any
+  object ParameterType extends js.Object {
+    val DEFAULT            = "DEFAULT".asInstanceOf[ParameterType]
+    val NODE_TYPE_SPECIFIC = "NODE_TYPE_SPECIFIC".asInstanceOf[ParameterType]
 
     val values = js.Object.freeze(js.Array(DEFAULT, NODE_TYPE_SPECIFIC))
   }
@@ -1168,12 +1166,13 @@ package dax {
       __obj.asInstanceOf[SSESpecification]
     }
   }
-
-  object SSEStatusEnum {
-    val ENABLING  = "ENABLING"
-    val ENABLED   = "ENABLED"
-    val DISABLING = "DISABLING"
-    val DISABLED  = "DISABLED"
+  @js.native
+  sealed trait SSEStatus extends js.Any
+  object SSEStatus extends js.Object {
+    val ENABLING  = "ENABLING".asInstanceOf[SSEStatus]
+    val ENABLED   = "ENABLED".asInstanceOf[SSEStatus]
+    val DISABLING = "DISABLING".asInstanceOf[SSEStatus]
+    val DISABLED  = "DISABLED".asInstanceOf[SSEStatus]
 
     val values = js.Object.freeze(js.Array(ENABLING, ENABLED, DISABLING, DISABLED))
   }
@@ -1199,11 +1198,12 @@ package dax {
       __obj.asInstanceOf[SecurityGroupMembership]
     }
   }
-
-  object SourceTypeEnum {
-    val CLUSTER         = "CLUSTER"
-    val PARAMETER_GROUP = "PARAMETER_GROUP"
-    val SUBNET_GROUP    = "SUBNET_GROUP"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val CLUSTER         = "CLUSTER".asInstanceOf[SourceType]
+    val PARAMETER_GROUP = "PARAMETER_GROUP".asInstanceOf[SourceType]
+    val SUBNET_GROUP    = "SUBNET_GROUP".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(js.Array(CLUSTER, PARAMETER_GROUP, SUBNET_GROUP))
   }

--- a/services/detective/src/main/scala/facade/amazonaws/services/Detective.scala
+++ b/services/detective/src/main/scala/facade/amazonaws/services/Detective.scala
@@ -16,7 +16,6 @@ package object detective {
   type GraphList              = js.Array[Graph]
   type MemberDetailList       = js.Array[MemberDetail]
   type MemberResultsLimit     = Int
-  type MemberStatus           = String
   type PaginationToken        = String
   type Timestamp              = js.Date
   type UnprocessedAccountList = js.Array[UnprocessedAccount]
@@ -464,12 +463,13 @@ package detective {
       __obj.asInstanceOf[MemberDetail]
     }
   }
-
-  object MemberStatusEnum {
-    val INVITED                  = "INVITED"
-    val VERIFICATION_IN_PROGRESS = "VERIFICATION_IN_PROGRESS"
-    val VERIFICATION_FAILED      = "VERIFICATION_FAILED"
-    val ENABLED                  = "ENABLED"
+  @js.native
+  sealed trait MemberStatus extends js.Any
+  object MemberStatus extends js.Object {
+    val INVITED                  = "INVITED".asInstanceOf[MemberStatus]
+    val VERIFICATION_IN_PROGRESS = "VERIFICATION_IN_PROGRESS".asInstanceOf[MemberStatus]
+    val VERIFICATION_FAILED      = "VERIFICATION_FAILED".asInstanceOf[MemberStatus]
+    val ENABLED                  = "ENABLED".asInstanceOf[MemberStatus]
 
     val values = js.Object.freeze(js.Array(INVITED, VERIFICATION_IN_PROGRESS, VERIFICATION_FAILED, ENABLED))
   }

--- a/services/devicefarm/src/main/scala/facade/amazonaws/services/DeviceFarm.scala
+++ b/services/devicefarm/src/main/scala/facade/amazonaws/services/DeviceFarm.scala
@@ -13,38 +13,23 @@ package object devicefarm {
   type AmazonResourceNames                = js.Array[AmazonResourceName]
   type AndroidPaths                       = js.Array[String]
   type AppPackagesCleanup                 = Boolean
-  type ArtifactCategory                   = String
-  type ArtifactType                       = String
   type Artifacts                          = js.Array[Artifact]
-  type BillingMethod                      = String
   type ClientId                           = String
   type ContentType                        = String
-  type CurrencyCode                       = String
   type DateTime                           = js.Date
-  type DeviceAttribute                    = String
-  type DeviceAvailability                 = String
   type DeviceFarmArn                      = String
-  type DeviceFilterAttribute              = String
   type DeviceFilterValues                 = js.Array[String]
   type DeviceFilters                      = js.Array[DeviceFilter]
-  type DeviceFormFactor                   = String
   type DeviceHostPaths                    = js.Array[String]
   type DeviceInstances                    = js.Array[DeviceInstance]
-  type DevicePlatform                     = String
   type DevicePoolCompatibilityResults     = js.Array[DevicePoolCompatibilityResult]
-  type DevicePoolType                     = String
   type DevicePools                        = js.Array[DevicePool]
   type Devices                            = js.Array[Device]
-  type ExecutionResult                    = String
-  type ExecutionResultCode                = String
-  type ExecutionStatus                    = String
   type Filter                             = String
   type HostAddress                        = String
   type IncompatibilityMessages            = js.Array[IncompatibilityMessage]
   type InstanceLabels                     = js.Array[String]
   type InstanceProfiles                   = js.Array[InstanceProfile]
-  type InstanceStatus                     = String
-  type InteractionMode                    = String
   type IosPaths                           = js.Array[String]
   type JobTimeoutMinutes                  = Int
   type Jobs                               = js.Array[Job]
@@ -53,15 +38,12 @@ package object devicefarm {
   type Message                            = String
   type Metadata                           = String
   type Name                               = String
-  type NetworkProfileType                 = String
   type NetworkProfiles                    = js.Array[NetworkProfile]
   type OfferingIdentifier                 = String
   type OfferingPromotionIdentifier        = String
   type OfferingPromotions                 = js.Array[OfferingPromotion]
   type OfferingStatusMap                  = js.Dictionary[OfferingStatus]
-  type OfferingTransactionType            = String
   type OfferingTransactions               = js.Array[OfferingTransaction]
-  type OfferingType                       = String
   type Offerings                          = js.Array[Offering]
   type PackageIds                         = js.Array[String]
   type PaginationToken                    = String
@@ -69,16 +51,13 @@ package object devicefarm {
   type Problems                           = js.Array[Problem]
   type Projects                           = js.Array[Project]
   type PurchasedDevicesMap                = js.Dictionary[Int]
-  type RecurringChargeFrequency           = String
   type RecurringCharges                   = js.Array[RecurringCharge]
   type RemoteAccessSessions               = js.Array[RemoteAccessSession]
   type ResourceDescription                = String
   type ResourceId                         = String
   type ResourceName                       = String
-  type RuleOperator                       = String
   type Rules                              = js.Array[Rule]
   type Runs                               = js.Array[Run]
-  type SampleType                         = String
   type Samples                            = js.Array[Sample]
   type ServiceDnsName                     = String
   type SkipAppResign                      = Boolean
@@ -90,22 +69,15 @@ package object devicefarm {
   type TagValue                           = String
   type TestGridProjects                   = js.Array[TestGridProject]
   type TestGridSessionActions             = js.Array[TestGridSessionAction]
-  type TestGridSessionArtifactCategory    = String
-  type TestGridSessionArtifactType        = String
   type TestGridSessionArtifacts           = js.Array[TestGridSessionArtifact]
-  type TestGridSessionStatus              = String
   type TestGridSessions                   = js.Array[TestGridSession]
   type TestGridUrlExpiresInSecondsInput   = Int
   type TestParameters                     = js.Dictionary[String]
-  type TestType                           = String
   type Tests                              = js.Array[Test]
   type TransactionIdentifier              = String
   type URL                                = String
   type UniqueProblems                     = js.Array[UniqueProblem]
   type UniqueProblemsByExecutionResultMap = js.Dictionary[UniqueProblems]
-  type UploadCategory                     = String
-  type UploadStatus                       = String
-  type UploadType                         = String
   type Uploads                            = js.Array[Upload]
   type VPCEConfigurationDescription       = String
   type VPCEConfigurationName              = String
@@ -455,44 +427,46 @@ package devicefarm {
       __obj.asInstanceOf[Artifact]
     }
   }
-
-  object ArtifactCategoryEnum {
-    val SCREENSHOT = "SCREENSHOT"
-    val FILE       = "FILE"
-    val LOG        = "LOG"
+  @js.native
+  sealed trait ArtifactCategory extends js.Any
+  object ArtifactCategory extends js.Object {
+    val SCREENSHOT = "SCREENSHOT".asInstanceOf[ArtifactCategory]
+    val FILE       = "FILE".asInstanceOf[ArtifactCategory]
+    val LOG        = "LOG".asInstanceOf[ArtifactCategory]
 
     val values = js.Object.freeze(js.Array(SCREENSHOT, FILE, LOG))
   }
-
-  object ArtifactTypeEnum {
-    val UNKNOWN                  = "UNKNOWN"
-    val SCREENSHOT               = "SCREENSHOT"
-    val DEVICE_LOG               = "DEVICE_LOG"
-    val MESSAGE_LOG              = "MESSAGE_LOG"
-    val VIDEO_LOG                = "VIDEO_LOG"
-    val RESULT_LOG               = "RESULT_LOG"
-    val SERVICE_LOG              = "SERVICE_LOG"
-    val WEBKIT_LOG               = "WEBKIT_LOG"
-    val INSTRUMENTATION_OUTPUT   = "INSTRUMENTATION_OUTPUT"
-    val EXERCISER_MONKEY_OUTPUT  = "EXERCISER_MONKEY_OUTPUT"
-    val CALABASH_JSON_OUTPUT     = "CALABASH_JSON_OUTPUT"
-    val CALABASH_PRETTY_OUTPUT   = "CALABASH_PRETTY_OUTPUT"
-    val CALABASH_STANDARD_OUTPUT = "CALABASH_STANDARD_OUTPUT"
-    val CALABASH_JAVA_XML_OUTPUT = "CALABASH_JAVA_XML_OUTPUT"
-    val AUTOMATION_OUTPUT        = "AUTOMATION_OUTPUT"
-    val APPIUM_SERVER_OUTPUT     = "APPIUM_SERVER_OUTPUT"
-    val APPIUM_JAVA_OUTPUT       = "APPIUM_JAVA_OUTPUT"
-    val APPIUM_JAVA_XML_OUTPUT   = "APPIUM_JAVA_XML_OUTPUT"
-    val APPIUM_PYTHON_OUTPUT     = "APPIUM_PYTHON_OUTPUT"
-    val APPIUM_PYTHON_XML_OUTPUT = "APPIUM_PYTHON_XML_OUTPUT"
-    val EXPLORER_EVENT_LOG       = "EXPLORER_EVENT_LOG"
-    val EXPLORER_SUMMARY_LOG     = "EXPLORER_SUMMARY_LOG"
-    val APPLICATION_CRASH_REPORT = "APPLICATION_CRASH_REPORT"
-    val XCTEST_LOG               = "XCTEST_LOG"
-    val VIDEO                    = "VIDEO"
-    val CUSTOMER_ARTIFACT        = "CUSTOMER_ARTIFACT"
-    val CUSTOMER_ARTIFACT_LOG    = "CUSTOMER_ARTIFACT_LOG"
-    val TESTSPEC_OUTPUT          = "TESTSPEC_OUTPUT"
+  @js.native
+  sealed trait ArtifactType extends js.Any
+  object ArtifactType extends js.Object {
+    val UNKNOWN                  = "UNKNOWN".asInstanceOf[ArtifactType]
+    val SCREENSHOT               = "SCREENSHOT".asInstanceOf[ArtifactType]
+    val DEVICE_LOG               = "DEVICE_LOG".asInstanceOf[ArtifactType]
+    val MESSAGE_LOG              = "MESSAGE_LOG".asInstanceOf[ArtifactType]
+    val VIDEO_LOG                = "VIDEO_LOG".asInstanceOf[ArtifactType]
+    val RESULT_LOG               = "RESULT_LOG".asInstanceOf[ArtifactType]
+    val SERVICE_LOG              = "SERVICE_LOG".asInstanceOf[ArtifactType]
+    val WEBKIT_LOG               = "WEBKIT_LOG".asInstanceOf[ArtifactType]
+    val INSTRUMENTATION_OUTPUT   = "INSTRUMENTATION_OUTPUT".asInstanceOf[ArtifactType]
+    val EXERCISER_MONKEY_OUTPUT  = "EXERCISER_MONKEY_OUTPUT".asInstanceOf[ArtifactType]
+    val CALABASH_JSON_OUTPUT     = "CALABASH_JSON_OUTPUT".asInstanceOf[ArtifactType]
+    val CALABASH_PRETTY_OUTPUT   = "CALABASH_PRETTY_OUTPUT".asInstanceOf[ArtifactType]
+    val CALABASH_STANDARD_OUTPUT = "CALABASH_STANDARD_OUTPUT".asInstanceOf[ArtifactType]
+    val CALABASH_JAVA_XML_OUTPUT = "CALABASH_JAVA_XML_OUTPUT".asInstanceOf[ArtifactType]
+    val AUTOMATION_OUTPUT        = "AUTOMATION_OUTPUT".asInstanceOf[ArtifactType]
+    val APPIUM_SERVER_OUTPUT     = "APPIUM_SERVER_OUTPUT".asInstanceOf[ArtifactType]
+    val APPIUM_JAVA_OUTPUT       = "APPIUM_JAVA_OUTPUT".asInstanceOf[ArtifactType]
+    val APPIUM_JAVA_XML_OUTPUT   = "APPIUM_JAVA_XML_OUTPUT".asInstanceOf[ArtifactType]
+    val APPIUM_PYTHON_OUTPUT     = "APPIUM_PYTHON_OUTPUT".asInstanceOf[ArtifactType]
+    val APPIUM_PYTHON_XML_OUTPUT = "APPIUM_PYTHON_XML_OUTPUT".asInstanceOf[ArtifactType]
+    val EXPLORER_EVENT_LOG       = "EXPLORER_EVENT_LOG".asInstanceOf[ArtifactType]
+    val EXPLORER_SUMMARY_LOG     = "EXPLORER_SUMMARY_LOG".asInstanceOf[ArtifactType]
+    val APPLICATION_CRASH_REPORT = "APPLICATION_CRASH_REPORT".asInstanceOf[ArtifactType]
+    val XCTEST_LOG               = "XCTEST_LOG".asInstanceOf[ArtifactType]
+    val VIDEO                    = "VIDEO".asInstanceOf[ArtifactType]
+    val CUSTOMER_ARTIFACT        = "CUSTOMER_ARTIFACT".asInstanceOf[ArtifactType]
+    val CUSTOMER_ARTIFACT_LOG    = "CUSTOMER_ARTIFACT_LOG".asInstanceOf[ArtifactType]
+    val TESTSPEC_OUTPUT          = "TESTSPEC_OUTPUT".asInstanceOf[ArtifactType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -527,10 +501,11 @@ package devicefarm {
       )
     )
   }
-
-  object BillingMethodEnum {
-    val METERED   = "METERED"
-    val UNMETERED = "UNMETERED"
+  @js.native
+  sealed trait BillingMethod extends js.Any
+  object BillingMethod extends js.Object {
+    val METERED   = "METERED".asInstanceOf[BillingMethod]
+    val UNMETERED = "UNMETERED".asInstanceOf[BillingMethod]
 
     val values = js.Object.freeze(js.Array(METERED, UNMETERED))
   }
@@ -1072,9 +1047,10 @@ package devicefarm {
       __obj.asInstanceOf[CreateVPCEConfigurationResult]
     }
   }
-
-  object CurrencyCodeEnum {
-    val USD = "USD"
+  @js.native
+  sealed trait CurrencyCode extends js.Any
+  object CurrencyCode extends js.Object {
+    val USD = "USD".asInstanceOf[CurrencyCode]
 
     val values = js.Object.freeze(js.Array(USD))
   }
@@ -1493,21 +1469,22 @@ package devicefarm {
       __obj.asInstanceOf[Device]
     }
   }
-
-  object DeviceAttributeEnum {
-    val ARN                   = "ARN"
-    val PLATFORM              = "PLATFORM"
-    val FORM_FACTOR           = "FORM_FACTOR"
-    val MANUFACTURER          = "MANUFACTURER"
-    val REMOTE_ACCESS_ENABLED = "REMOTE_ACCESS_ENABLED"
-    val REMOTE_DEBUG_ENABLED  = "REMOTE_DEBUG_ENABLED"
-    val APPIUM_VERSION        = "APPIUM_VERSION"
-    val INSTANCE_ARN          = "INSTANCE_ARN"
-    val INSTANCE_LABELS       = "INSTANCE_LABELS"
-    val FLEET_TYPE            = "FLEET_TYPE"
-    val OS_VERSION            = "OS_VERSION"
-    val MODEL                 = "MODEL"
-    val AVAILABILITY          = "AVAILABILITY"
+  @js.native
+  sealed trait DeviceAttribute extends js.Any
+  object DeviceAttribute extends js.Object {
+    val ARN                   = "ARN".asInstanceOf[DeviceAttribute]
+    val PLATFORM              = "PLATFORM".asInstanceOf[DeviceAttribute]
+    val FORM_FACTOR           = "FORM_FACTOR".asInstanceOf[DeviceAttribute]
+    val MANUFACTURER          = "MANUFACTURER".asInstanceOf[DeviceAttribute]
+    val REMOTE_ACCESS_ENABLED = "REMOTE_ACCESS_ENABLED".asInstanceOf[DeviceAttribute]
+    val REMOTE_DEBUG_ENABLED  = "REMOTE_DEBUG_ENABLED".asInstanceOf[DeviceAttribute]
+    val APPIUM_VERSION        = "APPIUM_VERSION".asInstanceOf[DeviceAttribute]
+    val INSTANCE_ARN          = "INSTANCE_ARN".asInstanceOf[DeviceAttribute]
+    val INSTANCE_LABELS       = "INSTANCE_LABELS".asInstanceOf[DeviceAttribute]
+    val FLEET_TYPE            = "FLEET_TYPE".asInstanceOf[DeviceAttribute]
+    val OS_VERSION            = "OS_VERSION".asInstanceOf[DeviceAttribute]
+    val MODEL                 = "MODEL".asInstanceOf[DeviceAttribute]
+    val AVAILABILITY          = "AVAILABILITY".asInstanceOf[DeviceAttribute]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1527,12 +1504,13 @@ package devicefarm {
       )
     )
   }
-
-  object DeviceAvailabilityEnum {
-    val TEMPORARY_NOT_AVAILABLE = "TEMPORARY_NOT_AVAILABLE"
-    val BUSY                    = "BUSY"
-    val AVAILABLE               = "AVAILABLE"
-    val HIGHLY_AVAILABLE        = "HIGHLY_AVAILABLE"
+  @js.native
+  sealed trait DeviceAvailability extends js.Any
+  object DeviceAvailability extends js.Object {
+    val TEMPORARY_NOT_AVAILABLE = "TEMPORARY_NOT_AVAILABLE".asInstanceOf[DeviceAvailability]
+    val BUSY                    = "BUSY".asInstanceOf[DeviceAvailability]
+    val AVAILABLE               = "AVAILABLE".asInstanceOf[DeviceAvailability]
+    val HIGHLY_AVAILABLE        = "HIGHLY_AVAILABLE".asInstanceOf[DeviceAvailability]
 
     val values = js.Object.freeze(js.Array(TEMPORARY_NOT_AVAILABLE, BUSY, AVAILABLE, HIGHLY_AVAILABLE))
   }
@@ -1562,20 +1540,21 @@ package devicefarm {
       __obj.asInstanceOf[DeviceFilter]
     }
   }
-
-  object DeviceFilterAttributeEnum {
-    val ARN                   = "ARN"
-    val PLATFORM              = "PLATFORM"
-    val OS_VERSION            = "OS_VERSION"
-    val MODEL                 = "MODEL"
-    val AVAILABILITY          = "AVAILABILITY"
-    val FORM_FACTOR           = "FORM_FACTOR"
-    val MANUFACTURER          = "MANUFACTURER"
-    val REMOTE_ACCESS_ENABLED = "REMOTE_ACCESS_ENABLED"
-    val REMOTE_DEBUG_ENABLED  = "REMOTE_DEBUG_ENABLED"
-    val INSTANCE_ARN          = "INSTANCE_ARN"
-    val INSTANCE_LABELS       = "INSTANCE_LABELS"
-    val FLEET_TYPE            = "FLEET_TYPE"
+  @js.native
+  sealed trait DeviceFilterAttribute extends js.Any
+  object DeviceFilterAttribute extends js.Object {
+    val ARN                   = "ARN".asInstanceOf[DeviceFilterAttribute]
+    val PLATFORM              = "PLATFORM".asInstanceOf[DeviceFilterAttribute]
+    val OS_VERSION            = "OS_VERSION".asInstanceOf[DeviceFilterAttribute]
+    val MODEL                 = "MODEL".asInstanceOf[DeviceFilterAttribute]
+    val AVAILABILITY          = "AVAILABILITY".asInstanceOf[DeviceFilterAttribute]
+    val FORM_FACTOR           = "FORM_FACTOR".asInstanceOf[DeviceFilterAttribute]
+    val MANUFACTURER          = "MANUFACTURER".asInstanceOf[DeviceFilterAttribute]
+    val REMOTE_ACCESS_ENABLED = "REMOTE_ACCESS_ENABLED".asInstanceOf[DeviceFilterAttribute]
+    val REMOTE_DEBUG_ENABLED  = "REMOTE_DEBUG_ENABLED".asInstanceOf[DeviceFilterAttribute]
+    val INSTANCE_ARN          = "INSTANCE_ARN".asInstanceOf[DeviceFilterAttribute]
+    val INSTANCE_LABELS       = "INSTANCE_LABELS".asInstanceOf[DeviceFilterAttribute]
+    val FLEET_TYPE            = "FLEET_TYPE".asInstanceOf[DeviceFilterAttribute]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1594,10 +1573,11 @@ package devicefarm {
       )
     )
   }
-
-  object DeviceFormFactorEnum {
-    val PHONE  = "PHONE"
-    val TABLET = "TABLET"
+  @js.native
+  sealed trait DeviceFormFactor extends js.Any
+  object DeviceFormFactor extends js.Object {
+    val PHONE  = "PHONE".asInstanceOf[DeviceFormFactor]
+    val TABLET = "TABLET".asInstanceOf[DeviceFormFactor]
 
     val values = js.Object.freeze(js.Array(PHONE, TABLET))
   }
@@ -1660,10 +1640,11 @@ package devicefarm {
       __obj.asInstanceOf[DeviceMinutes]
     }
   }
-
-  object DevicePlatformEnum {
-    val ANDROID = "ANDROID"
-    val IOS     = "IOS"
+  @js.native
+  sealed trait DevicePlatform extends js.Any
+  object DevicePlatform extends js.Object {
+    val ANDROID = "ANDROID".asInstanceOf[DevicePlatform]
+    val IOS     = "IOS".asInstanceOf[DevicePlatform]
 
     val values = js.Object.freeze(js.Array(ANDROID, IOS))
   }
@@ -1726,10 +1707,11 @@ package devicefarm {
       __obj.asInstanceOf[DevicePoolCompatibilityResult]
     }
   }
-
-  object DevicePoolTypeEnum {
-    val CURATED = "CURATED"
-    val PRIVATE = "PRIVATE"
+  @js.native
+  sealed trait DevicePoolType extends js.Any
+  object DevicePoolType extends js.Object {
+    val CURATED = "CURATED".asInstanceOf[DevicePoolType]
+    val PRIVATE = "PRIVATE".asInstanceOf[DevicePoolType]
 
     val values = js.Object.freeze(js.Array(CURATED, PRIVATE))
   }
@@ -1813,36 +1795,39 @@ package devicefarm {
       __obj.asInstanceOf[ExecutionConfiguration]
     }
   }
-
-  object ExecutionResultEnum {
-    val PENDING = "PENDING"
-    val PASSED  = "PASSED"
-    val WARNED  = "WARNED"
-    val FAILED  = "FAILED"
-    val SKIPPED = "SKIPPED"
-    val ERRORED = "ERRORED"
-    val STOPPED = "STOPPED"
+  @js.native
+  sealed trait ExecutionResult extends js.Any
+  object ExecutionResult extends js.Object {
+    val PENDING = "PENDING".asInstanceOf[ExecutionResult]
+    val PASSED  = "PASSED".asInstanceOf[ExecutionResult]
+    val WARNED  = "WARNED".asInstanceOf[ExecutionResult]
+    val FAILED  = "FAILED".asInstanceOf[ExecutionResult]
+    val SKIPPED = "SKIPPED".asInstanceOf[ExecutionResult]
+    val ERRORED = "ERRORED".asInstanceOf[ExecutionResult]
+    val STOPPED = "STOPPED".asInstanceOf[ExecutionResult]
 
     val values = js.Object.freeze(js.Array(PENDING, PASSED, WARNED, FAILED, SKIPPED, ERRORED, STOPPED))
   }
-
-  object ExecutionResultCodeEnum {
-    val PARSING_FAILED            = "PARSING_FAILED"
-    val VPC_ENDPOINT_SETUP_FAILED = "VPC_ENDPOINT_SETUP_FAILED"
+  @js.native
+  sealed trait ExecutionResultCode extends js.Any
+  object ExecutionResultCode extends js.Object {
+    val PARSING_FAILED            = "PARSING_FAILED".asInstanceOf[ExecutionResultCode]
+    val VPC_ENDPOINT_SETUP_FAILED = "VPC_ENDPOINT_SETUP_FAILED".asInstanceOf[ExecutionResultCode]
 
     val values = js.Object.freeze(js.Array(PARSING_FAILED, VPC_ENDPOINT_SETUP_FAILED))
   }
-
-  object ExecutionStatusEnum {
-    val PENDING             = "PENDING"
-    val PENDING_CONCURRENCY = "PENDING_CONCURRENCY"
-    val PENDING_DEVICE      = "PENDING_DEVICE"
-    val PROCESSING          = "PROCESSING"
-    val SCHEDULING          = "SCHEDULING"
-    val PREPARING           = "PREPARING"
-    val RUNNING             = "RUNNING"
-    val COMPLETED           = "COMPLETED"
-    val STOPPING            = "STOPPING"
+  @js.native
+  sealed trait ExecutionStatus extends js.Any
+  object ExecutionStatus extends js.Object {
+    val PENDING             = "PENDING".asInstanceOf[ExecutionStatus]
+    val PENDING_CONCURRENCY = "PENDING_CONCURRENCY".asInstanceOf[ExecutionStatus]
+    val PENDING_DEVICE      = "PENDING_DEVICE".asInstanceOf[ExecutionStatus]
+    val PROCESSING          = "PROCESSING".asInstanceOf[ExecutionStatus]
+    val SCHEDULING          = "SCHEDULING".asInstanceOf[ExecutionStatus]
+    val PREPARING           = "PREPARING".asInstanceOf[ExecutionStatus]
+    val RUNNING             = "RUNNING".asInstanceOf[ExecutionStatus]
+    val COMPLETED           = "COMPLETED".asInstanceOf[ExecutionStatus]
+    val STOPPING            = "STOPPING".asInstanceOf[ExecutionStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2661,20 +2646,22 @@ package devicefarm {
       __obj.asInstanceOf[InstanceProfile]
     }
   }
-
-  object InstanceStatusEnum {
-    val IN_USE        = "IN_USE"
-    val PREPARING     = "PREPARING"
-    val AVAILABLE     = "AVAILABLE"
-    val NOT_AVAILABLE = "NOT_AVAILABLE"
+  @js.native
+  sealed trait InstanceStatus extends js.Any
+  object InstanceStatus extends js.Object {
+    val IN_USE        = "IN_USE".asInstanceOf[InstanceStatus]
+    val PREPARING     = "PREPARING".asInstanceOf[InstanceStatus]
+    val AVAILABLE     = "AVAILABLE".asInstanceOf[InstanceStatus]
+    val NOT_AVAILABLE = "NOT_AVAILABLE".asInstanceOf[InstanceStatus]
 
     val values = js.Object.freeze(js.Array(IN_USE, PREPARING, AVAILABLE, NOT_AVAILABLE))
   }
-
-  object InteractionModeEnum {
-    val INTERACTIVE = "INTERACTIVE"
-    val NO_VIDEO    = "NO_VIDEO"
-    val VIDEO_ONLY  = "VIDEO_ONLY"
+  @js.native
+  sealed trait InteractionMode extends js.Any
+  object InteractionMode extends js.Object {
+    val INTERACTIVE = "INTERACTIVE".asInstanceOf[InteractionMode]
+    val NO_VIDEO    = "NO_VIDEO".asInstanceOf[InteractionMode]
+    val VIDEO_ONLY  = "VIDEO_ONLY".asInstanceOf[InteractionMode]
 
     val values = js.Object.freeze(js.Array(INTERACTIVE, NO_VIDEO, VIDEO_ONLY))
   }
@@ -3891,10 +3878,11 @@ package devicefarm {
       __obj.asInstanceOf[NetworkProfile]
     }
   }
-
-  object NetworkProfileTypeEnum {
-    val CURATED = "CURATED"
-    val PRIVATE = "PRIVATE"
+  @js.native
+  sealed trait NetworkProfileType extends js.Any
+  object NetworkProfileType extends js.Object {
+    val CURATED = "CURATED".asInstanceOf[NetworkProfileType]
+    val PRIVATE = "PRIVATE".asInstanceOf[NetworkProfileType]
 
     val values = js.Object.freeze(js.Array(CURATED, PRIVATE))
   }
@@ -4010,17 +3998,19 @@ package devicefarm {
       __obj.asInstanceOf[OfferingTransaction]
     }
   }
-
-  object OfferingTransactionTypeEnum {
-    val PURCHASE = "PURCHASE"
-    val RENEW    = "RENEW"
-    val SYSTEM   = "SYSTEM"
+  @js.native
+  sealed trait OfferingTransactionType extends js.Any
+  object OfferingTransactionType extends js.Object {
+    val PURCHASE = "PURCHASE".asInstanceOf[OfferingTransactionType]
+    val RENEW    = "RENEW".asInstanceOf[OfferingTransactionType]
+    val SYSTEM   = "SYSTEM".asInstanceOf[OfferingTransactionType]
 
     val values = js.Object.freeze(js.Array(PURCHASE, RENEW, SYSTEM))
   }
-
-  object OfferingTypeEnum {
-    val RECURRING = "RECURRING"
+  @js.native
+  sealed trait OfferingType extends js.Any
+  object OfferingType extends js.Object {
+    val RECURRING = "RECURRING".asInstanceOf[OfferingType]
 
     val values = js.Object.freeze(js.Array(RECURRING))
   }
@@ -4205,9 +4195,10 @@ package devicefarm {
       __obj.asInstanceOf[RecurringCharge]
     }
   }
-
-  object RecurringChargeFrequencyEnum {
-    val MONTHLY = "MONTHLY"
+  @js.native
+  sealed trait RecurringChargeFrequency extends js.Any
+  object RecurringChargeFrequency extends js.Object {
+    val MONTHLY = "MONTHLY".asInstanceOf[RecurringChargeFrequency]
 
     val values = js.Object.freeze(js.Array(MONTHLY))
   }
@@ -4378,16 +4369,17 @@ package devicefarm {
       __obj.asInstanceOf[Rule]
     }
   }
-
-  object RuleOperatorEnum {
-    val EQUALS                 = "EQUALS"
-    val LESS_THAN              = "LESS_THAN"
-    val LESS_THAN_OR_EQUALS    = "LESS_THAN_OR_EQUALS"
-    val GREATER_THAN           = "GREATER_THAN"
-    val GREATER_THAN_OR_EQUALS = "GREATER_THAN_OR_EQUALS"
-    val IN                     = "IN"
-    val NOT_IN                 = "NOT_IN"
-    val CONTAINS               = "CONTAINS"
+  @js.native
+  sealed trait RuleOperator extends js.Any
+  object RuleOperator extends js.Object {
+    val EQUALS                 = "EQUALS".asInstanceOf[RuleOperator]
+    val LESS_THAN              = "LESS_THAN".asInstanceOf[RuleOperator]
+    val LESS_THAN_OR_EQUALS    = "LESS_THAN_OR_EQUALS".asInstanceOf[RuleOperator]
+    val GREATER_THAN           = "GREATER_THAN".asInstanceOf[RuleOperator]
+    val GREATER_THAN_OR_EQUALS = "GREATER_THAN_OR_EQUALS".asInstanceOf[RuleOperator]
+    val IN                     = "IN".asInstanceOf[RuleOperator]
+    val NOT_IN                 = "NOT_IN".asInstanceOf[RuleOperator]
+    val CONTAINS               = "CONTAINS".asInstanceOf[RuleOperator]
 
     val values = js.Object.freeze(
       js.Array(EQUALS, LESS_THAN, LESS_THAN_OR_EQUALS, GREATER_THAN, GREATER_THAN_OR_EQUALS, IN, NOT_IN, CONTAINS)
@@ -4527,25 +4519,26 @@ package devicefarm {
       __obj.asInstanceOf[Sample]
     }
   }
-
-  object SampleTypeEnum {
-    val CPU                 = "CPU"
-    val MEMORY              = "MEMORY"
-    val THREADS             = "THREADS"
-    val RX_RATE             = "RX_RATE"
-    val TX_RATE             = "TX_RATE"
-    val RX                  = "RX"
-    val TX                  = "TX"
-    val NATIVE_FRAMES       = "NATIVE_FRAMES"
-    val NATIVE_FPS          = "NATIVE_FPS"
-    val NATIVE_MIN_DRAWTIME = "NATIVE_MIN_DRAWTIME"
-    val NATIVE_AVG_DRAWTIME = "NATIVE_AVG_DRAWTIME"
-    val NATIVE_MAX_DRAWTIME = "NATIVE_MAX_DRAWTIME"
-    val OPENGL_FRAMES       = "OPENGL_FRAMES"
-    val OPENGL_FPS          = "OPENGL_FPS"
-    val OPENGL_MIN_DRAWTIME = "OPENGL_MIN_DRAWTIME"
-    val OPENGL_AVG_DRAWTIME = "OPENGL_AVG_DRAWTIME"
-    val OPENGL_MAX_DRAWTIME = "OPENGL_MAX_DRAWTIME"
+  @js.native
+  sealed trait SampleType extends js.Any
+  object SampleType extends js.Object {
+    val CPU                 = "CPU".asInstanceOf[SampleType]
+    val MEMORY              = "MEMORY".asInstanceOf[SampleType]
+    val THREADS             = "THREADS".asInstanceOf[SampleType]
+    val RX_RATE             = "RX_RATE".asInstanceOf[SampleType]
+    val TX_RATE             = "TX_RATE".asInstanceOf[SampleType]
+    val RX                  = "RX".asInstanceOf[SampleType]
+    val TX                  = "TX".asInstanceOf[SampleType]
+    val NATIVE_FRAMES       = "NATIVE_FRAMES".asInstanceOf[SampleType]
+    val NATIVE_FPS          = "NATIVE_FPS".asInstanceOf[SampleType]
+    val NATIVE_MIN_DRAWTIME = "NATIVE_MIN_DRAWTIME".asInstanceOf[SampleType]
+    val NATIVE_AVG_DRAWTIME = "NATIVE_AVG_DRAWTIME".asInstanceOf[SampleType]
+    val NATIVE_MAX_DRAWTIME = "NATIVE_MAX_DRAWTIME".asInstanceOf[SampleType]
+    val OPENGL_FRAMES       = "OPENGL_FRAMES".asInstanceOf[SampleType]
+    val OPENGL_FPS          = "OPENGL_FPS".asInstanceOf[SampleType]
+    val OPENGL_MIN_DRAWTIME = "OPENGL_MIN_DRAWTIME".asInstanceOf[SampleType]
+    val OPENGL_AVG_DRAWTIME = "OPENGL_AVG_DRAWTIME".asInstanceOf[SampleType]
+    val OPENGL_MAX_DRAWTIME = "OPENGL_MAX_DRAWTIME".asInstanceOf[SampleType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5098,52 +5091,56 @@ package devicefarm {
       __obj.asInstanceOf[TestGridSessionArtifact]
     }
   }
-
-  object TestGridSessionArtifactCategoryEnum {
-    val VIDEO = "VIDEO"
-    val LOG   = "LOG"
+  @js.native
+  sealed trait TestGridSessionArtifactCategory extends js.Any
+  object TestGridSessionArtifactCategory extends js.Object {
+    val VIDEO = "VIDEO".asInstanceOf[TestGridSessionArtifactCategory]
+    val LOG   = "LOG".asInstanceOf[TestGridSessionArtifactCategory]
 
     val values = js.Object.freeze(js.Array(VIDEO, LOG))
   }
-
-  object TestGridSessionArtifactTypeEnum {
-    val UNKNOWN      = "UNKNOWN"
-    val VIDEO        = "VIDEO"
-    val SELENIUM_LOG = "SELENIUM_LOG"
+  @js.native
+  sealed trait TestGridSessionArtifactType extends js.Any
+  object TestGridSessionArtifactType extends js.Object {
+    val UNKNOWN      = "UNKNOWN".asInstanceOf[TestGridSessionArtifactType]
+    val VIDEO        = "VIDEO".asInstanceOf[TestGridSessionArtifactType]
+    val SELENIUM_LOG = "SELENIUM_LOG".asInstanceOf[TestGridSessionArtifactType]
 
     val values = js.Object.freeze(js.Array(UNKNOWN, VIDEO, SELENIUM_LOG))
   }
-
-  object TestGridSessionStatusEnum {
-    val ACTIVE  = "ACTIVE"
-    val CLOSED  = "CLOSED"
-    val ERRORED = "ERRORED"
+  @js.native
+  sealed trait TestGridSessionStatus extends js.Any
+  object TestGridSessionStatus extends js.Object {
+    val ACTIVE  = "ACTIVE".asInstanceOf[TestGridSessionStatus]
+    val CLOSED  = "CLOSED".asInstanceOf[TestGridSessionStatus]
+    val ERRORED = "ERRORED".asInstanceOf[TestGridSessionStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, CLOSED, ERRORED))
   }
-
-  object TestTypeEnum {
-    val BUILTIN_FUZZ            = "BUILTIN_FUZZ"
-    val BUILTIN_EXPLORER        = "BUILTIN_EXPLORER"
-    val WEB_PERFORMANCE_PROFILE = "WEB_PERFORMANCE_PROFILE"
-    val APPIUM_JAVA_JUNIT       = "APPIUM_JAVA_JUNIT"
-    val APPIUM_JAVA_TESTNG      = "APPIUM_JAVA_TESTNG"
-    val APPIUM_PYTHON           = "APPIUM_PYTHON"
-    val APPIUM_NODE             = "APPIUM_NODE"
-    val APPIUM_RUBY             = "APPIUM_RUBY"
-    val APPIUM_WEB_JAVA_JUNIT   = "APPIUM_WEB_JAVA_JUNIT"
-    val APPIUM_WEB_JAVA_TESTNG  = "APPIUM_WEB_JAVA_TESTNG"
-    val APPIUM_WEB_PYTHON       = "APPIUM_WEB_PYTHON"
-    val APPIUM_WEB_NODE         = "APPIUM_WEB_NODE"
-    val APPIUM_WEB_RUBY         = "APPIUM_WEB_RUBY"
-    val CALABASH                = "CALABASH"
-    val INSTRUMENTATION         = "INSTRUMENTATION"
-    val UIAUTOMATION            = "UIAUTOMATION"
-    val UIAUTOMATOR             = "UIAUTOMATOR"
-    val XCTEST                  = "XCTEST"
-    val XCTEST_UI               = "XCTEST_UI"
-    val REMOTE_ACCESS_RECORD    = "REMOTE_ACCESS_RECORD"
-    val REMOTE_ACCESS_REPLAY    = "REMOTE_ACCESS_REPLAY"
+  @js.native
+  sealed trait TestType extends js.Any
+  object TestType extends js.Object {
+    val BUILTIN_FUZZ            = "BUILTIN_FUZZ".asInstanceOf[TestType]
+    val BUILTIN_EXPLORER        = "BUILTIN_EXPLORER".asInstanceOf[TestType]
+    val WEB_PERFORMANCE_PROFILE = "WEB_PERFORMANCE_PROFILE".asInstanceOf[TestType]
+    val APPIUM_JAVA_JUNIT       = "APPIUM_JAVA_JUNIT".asInstanceOf[TestType]
+    val APPIUM_JAVA_TESTNG      = "APPIUM_JAVA_TESTNG".asInstanceOf[TestType]
+    val APPIUM_PYTHON           = "APPIUM_PYTHON".asInstanceOf[TestType]
+    val APPIUM_NODE             = "APPIUM_NODE".asInstanceOf[TestType]
+    val APPIUM_RUBY             = "APPIUM_RUBY".asInstanceOf[TestType]
+    val APPIUM_WEB_JAVA_JUNIT   = "APPIUM_WEB_JAVA_JUNIT".asInstanceOf[TestType]
+    val APPIUM_WEB_JAVA_TESTNG  = "APPIUM_WEB_JAVA_TESTNG".asInstanceOf[TestType]
+    val APPIUM_WEB_PYTHON       = "APPIUM_WEB_PYTHON".asInstanceOf[TestType]
+    val APPIUM_WEB_NODE         = "APPIUM_WEB_NODE".asInstanceOf[TestType]
+    val APPIUM_WEB_RUBY         = "APPIUM_WEB_RUBY".asInstanceOf[TestType]
+    val CALABASH                = "CALABASH".asInstanceOf[TestType]
+    val INSTRUMENTATION         = "INSTRUMENTATION".asInstanceOf[TestType]
+    val UIAUTOMATION            = "UIAUTOMATION".asInstanceOf[TestType]
+    val UIAUTOMATOR             = "UIAUTOMATOR".asInstanceOf[TestType]
+    val XCTEST                  = "XCTEST".asInstanceOf[TestType]
+    val XCTEST_UI               = "XCTEST_UI".asInstanceOf[TestType]
+    val REMOTE_ACCESS_RECORD    = "REMOTE_ACCESS_RECORD".asInstanceOf[TestType]
+    val REMOTE_ACCESS_REPLAY    = "REMOTE_ACCESS_REPLAY".asInstanceOf[TestType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5685,56 +5682,59 @@ package devicefarm {
       __obj.asInstanceOf[Upload]
     }
   }
-
-  object UploadCategoryEnum {
-    val CURATED = "CURATED"
-    val PRIVATE = "PRIVATE"
+  @js.native
+  sealed trait UploadCategory extends js.Any
+  object UploadCategory extends js.Object {
+    val CURATED = "CURATED".asInstanceOf[UploadCategory]
+    val PRIVATE = "PRIVATE".asInstanceOf[UploadCategory]
 
     val values = js.Object.freeze(js.Array(CURATED, PRIVATE))
   }
-
-  object UploadStatusEnum {
-    val INITIALIZED = "INITIALIZED"
-    val PROCESSING  = "PROCESSING"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait UploadStatus extends js.Any
+  object UploadStatus extends js.Object {
+    val INITIALIZED = "INITIALIZED".asInstanceOf[UploadStatus]
+    val PROCESSING  = "PROCESSING".asInstanceOf[UploadStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[UploadStatus]
+    val FAILED      = "FAILED".asInstanceOf[UploadStatus]
 
     val values = js.Object.freeze(js.Array(INITIALIZED, PROCESSING, SUCCEEDED, FAILED))
   }
-
-  object UploadTypeEnum {
-    val ANDROID_APP                         = "ANDROID_APP"
-    val IOS_APP                             = "IOS_APP"
-    val WEB_APP                             = "WEB_APP"
-    val EXTERNAL_DATA                       = "EXTERNAL_DATA"
-    val APPIUM_JAVA_JUNIT_TEST_PACKAGE      = "APPIUM_JAVA_JUNIT_TEST_PACKAGE"
-    val APPIUM_JAVA_TESTNG_TEST_PACKAGE     = "APPIUM_JAVA_TESTNG_TEST_PACKAGE"
-    val APPIUM_PYTHON_TEST_PACKAGE          = "APPIUM_PYTHON_TEST_PACKAGE"
-    val APPIUM_NODE_TEST_PACKAGE            = "APPIUM_NODE_TEST_PACKAGE"
-    val APPIUM_RUBY_TEST_PACKAGE            = "APPIUM_RUBY_TEST_PACKAGE"
-    val APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE  = "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE"
-    val APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE = "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE"
-    val APPIUM_WEB_PYTHON_TEST_PACKAGE      = "APPIUM_WEB_PYTHON_TEST_PACKAGE"
-    val APPIUM_WEB_NODE_TEST_PACKAGE        = "APPIUM_WEB_NODE_TEST_PACKAGE"
-    val APPIUM_WEB_RUBY_TEST_PACKAGE        = "APPIUM_WEB_RUBY_TEST_PACKAGE"
-    val CALABASH_TEST_PACKAGE               = "CALABASH_TEST_PACKAGE"
-    val INSTRUMENTATION_TEST_PACKAGE        = "INSTRUMENTATION_TEST_PACKAGE"
-    val UIAUTOMATION_TEST_PACKAGE           = "UIAUTOMATION_TEST_PACKAGE"
-    val UIAUTOMATOR_TEST_PACKAGE            = "UIAUTOMATOR_TEST_PACKAGE"
-    val XCTEST_TEST_PACKAGE                 = "XCTEST_TEST_PACKAGE"
-    val XCTEST_UI_TEST_PACKAGE              = "XCTEST_UI_TEST_PACKAGE"
-    val APPIUM_JAVA_JUNIT_TEST_SPEC         = "APPIUM_JAVA_JUNIT_TEST_SPEC"
-    val APPIUM_JAVA_TESTNG_TEST_SPEC        = "APPIUM_JAVA_TESTNG_TEST_SPEC"
-    val APPIUM_PYTHON_TEST_SPEC             = "APPIUM_PYTHON_TEST_SPEC"
-    val APPIUM_NODE_TEST_SPEC               = "APPIUM_NODE_TEST_SPEC"
-    val APPIUM_RUBY_TEST_SPEC               = "APPIUM_RUBY_TEST_SPEC"
-    val APPIUM_WEB_JAVA_JUNIT_TEST_SPEC     = "APPIUM_WEB_JAVA_JUNIT_TEST_SPEC"
-    val APPIUM_WEB_JAVA_TESTNG_TEST_SPEC    = "APPIUM_WEB_JAVA_TESTNG_TEST_SPEC"
-    val APPIUM_WEB_PYTHON_TEST_SPEC         = "APPIUM_WEB_PYTHON_TEST_SPEC"
-    val APPIUM_WEB_NODE_TEST_SPEC           = "APPIUM_WEB_NODE_TEST_SPEC"
-    val APPIUM_WEB_RUBY_TEST_SPEC           = "APPIUM_WEB_RUBY_TEST_SPEC"
-    val INSTRUMENTATION_TEST_SPEC           = "INSTRUMENTATION_TEST_SPEC"
-    val XCTEST_UI_TEST_SPEC                 = "XCTEST_UI_TEST_SPEC"
+  @js.native
+  sealed trait UploadType extends js.Any
+  object UploadType extends js.Object {
+    val ANDROID_APP                         = "ANDROID_APP".asInstanceOf[UploadType]
+    val IOS_APP                             = "IOS_APP".asInstanceOf[UploadType]
+    val WEB_APP                             = "WEB_APP".asInstanceOf[UploadType]
+    val EXTERNAL_DATA                       = "EXTERNAL_DATA".asInstanceOf[UploadType]
+    val APPIUM_JAVA_JUNIT_TEST_PACKAGE      = "APPIUM_JAVA_JUNIT_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_JAVA_TESTNG_TEST_PACKAGE     = "APPIUM_JAVA_TESTNG_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_PYTHON_TEST_PACKAGE          = "APPIUM_PYTHON_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_NODE_TEST_PACKAGE            = "APPIUM_NODE_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_RUBY_TEST_PACKAGE            = "APPIUM_RUBY_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE  = "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE = "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_WEB_PYTHON_TEST_PACKAGE      = "APPIUM_WEB_PYTHON_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_WEB_NODE_TEST_PACKAGE        = "APPIUM_WEB_NODE_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_WEB_RUBY_TEST_PACKAGE        = "APPIUM_WEB_RUBY_TEST_PACKAGE".asInstanceOf[UploadType]
+    val CALABASH_TEST_PACKAGE               = "CALABASH_TEST_PACKAGE".asInstanceOf[UploadType]
+    val INSTRUMENTATION_TEST_PACKAGE        = "INSTRUMENTATION_TEST_PACKAGE".asInstanceOf[UploadType]
+    val UIAUTOMATION_TEST_PACKAGE           = "UIAUTOMATION_TEST_PACKAGE".asInstanceOf[UploadType]
+    val UIAUTOMATOR_TEST_PACKAGE            = "UIAUTOMATOR_TEST_PACKAGE".asInstanceOf[UploadType]
+    val XCTEST_TEST_PACKAGE                 = "XCTEST_TEST_PACKAGE".asInstanceOf[UploadType]
+    val XCTEST_UI_TEST_PACKAGE              = "XCTEST_UI_TEST_PACKAGE".asInstanceOf[UploadType]
+    val APPIUM_JAVA_JUNIT_TEST_SPEC         = "APPIUM_JAVA_JUNIT_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_JAVA_TESTNG_TEST_SPEC        = "APPIUM_JAVA_TESTNG_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_PYTHON_TEST_SPEC             = "APPIUM_PYTHON_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_NODE_TEST_SPEC               = "APPIUM_NODE_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_RUBY_TEST_SPEC               = "APPIUM_RUBY_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_WEB_JAVA_JUNIT_TEST_SPEC     = "APPIUM_WEB_JAVA_JUNIT_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_WEB_JAVA_TESTNG_TEST_SPEC    = "APPIUM_WEB_JAVA_TESTNG_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_WEB_PYTHON_TEST_SPEC         = "APPIUM_WEB_PYTHON_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_WEB_NODE_TEST_SPEC           = "APPIUM_WEB_NODE_TEST_SPEC".asInstanceOf[UploadType]
+    val APPIUM_WEB_RUBY_TEST_SPEC           = "APPIUM_WEB_RUBY_TEST_SPEC".asInstanceOf[UploadType]
+    val INSTRUMENTATION_TEST_SPEC           = "INSTRUMENTATION_TEST_SPEC".asInstanceOf[UploadType]
+    val XCTEST_UI_TEST_SPEC                 = "XCTEST_UI_TEST_SPEC".asInstanceOf[UploadType]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/directconnect/src/main/scala/facade/amazonaws/services/DirectConnect.scala
+++ b/services/directconnect/src/main/scala/facade/amazonaws/services/DirectConnect.scala
@@ -8,82 +8,68 @@ import facade.amazonaws._
 
 package object directconnect {
   type ASN                 = Int
-  type AddressFamily       = String
   type AmazonAddress       = String
   type AssociatedGatewayId = String
   type AvailablePortSpeeds = js.Array[PortSpeed]
   @deprecated("Deprecated in AWS SDK", "forever")
-  type AwsDevice                                    = String
-  type AwsDeviceV2                                  = String
-  type BGPAuthKey                                   = String
-  type BGPPeerId                                    = String
-  type BGPPeerList                                  = js.Array[BGPPeer]
-  type BGPPeerState                                 = String
-  type BGPStatus                                    = String
-  type Bandwidth                                    = String
-  type BooleanFlag                                  = Boolean
-  type CIDR                                         = String
-  type ConnectionId                                 = String
-  type ConnectionList                               = js.Array[Connection]
-  type ConnectionName                               = String
-  type ConnectionState                              = String
-  type Count                                        = Int
-  type CustomerAddress                              = String
-  type DirectConnectGatewayAssociationId            = String
-  type DirectConnectGatewayAssociationList          = js.Array[DirectConnectGatewayAssociation]
-  type DirectConnectGatewayAssociationProposalId    = String
-  type DirectConnectGatewayAssociationProposalList  = js.Array[DirectConnectGatewayAssociationProposal]
-  type DirectConnectGatewayAssociationProposalState = String
-  type DirectConnectGatewayAssociationState         = String
-  type DirectConnectGatewayAttachmentList           = js.Array[DirectConnectGatewayAttachment]
-  type DirectConnectGatewayAttachmentState          = String
-  type DirectConnectGatewayAttachmentType           = String
-  type DirectConnectGatewayId                       = String
-  type DirectConnectGatewayList                     = js.Array[DirectConnectGateway]
-  type DirectConnectGatewayName                     = String
-  type DirectConnectGatewayState                    = String
-  type GatewayIdToAssociate                         = String
-  type GatewayIdentifier                            = String
-  type GatewayType                                  = String
-  type HasLogicalRedundancy                         = String
-  type InterconnectId                               = String
-  type InterconnectList                             = js.Array[Interconnect]
-  type InterconnectName                             = String
-  type InterconnectState                            = String
-  type JumboFrameCapable                            = Boolean
-  type LagId                                        = String
-  type LagList                                      = js.Array[Lag]
-  type LagName                                      = String
-  type LagState                                     = String
-  type LoaContent                                   = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type LoaContentType                               = String
-  type LoaIssueTime                                 = js.Date
-  type LocationCode                                 = String
-  type LocationList                                 = js.Array[Location]
-  type LocationName                                 = String
-  type LongAsn                                      = Double
-  type MTU                                          = Int
-  type MaxResultSetSize                             = Int
-  type OwnerAccount                                 = String
-  type PaginationToken                              = String
-  type PartnerName                                  = String
-  type PortSpeed                                    = String
-  type ProviderList                                 = js.Array[ProviderName]
-  type ProviderName                                 = String
-  type Region                                       = String
-  type ResourceArn                                  = String
-  type ResourceArnList                              = js.Array[ResourceArn]
-  type ResourceTagList                              = js.Array[ResourceTag]
-  type RouteFilterPrefixList                        = js.Array[RouteFilterPrefix]
-  type RouterConfig                                 = String
-  type StateChangeError                             = String
-  type TagKey                                       = String
-  type TagKeyList                                   = js.Array[TagKey]
-  type TagList                                      = js.Array[Tag]
-  type TagValue                                     = String
-  type VLAN                                         = Int
-  type VirtualGatewayId                             = String
-  type VirtualGatewayList                           = js.Array[VirtualGateway]
+  type AwsDevice                                   = String
+  type AwsDeviceV2                                 = String
+  type BGPAuthKey                                  = String
+  type BGPPeerId                                   = String
+  type BGPPeerList                                 = js.Array[BGPPeer]
+  type Bandwidth                                   = String
+  type BooleanFlag                                 = Boolean
+  type CIDR                                        = String
+  type ConnectionId                                = String
+  type ConnectionList                              = js.Array[Connection]
+  type ConnectionName                              = String
+  type Count                                       = Int
+  type CustomerAddress                             = String
+  type DirectConnectGatewayAssociationId           = String
+  type DirectConnectGatewayAssociationList         = js.Array[DirectConnectGatewayAssociation]
+  type DirectConnectGatewayAssociationProposalId   = String
+  type DirectConnectGatewayAssociationProposalList = js.Array[DirectConnectGatewayAssociationProposal]
+  type DirectConnectGatewayAttachmentList          = js.Array[DirectConnectGatewayAttachment]
+  type DirectConnectGatewayId                      = String
+  type DirectConnectGatewayList                    = js.Array[DirectConnectGateway]
+  type DirectConnectGatewayName                    = String
+  type GatewayIdToAssociate                        = String
+  type GatewayIdentifier                           = String
+  type InterconnectId                              = String
+  type InterconnectList                            = js.Array[Interconnect]
+  type InterconnectName                            = String
+  type JumboFrameCapable                           = Boolean
+  type LagId                                       = String
+  type LagList                                     = js.Array[Lag]
+  type LagName                                     = String
+  type LoaContent                                  = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type LoaIssueTime                                = js.Date
+  type LocationCode                                = String
+  type LocationList                                = js.Array[Location]
+  type LocationName                                = String
+  type LongAsn                                     = Double
+  type MTU                                         = Int
+  type MaxResultSetSize                            = Int
+  type OwnerAccount                                = String
+  type PaginationToken                             = String
+  type PartnerName                                 = String
+  type PortSpeed                                   = String
+  type ProviderList                                = js.Array[ProviderName]
+  type ProviderName                                = String
+  type Region                                      = String
+  type ResourceArn                                 = String
+  type ResourceArnList                             = js.Array[ResourceArn]
+  type ResourceTagList                             = js.Array[ResourceTag]
+  type RouteFilterPrefixList                       = js.Array[RouteFilterPrefix]
+  type RouterConfig                                = String
+  type StateChangeError                            = String
+  type TagKey                                      = String
+  type TagKeyList                                  = js.Array[TagKey]
+  type TagList                                     = js.Array[Tag]
+  type TagValue                                    = String
+  type VLAN                                        = Int
+  type VirtualGatewayId                            = String
+  type VirtualGatewayList                          = js.Array[VirtualGateway]
   @deprecated("Deprecated in AWS SDK", "forever")
   type VirtualGatewayRegion   = String
   type VirtualGatewayState    = String
@@ -91,7 +77,6 @@ package object directconnect {
   type VirtualInterfaceList   = js.Array[VirtualInterface]
   type VirtualInterfaceName   = String
   type VirtualInterfaceRegion = String
-  type VirtualInterfaceState  = String
   type VirtualInterfaceType   = String
 
   implicit final class DirectConnectOps(private val service: DirectConnect) extends AnyVal {
@@ -379,10 +364,11 @@ package directconnect {
       __obj.asInstanceOf[AcceptDirectConnectGatewayAssociationProposalResult]
     }
   }
-
-  object AddressFamilyEnum {
-    val ipv4 = "ipv4"
-    val ipv6 = "ipv6"
+  @js.native
+  sealed trait AddressFamily extends js.Any
+  object AddressFamily extends js.Object {
+    val ipv4 = "ipv4".asInstanceOf[AddressFamily]
+    val ipv6 = "ipv6".asInstanceOf[AddressFamily]
 
     val values = js.Object.freeze(js.Array(ipv4, ipv6))
   }
@@ -671,21 +657,23 @@ package directconnect {
       __obj.asInstanceOf[BGPPeer]
     }
   }
-
-  object BGPPeerStateEnum {
-    val verifying = "verifying"
-    val pending   = "pending"
-    val available = "available"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait BGPPeerState extends js.Any
+  object BGPPeerState extends js.Object {
+    val verifying = "verifying".asInstanceOf[BGPPeerState]
+    val pending   = "pending".asInstanceOf[BGPPeerState]
+    val available = "available".asInstanceOf[BGPPeerState]
+    val deleting  = "deleting".asInstanceOf[BGPPeerState]
+    val deleted   = "deleted".asInstanceOf[BGPPeerState]
 
     val values = js.Object.freeze(js.Array(verifying, pending, available, deleting, deleted))
   }
-
-  object BGPStatusEnum {
-    val up      = "up"
-    val down    = "down"
-    val unknown = "unknown"
+  @js.native
+  sealed trait BGPStatus extends js.Any
+  object BGPStatus extends js.Object {
+    val up      = "up".asInstanceOf[BGPStatus]
+    val down    = "down".asInstanceOf[BGPStatus]
+    val unknown = "unknown".asInstanceOf[BGPStatus]
 
     val values = js.Object.freeze(js.Array(up, down, unknown))
   }
@@ -901,17 +889,18 @@ package directconnect {
       __obj.asInstanceOf[Connection]
     }
   }
-
-  object ConnectionStateEnum {
-    val ordering  = "ordering"
-    val requested = "requested"
-    val pending   = "pending"
-    val available = "available"
-    val down      = "down"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
-    val rejected  = "rejected"
-    val unknown   = "unknown"
+  @js.native
+  sealed trait ConnectionState extends js.Any
+  object ConnectionState extends js.Object {
+    val ordering  = "ordering".asInstanceOf[ConnectionState]
+    val requested = "requested".asInstanceOf[ConnectionState]
+    val pending   = "pending".asInstanceOf[ConnectionState]
+    val available = "available".asInstanceOf[ConnectionState]
+    val down      = "down".asInstanceOf[ConnectionState]
+    val deleting  = "deleting".asInstanceOf[ConnectionState]
+    val deleted   = "deleted".asInstanceOf[ConnectionState]
+    val rejected  = "rejected".asInstanceOf[ConnectionState]
+    val unknown   = "unknown".asInstanceOf[ConnectionState]
 
     val values =
       js.Object.freeze(js.Array(ordering, requested, pending, available, down, deleting, deleted, rejected, unknown))
@@ -2103,21 +2092,23 @@ package directconnect {
       __obj.asInstanceOf[DirectConnectGatewayAssociationProposal]
     }
   }
-
-  object DirectConnectGatewayAssociationProposalStateEnum {
-    val requested = "requested"
-    val accepted  = "accepted"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait DirectConnectGatewayAssociationProposalState extends js.Any
+  object DirectConnectGatewayAssociationProposalState extends js.Object {
+    val requested = "requested".asInstanceOf[DirectConnectGatewayAssociationProposalState]
+    val accepted  = "accepted".asInstanceOf[DirectConnectGatewayAssociationProposalState]
+    val deleted   = "deleted".asInstanceOf[DirectConnectGatewayAssociationProposalState]
 
     val values = js.Object.freeze(js.Array(requested, accepted, deleted))
   }
-
-  object DirectConnectGatewayAssociationStateEnum {
-    val associating    = "associating"
-    val associated     = "associated"
-    val disassociating = "disassociating"
-    val disassociated  = "disassociated"
-    val updating       = "updating"
+  @js.native
+  sealed trait DirectConnectGatewayAssociationState extends js.Any
+  object DirectConnectGatewayAssociationState extends js.Object {
+    val associating    = "associating".asInstanceOf[DirectConnectGatewayAssociationState]
+    val associated     = "associated".asInstanceOf[DirectConnectGatewayAssociationState]
+    val disassociating = "disassociating".asInstanceOf[DirectConnectGatewayAssociationState]
+    val disassociated  = "disassociated".asInstanceOf[DirectConnectGatewayAssociationState]
+    val updating       = "updating".asInstanceOf[DirectConnectGatewayAssociationState]
 
     val values = js.Object.freeze(js.Array(associating, associated, disassociating, disassociated, updating))
   }
@@ -2160,28 +2151,31 @@ package directconnect {
       __obj.asInstanceOf[DirectConnectGatewayAttachment]
     }
   }
-
-  object DirectConnectGatewayAttachmentStateEnum {
-    val attaching = "attaching"
-    val attached  = "attached"
-    val detaching = "detaching"
-    val detached  = "detached"
+  @js.native
+  sealed trait DirectConnectGatewayAttachmentState extends js.Any
+  object DirectConnectGatewayAttachmentState extends js.Object {
+    val attaching = "attaching".asInstanceOf[DirectConnectGatewayAttachmentState]
+    val attached  = "attached".asInstanceOf[DirectConnectGatewayAttachmentState]
+    val detaching = "detaching".asInstanceOf[DirectConnectGatewayAttachmentState]
+    val detached  = "detached".asInstanceOf[DirectConnectGatewayAttachmentState]
 
     val values = js.Object.freeze(js.Array(attaching, attached, detaching, detached))
   }
-
-  object DirectConnectGatewayAttachmentTypeEnum {
-    val TransitVirtualInterface = "TransitVirtualInterface"
-    val PrivateVirtualInterface = "PrivateVirtualInterface"
+  @js.native
+  sealed trait DirectConnectGatewayAttachmentType extends js.Any
+  object DirectConnectGatewayAttachmentType extends js.Object {
+    val TransitVirtualInterface = "TransitVirtualInterface".asInstanceOf[DirectConnectGatewayAttachmentType]
+    val PrivateVirtualInterface = "PrivateVirtualInterface".asInstanceOf[DirectConnectGatewayAttachmentType]
 
     val values = js.Object.freeze(js.Array(TransitVirtualInterface, PrivateVirtualInterface))
   }
-
-  object DirectConnectGatewayStateEnum {
-    val pending   = "pending"
-    val available = "available"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait DirectConnectGatewayState extends js.Any
+  object DirectConnectGatewayState extends js.Object {
+    val pending   = "pending".asInstanceOf[DirectConnectGatewayState]
+    val available = "available".asInstanceOf[DirectConnectGatewayState]
+    val deleting  = "deleting".asInstanceOf[DirectConnectGatewayState]
+    val deleted   = "deleted".asInstanceOf[DirectConnectGatewayState]
 
     val values = js.Object.freeze(js.Array(pending, available, deleting, deleted))
   }
@@ -2206,18 +2200,20 @@ package directconnect {
       __obj.asInstanceOf[DisassociateConnectionFromLagRequest]
     }
   }
-
-  object GatewayTypeEnum {
-    val virtualPrivateGateway = "virtualPrivateGateway"
-    val transitGateway        = "transitGateway"
+  @js.native
+  sealed trait GatewayType extends js.Any
+  object GatewayType extends js.Object {
+    val virtualPrivateGateway = "virtualPrivateGateway".asInstanceOf[GatewayType]
+    val transitGateway        = "transitGateway".asInstanceOf[GatewayType]
 
     val values = js.Object.freeze(js.Array(virtualPrivateGateway, transitGateway))
   }
-
-  object HasLogicalRedundancyEnum {
-    val unknown = "unknown"
-    val yes     = "yes"
-    val no      = "no"
+  @js.native
+  sealed trait HasLogicalRedundancy extends js.Any
+  object HasLogicalRedundancy extends js.Object {
+    val unknown = "unknown".asInstanceOf[HasLogicalRedundancy]
+    val yes     = "yes".asInstanceOf[HasLogicalRedundancy]
+    val no      = "no".asInstanceOf[HasLogicalRedundancy]
 
     val values = js.Object.freeze(js.Array(unknown, yes, no))
   }
@@ -2279,15 +2275,16 @@ package directconnect {
       __obj.asInstanceOf[Interconnect]
     }
   }
-
-  object InterconnectStateEnum {
-    val requested = "requested"
-    val pending   = "pending"
-    val available = "available"
-    val down      = "down"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
-    val unknown   = "unknown"
+  @js.native
+  sealed trait InterconnectState extends js.Any
+  object InterconnectState extends js.Object {
+    val requested = "requested".asInstanceOf[InterconnectState]
+    val pending   = "pending".asInstanceOf[InterconnectState]
+    val available = "available".asInstanceOf[InterconnectState]
+    val down      = "down".asInstanceOf[InterconnectState]
+    val deleting  = "deleting".asInstanceOf[InterconnectState]
+    val deleted   = "deleted".asInstanceOf[InterconnectState]
+    val unknown   = "unknown".asInstanceOf[InterconnectState]
 
     val values = js.Object.freeze(js.Array(requested, pending, available, down, deleting, deleted, unknown))
   }
@@ -2374,15 +2371,16 @@ package directconnect {
       __obj.asInstanceOf[Lag]
     }
   }
-
-  object LagStateEnum {
-    val requested = "requested"
-    val pending   = "pending"
-    val available = "available"
-    val down      = "down"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
-    val unknown   = "unknown"
+  @js.native
+  sealed trait LagState extends js.Any
+  object LagState extends js.Object {
+    val requested = "requested".asInstanceOf[LagState]
+    val pending   = "pending".asInstanceOf[LagState]
+    val available = "available".asInstanceOf[LagState]
+    val down      = "down".asInstanceOf[LagState]
+    val deleting  = "deleting".asInstanceOf[LagState]
+    val deleted   = "deleted".asInstanceOf[LagState]
+    val unknown   = "unknown".asInstanceOf[LagState]
 
     val values = js.Object.freeze(js.Array(requested, pending, available, down, deleting, deleted, unknown))
   }
@@ -2424,9 +2422,10 @@ package directconnect {
       __obj.asInstanceOf[Loa]
     }
   }
-
-  object LoaContentTypeEnum {
-    val `application/pdf` = "application/pdf"
+  @js.native
+  sealed trait LoaContentType extends js.Any
+  object LoaContentType extends js.Object {
+    val `application/pdf` = "application/pdf".asInstanceOf[LoaContentType]
 
     val values = js.Object.freeze(js.Array(`application/pdf`))
   }
@@ -3131,17 +3130,18 @@ package directconnect {
       __obj.asInstanceOf[VirtualInterface]
     }
   }
-
-  object VirtualInterfaceStateEnum {
-    val confirming = "confirming"
-    val verifying  = "verifying"
-    val pending    = "pending"
-    val available  = "available"
-    val down       = "down"
-    val deleting   = "deleting"
-    val deleted    = "deleted"
-    val rejected   = "rejected"
-    val unknown    = "unknown"
+  @js.native
+  sealed trait VirtualInterfaceState extends js.Any
+  object VirtualInterfaceState extends js.Object {
+    val confirming = "confirming".asInstanceOf[VirtualInterfaceState]
+    val verifying  = "verifying".asInstanceOf[VirtualInterfaceState]
+    val pending    = "pending".asInstanceOf[VirtualInterfaceState]
+    val available  = "available".asInstanceOf[VirtualInterfaceState]
+    val down       = "down".asInstanceOf[VirtualInterfaceState]
+    val deleting   = "deleting".asInstanceOf[VirtualInterfaceState]
+    val deleted    = "deleted".asInstanceOf[VirtualInterfaceState]
+    val rejected   = "rejected".asInstanceOf[VirtualInterfaceState]
+    val unknown    = "unknown".asInstanceOf[VirtualInterfaceState]
 
     val values =
       js.Object.freeze(js.Array(confirming, verifying, pending, available, down, deleting, deleted, rejected, unknown))

--- a/services/directoryservice/src/main/scala/facade/amazonaws/services/DirectoryService.scala
+++ b/services/directoryservice/src/main/scala/facade/amazonaws/services/DirectoryService.scala
@@ -20,7 +20,6 @@ package object directoryservice {
   type CertificateExpiryDateTime                  = js.Date
   type CertificateId                              = String
   type CertificateRegisteredDateTime              = js.Date
-  type CertificateState                           = String
   type CertificateStateReason                     = String
   type CertificatesInfo                           = js.Array[CertificateInfo]
   type CidrIp                                     = String
@@ -39,32 +38,24 @@ package object directoryservice {
   type Description                                = String
   type DesiredNumberOfDomainControllers           = Int
   type DirectoryDescriptions                      = js.Array[DirectoryDescription]
-  type DirectoryEdition                           = String
   type DirectoryId                                = String
   type DirectoryIds                               = js.Array[DirectoryId]
   type DirectoryName                              = String
   type DirectoryShortName                         = String
-  type DirectorySize                              = String
-  type DirectoryStage                             = String
-  type DirectoryType                              = String
   type DnsIpAddrs                                 = js.Array[IpAddr]
   type DomainControllerId                         = String
   type DomainControllerIds                        = js.Array[DomainControllerId]
-  type DomainControllerStatus                     = String
   type DomainControllerStatusReason               = String
   type DomainControllers                          = js.Array[DomainController]
   type EndDateTime                                = js.Date
   type EventTopics                                = js.Array[EventTopic]
   type IpAddr                                     = String
   type IpAddrs                                    = js.Array[IpAddr]
-  type IpRouteStatusMsg                           = String
   type IpRouteStatusReason                        = String
   type IpRoutes                                   = js.Array[IpRoute]
   type IpRoutesInfo                               = js.Array[IpRouteInfo]
   type LDAPSSettingsInfo                          = js.Array[LDAPSSettingInfo]
-  type LDAPSStatus                                = String
   type LDAPSStatusReason                          = String
-  type LDAPSType                                  = String
   type LastUpdatedDateTime                        = js.Date
   type LaunchTime                                 = js.Date
   type LdifContent                                = String
@@ -78,34 +69,25 @@ package object directoryservice {
   type PageLimit                                  = Int
   type Password                                   = String
   type PortNumber                                 = Int
-  type RadiusAuthenticationProtocol               = String
   type RadiusDisplayLabel                         = String
   type RadiusRetries                              = Int
   type RadiusSharedSecret                         = String
-  type RadiusStatus                               = String
   type RadiusTimeout                              = Int
   type RemoteDomainName                           = String
   type RemoteDomainNames                          = js.Array[RemoteDomainName]
-  type ReplicationScope                           = String
   type RequestId                                  = String
   type ResourceId                                 = String
   type SID                                        = String
   type SchemaExtensionId                          = String
-  type SchemaExtensionStatus                      = String
   type SchemaExtensionStatusReason                = String
   type SchemaExtensionsInfo                       = js.Array[SchemaExtensionInfo]
   type SecurityGroupId                            = String
-  type SelectiveAuth                              = String
   type Server                                     = String
   type Servers                                    = js.Array[Server]
-  type ShareMethod                                = String
-  type ShareStatus                                = String
   type SharedDirectories                          = js.Array[SharedDirectory]
   type SnapshotId                                 = String
   type SnapshotIds                                = js.Array[SnapshotId]
   type SnapshotName                               = String
-  type SnapshotStatus                             = String
-  type SnapshotType                               = String
   type Snapshots                                  = js.Array[Snapshot]
   type SsoEnabled                                 = Boolean
   type StageReason                                = String
@@ -120,18 +102,13 @@ package object directoryservice {
   type TagValue                                   = String
   type Tags                                       = js.Array[Tag]
   type TargetId                                   = String
-  type TargetType                                 = String
   type TopicArn                                   = String
   type TopicName                                  = String
   type TopicNames                                 = js.Array[TopicName]
-  type TopicStatus                                = String
-  type TrustDirection                             = String
   type TrustId                                    = String
   type TrustIds                                   = js.Array[TrustId]
   type TrustPassword                              = String
-  type TrustState                                 = String
   type TrustStateReason                           = String
-  type TrustType                                  = String
   type Trusts                                     = js.Array[Trust]
   type UpdateSecurityGroupForDirectoryControllers = Boolean
   type UseSameUsername                            = Boolean
@@ -568,14 +545,15 @@ package directoryservice {
       __obj.asInstanceOf[CertificateInfo]
     }
   }
-
-  object CertificateStateEnum {
-    val Registering      = "Registering"
-    val Registered       = "Registered"
-    val RegisterFailed   = "RegisterFailed"
-    val Deregistering    = "Deregistering"
-    val Deregistered     = "Deregistered"
-    val DeregisterFailed = "DeregisterFailed"
+  @js.native
+  sealed trait CertificateState extends js.Any
+  object CertificateState extends js.Object {
+    val Registering      = "Registering".asInstanceOf[CertificateState]
+    val Registered       = "Registered".asInstanceOf[CertificateState]
+    val RegisterFailed   = "RegisterFailed".asInstanceOf[CertificateState]
+    val Deregistering    = "Deregistering".asInstanceOf[CertificateState]
+    val Deregistered     = "Deregistered".asInstanceOf[CertificateState]
+    val DeregisterFailed = "DeregisterFailed".asInstanceOf[CertificateState]
 
     val values =
       js.Object.freeze(js.Array(Registering, Registered, RegisterFailed, Deregistering, Deregistered, DeregisterFailed))
@@ -1917,10 +1895,11 @@ package directoryservice {
       __obj.asInstanceOf[DirectoryDescription]
     }
   }
-
-  object DirectoryEditionEnum {
-    val Enterprise = "Enterprise"
-    val Standard   = "Standard"
+  @js.native
+  sealed trait DirectoryEdition extends js.Any
+  object DirectoryEdition extends js.Object {
+    val Enterprise = "Enterprise".asInstanceOf[DirectoryEdition]
+    val Standard   = "Standard".asInstanceOf[DirectoryEdition]
 
     val values = js.Object.freeze(js.Array(Enterprise, Standard))
   }
@@ -1985,26 +1964,28 @@ package directoryservice {
       __obj.asInstanceOf[DirectoryLimits]
     }
   }
-
-  object DirectorySizeEnum {
-    val Small = "Small"
-    val Large = "Large"
+  @js.native
+  sealed trait DirectorySize extends js.Any
+  object DirectorySize extends js.Object {
+    val Small = "Small".asInstanceOf[DirectorySize]
+    val Large = "Large".asInstanceOf[DirectorySize]
 
     val values = js.Object.freeze(js.Array(Small, Large))
   }
-
-  object DirectoryStageEnum {
-    val Requested     = "Requested"
-    val Creating      = "Creating"
-    val Created       = "Created"
-    val Active        = "Active"
-    val Inoperable    = "Inoperable"
-    val Impaired      = "Impaired"
-    val Restoring     = "Restoring"
-    val RestoreFailed = "RestoreFailed"
-    val Deleting      = "Deleting"
-    val Deleted       = "Deleted"
-    val Failed        = "Failed"
+  @js.native
+  sealed trait DirectoryStage extends js.Any
+  object DirectoryStage extends js.Object {
+    val Requested     = "Requested".asInstanceOf[DirectoryStage]
+    val Creating      = "Creating".asInstanceOf[DirectoryStage]
+    val Created       = "Created".asInstanceOf[DirectoryStage]
+    val Active        = "Active".asInstanceOf[DirectoryStage]
+    val Inoperable    = "Inoperable".asInstanceOf[DirectoryStage]
+    val Impaired      = "Impaired".asInstanceOf[DirectoryStage]
+    val Restoring     = "Restoring".asInstanceOf[DirectoryStage]
+    val RestoreFailed = "RestoreFailed".asInstanceOf[DirectoryStage]
+    val Deleting      = "Deleting".asInstanceOf[DirectoryStage]
+    val Deleted       = "Deleted".asInstanceOf[DirectoryStage]
+    val Failed        = "Failed".asInstanceOf[DirectoryStage]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2022,12 +2003,13 @@ package directoryservice {
       )
     )
   }
-
-  object DirectoryTypeEnum {
-    val SimpleAD          = "SimpleAD"
-    val ADConnector       = "ADConnector"
-    val MicrosoftAD       = "MicrosoftAD"
-    val SharedMicrosoftAD = "SharedMicrosoftAD"
+  @js.native
+  sealed trait DirectoryType extends js.Any
+  object DirectoryType extends js.Object {
+    val SimpleAD          = "SimpleAD".asInstanceOf[DirectoryType]
+    val ADConnector       = "ADConnector".asInstanceOf[DirectoryType]
+    val MicrosoftAD       = "MicrosoftAD".asInstanceOf[DirectoryType]
+    val SharedMicrosoftAD = "SharedMicrosoftAD".asInstanceOf[DirectoryType]
 
     val values = js.Object.freeze(js.Array(SimpleAD, ADConnector, MicrosoftAD, SharedMicrosoftAD))
   }
@@ -2245,15 +2227,16 @@ package directoryservice {
       __obj.asInstanceOf[DomainController]
     }
   }
-
-  object DomainControllerStatusEnum {
-    val Creating  = "Creating"
-    val Active    = "Active"
-    val Impaired  = "Impaired"
-    val Restoring = "Restoring"
-    val Deleting  = "Deleting"
-    val Deleted   = "Deleted"
-    val Failed    = "Failed"
+  @js.native
+  sealed trait DomainControllerStatus extends js.Any
+  object DomainControllerStatus extends js.Object {
+    val Creating  = "Creating".asInstanceOf[DomainControllerStatus]
+    val Active    = "Active".asInstanceOf[DomainControllerStatus]
+    val Impaired  = "Impaired".asInstanceOf[DomainControllerStatus]
+    val Restoring = "Restoring".asInstanceOf[DomainControllerStatus]
+    val Deleting  = "Deleting".asInstanceOf[DomainControllerStatus]
+    val Deleted   = "Deleted".asInstanceOf[DomainControllerStatus]
+    val Failed    = "Failed".asInstanceOf[DomainControllerStatus]
 
     val values = js.Object.freeze(js.Array(Creating, Active, Impaired, Restoring, Deleting, Deleted, Failed))
   }
@@ -2536,14 +2519,15 @@ package directoryservice {
       __obj.asInstanceOf[IpRouteInfo]
     }
   }
-
-  object IpRouteStatusMsgEnum {
-    val Adding       = "Adding"
-    val Added        = "Added"
-    val Removing     = "Removing"
-    val Removed      = "Removed"
-    val AddFailed    = "AddFailed"
-    val RemoveFailed = "RemoveFailed"
+  @js.native
+  sealed trait IpRouteStatusMsg extends js.Any
+  object IpRouteStatusMsg extends js.Object {
+    val Adding       = "Adding".asInstanceOf[IpRouteStatusMsg]
+    val Added        = "Added".asInstanceOf[IpRouteStatusMsg]
+    val Removing     = "Removing".asInstanceOf[IpRouteStatusMsg]
+    val Removed      = "Removed".asInstanceOf[IpRouteStatusMsg]
+    val AddFailed    = "AddFailed".asInstanceOf[IpRouteStatusMsg]
+    val RemoveFailed = "RemoveFailed".asInstanceOf[IpRouteStatusMsg]
 
     val values = js.Object.freeze(js.Array(Adding, Added, Removing, Removed, AddFailed, RemoveFailed))
   }
@@ -2572,18 +2556,20 @@ package directoryservice {
       __obj.asInstanceOf[LDAPSSettingInfo]
     }
   }
-
-  object LDAPSStatusEnum {
-    val Enabling     = "Enabling"
-    val Enabled      = "Enabled"
-    val EnableFailed = "EnableFailed"
-    val Disabled     = "Disabled"
+  @js.native
+  sealed trait LDAPSStatus extends js.Any
+  object LDAPSStatus extends js.Object {
+    val Enabling     = "Enabling".asInstanceOf[LDAPSStatus]
+    val Enabled      = "Enabled".asInstanceOf[LDAPSStatus]
+    val EnableFailed = "EnableFailed".asInstanceOf[LDAPSStatus]
+    val Disabled     = "Disabled".asInstanceOf[LDAPSStatus]
 
     val values = js.Object.freeze(js.Array(Enabling, Enabled, EnableFailed, Disabled))
   }
-
-  object LDAPSTypeEnum {
-    val Client = "Client"
+  @js.native
+  sealed trait LDAPSType extends js.Any
+  object LDAPSType extends js.Object {
+    val Client = "Client".asInstanceOf[LDAPSType]
 
     val values = js.Object.freeze(js.Array(Client))
   }
@@ -2861,12 +2847,13 @@ package directoryservice {
       __obj.asInstanceOf[OwnerDirectoryDescription]
     }
   }
-
-  object RadiusAuthenticationProtocolEnum {
-    val PAP         = "PAP"
-    val CHAP        = "CHAP"
-    val `MS-CHAPv1` = "MS-CHAPv1"
-    val `MS-CHAPv2` = "MS-CHAPv2"
+  @js.native
+  sealed trait RadiusAuthenticationProtocol extends js.Any
+  object RadiusAuthenticationProtocol extends js.Object {
+    val PAP         = "PAP".asInstanceOf[RadiusAuthenticationProtocol]
+    val CHAP        = "CHAP".asInstanceOf[RadiusAuthenticationProtocol]
+    val `MS-CHAPv1` = "MS-CHAPv1".asInstanceOf[RadiusAuthenticationProtocol]
+    val `MS-CHAPv2` = "MS-CHAPv2".asInstanceOf[RadiusAuthenticationProtocol]
 
     val values = js.Object.freeze(js.Array(PAP, CHAP, `MS-CHAPv1`, `MS-CHAPv2`))
   }
@@ -2910,11 +2897,12 @@ package directoryservice {
       __obj.asInstanceOf[RadiusSettings]
     }
   }
-
-  object RadiusStatusEnum {
-    val Creating  = "Creating"
-    val Completed = "Completed"
-    val Failed    = "Failed"
+  @js.native
+  sealed trait RadiusStatus extends js.Any
+  object RadiusStatus extends js.Object {
+    val Creating  = "Creating".asInstanceOf[RadiusStatus]
+    val Completed = "Completed".asInstanceOf[RadiusStatus]
+    val Failed    = "Failed".asInstanceOf[RadiusStatus]
 
     val values = js.Object.freeze(js.Array(Creating, Completed, Failed))
   }
@@ -3097,9 +3085,10 @@ package directoryservice {
       __obj.asInstanceOf[RemoveTagsFromResourceResult]
     }
   }
-
-  object ReplicationScopeEnum {
-    val Domain = "Domain"
+  @js.native
+  sealed trait ReplicationScope extends js.Any
+  object ReplicationScope extends js.Object {
+    val Domain = "Domain".asInstanceOf[ReplicationScope]
 
     val values = js.Object.freeze(js.Array(Domain))
   }
@@ -3216,17 +3205,18 @@ package directoryservice {
       __obj.asInstanceOf[SchemaExtensionInfo]
     }
   }
-
-  object SchemaExtensionStatusEnum {
-    val Initializing       = "Initializing"
-    val CreatingSnapshot   = "CreatingSnapshot"
-    val UpdatingSchema     = "UpdatingSchema"
-    val Replicating        = "Replicating"
-    val CancelInProgress   = "CancelInProgress"
-    val RollbackInProgress = "RollbackInProgress"
-    val Cancelled          = "Cancelled"
-    val Failed             = "Failed"
-    val Completed          = "Completed"
+  @js.native
+  sealed trait SchemaExtensionStatus extends js.Any
+  object SchemaExtensionStatus extends js.Object {
+    val Initializing       = "Initializing".asInstanceOf[SchemaExtensionStatus]
+    val CreatingSnapshot   = "CreatingSnapshot".asInstanceOf[SchemaExtensionStatus]
+    val UpdatingSchema     = "UpdatingSchema".asInstanceOf[SchemaExtensionStatus]
+    val Replicating        = "Replicating".asInstanceOf[SchemaExtensionStatus]
+    val CancelInProgress   = "CancelInProgress".asInstanceOf[SchemaExtensionStatus]
+    val RollbackInProgress = "RollbackInProgress".asInstanceOf[SchemaExtensionStatus]
+    val Cancelled          = "Cancelled".asInstanceOf[SchemaExtensionStatus]
+    val Failed             = "Failed".asInstanceOf[SchemaExtensionStatus]
+    val Completed          = "Completed".asInstanceOf[SchemaExtensionStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3242,10 +3232,11 @@ package directoryservice {
       )
     )
   }
-
-  object SelectiveAuthEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait SelectiveAuth extends js.Any
+  object SelectiveAuth extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[SelectiveAuth]
+    val Disabled = "Disabled".asInstanceOf[SelectiveAuth]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
@@ -3292,24 +3283,26 @@ package directoryservice {
       __obj.asInstanceOf[ShareDirectoryResult]
     }
   }
-
-  object ShareMethodEnum {
-    val ORGANIZATIONS = "ORGANIZATIONS"
-    val HANDSHAKE     = "HANDSHAKE"
+  @js.native
+  sealed trait ShareMethod extends js.Any
+  object ShareMethod extends js.Object {
+    val ORGANIZATIONS = "ORGANIZATIONS".asInstanceOf[ShareMethod]
+    val HANDSHAKE     = "HANDSHAKE".asInstanceOf[ShareMethod]
 
     val values = js.Object.freeze(js.Array(ORGANIZATIONS, HANDSHAKE))
   }
-
-  object ShareStatusEnum {
-    val Shared            = "Shared"
-    val PendingAcceptance = "PendingAcceptance"
-    val Rejected          = "Rejected"
-    val Rejecting         = "Rejecting"
-    val RejectFailed      = "RejectFailed"
-    val Sharing           = "Sharing"
-    val ShareFailed       = "ShareFailed"
-    val Deleted           = "Deleted"
-    val Deleting          = "Deleting"
+  @js.native
+  sealed trait ShareStatus extends js.Any
+  object ShareStatus extends js.Object {
+    val Shared            = "Shared".asInstanceOf[ShareStatus]
+    val PendingAcceptance = "PendingAcceptance".asInstanceOf[ShareStatus]
+    val Rejected          = "Rejected".asInstanceOf[ShareStatus]
+    val Rejecting         = "Rejecting".asInstanceOf[ShareStatus]
+    val RejectFailed      = "RejectFailed".asInstanceOf[ShareStatus]
+    val Sharing           = "Sharing".asInstanceOf[ShareStatus]
+    val ShareFailed       = "ShareFailed".asInstanceOf[ShareStatus]
+    val Deleted           = "Deleted".asInstanceOf[ShareStatus]
+    val Deleting          = "Deleting".asInstanceOf[ShareStatus]
 
     val values = js.Object.freeze(
       js.Array(Shared, PendingAcceptance, Rejected, Rejecting, RejectFailed, Sharing, ShareFailed, Deleted, Deleting)
@@ -3445,18 +3438,20 @@ package directoryservice {
       __obj.asInstanceOf[SnapshotLimits]
     }
   }
-
-  object SnapshotStatusEnum {
-    val Creating  = "Creating"
-    val Completed = "Completed"
-    val Failed    = "Failed"
+  @js.native
+  sealed trait SnapshotStatus extends js.Any
+  object SnapshotStatus extends js.Object {
+    val Creating  = "Creating".asInstanceOf[SnapshotStatus]
+    val Completed = "Completed".asInstanceOf[SnapshotStatus]
+    val Failed    = "Failed".asInstanceOf[SnapshotStatus]
 
     val values = js.Object.freeze(js.Array(Creating, Completed, Failed))
   }
-
-  object SnapshotTypeEnum {
-    val Auto   = "Auto"
-    val Manual = "Manual"
+  @js.native
+  sealed trait SnapshotType extends js.Any
+  object SnapshotType extends js.Object {
+    val Auto   = "Auto".asInstanceOf[SnapshotType]
+    val Manual = "Manual".asInstanceOf[SnapshotType]
 
     val values = js.Object.freeze(js.Array(Auto, Manual))
   }
@@ -3527,18 +3522,20 @@ package directoryservice {
       __obj.asInstanceOf[Tag]
     }
   }
-
-  object TargetTypeEnum {
-    val ACCOUNT = "ACCOUNT"
+  @js.native
+  sealed trait TargetType extends js.Any
+  object TargetType extends js.Object {
+    val ACCOUNT = "ACCOUNT".asInstanceOf[TargetType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT))
   }
-
-  object TopicStatusEnum {
-    val Registered        = "Registered"
-    val `Topic not found` = "Topic not found"
-    val Failed            = "Failed"
-    val Deleted           = "Deleted"
+  @js.native
+  sealed trait TopicStatus extends js.Any
+  object TopicStatus extends js.Object {
+    val Registered        = "Registered".asInstanceOf[TopicStatus]
+    val `Topic not found` = "Topic not found".asInstanceOf[TopicStatus]
+    val Failed            = "Failed".asInstanceOf[TopicStatus]
+    val Deleted           = "Deleted".asInstanceOf[TopicStatus]
 
     val values = js.Object.freeze(js.Array(Registered, `Topic not found`, Failed, Deleted))
   }
@@ -3591,27 +3588,29 @@ package directoryservice {
       __obj.asInstanceOf[Trust]
     }
   }
-
-  object TrustDirectionEnum {
-    val `One-Way: Outgoing` = "One-Way: Outgoing"
-    val `One-Way: Incoming` = "One-Way: Incoming"
-    val `Two-Way`           = "Two-Way"
+  @js.native
+  sealed trait TrustDirection extends js.Any
+  object TrustDirection extends js.Object {
+    val `One-Way: Outgoing` = "One-Way: Outgoing".asInstanceOf[TrustDirection]
+    val `One-Way: Incoming` = "One-Way: Incoming".asInstanceOf[TrustDirection]
+    val `Two-Way`           = "Two-Way".asInstanceOf[TrustDirection]
 
     val values = js.Object.freeze(js.Array(`One-Way: Outgoing`, `One-Way: Incoming`, `Two-Way`))
   }
-
-  object TrustStateEnum {
-    val Creating     = "Creating"
-    val Created      = "Created"
-    val Verifying    = "Verifying"
-    val VerifyFailed = "VerifyFailed"
-    val Verified     = "Verified"
-    val Updating     = "Updating"
-    val UpdateFailed = "UpdateFailed"
-    val Updated      = "Updated"
-    val Deleting     = "Deleting"
-    val Deleted      = "Deleted"
-    val Failed       = "Failed"
+  @js.native
+  sealed trait TrustState extends js.Any
+  object TrustState extends js.Object {
+    val Creating     = "Creating".asInstanceOf[TrustState]
+    val Created      = "Created".asInstanceOf[TrustState]
+    val Verifying    = "Verifying".asInstanceOf[TrustState]
+    val VerifyFailed = "VerifyFailed".asInstanceOf[TrustState]
+    val Verified     = "Verified".asInstanceOf[TrustState]
+    val Updating     = "Updating".asInstanceOf[TrustState]
+    val UpdateFailed = "UpdateFailed".asInstanceOf[TrustState]
+    val Updated      = "Updated".asInstanceOf[TrustState]
+    val Deleting     = "Deleting".asInstanceOf[TrustState]
+    val Deleted      = "Deleted".asInstanceOf[TrustState]
+    val Failed       = "Failed".asInstanceOf[TrustState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3629,10 +3628,11 @@ package directoryservice {
       )
     )
   }
-
-  object TrustTypeEnum {
-    val Forest   = "Forest"
-    val External = "External"
+  @js.native
+  sealed trait TrustType extends js.Any
+  object TrustType extends js.Object {
+    val Forest   = "Forest".asInstanceOf[TrustType]
+    val External = "External".asInstanceOf[TrustType]
 
     val values = js.Object.freeze(js.Array(Forest, External))
   }

--- a/services/dlm/src/main/scala/facade/amazonaws/services/DLM.scala
+++ b/services/dlm/src/main/scala/facade/amazonaws/services/DLM.scala
@@ -7,46 +7,40 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object dlm {
-  type AvailabilityZone            = String
-  type AvailabilityZoneList        = js.Array[AvailabilityZone]
-  type CmkArn                      = String
-  type CopyTags                    = Boolean
-  type CopyTagsNullable            = Boolean
-  type Count                       = Int
-  type CrossRegionCopyRules        = js.Array[CrossRegionCopyRule]
-  type Encrypted                   = Boolean
-  type ExcludeBootVolume           = Boolean
-  type ExecutionRoleArn            = String
-  type GettablePolicyStateValues   = String
-  type Interval                    = Int
-  type IntervalUnitValues          = String
-  type LifecyclePolicySummaryList  = js.Array[LifecyclePolicySummary]
-  type PolicyArn                   = String
-  type PolicyDescription           = String
-  type PolicyId                    = String
-  type PolicyIdList                = js.Array[PolicyId]
-  type PolicyTypeValues            = String
-  type ResourceTypeValues          = String
-  type ResourceTypeValuesList      = js.Array[ResourceTypeValues]
-  type RetentionIntervalUnitValues = String
-  type ScheduleList                = js.Array[Schedule]
-  type ScheduleName                = String
-  type SettablePolicyStateValues   = String
-  type StatusMessage               = String
-  type TagFilter                   = String
-  type TagKey                      = String
-  type TagKeyList                  = js.Array[TagKey]
-  type TagMap                      = js.Dictionary[TagValue]
-  type TagValue                    = String
-  type TagsToAddFilterList         = js.Array[TagFilter]
-  type TagsToAddList               = js.Array[Tag]
-  type TargetRegion                = String
-  type TargetTagList               = js.Array[Tag]
-  type TargetTagsFilterList        = js.Array[TagFilter]
-  type Time                        = String
-  type TimesList                   = js.Array[Time]
-  type Timestamp                   = js.Date
-  type VariableTagsList            = js.Array[Tag]
+  type AvailabilityZone           = String
+  type AvailabilityZoneList       = js.Array[AvailabilityZone]
+  type CmkArn                     = String
+  type CopyTags                   = Boolean
+  type CopyTagsNullable           = Boolean
+  type Count                      = Int
+  type CrossRegionCopyRules       = js.Array[CrossRegionCopyRule]
+  type Encrypted                  = Boolean
+  type ExcludeBootVolume          = Boolean
+  type ExecutionRoleArn           = String
+  type Interval                   = Int
+  type LifecyclePolicySummaryList = js.Array[LifecyclePolicySummary]
+  type PolicyArn                  = String
+  type PolicyDescription          = String
+  type PolicyId                   = String
+  type PolicyIdList               = js.Array[PolicyId]
+  type ResourceTypeValuesList     = js.Array[ResourceTypeValues]
+  type ScheduleList               = js.Array[Schedule]
+  type ScheduleName               = String
+  type StatusMessage              = String
+  type TagFilter                  = String
+  type TagKey                     = String
+  type TagKeyList                 = js.Array[TagKey]
+  type TagMap                     = js.Dictionary[TagValue]
+  type TagValue                   = String
+  type TagsToAddFilterList        = js.Array[TagFilter]
+  type TagsToAddList              = js.Array[Tag]
+  type TargetRegion               = String
+  type TargetTagList              = js.Array[Tag]
+  type TargetTagsFilterList       = js.Array[TagFilter]
+  type Time                       = String
+  type TimesList                  = js.Array[Time]
+  type Timestamp                  = js.Date
+  type VariableTagsList           = js.Array[Tag]
 
   implicit final class DLMOps(private val service: DLM) extends AnyVal {
 
@@ -354,17 +348,19 @@ package dlm {
       __obj.asInstanceOf[GetLifecyclePolicyResponse]
     }
   }
-
-  object GettablePolicyStateValuesEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
-    val ERROR    = "ERROR"
+  @js.native
+  sealed trait GettablePolicyStateValues extends js.Any
+  object GettablePolicyStateValues extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[GettablePolicyStateValues]
+    val DISABLED = "DISABLED".asInstanceOf[GettablePolicyStateValues]
+    val ERROR    = "ERROR".asInstanceOf[GettablePolicyStateValues]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED, ERROR))
   }
-
-  object IntervalUnitValuesEnum {
-    val HOURS = "HOURS"
+  @js.native
+  sealed trait IntervalUnitValues extends js.Any
+  object IntervalUnitValues extends js.Object {
+    val HOURS = "HOURS".asInstanceOf[IntervalUnitValues]
 
     val values = js.Object.freeze(js.Array(HOURS))
   }
@@ -526,16 +522,18 @@ package dlm {
       __obj.asInstanceOf[PolicyDetails]
     }
   }
-
-  object PolicyTypeValuesEnum {
-    val EBS_SNAPSHOT_MANAGEMENT = "EBS_SNAPSHOT_MANAGEMENT"
+  @js.native
+  sealed trait PolicyTypeValues extends js.Any
+  object PolicyTypeValues extends js.Object {
+    val EBS_SNAPSHOT_MANAGEMENT = "EBS_SNAPSHOT_MANAGEMENT".asInstanceOf[PolicyTypeValues]
 
     val values = js.Object.freeze(js.Array(EBS_SNAPSHOT_MANAGEMENT))
   }
-
-  object ResourceTypeValuesEnum {
-    val VOLUME   = "VOLUME"
-    val INSTANCE = "INSTANCE"
+  @js.native
+  sealed trait ResourceTypeValues extends js.Any
+  object ResourceTypeValues extends js.Object {
+    val VOLUME   = "VOLUME".asInstanceOf[ResourceTypeValues]
+    val INSTANCE = "INSTANCE".asInstanceOf[ResourceTypeValues]
 
     val values = js.Object.freeze(js.Array(VOLUME, INSTANCE))
   }
@@ -564,12 +562,13 @@ package dlm {
       __obj.asInstanceOf[RetainRule]
     }
   }
-
-  object RetentionIntervalUnitValuesEnum {
-    val DAYS   = "DAYS"
-    val WEEKS  = "WEEKS"
-    val MONTHS = "MONTHS"
-    val YEARS  = "YEARS"
+  @js.native
+  sealed trait RetentionIntervalUnitValues extends js.Any
+  object RetentionIntervalUnitValues extends js.Object {
+    val DAYS   = "DAYS".asInstanceOf[RetentionIntervalUnitValues]
+    val WEEKS  = "WEEKS".asInstanceOf[RetentionIntervalUnitValues]
+    val MONTHS = "MONTHS".asInstanceOf[RetentionIntervalUnitValues]
+    val YEARS  = "YEARS".asInstanceOf[RetentionIntervalUnitValues]
 
     val values = js.Object.freeze(js.Array(DAYS, WEEKS, MONTHS, YEARS))
   }
@@ -613,10 +612,11 @@ package dlm {
       __obj.asInstanceOf[Schedule]
     }
   }
-
-  object SettablePolicyStateValuesEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait SettablePolicyStateValues extends js.Any
+  object SettablePolicyStateValues extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[SettablePolicyStateValues]
+    val DISABLED = "DISABLED".asInstanceOf[SettablePolicyStateValues]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }

--- a/services/dms/src/main/scala/facade/amazonaws/services/DMS.scala
+++ b/services/dms/src/main/scala/facade/amazonaws/services/DMS.scala
@@ -8,18 +8,11 @@ import facade.amazonaws._
 
 package object dms {
   type AccountQuotaList                        = js.Array[AccountQuota]
-  type AuthMechanismValue                      = String
-  type AuthTypeValue                           = String
   type AvailabilityZonesList                   = js.Array[String]
   type BooleanOptional                         = Boolean
   type CertificateList                         = js.Array[Certificate]
   type CertificateWallet                       = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type CompressionTypeValue                    = String
   type ConnectionList                          = js.Array[Connection]
-  type DataFormatValue                         = String
-  type DmsSslModeValue                         = String
-  type EncodingTypeValue                       = String
-  type EncryptionModeValue                     = String
   type EndpointList                            = js.Array[Endpoint]
   type EventCategoriesList                     = js.Array[String]
   type EventCategoryGroupList                  = js.Array[EventCategoryGroup]
@@ -29,17 +22,9 @@ package object dms {
   type FilterValueList                         = js.Array[String]
   type IntegerOptional                         = Int
   type KeyList                                 = js.Array[String]
-  type MessageFormatValue                      = String
-  type MigrationTypeValue                      = String
-  type NestingLevelValue                       = String
   type OrderableReplicationInstanceList        = js.Array[OrderableReplicationInstance]
-  type ParquetVersionValue                     = String
   type PendingMaintenanceActionDetails         = js.Array[PendingMaintenanceAction]
   type PendingMaintenanceActions               = js.Array[ResourcePendingMaintenanceActions]
-  type RefreshSchemasStatusTypeValue           = String
-  type ReleaseStatusValues                     = String
-  type ReloadOptionValue                       = String
-  type ReplicationEndpointTypeValue            = String
   type ReplicationInstanceList                 = js.Array[ReplicationInstance]
   type ReplicationInstancePrivateIpAddressList = js.Array[String]
   type ReplicationInstancePublicIpAddressList  = js.Array[String]
@@ -50,8 +35,6 @@ package object dms {
   type SchemaList                              = js.Array[String]
   type SecretString                            = String
   type SourceIdsList                           = js.Array[String]
-  type SourceType                              = String
-  type StartReplicationTaskTypeValue           = String
   type SubnetIdentifierList                    = js.Array[String]
   type SubnetList                              = js.Array[Subnet]
   type SupportedEndpointTypeList               = js.Array[SupportedEndpointType]
@@ -405,18 +388,20 @@ package dms {
       __obj.asInstanceOf[ApplyPendingMaintenanceActionResponse]
     }
   }
-
-  object AuthMechanismValueEnum {
-    val default     = "default"
-    val mongodb_cr  = "mongodb_cr"
-    val scram_sha_1 = "scram_sha_1"
+  @js.native
+  sealed trait AuthMechanismValue extends js.Any
+  object AuthMechanismValue extends js.Object {
+    val default     = "default".asInstanceOf[AuthMechanismValue]
+    val mongodb_cr  = "mongodb_cr".asInstanceOf[AuthMechanismValue]
+    val scram_sha_1 = "scram_sha_1".asInstanceOf[AuthMechanismValue]
 
     val values = js.Object.freeze(js.Array(default, mongodb_cr, scram_sha_1))
   }
-
-  object AuthTypeValueEnum {
-    val no       = "no"
-    val password = "password"
+  @js.native
+  sealed trait AuthTypeValue extends js.Any
+  object AuthTypeValue extends js.Object {
+    val no       = "no".asInstanceOf[AuthTypeValue]
+    val password = "password".asInstanceOf[AuthTypeValue]
 
     val values = js.Object.freeze(js.Array(no, password))
   }
@@ -485,10 +470,11 @@ package dms {
       __obj.asInstanceOf[Certificate]
     }
   }
-
-  object CompressionTypeValueEnum {
-    val none = "none"
-    val gzip = "gzip"
+  @js.native
+  sealed trait CompressionTypeValue extends js.Any
+  object CompressionTypeValue extends js.Object {
+    val none = "none".asInstanceOf[CompressionTypeValue]
+    val gzip = "gzip".asInstanceOf[CompressionTypeValue]
 
     val values = js.Object.freeze(js.Array(none, gzip))
   }
@@ -893,10 +879,11 @@ package dms {
       __obj.asInstanceOf[CreateReplicationTaskResponse]
     }
   }
-
-  object DataFormatValueEnum {
-    val csv     = "csv"
-    val parquet = "parquet"
+  @js.native
+  sealed trait DataFormatValue extends js.Any
+  object DataFormatValue extends js.Object {
+    val csv     = "csv".asInstanceOf[DataFormatValue]
+    val parquet = "parquet".asInstanceOf[DataFormatValue]
 
     val values = js.Object.freeze(js.Array(csv, parquet))
   }
@@ -2036,12 +2023,13 @@ package dms {
       __obj.asInstanceOf[DescribeTableStatisticsResponse]
     }
   }
-
-  object DmsSslModeValueEnum {
-    val none          = "none"
-    val require       = "require"
-    val `verify-ca`   = "verify-ca"
-    val `verify-full` = "verify-full"
+  @js.native
+  sealed trait DmsSslModeValue extends js.Any
+  object DmsSslModeValue extends js.Object {
+    val none          = "none".asInstanceOf[DmsSslModeValue]
+    val require       = "require".asInstanceOf[DmsSslModeValue]
+    val `verify-ca`   = "verify-ca".asInstanceOf[DmsSslModeValue]
+    val `verify-full` = "verify-full".asInstanceOf[DmsSslModeValue]
 
     val values = js.Object.freeze(js.Array(none, require, `verify-ca`, `verify-full`))
   }
@@ -2118,18 +2106,20 @@ package dms {
       __obj.asInstanceOf[ElasticsearchSettings]
     }
   }
-
-  object EncodingTypeValueEnum {
-    val plain              = "plain"
-    val `plain-dictionary` = "plain-dictionary"
-    val `rle-dictionary`   = "rle-dictionary"
+  @js.native
+  sealed trait EncodingTypeValue extends js.Any
+  object EncodingTypeValue extends js.Object {
+    val plain              = "plain".asInstanceOf[EncodingTypeValue]
+    val `plain-dictionary` = "plain-dictionary".asInstanceOf[EncodingTypeValue]
+    val `rle-dictionary`   = "rle-dictionary".asInstanceOf[EncodingTypeValue]
 
     val values = js.Object.freeze(js.Array(plain, `plain-dictionary`, `rle-dictionary`))
   }
-
-  object EncryptionModeValueEnum {
-    val `sse-s3`  = "sse-s3"
-    val `sse-kms` = "sse-kms"
+  @js.native
+  sealed trait EncryptionModeValue extends js.Any
+  object EncryptionModeValue extends js.Object {
+    val `sse-s3`  = "sse-s3".asInstanceOf[EncryptionModeValue]
+    val `sse-kms` = "sse-kms".asInstanceOf[EncryptionModeValue]
 
     val values = js.Object.freeze(js.Array(`sse-s3`, `sse-kms`))
   }
@@ -2451,17 +2441,19 @@ package dms {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object MessageFormatValueEnum {
-    val json = "json"
+  @js.native
+  sealed trait MessageFormatValue extends js.Any
+  object MessageFormatValue extends js.Object {
+    val json = "json".asInstanceOf[MessageFormatValue]
 
     val values = js.Object.freeze(js.Array(json))
   }
-
-  object MigrationTypeValueEnum {
-    val `full-load`         = "full-load"
-    val cdc                 = "cdc"
-    val `full-load-and-cdc` = "full-load-and-cdc"
+  @js.native
+  sealed trait MigrationTypeValue extends js.Any
+  object MigrationTypeValue extends js.Object {
+    val `full-load`         = "full-load".asInstanceOf[MigrationTypeValue]
+    val cdc                 = "cdc".asInstanceOf[MigrationTypeValue]
+    val `full-load-and-cdc` = "full-load-and-cdc".asInstanceOf[MigrationTypeValue]
 
     val values = js.Object.freeze(js.Array(`full-load`, cdc, `full-load-and-cdc`))
   }
@@ -2856,10 +2848,11 @@ package dms {
       __obj.asInstanceOf[MongoDbSettings]
     }
   }
-
-  object NestingLevelValueEnum {
-    val none = "none"
-    val one  = "one"
+  @js.native
+  sealed trait NestingLevelValue extends js.Any
+  object NestingLevelValue extends js.Object {
+    val none = "none".asInstanceOf[NestingLevelValue]
+    val one  = "one".asInstanceOf[NestingLevelValue]
 
     val values = js.Object.freeze(js.Array(none, one))
   }
@@ -2906,10 +2899,11 @@ package dms {
       __obj.asInstanceOf[OrderableReplicationInstance]
     }
   }
-
-  object ParquetVersionValueEnum {
-    val `parquet-1-0` = "parquet-1-0"
-    val `parquet-2-0` = "parquet-2-0"
+  @js.native
+  sealed trait ParquetVersionValue extends js.Any
+  object ParquetVersionValue extends js.Object {
+    val `parquet-1-0` = "parquet-1-0".asInstanceOf[ParquetVersionValue]
+    val `parquet-2-0` = "parquet-2-0".asInstanceOf[ParquetVersionValue]
 
     val values = js.Object.freeze(js.Array(`parquet-1-0`, `parquet-2-0`))
   }
@@ -3153,24 +3147,27 @@ package dms {
       __obj.asInstanceOf[RefreshSchemasStatus]
     }
   }
-
-  object RefreshSchemasStatusTypeValueEnum {
-    val successful = "successful"
-    val failed     = "failed"
-    val refreshing = "refreshing"
+  @js.native
+  sealed trait RefreshSchemasStatusTypeValue extends js.Any
+  object RefreshSchemasStatusTypeValue extends js.Object {
+    val successful = "successful".asInstanceOf[RefreshSchemasStatusTypeValue]
+    val failed     = "failed".asInstanceOf[RefreshSchemasStatusTypeValue]
+    val refreshing = "refreshing".asInstanceOf[RefreshSchemasStatusTypeValue]
 
     val values = js.Object.freeze(js.Array(successful, failed, refreshing))
   }
-
-  object ReleaseStatusValuesEnum {
-    val beta = "beta"
+  @js.native
+  sealed trait ReleaseStatusValues extends js.Any
+  object ReleaseStatusValues extends js.Object {
+    val beta = "beta".asInstanceOf[ReleaseStatusValues]
 
     val values = js.Object.freeze(js.Array(beta))
   }
-
-  object ReloadOptionValueEnum {
-    val `data-reload`   = "data-reload"
-    val `validate-only` = "validate-only"
+  @js.native
+  sealed trait ReloadOptionValue extends js.Any
+  object ReloadOptionValue extends js.Object {
+    val `data-reload`   = "data-reload".asInstanceOf[ReloadOptionValue]
+    val `validate-only` = "validate-only".asInstanceOf[ReloadOptionValue]
 
     val values = js.Object.freeze(js.Array(`data-reload`, `validate-only`))
   }
@@ -3254,10 +3251,11 @@ package dms {
       __obj.asInstanceOf[RemoveTagsFromResourceResponse]
     }
   }
-
-  object ReplicationEndpointTypeValueEnum {
-    val source = "source"
-    val target = "target"
+  @js.native
+  sealed trait ReplicationEndpointTypeValue extends js.Any
+  object ReplicationEndpointTypeValue extends js.Object {
+    val source = "source".asInstanceOf[ReplicationEndpointTypeValue]
+    val target = "target".asInstanceOf[ReplicationEndpointTypeValue]
 
     val values = js.Object.freeze(js.Array(source, target))
   }
@@ -3717,9 +3715,10 @@ package dms {
       __obj.asInstanceOf[S3Settings]
     }
   }
-
-  object SourceTypeEnum {
-    val `replication-instance` = "replication-instance"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val `replication-instance` = "replication-instance".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(js.Array(`replication-instance`))
   }
@@ -3815,11 +3814,12 @@ package dms {
       __obj.asInstanceOf[StartReplicationTaskResponse]
     }
   }
-
-  object StartReplicationTaskTypeValueEnum {
-    val `start-replication` = "start-replication"
-    val `resume-processing` = "resume-processing"
-    val `reload-target`     = "reload-target"
+  @js.native
+  sealed trait StartReplicationTaskTypeValue extends js.Any
+  object StartReplicationTaskTypeValue extends js.Object {
+    val `start-replication` = "start-replication".asInstanceOf[StartReplicationTaskTypeValue]
+    val `resume-processing` = "resume-processing".asInstanceOf[StartReplicationTaskTypeValue]
+    val `reload-target`     = "reload-target".asInstanceOf[StartReplicationTaskTypeValue]
 
     val values = js.Object.freeze(js.Array(`start-replication`, `resume-processing`, `reload-target`))
   }

--- a/services/docdb/src/main/scala/facade/amazonaws/services/DocDB.scala
+++ b/services/docdb/src/main/scala/facade/amazonaws/services/DocDB.scala
@@ -7,7 +7,6 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object docdb {
-  type ApplyMethod                     = String
   type AttributeValueList              = js.Array[String]
   type AvailabilityZoneList            = js.Array[AvailabilityZone]
   type AvailabilityZones               = js.Array[String]
@@ -35,7 +34,6 @@ package object docdb {
   type ParametersList                  = js.Array[Parameter]
   type PendingMaintenanceActionDetails = js.Array[PendingMaintenanceAction]
   type PendingMaintenanceActions       = js.Array[ResourcePendingMaintenanceActions]
-  type SourceType                      = String
   type SubnetIdentifierList            = js.Array[String]
   type SubnetList                      = js.Array[Subnet]
   type TStamp                          = js.Date
@@ -258,10 +256,11 @@ package docdb {
       __obj.asInstanceOf[AddTagsToResourceMessage]
     }
   }
-
-  object ApplyMethodEnum {
-    val immediate        = "immediate"
-    val `pending-reboot` = "pending-reboot"
+  @js.native
+  sealed trait ApplyMethod extends js.Any
+  object ApplyMethod extends js.Object {
+    val immediate        = "immediate".asInstanceOf[ApplyMethod]
+    val `pending-reboot` = "pending-reboot".asInstanceOf[ApplyMethod]
 
     val values = js.Object.freeze(js.Array(immediate, `pending-reboot`))
   }
@@ -3115,14 +3114,15 @@ package docdb {
       __obj.asInstanceOf[RestoreDBClusterToPointInTimeResult]
     }
   }
-
-  object SourceTypeEnum {
-    val `db-instance`         = "db-instance"
-    val `db-parameter-group`  = "db-parameter-group"
-    val `db-security-group`   = "db-security-group"
-    val `db-snapshot`         = "db-snapshot"
-    val `db-cluster`          = "db-cluster"
-    val `db-cluster-snapshot` = "db-cluster-snapshot"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val `db-instance`         = "db-instance".asInstanceOf[SourceType]
+    val `db-parameter-group`  = "db-parameter-group".asInstanceOf[SourceType]
+    val `db-security-group`   = "db-security-group".asInstanceOf[SourceType]
+    val `db-snapshot`         = "db-snapshot".asInstanceOf[SourceType]
+    val `db-cluster`          = "db-cluster".asInstanceOf[SourceType]
+    val `db-cluster-snapshot` = "db-cluster-snapshot".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDB.scala
+++ b/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDB.scala
@@ -8,7 +8,6 @@ import facade.amazonaws._
 
 package object dynamodb {
   type ArchivalReason                                    = String
-  type AttributeAction                                   = String
   type AttributeDefinitions                              = js.Array[AttributeDefinition]
   type AttributeMap                                      = js.Dictionary[AttributeValue]
   type AttributeName                                     = String
@@ -23,31 +22,22 @@ package object dynamodb {
   type BackupCreationDateTime                            = js.Date
   type BackupName                                        = String
   type BackupSizeBytes                                   = Double
-  type BackupStatus                                      = String
   type BackupSummaries                                   = js.Array[BackupSummary]
-  type BackupType                                        = String
-  type BackupTypeFilter                                  = String
   type BackupsInputLimit                                 = Int
   type BatchGetRequestMap                                = js.Dictionary[KeysAndAttributes]
   type BatchGetResponseMap                               = js.Dictionary[ItemList]
   type BatchWriteItemRequestMap                          = js.Dictionary[WriteRequests]
-  type BillingMode                                       = String
   type BinaryAttributeValue                              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type BinarySetAttributeValue                           = js.Array[BinaryAttributeValue]
   type BooleanAttributeValue                             = Boolean
   type BooleanObject                                     = Boolean
   type ClientRequestToken                                = String
-  type ComparisonOperator                                = String
   type ConditionExpression                               = String
-  type ConditionalOperator                               = String
   type ConsistentRead                                    = Boolean
   type ConsumedCapacityMultiple                          = js.Array[ConsumedCapacity]
   type ConsumedCapacityUnits                             = Double
-  type ContinuousBackupsStatus                           = String
-  type ContributorInsightsAction                         = String
   type ContributorInsightsRule                           = String
   type ContributorInsightsRuleList                       = js.Array[ContributorInsightsRule]
-  type ContributorInsightsStatus                         = String
   type ContributorInsightsSummaries                      = js.Array[ContributorInsightsSummary]
   type Date                                              = js.Date
   type Endpoints                                         = js.Array[Endpoint]
@@ -67,9 +57,7 @@ package object dynamodb {
   type GlobalTableArnString                              = String
   type GlobalTableGlobalSecondaryIndexSettingsUpdateList = js.Array[GlobalTableGlobalSecondaryIndexSettingsUpdate]
   type GlobalTableList                                   = js.Array[GlobalTable]
-  type GlobalTableStatus                                 = String
   type IndexName                                         = String
-  type IndexStatus                                       = String
   type IntegerObject                                     = Int
   type ItemCollectionKeyAttributeMap                     = js.Dictionary[AttributeValue]
   type ItemCollectionMetricsMultiple                     = js.Array[ItemCollectionMetrics]
@@ -87,7 +75,6 @@ package object dynamodb {
   type KeyList                                           = js.Array[Key]
   type KeySchema                                         = js.Array[KeySchemaElement]
   type KeySchemaAttributeName                            = String
-  type KeyType                                           = String
   type LastUpdateDateTime                                = js.Date
   type ListAttributeValue                                = js.Array[AttributeValue]
   type ListContributorInsightsLimit                      = Int
@@ -103,11 +90,9 @@ package object dynamodb {
   type NullAttributeValue                                = Boolean
   type NumberAttributeValue                              = String
   type NumberSetAttributeValue                           = js.Array[NumberAttributeValue]
-  type PointInTimeRecoveryStatus                         = String
   type PositiveIntegerObject                             = Int
   type PositiveLongObject                                = Double
   type ProjectionExpression                              = String
-  type ProjectionType                                    = String
   type PutItemInputAttributeMap                          = js.Dictionary[AttributeValue]
   type RegionName                                        = String
   type ReplicaAutoScalingDescriptionList                 = js.Array[ReplicaAutoScalingDescription]
@@ -123,28 +108,18 @@ package object dynamodb {
   type ReplicaList                                        = js.Array[Replica]
   type ReplicaSettingsDescriptionList                     = js.Array[ReplicaSettingsDescription]
   type ReplicaSettingsUpdateList                          = js.Array[ReplicaSettingsUpdate]
-  type ReplicaStatus                                      = String
   type ReplicaStatusDescription                           = String
   type ReplicaStatusPercentProgress                       = String
   type ReplicaUpdateList                                  = js.Array[ReplicaUpdate]
   type ReplicationGroupUpdateList                         = js.Array[ReplicationGroupUpdate]
   type ResourceArnString                                  = String
   type RestoreInProgress                                  = Boolean
-  type ReturnConsumedCapacity                             = String
-  type ReturnItemCollectionMetrics                        = String
-  type ReturnValue                                        = String
-  type ReturnValuesOnConditionCheckFailure                = String
   type SSEEnabled                                         = Boolean
-  type SSEStatus                                          = String
-  type SSEType                                            = String
-  type ScalarAttributeType                                = String
   type ScanSegment                                        = Int
   type ScanTotalSegments                                  = Int
   type SecondaryIndexesCapacityMap                        = js.Dictionary[Capacity]
-  type Select                                             = String
   type StreamArn                                          = String
   type StreamEnabled                                      = Boolean
-  type StreamViewType                                     = String
   type StringAttributeValue                               = String
   type StringSetAttributeValue                            = js.Array[StringAttributeValue]
   type TableArn                                           = String
@@ -152,7 +127,6 @@ package object dynamodb {
   type TableId                                            = String
   type TableName                                          = String
   type TableNameList                                      = js.Array[TableName]
-  type TableStatus                                        = String
   type TagKeyList                                         = js.Array[TagKeyString]
   type TagKeyString                                       = String
   type TagList                                            = js.Array[Tag]
@@ -161,7 +135,6 @@ package object dynamodb {
   type TimeRangeUpperBound                                = js.Date
   type TimeToLiveAttributeName                            = String
   type TimeToLiveEnabled                                  = Boolean
-  type TimeToLiveStatus                                   = String
   type TransactGetItemList                                = js.Array[TransactGetItem]
   type TransactWriteItemList                              = js.Array[TransactWriteItem]
   type UpdateExpression                                   = String
@@ -348,11 +321,12 @@ package dynamodb {
       __obj.asInstanceOf[ArchivalSummary]
     }
   }
-
-  object AttributeActionEnum {
-    val ADD    = "ADD"
-    val PUT    = "PUT"
-    val DELETE = "DELETE"
+  @js.native
+  sealed trait AttributeAction extends js.Any
+  object AttributeAction extends js.Object {
+    val ADD    = "ADD".asInstanceOf[AttributeAction]
+    val PUT    = "PUT".asInstanceOf[AttributeAction]
+    val DELETE = "DELETE".asInstanceOf[AttributeAction]
 
     val values = js.Object.freeze(js.Array(ADD, PUT, DELETE))
   }
@@ -736,11 +710,12 @@ package dynamodb {
       __obj.asInstanceOf[BackupDetails]
     }
   }
-
-  object BackupStatusEnum {
-    val CREATING  = "CREATING"
-    val DELETED   = "DELETED"
-    val AVAILABLE = "AVAILABLE"
+  @js.native
+  sealed trait BackupStatus extends js.Any
+  object BackupStatus extends js.Object {
+    val CREATING  = "CREATING".asInstanceOf[BackupStatus]
+    val DELETED   = "DELETED".asInstanceOf[BackupStatus]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[BackupStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, DELETED, AVAILABLE))
   }
@@ -790,20 +765,22 @@ package dynamodb {
       __obj.asInstanceOf[BackupSummary]
     }
   }
-
-  object BackupTypeEnum {
-    val USER       = "USER"
-    val SYSTEM     = "SYSTEM"
-    val AWS_BACKUP = "AWS_BACKUP"
+  @js.native
+  sealed trait BackupType extends js.Any
+  object BackupType extends js.Object {
+    val USER       = "USER".asInstanceOf[BackupType]
+    val SYSTEM     = "SYSTEM".asInstanceOf[BackupType]
+    val AWS_BACKUP = "AWS_BACKUP".asInstanceOf[BackupType]
 
     val values = js.Object.freeze(js.Array(USER, SYSTEM, AWS_BACKUP))
   }
-
-  object BackupTypeFilterEnum {
-    val USER       = "USER"
-    val SYSTEM     = "SYSTEM"
-    val AWS_BACKUP = "AWS_BACKUP"
-    val ALL        = "ALL"
+  @js.native
+  sealed trait BackupTypeFilter extends js.Any
+  object BackupTypeFilter extends js.Object {
+    val USER       = "USER".asInstanceOf[BackupTypeFilter]
+    val SYSTEM     = "SYSTEM".asInstanceOf[BackupTypeFilter]
+    val AWS_BACKUP = "AWS_BACKUP".asInstanceOf[BackupTypeFilter]
+    val ALL        = "ALL".asInstanceOf[BackupTypeFilter]
 
     val values = js.Object.freeze(js.Array(USER, SYSTEM, AWS_BACKUP, ALL))
   }
@@ -910,10 +887,11 @@ package dynamodb {
       __obj.asInstanceOf[BatchWriteItemOutput]
     }
   }
-
-  object BillingModeEnum {
-    val PROVISIONED     = "PROVISIONED"
-    val PAY_PER_REQUEST = "PAY_PER_REQUEST"
+  @js.native
+  sealed trait BillingMode extends js.Any
+  object BillingMode extends js.Object {
+    val PROVISIONED     = "PROVISIONED".asInstanceOf[BillingMode]
+    val PAY_PER_REQUEST = "PAY_PER_REQUEST".asInstanceOf[BillingMode]
 
     val values = js.Object.freeze(js.Array(PROVISIONED, PAY_PER_REQUEST))
   }
@@ -966,21 +944,22 @@ package dynamodb {
       __obj.asInstanceOf[Capacity]
     }
   }
-
-  object ComparisonOperatorEnum {
-    val EQ           = "EQ"
-    val NE           = "NE"
-    val IN           = "IN"
-    val LE           = "LE"
-    val LT           = "LT"
-    val GE           = "GE"
-    val GT           = "GT"
-    val BETWEEN      = "BETWEEN"
-    val NOT_NULL     = "NOT_NULL"
-    val NULL         = "NULL"
-    val CONTAINS     = "CONTAINS"
-    val NOT_CONTAINS = "NOT_CONTAINS"
-    val BEGINS_WITH  = "BEGINS_WITH"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val EQ           = "EQ".asInstanceOf[ComparisonOperator]
+    val NE           = "NE".asInstanceOf[ComparisonOperator]
+    val IN           = "IN".asInstanceOf[ComparisonOperator]
+    val LE           = "LE".asInstanceOf[ComparisonOperator]
+    val LT           = "LT".asInstanceOf[ComparisonOperator]
+    val GE           = "GE".asInstanceOf[ComparisonOperator]
+    val GT           = "GT".asInstanceOf[ComparisonOperator]
+    val BETWEEN      = "BETWEEN".asInstanceOf[ComparisonOperator]
+    val NOT_NULL     = "NOT_NULL".asInstanceOf[ComparisonOperator]
+    val NULL         = "NULL".asInstanceOf[ComparisonOperator]
+    val CONTAINS     = "CONTAINS".asInstanceOf[ComparisonOperator]
+    val NOT_CONTAINS = "NOT_CONTAINS".asInstanceOf[ComparisonOperator]
+    val BEGINS_WITH  = "BEGINS_WITH".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(
       js.Array(EQ, NE, IN, LE, LT, GE, GT, BETWEEN, NOT_NULL, NULL, CONTAINS, NOT_CONTAINS, BEGINS_WITH)
@@ -1054,10 +1033,11 @@ package dynamodb {
       __obj.asInstanceOf[ConditionCheck]
     }
   }
-
-  object ConditionalOperatorEnum {
-    val AND = "AND"
-    val OR  = "OR"
+  @js.native
+  sealed trait ConditionalOperator extends js.Any
+  object ConditionalOperator extends js.Object {
+    val AND = "AND".asInstanceOf[ConditionalOperator]
+    val OR  = "OR".asInstanceOf[ConditionalOperator]
 
     val values = js.Object.freeze(js.Array(AND, OR))
   }
@@ -1124,27 +1104,30 @@ package dynamodb {
       __obj.asInstanceOf[ContinuousBackupsDescription]
     }
   }
-
-  object ContinuousBackupsStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait ContinuousBackupsStatus extends js.Any
+  object ContinuousBackupsStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[ContinuousBackupsStatus]
+    val DISABLED = "DISABLED".asInstanceOf[ContinuousBackupsStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
-
-  object ContributorInsightsActionEnum {
-    val ENABLE  = "ENABLE"
-    val DISABLE = "DISABLE"
+  @js.native
+  sealed trait ContributorInsightsAction extends js.Any
+  object ContributorInsightsAction extends js.Object {
+    val ENABLE  = "ENABLE".asInstanceOf[ContributorInsightsAction]
+    val DISABLE = "DISABLE".asInstanceOf[ContributorInsightsAction]
 
     val values = js.Object.freeze(js.Array(ENABLE, DISABLE))
   }
-
-  object ContributorInsightsStatusEnum {
-    val ENABLING  = "ENABLING"
-    val ENABLED   = "ENABLED"
-    val DISABLING = "DISABLING"
-    val DISABLED  = "DISABLED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait ContributorInsightsStatus extends js.Any
+  object ContributorInsightsStatus extends js.Object {
+    val ENABLING  = "ENABLING".asInstanceOf[ContributorInsightsStatus]
+    val ENABLED   = "ENABLED".asInstanceOf[ContributorInsightsStatus]
+    val DISABLING = "DISABLING".asInstanceOf[ContributorInsightsStatus]
+    val DISABLED  = "DISABLED".asInstanceOf[ContributorInsightsStatus]
+    val FAILED    = "FAILED".asInstanceOf[ContributorInsightsStatus]
 
     val values = js.Object.freeze(js.Array(ENABLING, ENABLED, DISABLING, DISABLED, FAILED))
   }
@@ -2469,21 +2452,23 @@ package dynamodb {
       __obj.asInstanceOf[GlobalTableGlobalSecondaryIndexSettingsUpdate]
     }
   }
-
-  object GlobalTableStatusEnum {
-    val CREATING = "CREATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
-    val UPDATING = "UPDATING"
+  @js.native
+  sealed trait GlobalTableStatus extends js.Any
+  object GlobalTableStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[GlobalTableStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[GlobalTableStatus]
+    val DELETING = "DELETING".asInstanceOf[GlobalTableStatus]
+    val UPDATING = "UPDATING".asInstanceOf[GlobalTableStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING, UPDATING))
   }
-
-  object IndexStatusEnum {
-    val CREATING = "CREATING"
-    val UPDATING = "UPDATING"
-    val DELETING = "DELETING"
-    val ACTIVE   = "ACTIVE"
+  @js.native
+  sealed trait IndexStatus extends js.Any
+  object IndexStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[IndexStatus]
+    val UPDATING = "UPDATING".asInstanceOf[IndexStatus]
+    val DELETING = "DELETING".asInstanceOf[IndexStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[IndexStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, UPDATING, DELETING, ACTIVE))
   }
@@ -2554,10 +2539,11 @@ package dynamodb {
       __obj.asInstanceOf[KeySchemaElement]
     }
   }
-
-  object KeyTypeEnum {
-    val HASH  = "HASH"
-    val RANGE = "RANGE"
+  @js.native
+  sealed trait KeyType extends js.Any
+  object KeyType extends js.Object {
+    val HASH  = "HASH".asInstanceOf[KeyType]
+    val RANGE = "RANGE".asInstanceOf[KeyType]
 
     val values = js.Object.freeze(js.Array(HASH, RANGE))
   }
@@ -2953,10 +2939,11 @@ package dynamodb {
       __obj.asInstanceOf[PointInTimeRecoverySpecification]
     }
   }
-
-  object PointInTimeRecoveryStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait PointInTimeRecoveryStatus extends js.Any
+  object PointInTimeRecoveryStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[PointInTimeRecoveryStatus]
+    val DISABLED = "DISABLED".asInstanceOf[PointInTimeRecoveryStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -2982,11 +2969,12 @@ package dynamodb {
       __obj.asInstanceOf[Projection]
     }
   }
-
-  object ProjectionTypeEnum {
-    val ALL       = "ALL"
-    val KEYS_ONLY = "KEYS_ONLY"
-    val INCLUDE   = "INCLUDE"
+  @js.native
+  sealed trait ProjectionType extends js.Any
+  object ProjectionType extends js.Object {
+    val ALL       = "ALL".asInstanceOf[ProjectionType]
+    val KEYS_ONLY = "KEYS_ONLY".asInstanceOf[ProjectionType]
+    val INCLUDE   = "INCLUDE".asInstanceOf[ProjectionType]
 
     val values = js.Object.freeze(js.Array(ALL, KEYS_ONLY, INCLUDE))
   }
@@ -3704,13 +3692,14 @@ package dynamodb {
       __obj.asInstanceOf[ReplicaSettingsUpdate]
     }
   }
-
-  object ReplicaStatusEnum {
-    val CREATING        = "CREATING"
-    val CREATION_FAILED = "CREATION_FAILED"
-    val UPDATING        = "UPDATING"
-    val DELETING        = "DELETING"
-    val ACTIVE          = "ACTIVE"
+  @js.native
+  sealed trait ReplicaStatus extends js.Any
+  object ReplicaStatus extends js.Object {
+    val CREATING        = "CREATING".asInstanceOf[ReplicaStatus]
+    val CREATION_FAILED = "CREATION_FAILED".asInstanceOf[ReplicaStatus]
+    val UPDATING        = "UPDATING".asInstanceOf[ReplicaStatus]
+    val DELETING        = "DELETING".asInstanceOf[ReplicaStatus]
+    val ACTIVE          = "ACTIVE".asInstanceOf[ReplicaStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, CREATION_FAILED, UPDATING, DELETING, ACTIVE))
   }
@@ -3930,34 +3919,39 @@ package dynamodb {
     *  * <code>TOTAL</code> - The response includes only the aggregate <code>ConsumedCapacity</code> for the operation.
     *  * <code>NONE</code> - No <code>ConsumedCapacity</code> details are included in the response.
     */
-  object ReturnConsumedCapacityEnum {
-    val INDEXES = "INDEXES"
-    val TOTAL   = "TOTAL"
-    val NONE    = "NONE"
+  @js.native
+  sealed trait ReturnConsumedCapacity extends js.Any
+  object ReturnConsumedCapacity extends js.Object {
+    val INDEXES = "INDEXES".asInstanceOf[ReturnConsumedCapacity]
+    val TOTAL   = "TOTAL".asInstanceOf[ReturnConsumedCapacity]
+    val NONE    = "NONE".asInstanceOf[ReturnConsumedCapacity]
 
     val values = js.Object.freeze(js.Array(INDEXES, TOTAL, NONE))
   }
-
-  object ReturnItemCollectionMetricsEnum {
-    val SIZE = "SIZE"
-    val NONE = "NONE"
+  @js.native
+  sealed trait ReturnItemCollectionMetrics extends js.Any
+  object ReturnItemCollectionMetrics extends js.Object {
+    val SIZE = "SIZE".asInstanceOf[ReturnItemCollectionMetrics]
+    val NONE = "NONE".asInstanceOf[ReturnItemCollectionMetrics]
 
     val values = js.Object.freeze(js.Array(SIZE, NONE))
   }
-
-  object ReturnValueEnum {
-    val NONE        = "NONE"
-    val ALL_OLD     = "ALL_OLD"
-    val UPDATED_OLD = "UPDATED_OLD"
-    val ALL_NEW     = "ALL_NEW"
-    val UPDATED_NEW = "UPDATED_NEW"
+  @js.native
+  sealed trait ReturnValue extends js.Any
+  object ReturnValue extends js.Object {
+    val NONE        = "NONE".asInstanceOf[ReturnValue]
+    val ALL_OLD     = "ALL_OLD".asInstanceOf[ReturnValue]
+    val UPDATED_OLD = "UPDATED_OLD".asInstanceOf[ReturnValue]
+    val ALL_NEW     = "ALL_NEW".asInstanceOf[ReturnValue]
+    val UPDATED_NEW = "UPDATED_NEW".asInstanceOf[ReturnValue]
 
     val values = js.Object.freeze(js.Array(NONE, ALL_OLD, UPDATED_OLD, ALL_NEW, UPDATED_NEW))
   }
-
-  object ReturnValuesOnConditionCheckFailureEnum {
-    val ALL_OLD = "ALL_OLD"
-    val NONE    = "NONE"
+  @js.native
+  sealed trait ReturnValuesOnConditionCheckFailure extends js.Any
+  object ReturnValuesOnConditionCheckFailure extends js.Object {
+    val ALL_OLD = "ALL_OLD".asInstanceOf[ReturnValuesOnConditionCheckFailure]
+    val NONE    = "NONE".asInstanceOf[ReturnValuesOnConditionCheckFailure]
 
     val values = js.Object.freeze(js.Array(ALL_OLD, NONE))
   }
@@ -4016,28 +4010,31 @@ package dynamodb {
       __obj.asInstanceOf[SSESpecification]
     }
   }
-
-  object SSEStatusEnum {
-    val ENABLING  = "ENABLING"
-    val ENABLED   = "ENABLED"
-    val DISABLING = "DISABLING"
-    val DISABLED  = "DISABLED"
-    val UPDATING  = "UPDATING"
+  @js.native
+  sealed trait SSEStatus extends js.Any
+  object SSEStatus extends js.Object {
+    val ENABLING  = "ENABLING".asInstanceOf[SSEStatus]
+    val ENABLED   = "ENABLED".asInstanceOf[SSEStatus]
+    val DISABLING = "DISABLING".asInstanceOf[SSEStatus]
+    val DISABLED  = "DISABLED".asInstanceOf[SSEStatus]
+    val UPDATING  = "UPDATING".asInstanceOf[SSEStatus]
 
     val values = js.Object.freeze(js.Array(ENABLING, ENABLED, DISABLING, DISABLED, UPDATING))
   }
-
-  object SSETypeEnum {
-    val AES256 = "AES256"
-    val KMS    = "KMS"
+  @js.native
+  sealed trait SSEType extends js.Any
+  object SSEType extends js.Object {
+    val AES256 = "AES256".asInstanceOf[SSEType]
+    val KMS    = "KMS".asInstanceOf[SSEType]
 
     val values = js.Object.freeze(js.Array(AES256, KMS))
   }
-
-  object ScalarAttributeTypeEnum {
-    val S = "S"
-    val N = "N"
-    val B = "B"
+  @js.native
+  sealed trait ScalarAttributeType extends js.Any
+  object ScalarAttributeType extends js.Object {
+    val S = "S".asInstanceOf[ScalarAttributeType]
+    val N = "N".asInstanceOf[ScalarAttributeType]
+    val B = "B".asInstanceOf[ScalarAttributeType]
 
     val values = js.Object.freeze(js.Array(S, N, B))
   }
@@ -4140,12 +4137,13 @@ package dynamodb {
       __obj.asInstanceOf[ScanOutput]
     }
   }
-
-  object SelectEnum {
-    val ALL_ATTRIBUTES           = "ALL_ATTRIBUTES"
-    val ALL_PROJECTED_ATTRIBUTES = "ALL_PROJECTED_ATTRIBUTES"
-    val SPECIFIC_ATTRIBUTES      = "SPECIFIC_ATTRIBUTES"
-    val COUNT                    = "COUNT"
+  @js.native
+  sealed trait Select extends js.Any
+  object Select extends js.Object {
+    val ALL_ATTRIBUTES           = "ALL_ATTRIBUTES".asInstanceOf[Select]
+    val ALL_PROJECTED_ATTRIBUTES = "ALL_PROJECTED_ATTRIBUTES".asInstanceOf[Select]
+    val SPECIFIC_ATTRIBUTES      = "SPECIFIC_ATTRIBUTES".asInstanceOf[Select]
+    val COUNT                    = "COUNT".asInstanceOf[Select]
 
     val values = js.Object.freeze(js.Array(ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT))
   }
@@ -4249,12 +4247,13 @@ package dynamodb {
       __obj.asInstanceOf[StreamSpecification]
     }
   }
-
-  object StreamViewTypeEnum {
-    val NEW_IMAGE          = "NEW_IMAGE"
-    val OLD_IMAGE          = "OLD_IMAGE"
-    val NEW_AND_OLD_IMAGES = "NEW_AND_OLD_IMAGES"
-    val KEYS_ONLY          = "KEYS_ONLY"
+  @js.native
+  sealed trait StreamViewType extends js.Any
+  object StreamViewType extends js.Object {
+    val NEW_IMAGE          = "NEW_IMAGE".asInstanceOf[StreamViewType]
+    val OLD_IMAGE          = "OLD_IMAGE".asInstanceOf[StreamViewType]
+    val NEW_AND_OLD_IMAGES = "NEW_AND_OLD_IMAGES".asInstanceOf[StreamViewType]
+    val KEYS_ONLY          = "KEYS_ONLY".asInstanceOf[StreamViewType]
 
     val values = js.Object.freeze(js.Array(NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES, KEYS_ONLY))
   }
@@ -4362,15 +4361,16 @@ package dynamodb {
       __obj.asInstanceOf[TableDescription]
     }
   }
-
-  object TableStatusEnum {
-    val CREATING                            = "CREATING"
-    val UPDATING                            = "UPDATING"
-    val DELETING                            = "DELETING"
-    val ACTIVE                              = "ACTIVE"
-    val INACCESSIBLE_ENCRYPTION_CREDENTIALS = "INACCESSIBLE_ENCRYPTION_CREDENTIALS"
-    val ARCHIVING                           = "ARCHIVING"
-    val ARCHIVED                            = "ARCHIVED"
+  @js.native
+  sealed trait TableStatus extends js.Any
+  object TableStatus extends js.Object {
+    val CREATING                            = "CREATING".asInstanceOf[TableStatus]
+    val UPDATING                            = "UPDATING".asInstanceOf[TableStatus]
+    val DELETING                            = "DELETING".asInstanceOf[TableStatus]
+    val ACTIVE                              = "ACTIVE".asInstanceOf[TableStatus]
+    val INACCESSIBLE_ENCRYPTION_CREDENTIALS = "INACCESSIBLE_ENCRYPTION_CREDENTIALS".asInstanceOf[TableStatus]
+    val ARCHIVING                           = "ARCHIVING".asInstanceOf[TableStatus]
+    val ARCHIVED                            = "ARCHIVED".asInstanceOf[TableStatus]
 
     val values = js.Object.freeze(
       js.Array(CREATING, UPDATING, DELETING, ACTIVE, INACCESSIBLE_ENCRYPTION_CREDENTIALS, ARCHIVING, ARCHIVED)
@@ -4469,12 +4469,13 @@ package dynamodb {
       __obj.asInstanceOf[TimeToLiveSpecification]
     }
   }
-
-  object TimeToLiveStatusEnum {
-    val ENABLING  = "ENABLING"
-    val DISABLING = "DISABLING"
-    val ENABLED   = "ENABLED"
-    val DISABLED  = "DISABLED"
+  @js.native
+  sealed trait TimeToLiveStatus extends js.Any
+  object TimeToLiveStatus extends js.Object {
+    val ENABLING  = "ENABLING".asInstanceOf[TimeToLiveStatus]
+    val DISABLING = "DISABLING".asInstanceOf[TimeToLiveStatus]
+    val ENABLED   = "ENABLED".asInstanceOf[TimeToLiveStatus]
+    val DISABLED  = "DISABLED".asInstanceOf[TimeToLiveStatus]
 
     val values = js.Object.freeze(js.Array(ENABLING, DISABLING, ENABLED, DISABLED))
   }

--- a/services/dynamodbstreams/src/main/scala/facade/amazonaws/services/DynamoDBStreams.scala
+++ b/services/dynamodbstreams/src/main/scala/facade/amazonaws/services/DynamoDBStreams.scala
@@ -16,13 +16,11 @@ package object dynamodbstreams {
   type ErrorMessage            = String
   type KeySchema               = js.Array[KeySchemaElement]
   type KeySchemaAttributeName  = String
-  type KeyType                 = String
   type ListAttributeValue      = js.Array[AttributeValue]
   type MapAttributeValue       = js.Dictionary[AttributeValue]
   type NullAttributeValue      = Boolean
   type NumberAttributeValue    = String
   type NumberSetAttributeValue = js.Array[NumberAttributeValue]
-  type OperationType           = String
   type PositiveIntegerObject   = Int
   type PositiveLongObject      = Double
   type RecordList              = js.Array[Record]
@@ -30,11 +28,8 @@ package object dynamodbstreams {
   type ShardDescriptionList    = js.Array[Shard]
   type ShardId                 = String
   type ShardIterator           = String
-  type ShardIteratorType       = String
   type StreamArn               = String
   type StreamList              = js.Array[Stream]
-  type StreamStatus            = String
-  type StreamViewType          = String
   type StringAttributeValue    = String
   type StringSetAttributeValue = js.Array[StringAttributeValue]
   type TableName               = String
@@ -317,10 +312,11 @@ package dynamodbstreams {
       __obj.asInstanceOf[KeySchemaElement]
     }
   }
-
-  object KeyTypeEnum {
-    val HASH  = "HASH"
-    val RANGE = "RANGE"
+  @js.native
+  sealed trait KeyType extends js.Any
+  object KeyType extends js.Object {
+    val HASH  = "HASH".asInstanceOf[KeyType]
+    val RANGE = "RANGE".asInstanceOf[KeyType]
 
     val values = js.Object.freeze(js.Array(HASH, RANGE))
   }
@@ -379,11 +375,12 @@ package dynamodbstreams {
       __obj.asInstanceOf[ListStreamsOutput]
     }
   }
-
-  object OperationTypeEnum {
-    val INSERT = "INSERT"
-    val MODIFY = "MODIFY"
-    val REMOVE = "REMOVE"
+  @js.native
+  sealed trait OperationType extends js.Any
+  object OperationType extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[OperationType]
+    val MODIFY = "MODIFY".asInstanceOf[OperationType]
+    val REMOVE = "REMOVE".asInstanceOf[OperationType]
 
     val values = js.Object.freeze(js.Array(INSERT, MODIFY, REMOVE))
   }
@@ -479,12 +476,13 @@ package dynamodbstreams {
       __obj.asInstanceOf[Shard]
     }
   }
-
-  object ShardIteratorTypeEnum {
-    val TRIM_HORIZON          = "TRIM_HORIZON"
-    val LATEST                = "LATEST"
-    val AT_SEQUENCE_NUMBER    = "AT_SEQUENCE_NUMBER"
-    val AFTER_SEQUENCE_NUMBER = "AFTER_SEQUENCE_NUMBER"
+  @js.native
+  sealed trait ShardIteratorType extends js.Any
+  object ShardIteratorType extends js.Object {
+    val TRIM_HORIZON          = "TRIM_HORIZON".asInstanceOf[ShardIteratorType]
+    val LATEST                = "LATEST".asInstanceOf[ShardIteratorType]
+    val AT_SEQUENCE_NUMBER    = "AT_SEQUENCE_NUMBER".asInstanceOf[ShardIteratorType]
+    val AFTER_SEQUENCE_NUMBER = "AFTER_SEQUENCE_NUMBER".asInstanceOf[ShardIteratorType]
 
     val values = js.Object.freeze(js.Array(TRIM_HORIZON, LATEST, AT_SEQUENCE_NUMBER, AFTER_SEQUENCE_NUMBER))
   }
@@ -595,21 +593,23 @@ package dynamodbstreams {
       __obj.asInstanceOf[StreamRecord]
     }
   }
-
-  object StreamStatusEnum {
-    val ENABLING  = "ENABLING"
-    val ENABLED   = "ENABLED"
-    val DISABLING = "DISABLING"
-    val DISABLED  = "DISABLED"
+  @js.native
+  sealed trait StreamStatus extends js.Any
+  object StreamStatus extends js.Object {
+    val ENABLING  = "ENABLING".asInstanceOf[StreamStatus]
+    val ENABLED   = "ENABLED".asInstanceOf[StreamStatus]
+    val DISABLING = "DISABLING".asInstanceOf[StreamStatus]
+    val DISABLED  = "DISABLED".asInstanceOf[StreamStatus]
 
     val values = js.Object.freeze(js.Array(ENABLING, ENABLED, DISABLING, DISABLED))
   }
-
-  object StreamViewTypeEnum {
-    val NEW_IMAGE          = "NEW_IMAGE"
-    val OLD_IMAGE          = "OLD_IMAGE"
-    val NEW_AND_OLD_IMAGES = "NEW_AND_OLD_IMAGES"
-    val KEYS_ONLY          = "KEYS_ONLY"
+  @js.native
+  sealed trait StreamViewType extends js.Any
+  object StreamViewType extends js.Object {
+    val NEW_IMAGE          = "NEW_IMAGE".asInstanceOf[StreamViewType]
+    val OLD_IMAGE          = "OLD_IMAGE".asInstanceOf[StreamViewType]
+    val NEW_AND_OLD_IMAGES = "NEW_AND_OLD_IMAGES".asInstanceOf[StreamViewType]
+    val KEYS_ONLY          = "KEYS_ONLY".asInstanceOf[StreamViewType]
 
     val values = js.Object.freeze(js.Array(NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES, KEYS_ONLY))
   }

--- a/services/ebs/src/main/scala/facade/amazonaws/services/EBS.scala
+++ b/services/ebs/src/main/scala/facade/amazonaws/services/EBS.scala
@@ -7,20 +7,19 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object ebs {
-  type BlockData         = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type BlockIndex        = Int
-  type BlockSize         = Int
-  type BlockToken        = String
-  type Blocks            = js.Array[Block]
-  type ChangedBlocks     = js.Array[ChangedBlock]
-  type Checksum          = String
-  type ChecksumAlgorithm = String
-  type DataLength        = Int
-  type MaxResults        = Int
-  type PageToken         = String
-  type SnapshotId        = String
-  type TimeStamp         = js.Date
-  type VolumeSize        = Double
+  type BlockData     = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type BlockIndex    = Int
+  type BlockSize     = Int
+  type BlockToken    = String
+  type Blocks        = js.Array[Block]
+  type ChangedBlocks = js.Array[ChangedBlock]
+  type Checksum      = String
+  type DataLength    = Int
+  type MaxResults    = Int
+  type PageToken     = String
+  type SnapshotId    = String
+  type TimeStamp     = js.Date
+  type VolumeSize    = Double
 
   implicit final class EBSOps(private val service: EBS) extends AnyVal {
 
@@ -90,9 +89,10 @@ package ebs {
       __obj.asInstanceOf[ChangedBlock]
     }
   }
-
-  object ChecksumAlgorithmEnum {
-    val SHA256 = "SHA256"
+  @js.native
+  sealed trait ChecksumAlgorithm extends js.Any
+  object ChecksumAlgorithm extends js.Object {
+    val SHA256 = "SHA256".asInstanceOf[ChecksumAlgorithm]
 
     val values = js.Object.freeze(js.Array(SHA256))
   }

--- a/services/ec2/src/main/scala/facade/amazonaws/services/EC2.scala
+++ b/services/ec2/src/main/scala/facade/amazonaws/services/EC2.scala
@@ -8,40 +8,24 @@ import facade.amazonaws._
 
 package object ec2 {
   type AccountAttributeList                             = js.Array[AccountAttribute]
-  type AccountAttributeName                             = String
   type AccountAttributeNameStringList                   = js.Array[AccountAttributeName]
   type AccountAttributeValueList                        = js.Array[AccountAttributeValue]
   type ActiveInstanceSet                                = js.Array[ActiveInstance]
-  type ActivityStatus                                   = String
   type AddressList                                      = js.Array[Address]
-  type Affinity                                         = String
   type AllocationId                                     = String
   type AllocationIdList                                 = js.Array[String]
-  type AllocationState                                  = String
-  type AllocationStrategy                               = String
   type AllowedPrincipalSet                              = js.Array[AllowedPrincipal]
-  type AllowsMultipleInstanceTypes                      = String
-  type ArchitectureType                                 = String
   type ArchitectureTypeList                             = js.Array[ArchitectureType]
-  type ArchitectureValues                               = String
   type AssignedPrivateIpAddressList                     = js.Array[AssignedPrivateIpAddress]
-  type AssociatedNetworkType                            = String
   type AssociatedTargetNetworkSet                       = js.Array[AssociatedTargetNetwork]
   type AssociationIdList                                = js.Array[IamInstanceProfileAssociationId]
-  type AssociationStatusCode                            = String
-  type AttachmentStatus                                 = String
   type AuthorizationRuleSet                             = js.Array[AuthorizationRule]
-  type AutoAcceptSharedAttachmentsValue                 = String
-  type AutoPlacement                                    = String
   type AutoRecoveryFlag                                 = Boolean
   type AvailabilityZoneList                             = js.Array[AvailabilityZone]
   type AvailabilityZoneMessageList                      = js.Array[AvailabilityZoneMessage]
-  type AvailabilityZoneOptInStatus                      = String
-  type AvailabilityZoneState                            = String
   type AvailabilityZoneStringList                       = js.Array[String]
   type AvailableInstanceCapacityList                    = js.Array[InstanceCapacity]
   type BareMetalFlag                                    = Boolean
-  type BatchState                                       = String
   type BillingProductList                               = js.Array[String]
   type Blob                                             = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type BlockDeviceMappingList                           = js.Array[BlockDeviceMapping]
@@ -49,38 +33,24 @@ package object ec2 {
   type BundleId                                         = String
   type BundleIdStringList                               = js.Array[BundleId]
   type BundleTaskList                                   = js.Array[BundleTask]
-  type BundleTaskState                                  = String
   type BurstablePerformanceFlag                         = Boolean
   type ByoipCidrSet                                     = js.Array[ByoipCidr]
-  type ByoipCidrState                                   = String
-  type CancelBatchErrorCode                             = String
   type CancelSpotFleetRequestsErrorSet                  = js.Array[CancelSpotFleetRequestsErrorItem]
   type CancelSpotFleetRequestsSuccessSet                = js.Array[CancelSpotFleetRequestsSuccessItem]
-  type CancelSpotInstanceRequestState                   = String
   type CancelledSpotInstanceRequestList                 = js.Array[CancelledSpotInstanceRequest]
   type CapacityReservationId                            = String
   type CapacityReservationIdSet                         = js.Array[String]
-  type CapacityReservationInstancePlatform              = String
-  type CapacityReservationPreference                    = String
   type CapacityReservationSet                           = js.Array[CapacityReservation]
-  type CapacityReservationState                         = String
-  type CapacityReservationTenancy                       = String
   type CidrBlockSet                                     = js.Array[CidrBlock]
   type ClassicLinkDnsSupportList                        = js.Array[ClassicLinkDnsSupport]
   type ClassicLinkInstanceList                          = js.Array[ClassicLinkInstance]
   type ClassicLoadBalancers                             = js.Array[ClassicLoadBalancer]
-  type ClientCertificateRevocationListStatusCode        = String
   type ClientVpnAuthenticationList                      = js.Array[ClientVpnAuthentication]
   type ClientVpnAuthenticationRequestList               = js.Array[ClientVpnAuthenticationRequest]
-  type ClientVpnAuthenticationType                      = String
-  type ClientVpnAuthorizationRuleStatusCode             = String
   type ClientVpnConnectionSet                           = js.Array[ClientVpnConnection]
-  type ClientVpnConnectionStatusCode                    = String
   type ClientVpnEndpointId                              = String
   type ClientVpnEndpointIdList                          = js.Array[ClientVpnEndpointId]
-  type ClientVpnEndpointStatusCode                      = String
   type ClientVpnRouteSet                                = js.Array[ClientVpnRoute]
-  type ClientVpnRouteStatusCode                         = String
   type ClientVpnSecurityGroupIdSet                      = js.Array[String]
   type CoipAddressUsageSet                              = js.Array[CoipAddressUsage]
   type CoipPoolId                                       = String
@@ -89,39 +59,27 @@ package object ec2 {
   type CoipPoolSet                                      = js.Array[CoipPool]
   type ConnectionNotificationId                         = String
   type ConnectionNotificationSet                        = js.Array[ConnectionNotification]
-  type ConnectionNotificationState                      = String
-  type ConnectionNotificationType                       = String
-  type ContainerFormat                                  = String
   type ConversionIdStringList                           = js.Array[ConversionTaskId]
   type ConversionTaskId                                 = String
-  type ConversionTaskState                              = String
-  type CopyTagsFromSource                               = String
   type CoreCount                                        = Int
   type CoreCountList                                    = js.Array[CoreCount]
   type CreateFleetErrorsSet                             = js.Array[CreateFleetError]
   type CreateFleetInstancesSet                          = js.Array[CreateFleetInstance]
   type CreateVolumePermissionList                       = js.Array[CreateVolumePermission]
-  type CurrencyCodeValues                               = String
   type CurrentGenerationFlag                            = Boolean
   type CustomerGatewayId                                = String
   type CustomerGatewayIdStringList                      = js.Array[CustomerGatewayId]
   type CustomerGatewayList                              = js.Array[CustomerGateway]
   type DITMaxResults                                    = Int
   type DITOMaxResults                                   = Int
-  type DatafeedSubscriptionState                        = String
   type DateTime                                         = js.Date
   type DedicatedHostFlag                                = Boolean
   type DedicatedHostId                                  = String
-  type DefaultRouteTableAssociationValue                = String
-  type DefaultRouteTablePropagationValue                = String
-  type DefaultTargetCapacityType                        = String
   type DefaultingDhcpOptionsId                          = String
-  type DeleteFleetErrorCode                             = String
   type DeleteFleetErrorSet                              = js.Array[DeleteFleetErrorItem]
   type DeleteFleetSuccessSet                            = js.Array[DeleteFleetSuccessItem]
   type DeleteLaunchTemplateVersionsResponseErrorSet     = js.Array[DeleteLaunchTemplateVersionsResponseErrorItem]
   type DeleteLaunchTemplateVersionsResponseSuccessSet   = js.Array[DeleteLaunchTemplateVersionsResponseSuccessItem]
-  type DeleteQueuedReservedInstancesErrorCode           = String
   type DeleteQueuedReservedInstancesIdList              = js.Array[ReservationId]
   type DescribeByoipCidrsMaxResults                     = Int
   type DescribeCapacityReservationsMaxResults           = Int
@@ -164,7 +122,6 @@ package object ec2 {
   type DescribeVpcClassicLinkDnsSupportNextToken        = String
   type DescribeVpcPeeringConnectionsMaxResults          = Int
   type DescribeVpcsMaxResults                           = Int
-  type DeviceType                                       = String
   type DhcpConfigurationList                            = js.Array[DhcpConfiguration]
   type DhcpConfigurationValueList                       = js.Array[AttributeValue]
   type DhcpOptionsId                                    = String
@@ -174,17 +131,10 @@ package object ec2 {
   type DisableFastSnapshotRestoreStateErrorSet          = js.Array[DisableFastSnapshotRestoreStateErrorItem]
   type DisableFastSnapshotRestoreSuccessSet             = js.Array[DisableFastSnapshotRestoreSuccessItem]
   type DiskCount                                        = Int
-  type DiskImageFormat                                  = String
   type DiskImageList                                    = js.Array[DiskImage]
   type DiskInfoList                                     = js.Array[DiskInfo]
   type DiskSize                                         = Double
-  type DiskType                                         = String
   type DnsEntrySet                                      = js.Array[DnsEntry]
-  type DnsNameState                                     = String
-  type DnsSupportValue                                  = String
-  type DomainType                                       = String
-  type EbsEncryptionSupport                             = String
-  type EbsOptimizedSupport                              = String
   type EgressOnlyInternetGatewayId                      = String
   type EgressOnlyInternetGatewayIdList                  = js.Array[EgressOnlyInternetGatewayId]
   type EgressOnlyInternetGatewayList                    = js.Array[EgressOnlyInternetGateway]
@@ -195,64 +145,43 @@ package object ec2 {
   type ElasticGpuSpecificationList                      = js.Array[ElasticGpuSpecification]
   type ElasticGpuSpecificationResponseList              = js.Array[ElasticGpuSpecificationResponse]
   type ElasticGpuSpecifications                         = js.Array[ElasticGpuSpecification]
-  type ElasticGpuState                                  = String
-  type ElasticGpuStatus                                 = String
   type ElasticInferenceAcceleratorAssociationList       = js.Array[ElasticInferenceAcceleratorAssociation]
   type ElasticInferenceAcceleratorCount                 = Int
   type ElasticInferenceAccelerators                     = js.Array[ElasticInferenceAccelerator]
   type ElasticIpAssociationId                           = String
-  type EnaSupport                                       = String
   type EnableFastSnapshotRestoreErrorSet                = js.Array[EnableFastSnapshotRestoreErrorItem]
   type EnableFastSnapshotRestoreStateErrorSet           = js.Array[EnableFastSnapshotRestoreStateErrorItem]
   type EnableFastSnapshotRestoreSuccessSet              = js.Array[EnableFastSnapshotRestoreSuccessItem]
-  type EndDateType                                      = String
   type EndpointSet                                      = js.Array[ClientVpnEndpoint]
-  type EventCode                                        = String
-  type EventType                                        = String
-  type ExcessCapacityTerminationPolicy                  = String
   type ExecutableByStringList                           = js.Array[String]
-  type ExportEnvironment                                = String
   type ExportImageTaskId                                = String
   type ExportImageTaskIdList                            = js.Array[ExportImageTaskId]
   type ExportImageTaskList                              = js.Array[ExportImageTask]
   type ExportTaskId                                     = String
   type ExportTaskIdStringList                           = js.Array[String]
   type ExportTaskList                                   = js.Array[ExportTask]
-  type ExportTaskState                                  = String
   type FailedQueuedPurchaseDeletionSet                  = js.Array[FailedQueuedPurchaseDeletion]
-  type FastSnapshotRestoreStateCode                     = String
   type FilterList                                       = js.Array[Filter]
-  type FleetActivityStatus                              = String
-  type FleetCapacityReservationUsageStrategy            = String
-  type FleetEventType                                   = String
-  type FleetExcessCapacityTerminationPolicy             = String
   type FleetIdSet                                       = js.Array[FleetIdentifier]
   type FleetIdentifier                                  = String
   type FleetLaunchTemplateConfigList                    = js.Array[FleetLaunchTemplateConfig]
   type FleetLaunchTemplateConfigListRequest             = js.Array[FleetLaunchTemplateConfigRequest]
   type FleetLaunchTemplateOverridesList                 = js.Array[FleetLaunchTemplateOverrides]
   type FleetLaunchTemplateOverridesListRequest          = js.Array[FleetLaunchTemplateOverridesRequest]
-  type FleetOnDemandAllocationStrategy                  = String
   type FleetSet                                         = js.Array[FleetData]
-  type FleetStateCode                                   = String
-  type FleetType                                        = String
   type FlowLogIdList                                    = js.Array[VpcFlowLogId]
   type FlowLogResourceId                                = String
   type FlowLogResourceIds                               = js.Array[FlowLogResourceId]
   type FlowLogSet                                       = js.Array[FlowLog]
-  type FlowLogsResourceType                             = String
   type FpgaDeviceCount                                  = Int
   type FpgaDeviceInfoList                               = js.Array[FpgaDeviceInfo]
   type FpgaDeviceManufacturerName                       = String
   type FpgaDeviceMemorySize                             = Int
   type FpgaDeviceName                                   = String
-  type FpgaImageAttributeName                           = String
   type FpgaImageId                                      = String
   type FpgaImageIdList                                  = js.Array[FpgaImageId]
   type FpgaImageList                                    = js.Array[FpgaImage]
-  type FpgaImageStateCode                               = String
   type FreeTierEligibleFlag                             = Boolean
-  type GatewayType                                      = String
   type GetCapacityReservationUsageRequestMaxResults     = Int
   type GpuDeviceCount                                   = Int
   type GpuDeviceInfoList                                = js.Array[GpuDeviceInfo]
@@ -270,26 +199,18 @@ package object ec2 {
   type HostInstanceList                                 = js.Array[HostInstance]
   type HostList                                         = js.Array[Host]
   type HostOfferingSet                                  = js.Array[HostOffering]
-  type HostRecovery                                     = String
   type HostReservationId                                = String
   type HostReservationIdSet                             = js.Array[HostReservationId]
   type HostReservationSet                               = js.Array[HostReservation]
-  type HostTenancy                                      = String
-  type HttpTokensState                                  = String
-  type HypervisorType                                   = String
   type IKEVersionsList                                  = js.Array[IKEVersionsListValue]
   type IKEVersionsRequestList                           = js.Array[IKEVersionsRequestListValue]
   type IamInstanceProfileAssociationId                  = String
   type IamInstanceProfileAssociationSet                 = js.Array[IamInstanceProfileAssociation]
-  type IamInstanceProfileAssociationState               = String
   type IdFormatList                                     = js.Array[IdFormat]
-  type ImageAttributeName                               = String
   type ImageDiskContainerList                           = js.Array[ImageDiskContainer]
   type ImageId                                          = String
   type ImageIdStringList                                = js.Array[ImageId]
   type ImageList                                        = js.Array[Image]
-  type ImageState                                       = String
-  type ImageTypeValues                                  = String
   type ImportImageLicenseSpecificationListRequest       = js.Array[ImportImageLicenseConfigurationRequest]
   type ImportImageLicenseSpecificationListResponse      = js.Array[ImportImageLicenseConfigurationResponse]
   type ImportImageTaskId                                = String
@@ -304,44 +225,32 @@ package object ec2 {
   type InferenceDeviceInfoList                          = js.Array[InferenceDeviceInfo]
   type InferenceDeviceManufacturerName                  = String
   type InferenceDeviceName                              = String
-  type InstanceAttributeName                            = String
   type InstanceBlockDeviceMappingList                   = js.Array[InstanceBlockDeviceMapping]
   type InstanceBlockDeviceMappingSpecificationList      = js.Array[InstanceBlockDeviceMappingSpecification]
   type InstanceCountList                                = js.Array[InstanceCount]
   type InstanceCreditSpecificationList                  = js.Array[InstanceCreditSpecification]
   type InstanceCreditSpecificationListRequest           = js.Array[InstanceCreditSpecificationRequest]
   type InstanceEventId                                  = String
-  type InstanceHealthStatus                             = String
   type InstanceId                                       = String
   type InstanceIdSet                                    = js.Array[String]
   type InstanceIdStringList                             = js.Array[InstanceId]
   type InstanceIdsSet                                   = js.Array[InstanceId]
-  type InstanceInterruptionBehavior                     = String
   type InstanceIpv6AddressList                          = js.Array[InstanceIpv6Address]
   type InstanceIpv6AddressListRequest                   = js.Array[InstanceIpv6AddressRequest]
-  type InstanceLifecycle                                = String
-  type InstanceLifecycleType                            = String
   type InstanceList                                     = js.Array[Instance]
-  type InstanceMatchCriteria                            = String
-  type InstanceMetadataEndpointState                    = String
-  type InstanceMetadataOptionsState                     = String
   type InstanceMonitoringList                           = js.Array[InstanceMonitoring]
   type InstanceNetworkInterfaceList                     = js.Array[InstanceNetworkInterface]
   type InstanceNetworkInterfaceSpecificationList        = js.Array[InstanceNetworkInterfaceSpecification]
   type InstancePrivateIpAddressList                     = js.Array[InstancePrivateIpAddress]
   type InstanceStateChangeList                          = js.Array[InstanceStateChange]
-  type InstanceStateName                                = String
   type InstanceStatusDetailsList                        = js.Array[InstanceStatusDetails]
   type InstanceStatusEventList                          = js.Array[InstanceStatusEvent]
   type InstanceStatusList                               = js.Array[InstanceStatus]
   type InstanceStorageFlag                              = Boolean
-  type InstanceType                                     = String
-  type InstanceTypeHypervisor                           = String
   type InstanceTypeInfoList                             = js.Array[InstanceTypeInfo]
   type InstanceTypeList                                 = js.Array[InstanceType]
   type InstanceTypeOfferingsList                        = js.Array[InstanceTypeOffering]
   type InstanceUsageSet                                 = js.Array[InstanceUsage]
-  type InterfacePermissionType                          = String
   type InternetGatewayAttachmentList                    = js.Array[InternetGatewayAttachment]
   type InternetGatewayId                                = String
   type InternetGatewayIdList                            = js.Array[InternetGatewayId]
@@ -360,7 +269,6 @@ package object ec2 {
   type Ipv6PoolMaxResults                               = Int
   type Ipv6PoolSet                                      = js.Array[Ipv6Pool]
   type Ipv6RangeList                                    = js.Array[Ipv6Range]
-  type Ipv6SupportValue                                 = String
   type KernelId                                         = String
   type KeyNameStringList                                = js.Array[KeyPairName]
   type KeyPairId                                        = String
@@ -377,12 +285,8 @@ package object ec2 {
   type LaunchTemplateElasticInferenceAcceleratorList    = js.Array[LaunchTemplateElasticInferenceAccelerator]
   type LaunchTemplateElasticInferenceAcceleratorResponseList =
     js.Array[LaunchTemplateElasticInferenceAcceleratorResponse]
-  type LaunchTemplateErrorCode                     = String
-  type LaunchTemplateHttpTokensState               = String
-  type LaunchTemplateId                            = String
-  type LaunchTemplateIdStringList                  = js.Array[LaunchTemplateId]
-  type LaunchTemplateInstanceMetadataEndpointState = String
-  type LaunchTemplateInstanceMetadataOptionsState  = String
+  type LaunchTemplateId           = String
+  type LaunchTemplateIdStringList = js.Array[LaunchTemplateId]
   type LaunchTemplateInstanceNetworkInterfaceSpecificationList =
     js.Array[LaunchTemplateInstanceNetworkInterfaceSpecification]
   type LaunchTemplateInstanceNetworkInterfaceSpecificationRequestList =
@@ -398,15 +302,12 @@ package object ec2 {
   type LaunchTemplateVersionSet                                 = js.Array[LaunchTemplateVersion]
   type LicenseList                                              = js.Array[LicenseConfiguration]
   type LicenseSpecificationListRequest                          = js.Array[LicenseConfigurationRequest]
-  type ListingState                                             = String
-  type ListingStatus                                            = String
   type LoadPermissionList                                       = js.Array[LoadPermission]
   type LoadPermissionListRequest                                = js.Array[LoadPermissionRequest]
   type LocalGatewayId                                           = String
   type LocalGatewayIdSet                                        = js.Array[LocalGatewayId]
   type LocalGatewayMaxResults                                   = Int
   type LocalGatewayRouteList                                    = js.Array[LocalGatewayRoute]
-  type LocalGatewayRouteState                                   = String
   type LocalGatewayRouteTableIdSet                              = js.Array[LocalGatewayRoutetableId]
   type LocalGatewayRouteTableSet                                = js.Array[LocalGatewayRouteTable]
   type LocalGatewayRouteTableVirtualInterfaceGroupAssociationId = String
@@ -417,7 +318,6 @@ package object ec2 {
   type LocalGatewayRouteTableVpcAssociationId            = String
   type LocalGatewayRouteTableVpcAssociationIdSet         = js.Array[LocalGatewayRouteTableVpcAssociationId]
   type LocalGatewayRouteTableVpcAssociationSet           = js.Array[LocalGatewayRouteTableVpcAssociation]
-  type LocalGatewayRouteType                             = String
   type LocalGatewayRoutetableId                          = String
   type LocalGatewaySet                                   = js.Array[LocalGateway]
   type LocalGatewayVirtualInterfaceGroupId               = String
@@ -427,25 +327,17 @@ package object ec2 {
   type LocalGatewayVirtualInterfaceIdSet                 = js.Array[LocalGatewayVirtualInterfaceId]
   type LocalGatewayVirtualInterfaceSet                   = js.Array[LocalGatewayVirtualInterface]
   type Location                                          = String
-  type LocationType                                      = String
-  type LogDestinationType                                = String
-  type MarketType                                        = String
   type MaxIpv4AddrPerInterface                           = Int
   type MaxIpv6AddrPerInterface                           = Int
   type MaxNetworkInterfaces                              = Int
   type MaxResults                                        = Int
-  type MembershipType                                    = String
   type MemorySize                                        = Double
   type MillisecondDateTime                               = js.Date
-  type MonitoringState                                   = String
-  type MoveStatus                                        = String
   type MovingAddressStatusSet                            = js.Array[MovingAddressStatus]
-  type MulticastSupportValue                             = String
   type NatGatewayAddressList                             = js.Array[NatGatewayAddress]
   type NatGatewayId                                      = String
   type NatGatewayIdStringList                            = js.Array[NatGatewayId]
   type NatGatewayList                                    = js.Array[NatGateway]
-  type NatGatewayState                                   = String
   type NetworkAclAssociationId                           = String
   type NetworkAclAssociationList                         = js.Array[NetworkAclAssociation]
   type NetworkAclEntryList                               = js.Array[NetworkAclEntry]
@@ -453,8 +345,6 @@ package object ec2 {
   type NetworkAclIdStringList                            = js.Array[NetworkAclId]
   type NetworkAclList                                    = js.Array[NetworkAcl]
   type NetworkInterfaceAttachmentId                      = String
-  type NetworkInterfaceAttribute                         = String
-  type NetworkInterfaceCreationType                      = String
   type NetworkInterfaceId                                = String
   type NetworkInterfaceIdList                            = js.Array[NetworkInterfaceId]
   type NetworkInterfaceIpv6AddressesList                 = js.Array[NetworkInterfaceIpv6Address]
@@ -462,23 +352,14 @@ package object ec2 {
   type NetworkInterfacePermissionId                      = String
   type NetworkInterfacePermissionIdList                  = js.Array[NetworkInterfacePermissionId]
   type NetworkInterfacePermissionList                    = js.Array[NetworkInterfacePermission]
-  type NetworkInterfacePermissionStateCode               = String
   type NetworkInterfacePrivateIpAddressList              = js.Array[NetworkInterfacePrivateIpAddress]
-  type NetworkInterfaceStatus                            = String
-  type NetworkInterfaceType                              = String
   type NetworkPerformance                                = String
   type NewDhcpConfigurationList                          = js.Array[NewDhcpConfiguration]
   type NextToken                                         = String
   type OccurrenceDayRequestSet                           = js.Array[Int]
   type OccurrenceDaySet                                  = js.Array[Int]
-  type OfferingClassType                                 = String
   type OfferingId                                        = String
-  type OfferingTypeValues                                = String
-  type OnDemandAllocationStrategy                        = String
-  type OperationType                                     = String
   type OwnerStringList                                   = js.Array[String]
-  type PaymentOption                                     = String
-  type PermissionGroup                                   = String
   type Phase1DHGroupNumbersList                          = js.Array[Phase1DHGroupNumbersListValue]
   type Phase1DHGroupNumbersRequestList                   = js.Array[Phase1DHGroupNumbersRequestListValue]
   type Phase1EncryptionAlgorithmsList                    = js.Array[Phase1EncryptionAlgorithmsListValue]
@@ -495,12 +376,8 @@ package object ec2 {
   type PlacementGroupIdStringList                        = js.Array[PlacementGroupId]
   type PlacementGroupList                                = js.Array[PlacementGroup]
   type PlacementGroupName                                = String
-  type PlacementGroupState                               = String
-  type PlacementGroupStrategy                            = String
   type PlacementGroupStrategyList                        = js.Array[PlacementGroupStrategy]
   type PlacementGroupStringList                          = js.Array[PlacementGroupName]
-  type PlacementStrategy                                 = String
-  type PlatformValues                                    = String
   type PoolCidrBlocksSet                                 = js.Array[PoolCidrBlock]
   type PoolMaxResults                                    = Int
   type PrefixListIdList                                  = js.Array[PrefixListId]
@@ -512,14 +389,12 @@ package object ec2 {
   type PriceScheduleSpecificationList                    = js.Array[PriceScheduleSpecification]
   type PricingDetailsList                                = js.Array[PricingDetail]
   type PrincipalIdFormatList                             = js.Array[PrincipalIdFormat]
-  type PrincipalType                                     = String
   type PrivateIpAddressConfigSet                         = js.Array[ScheduledInstancesPrivateIpAddressConfig]
   type PrivateIpAddressSpecificationList                 = js.Array[PrivateIpAddressSpecification]
   type PrivateIpAddressStringList                        = js.Array[String]
   type ProcessorSustainedClockSpeed                      = Double
   type ProductCodeList                                   = js.Array[ProductCode]
   type ProductCodeStringList                             = js.Array[String]
-  type ProductCodeValues                                 = String
   type ProductDescriptionList                            = js.Array[String]
   type PropagatingVgwList                                = js.Array[PropagatingVgw]
   type PublicIpStringList                                = js.Array[String]
@@ -529,15 +404,11 @@ package object ec2 {
   type PurchaseRequestSet                                = js.Array[PurchaseRequest]
   type PurchaseSet                                       = js.Array[Purchase]
   type PurchasedScheduledInstanceSet                     = js.Array[ScheduledInstance]
-  type RIProductDescription                              = String
   type RamdiskId                                         = String
   type ReasonCodesList                                   = js.Array[ReportInstanceReasonCodes]
-  type RecurringChargeFrequency                          = String
   type RecurringChargesList                              = js.Array[RecurringCharge]
   type RegionList                                        = js.Array[Region]
   type RegionNameStringList                              = js.Array[String]
-  type ReportInstanceReasonCodes                         = String
-  type ReportStatusType                                  = String
   type RequestHostIdList                                 = js.Array[DedicatedHostId]
   type RequestHostIdSet                                  = js.Array[DedicatedHostId]
   type RequestInstanceTypeList                           = js.Array[InstanceType]
@@ -545,10 +416,8 @@ package object ec2 {
   type RequestSpotLaunchSpecificationSecurityGroupList   = js.Array[SecurityGroupName]
   type ReservationId                                     = String
   type ReservationList                                   = js.Array[Reservation]
-  type ReservationState                                  = String
   type ReservedInstanceIdSet                             = js.Array[ReservationId]
   type ReservedInstanceReservationValueSet               = js.Array[ReservedInstanceReservationValue]
-  type ReservedInstanceState                             = String
   type ReservedInstancesConfigurationList                = js.Array[ReservedInstancesConfiguration]
   type ReservedInstancesIdStringList                     = js.Array[ReservationId]
   type ReservedInstancesList                             = js.Array[ReservedInstances]
@@ -562,27 +431,19 @@ package object ec2 {
   type ReservedInstancesOfferingIdStringList             = js.Array[ReservedInstancesOfferingId]
   type ReservedInstancesOfferingList                     = js.Array[ReservedInstancesOffering]
   type ReservedIntancesIds                               = js.Array[ReservedInstancesId]
-  type ResetFpgaImageAttributeName                       = String
-  type ResetImageAttributeName                           = String
   type ResourceIdList                                    = js.Array[TaggableResourceId]
   type ResourceList                                      = js.Array[String]
-  type ResourceType                                      = String
   type ResponseHostIdList                                = js.Array[String]
   type ResponseHostIdSet                                 = js.Array[String]
   type RestorableByStringList                            = js.Array[String]
-  type RootDeviceType                                    = String
   type RootDeviceTypeList                                = js.Array[RootDeviceType]
   type RouteGatewayId                                    = String
   type RouteList                                         = js.Array[Route]
-  type RouteOrigin                                       = String
-  type RouteState                                        = String
   type RouteTableAssociationId                           = String
   type RouteTableAssociationList                         = js.Array[RouteTableAssociation]
-  type RouteTableAssociationStateCode                    = String
   type RouteTableId                                      = String
   type RouteTableIdStringList                            = js.Array[RouteTableId]
   type RouteTableList                                    = js.Array[RouteTable]
-  type RuleAction                                        = String
   type ScheduledInstanceAvailabilitySet                  = js.Array[ScheduledInstanceAvailability]
   type ScheduledInstanceId                               = String
   type ScheduledInstanceIdRequestSet                     = js.Array[ScheduledInstanceId]
@@ -600,46 +461,30 @@ package object ec2 {
   type SensitiveUserData                                 = String
   type ServiceConfigurationSet                           = js.Array[ServiceConfiguration]
   type ServiceDetailSet                                  = js.Array[ServiceDetail]
-  type ServiceState                                      = String
-  type ServiceType                                       = String
   type ServiceTypeDetailSet                              = js.Array[ServiceTypeDetail]
-  type ShutdownBehavior                                  = String
-  type SnapshotAttributeName                             = String
   type SnapshotDetailList                                = js.Array[SnapshotDetail]
   type SnapshotId                                        = String
   type SnapshotIdStringList                              = js.Array[SnapshotId]
   type SnapshotList                                      = js.Array[Snapshot]
   type SnapshotSet                                       = js.Array[SnapshotInfo]
-  type SnapshotState                                     = String
-  type SpotAllocationStrategy                            = String
   type SpotFleetRequestConfigSet                         = js.Array[SpotFleetRequestConfig]
   type SpotFleetRequestId                                = String
   type SpotFleetRequestIdList                            = js.Array[SpotFleetRequestId]
   type SpotFleetTagSpecificationList                     = js.Array[SpotFleetTagSpecification]
-  type SpotInstanceInterruptionBehavior                  = String
   type SpotInstanceRequestId                             = String
   type SpotInstanceRequestIdList                         = js.Array[SpotInstanceRequestId]
   type SpotInstanceRequestList                           = js.Array[SpotInstanceRequest]
-  type SpotInstanceState                                 = String
-  type SpotInstanceType                                  = String
   type SpotPriceHistoryList                              = js.Array[SpotPrice]
   type StaleIpPermissionSet                              = js.Array[StaleIpPermission]
   type StaleSecurityGroupSet                             = js.Array[StaleSecurityGroup]
-  type State                                             = String
-  type Status                                            = String
-  type StatusName                                        = String
-  type StatusType                                        = String
   type SubnetAssociationList                             = js.Array[SubnetAssociation]
   type SubnetCidrAssociationId                           = String
-  type SubnetCidrBlockStateCode                          = String
   type SubnetId                                          = String
   type SubnetIdStringList                                = js.Array[SubnetId]
   type SubnetIpv6CidrBlockAssociationSet                 = js.Array[SubnetIpv6CidrBlockAssociation]
   type SubnetList                                        = js.Array[Subnet]
-  type SubnetState                                       = String
   type SuccessfulInstanceCreditSpecificationSet          = js.Array[SuccessfulInstanceCreditSpecificationItem]
   type SuccessfulQueuedPurchaseDeletionSet               = js.Array[SuccessfulQueuedPurchaseDeletion]
-  type SummaryStatus                                     = String
   type TagDescriptionList                                = js.Array[TagDescription]
   type TagList                                           = js.Array[Tag]
   type TagSpecificationList                              = js.Array[TagSpecification]
@@ -648,23 +493,16 @@ package object ec2 {
   type TargetGroups                                      = js.Array[TargetGroup]
   type TargetNetworkSet                                  = js.Array[TargetNetwork]
   type TargetReservationValueSet                         = js.Array[TargetReservationValue]
-  type TelemetryStatus                                   = String
-  type Tenancy                                           = String
   type TerminateConnectionStatusSet                      = js.Array[TerminateConnectionStatus]
   type ThreadsPerCore                                    = Int
   type ThreadsPerCoreList                                = js.Array[ThreadsPerCore]
-  type TrafficDirection                                  = String
   type TrafficMirrorFilterId                             = String
   type TrafficMirrorFilterIdList                         = js.Array[TrafficMirrorFilterId]
-  type TrafficMirrorFilterRuleField                      = String
   type TrafficMirrorFilterRuleFieldList                  = js.Array[TrafficMirrorFilterRuleField]
   type TrafficMirrorFilterRuleId                         = String
   type TrafficMirrorFilterRuleList                       = js.Array[TrafficMirrorFilterRule]
   type TrafficMirrorFilterSet                            = js.Array[TrafficMirrorFilter]
-  type TrafficMirrorNetworkService                       = String
   type TrafficMirrorNetworkServiceList                   = js.Array[TrafficMirrorNetworkService]
-  type TrafficMirrorRuleAction                           = String
-  type TrafficMirrorSessionField                         = String
   type TrafficMirrorSessionFieldList                     = js.Array[TrafficMirrorSessionField]
   type TrafficMirrorSessionId                            = String
   type TrafficMirrorSessionIdList                        = js.Array[TrafficMirrorSessionId]
@@ -672,51 +510,35 @@ package object ec2 {
   type TrafficMirrorTargetId                             = String
   type TrafficMirrorTargetIdList                         = js.Array[TrafficMirrorTargetId]
   type TrafficMirrorTargetSet                            = js.Array[TrafficMirrorTarget]
-  type TrafficMirrorTargetType                           = String
   type TrafficMirroringMaxResults                        = Int
-  type TrafficType                                       = String
-  type TransitGatewayAssociationState                    = String
   type TransitGatewayAttachmentId                        = String
   type TransitGatewayAttachmentIdStringList              = js.Array[TransitGatewayAttachmentId]
   type TransitGatewayAttachmentList                      = js.Array[TransitGatewayAttachment]
   type TransitGatewayAttachmentPropagationList           = js.Array[TransitGatewayAttachmentPropagation]
-  type TransitGatewayAttachmentResourceType              = String
-  type TransitGatewayAttachmentState                     = String
   type TransitGatewayId                                  = String
   type TransitGatewayIdStringList                        = js.Array[TransitGatewayId]
   type TransitGatewayList                                = js.Array[TransitGateway]
   type TransitGatewayMaxResults                          = Int
-  type TransitGatewayMulitcastDomainAssociationState     = String
   type TransitGatewayMulticastDomainAssociationList      = js.Array[TransitGatewayMulticastDomainAssociation]
   type TransitGatewayMulticastDomainId                   = String
   type TransitGatewayMulticastDomainIdStringList         = js.Array[String]
   type TransitGatewayMulticastDomainList                 = js.Array[TransitGatewayMulticastDomain]
-  type TransitGatewayMulticastDomainState                = String
   type TransitGatewayMulticastGroupList                  = js.Array[TransitGatewayMulticastGroup]
   type TransitGatewayNetworkInterfaceIdList              = js.Array[NetworkInterfaceId]
   type TransitGatewayPeeringAttachmentList               = js.Array[TransitGatewayPeeringAttachment]
-  type TransitGatewayPropagationState                    = String
   type TransitGatewayRouteAttachmentList                 = js.Array[TransitGatewayRouteAttachment]
   type TransitGatewayRouteList                           = js.Array[TransitGatewayRoute]
-  type TransitGatewayRouteState                          = String
   type TransitGatewayRouteTableAssociationList           = js.Array[TransitGatewayRouteTableAssociation]
   type TransitGatewayRouteTableId                        = String
   type TransitGatewayRouteTableIdStringList              = js.Array[String]
   type TransitGatewayRouteTableList                      = js.Array[TransitGatewayRouteTable]
   type TransitGatewayRouteTablePropagationList           = js.Array[TransitGatewayRouteTablePropagation]
-  type TransitGatewayRouteTableState                     = String
-  type TransitGatewayRouteType                           = String
-  type TransitGatewayState                               = String
   type TransitGatewaySubnetIdList                        = js.Array[SubnetId]
   type TransitGatewayVpcAttachmentList                   = js.Array[TransitGatewayVpcAttachment]
-  type TransportProtocol                                 = String
   type TunnelOptionsList                                 = js.Array[TunnelOption]
-  type UnlimitedSupportedInstanceFamily                  = String
-  type UnsuccessfulInstanceCreditSpecificationErrorCode  = String
   type UnsuccessfulInstanceCreditSpecificationSet        = js.Array[UnsuccessfulInstanceCreditSpecificationItem]
   type UnsuccessfulItemList                              = js.Array[UnsuccessfulItem]
   type UnsuccessfulItemSet                               = js.Array[UnsuccessfulItem]
-  type UsageClassType                                    = String
   type UsageClassTypeList                                = js.Array[UsageClassType]
   type UserGroupStringList                               = js.Array[String]
   type UserIdGroupPairList                               = js.Array[UserIdGroupPair]
@@ -727,29 +549,19 @@ package object ec2 {
   type VersionDescription                                = String
   type VersionStringList                                 = js.Array[String]
   type VgwTelemetryList                                  = js.Array[VgwTelemetry]
-  type VirtualizationType                                = String
   type VolumeAttachmentList                              = js.Array[VolumeAttachment]
-  type VolumeAttachmentState                             = String
-  type VolumeAttributeName                               = String
   type VolumeId                                          = String
   type VolumeIdStringList                                = js.Array[VolumeId]
   type VolumeList                                        = js.Array[Volume]
   type VolumeModificationList                            = js.Array[VolumeModification]
-  type VolumeModificationState                           = String
-  type VolumeState                                       = String
   type VolumeStatusActionsList                           = js.Array[VolumeStatusAction]
   type VolumeStatusAttachmentStatusList                  = js.Array[VolumeStatusAttachmentStatus]
   type VolumeStatusDetailsList                           = js.Array[VolumeStatusDetails]
   type VolumeStatusEventsList                            = js.Array[VolumeStatusEvent]
-  type VolumeStatusInfoStatus                            = String
   type VolumeStatusList                                  = js.Array[VolumeStatusItem]
-  type VolumeStatusName                                  = String
-  type VolumeType                                        = String
   type VpcAttachmentList                                 = js.Array[VpcAttachment]
-  type VpcAttributeName                                  = String
   type VpcCidrAssociationId                              = String
   type VpcCidrBlockAssociationSet                        = js.Array[VpcCidrBlockAssociation]
-  type VpcCidrBlockStateCode                             = String
   type VpcClassicLinkIdList                              = js.Array[VpcId]
   type VpcClassicLinkList                                = js.Array[VpcClassicLink]
   type VpcEndpointConnectionSet                          = js.Array[VpcEndpointConnection]
@@ -761,7 +573,6 @@ package object ec2 {
   type VpcEndpointServiceIdList                          = js.Array[VpcEndpointServiceId]
   type VpcEndpointSet                                    = js.Array[VpcEndpoint]
   type VpcEndpointSubnetIdList                           = js.Array[SubnetId]
-  type VpcEndpointType                                   = String
   type VpcFlowLogId                                      = String
   type VpcId                                             = String
   type VpcIdStringList                                   = js.Array[VpcId]
@@ -770,24 +581,16 @@ package object ec2 {
   type VpcPeeringConnectionId                            = String
   type VpcPeeringConnectionIdList                        = js.Array[VpcPeeringConnectionId]
   type VpcPeeringConnectionList                          = js.Array[VpcPeeringConnection]
-  type VpcPeeringConnectionStateReasonCode               = String
-  type VpcState                                          = String
-  type VpcTenancy                                        = String
   type VpnConnectionId                                   = String
   type VpnConnectionIdStringList                         = js.Array[VpnConnectionId]
   type VpnConnectionList                                 = js.Array[VpnConnection]
-  type VpnEcmpSupportValue                               = String
   type VpnGatewayId                                      = String
   type VpnGatewayIdStringList                            = js.Array[VpnGatewayId]
   type VpnGatewayList                                    = js.Array[VpnGateway]
-  type VpnProtocol                                       = String
-  type VpnState                                          = String
   type VpnStaticRouteList                                = js.Array[VpnStaticRoute]
-  type VpnStaticRouteSource                              = String
   type VpnTunnelOptionsSpecificationsList                = js.Array[VpnTunnelOptionsSpecification]
   type ZoneIdStringList                                  = js.Array[String]
   type ZoneNameStringList                                = js.Array[String]
-  type scope                                             = String
   type totalFpgaMemory                                   = Int
   type totalGpuMemory                                    = Int
 
@@ -2872,10 +2675,11 @@ package ec2 {
       __obj.asInstanceOf[AccountAttribute]
     }
   }
-
-  object AccountAttributeNameEnum {
-    val `supported-platforms` = "supported-platforms"
-    val `default-vpc`         = "default-vpc"
+  @js.native
+  sealed trait AccountAttributeName extends js.Any
+  object AccountAttributeName extends js.Object {
+    val `supported-platforms` = "supported-platforms".asInstanceOf[AccountAttributeName]
+    val `default-vpc`         = "default-vpc".asInstanceOf[AccountAttributeName]
 
     val values = js.Object.freeze(js.Array(`supported-platforms`, `default-vpc`))
   }
@@ -2926,12 +2730,13 @@ package ec2 {
       __obj.asInstanceOf[ActiveInstance]
     }
   }
-
-  object ActivityStatusEnum {
-    val error               = "error"
-    val pending_fulfillment = "pending_fulfillment"
-    val pending_termination = "pending_termination"
-    val fulfilled           = "fulfilled"
+  @js.native
+  sealed trait ActivityStatus extends js.Any
+  object ActivityStatus extends js.Object {
+    val error               = "error".asInstanceOf[ActivityStatus]
+    val pending_fulfillment = "pending_fulfillment".asInstanceOf[ActivityStatus]
+    val pending_termination = "pending_termination".asInstanceOf[ActivityStatus]
+    val fulfilled           = "fulfilled".asInstanceOf[ActivityStatus]
 
     val values = js.Object.freeze(js.Array(error, pending_fulfillment, pending_termination, fulfilled))
   }
@@ -3027,10 +2832,11 @@ package ec2 {
       __obj.asInstanceOf[AdvertiseByoipCidrResult]
     }
   }
-
-  object AffinityEnum {
-    val default = "default"
-    val host    = "host"
+  @js.native
+  sealed trait Affinity extends js.Any
+  object Affinity extends js.Object {
+    val default = "default".asInstanceOf[Affinity]
+    val host    = "host".asInstanceOf[Affinity]
 
     val values = js.Object.freeze(js.Array(default, host))
   }
@@ -3157,24 +2963,26 @@ package ec2 {
       __obj.asInstanceOf[AllocateHostsResult]
     }
   }
-
-  object AllocationStateEnum {
-    val available                    = "available"
-    val `under-assessment`           = "under-assessment"
-    val `permanent-failure`          = "permanent-failure"
-    val released                     = "released"
-    val `released-permanent-failure` = "released-permanent-failure"
-    val pending                      = "pending"
+  @js.native
+  sealed trait AllocationState extends js.Any
+  object AllocationState extends js.Object {
+    val available                    = "available".asInstanceOf[AllocationState]
+    val `under-assessment`           = "under-assessment".asInstanceOf[AllocationState]
+    val `permanent-failure`          = "permanent-failure".asInstanceOf[AllocationState]
+    val released                     = "released".asInstanceOf[AllocationState]
+    val `released-permanent-failure` = "released-permanent-failure".asInstanceOf[AllocationState]
+    val pending                      = "pending".asInstanceOf[AllocationState]
 
     val values = js.Object.freeze(
       js.Array(available, `under-assessment`, `permanent-failure`, released, `released-permanent-failure`, pending)
     )
   }
-
-  object AllocationStrategyEnum {
-    val lowestPrice       = "lowestPrice"
-    val diversified       = "diversified"
-    val capacityOptimized = "capacityOptimized"
+  @js.native
+  sealed trait AllocationStrategy extends js.Any
+  object AllocationStrategy extends js.Object {
+    val lowestPrice       = "lowestPrice".asInstanceOf[AllocationStrategy]
+    val diversified       = "diversified".asInstanceOf[AllocationStrategy]
+    val capacityOptimized = "capacityOptimized".asInstanceOf[AllocationStrategy]
 
     val values = js.Object.freeze(js.Array(lowestPrice, diversified, capacityOptimized))
   }
@@ -3200,10 +3008,11 @@ package ec2 {
       __obj.asInstanceOf[AllowedPrincipal]
     }
   }
-
-  object AllowsMultipleInstanceTypesEnum {
-    val on  = "on"
-    val off = "off"
+  @js.native
+  sealed trait AllowsMultipleInstanceTypes extends js.Any
+  object AllowsMultipleInstanceTypes extends js.Object {
+    val on  = "on".asInstanceOf[AllowsMultipleInstanceTypes]
+    val off = "off".asInstanceOf[AllowsMultipleInstanceTypes]
 
     val values = js.Object.freeze(js.Array(on, off))
   }
@@ -3250,19 +3059,21 @@ package ec2 {
       __obj.asInstanceOf[ApplySecurityGroupsToClientVpnTargetNetworkResult]
     }
   }
-
-  object ArchitectureTypeEnum {
-    val i386   = "i386"
-    val x86_64 = "x86_64"
-    val arm64  = "arm64"
+  @js.native
+  sealed trait ArchitectureType extends js.Any
+  object ArchitectureType extends js.Object {
+    val i386   = "i386".asInstanceOf[ArchitectureType]
+    val x86_64 = "x86_64".asInstanceOf[ArchitectureType]
+    val arm64  = "arm64".asInstanceOf[ArchitectureType]
 
     val values = js.Object.freeze(js.Array(i386, x86_64, arm64))
   }
-
-  object ArchitectureValuesEnum {
-    val i386   = "i386"
-    val x86_64 = "x86_64"
-    val arm64  = "arm64"
+  @js.native
+  sealed trait ArchitectureValues extends js.Any
+  object ArchitectureValues extends js.Object {
+    val i386   = "i386".asInstanceOf[ArchitectureValues]
+    val x86_64 = "x86_64".asInstanceOf[ArchitectureValues]
+    val arm64  = "arm64".asInstanceOf[ArchitectureValues]
 
     val values = js.Object.freeze(js.Array(i386, x86_64, arm64))
   }
@@ -3770,9 +3581,10 @@ package ec2 {
       __obj.asInstanceOf[AssociateVpcCidrBlockResult]
     }
   }
-
-  object AssociatedNetworkTypeEnum {
-    val vpc = "vpc"
+  @js.native
+  sealed trait AssociatedNetworkType extends js.Any
+  object AssociatedNetworkType extends js.Object {
+    val vpc = "vpc".asInstanceOf[AssociatedNetworkType]
 
     val values = js.Object.freeze(js.Array(vpc))
   }
@@ -3820,13 +3632,14 @@ package ec2 {
       __obj.asInstanceOf[AssociationStatus]
     }
   }
-
-  object AssociationStatusCodeEnum {
-    val associating          = "associating"
-    val associated           = "associated"
-    val `association-failed` = "association-failed"
-    val disassociating       = "disassociating"
-    val disassociated        = "disassociated"
+  @js.native
+  sealed trait AssociationStatusCode extends js.Any
+  object AssociationStatusCode extends js.Object {
+    val associating          = "associating".asInstanceOf[AssociationStatusCode]
+    val associated           = "associated".asInstanceOf[AssociationStatusCode]
+    val `association-failed` = "association-failed".asInstanceOf[AssociationStatusCode]
+    val disassociating       = "disassociating".asInstanceOf[AssociationStatusCode]
+    val disassociated        = "disassociated".asInstanceOf[AssociationStatusCode]
 
     val values =
       js.Object.freeze(js.Array(associating, associated, `association-failed`, disassociating, disassociated))
@@ -4020,12 +3833,13 @@ package ec2 {
       __obj.asInstanceOf[AttachVpnGatewayResult]
     }
   }
-
-  object AttachmentStatusEnum {
-    val attaching = "attaching"
-    val attached  = "attached"
-    val detaching = "detaching"
-    val detached  = "detached"
+  @js.native
+  sealed trait AttachmentStatus extends js.Any
+  object AttachmentStatus extends js.Object {
+    val attaching = "attaching".asInstanceOf[AttachmentStatus]
+    val attached  = "attached".asInstanceOf[AttachmentStatus]
+    val detaching = "detaching".asInstanceOf[AttachmentStatus]
+    val detached  = "detached".asInstanceOf[AttachmentStatus]
 
     val values = js.Object.freeze(js.Array(attaching, attached, detaching, detached))
   }
@@ -4242,17 +4056,19 @@ package ec2 {
       __obj.asInstanceOf[AuthorizeSecurityGroupIngressRequest]
     }
   }
-
-  object AutoAcceptSharedAttachmentsValueEnum {
-    val enable  = "enable"
-    val disable = "disable"
+  @js.native
+  sealed trait AutoAcceptSharedAttachmentsValue extends js.Any
+  object AutoAcceptSharedAttachmentsValue extends js.Object {
+    val enable  = "enable".asInstanceOf[AutoAcceptSharedAttachmentsValue]
+    val disable = "disable".asInstanceOf[AutoAcceptSharedAttachmentsValue]
 
     val values = js.Object.freeze(js.Array(enable, disable))
   }
-
-  object AutoPlacementEnum {
-    val on  = "on"
-    val off = "off"
+  @js.native
+  sealed trait AutoPlacement extends js.Any
+  object AutoPlacement extends js.Object {
+    val on  = "on".asInstanceOf[AutoPlacement]
+    val off = "off".asInstanceOf[AutoPlacement]
 
     val values = js.Object.freeze(js.Array(on, off))
   }
@@ -4315,20 +4131,22 @@ package ec2 {
       __obj.asInstanceOf[AvailabilityZoneMessage]
     }
   }
-
-  object AvailabilityZoneOptInStatusEnum {
-    val `opt-in-not-required` = "opt-in-not-required"
-    val `opted-in`            = "opted-in"
-    val `not-opted-in`        = "not-opted-in"
+  @js.native
+  sealed trait AvailabilityZoneOptInStatus extends js.Any
+  object AvailabilityZoneOptInStatus extends js.Object {
+    val `opt-in-not-required` = "opt-in-not-required".asInstanceOf[AvailabilityZoneOptInStatus]
+    val `opted-in`            = "opted-in".asInstanceOf[AvailabilityZoneOptInStatus]
+    val `not-opted-in`        = "not-opted-in".asInstanceOf[AvailabilityZoneOptInStatus]
 
     val values = js.Object.freeze(js.Array(`opt-in-not-required`, `opted-in`, `not-opted-in`))
   }
-
-  object AvailabilityZoneStateEnum {
-    val available   = "available"
-    val information = "information"
-    val impaired    = "impaired"
-    val unavailable = "unavailable"
+  @js.native
+  sealed trait AvailabilityZoneState extends js.Any
+  object AvailabilityZoneState extends js.Object {
+    val available   = "available".asInstanceOf[AvailabilityZoneState]
+    val information = "information".asInstanceOf[AvailabilityZoneState]
+    val impaired    = "impaired".asInstanceOf[AvailabilityZoneState]
+    val unavailable = "unavailable".asInstanceOf[AvailabilityZoneState]
 
     val values = js.Object.freeze(js.Array(available, information, impaired, unavailable))
   }
@@ -4356,15 +4174,16 @@ package ec2 {
       __obj.asInstanceOf[AvailableCapacity]
     }
   }
-
-  object BatchStateEnum {
-    val submitted             = "submitted"
-    val active                = "active"
-    val cancelled             = "cancelled"
-    val failed                = "failed"
-    val cancelled_running     = "cancelled_running"
-    val cancelled_terminating = "cancelled_terminating"
-    val modifying             = "modifying"
+  @js.native
+  sealed trait BatchState extends js.Any
+  object BatchState extends js.Object {
+    val submitted             = "submitted".asInstanceOf[BatchState]
+    val active                = "active".asInstanceOf[BatchState]
+    val cancelled             = "cancelled".asInstanceOf[BatchState]
+    val failed                = "failed".asInstanceOf[BatchState]
+    val cancelled_running     = "cancelled_running".asInstanceOf[BatchState]
+    val cancelled_terminating = "cancelled_terminating".asInstanceOf[BatchState]
+    val modifying             = "modifying".asInstanceOf[BatchState]
 
     val values = js.Object.freeze(
       js.Array(submitted, active, cancelled, failed, cancelled_running, cancelled_terminating, modifying)
@@ -4522,15 +4341,16 @@ package ec2 {
       __obj.asInstanceOf[BundleTaskError]
     }
   }
-
-  object BundleTaskStateEnum {
-    val pending                = "pending"
-    val `waiting-for-shutdown` = "waiting-for-shutdown"
-    val bundling               = "bundling"
-    val storing                = "storing"
-    val cancelling             = "cancelling"
-    val complete               = "complete"
-    val failed                 = "failed"
+  @js.native
+  sealed trait BundleTaskState extends js.Any
+  object BundleTaskState extends js.Object {
+    val pending                = "pending".asInstanceOf[BundleTaskState]
+    val `waiting-for-shutdown` = "waiting-for-shutdown".asInstanceOf[BundleTaskState]
+    val bundling               = "bundling".asInstanceOf[BundleTaskState]
+    val storing                = "storing".asInstanceOf[BundleTaskState]
+    val cancelling             = "cancelling".asInstanceOf[BundleTaskState]
+    val complete               = "complete".asInstanceOf[BundleTaskState]
+    val failed                 = "failed".asInstanceOf[BundleTaskState]
 
     val values =
       js.Object.freeze(js.Array(pending, `waiting-for-shutdown`, bundling, storing, cancelling, complete, failed))
@@ -4563,16 +4383,17 @@ package ec2 {
       __obj.asInstanceOf[ByoipCidr]
     }
   }
-
-  object ByoipCidrStateEnum {
-    val advertised                              = "advertised"
-    val deprovisioned                           = "deprovisioned"
-    val `failed-deprovision`                    = "failed-deprovision"
-    val `failed-provision`                      = "failed-provision"
-    val `pending-deprovision`                   = "pending-deprovision"
-    val `pending-provision`                     = "pending-provision"
-    val provisioned                             = "provisioned"
-    val `provisioned-not-publicly-advertisable` = "provisioned-not-publicly-advertisable"
+  @js.native
+  sealed trait ByoipCidrState extends js.Any
+  object ByoipCidrState extends js.Object {
+    val advertised                              = "advertised".asInstanceOf[ByoipCidrState]
+    val deprovisioned                           = "deprovisioned".asInstanceOf[ByoipCidrState]
+    val `failed-deprovision`                    = "failed-deprovision".asInstanceOf[ByoipCidrState]
+    val `failed-provision`                      = "failed-provision".asInstanceOf[ByoipCidrState]
+    val `pending-deprovision`                   = "pending-deprovision".asInstanceOf[ByoipCidrState]
+    val `pending-provision`                     = "pending-provision".asInstanceOf[ByoipCidrState]
+    val provisioned                             = "provisioned".asInstanceOf[ByoipCidrState]
+    val `provisioned-not-publicly-advertisable` = "provisioned-not-publicly-advertisable".asInstanceOf[ByoipCidrState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4587,12 +4408,13 @@ package ec2 {
       )
     )
   }
-
-  object CancelBatchErrorCodeEnum {
-    val fleetRequestIdDoesNotExist        = "fleetRequestIdDoesNotExist"
-    val fleetRequestIdMalformed           = "fleetRequestIdMalformed"
-    val fleetRequestNotInCancellableState = "fleetRequestNotInCancellableState"
-    val unexpectedError                   = "unexpectedError"
+  @js.native
+  sealed trait CancelBatchErrorCode extends js.Any
+  object CancelBatchErrorCode extends js.Object {
+    val fleetRequestIdDoesNotExist        = "fleetRequestIdDoesNotExist".asInstanceOf[CancelBatchErrorCode]
+    val fleetRequestIdMalformed           = "fleetRequestIdMalformed".asInstanceOf[CancelBatchErrorCode]
+    val fleetRequestNotInCancellableState = "fleetRequestNotInCancellableState".asInstanceOf[CancelBatchErrorCode]
+    val unexpectedError                   = "unexpectedError".asInstanceOf[CancelBatchErrorCode]
 
     val values = js.Object.freeze(
       js.Array(fleetRequestIdDoesNotExist, fleetRequestIdMalformed, fleetRequestNotInCancellableState, unexpectedError)
@@ -4930,13 +4752,14 @@ package ec2 {
       __obj.asInstanceOf[CancelSpotFleetRequestsSuccessItem]
     }
   }
-
-  object CancelSpotInstanceRequestStateEnum {
-    val active    = "active"
-    val open      = "open"
-    val closed    = "closed"
-    val cancelled = "cancelled"
-    val completed = "completed"
+  @js.native
+  sealed trait CancelSpotInstanceRequestState extends js.Any
+  object CancelSpotInstanceRequestState extends js.Object {
+    val active    = "active".asInstanceOf[CancelSpotInstanceRequestState]
+    val open      = "open".asInstanceOf[CancelSpotInstanceRequestState]
+    val closed    = "closed".asInstanceOf[CancelSpotInstanceRequestState]
+    val cancelled = "cancelled".asInstanceOf[CancelSpotInstanceRequestState]
+    val completed = "completed".asInstanceOf[CancelSpotInstanceRequestState]
 
     val values = js.Object.freeze(js.Array(active, open, closed, cancelled, completed))
   }
@@ -5077,19 +4900,24 @@ package ec2 {
       __obj.asInstanceOf[CapacityReservation]
     }
   }
-
-  object CapacityReservationInstancePlatformEnum {
-    val `Linux/UNIX`                         = "Linux/UNIX"
-    val `Red Hat Enterprise Linux`           = "Red Hat Enterprise Linux"
-    val `SUSE Linux`                         = "SUSE Linux"
-    val Windows                              = "Windows"
-    val `Windows with SQL Server`            = "Windows with SQL Server"
-    val `Windows with SQL Server Enterprise` = "Windows with SQL Server Enterprise"
-    val `Windows with SQL Server Standard`   = "Windows with SQL Server Standard"
-    val `Windows with SQL Server Web`        = "Windows with SQL Server Web"
-    val `Linux with SQL Server Standard`     = "Linux with SQL Server Standard"
-    val `Linux with SQL Server Web`          = "Linux with SQL Server Web"
-    val `Linux with SQL Server Enterprise`   = "Linux with SQL Server Enterprise"
+  @js.native
+  sealed trait CapacityReservationInstancePlatform extends js.Any
+  object CapacityReservationInstancePlatform extends js.Object {
+    val `Linux/UNIX`               = "Linux/UNIX".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Red Hat Enterprise Linux` = "Red Hat Enterprise Linux".asInstanceOf[CapacityReservationInstancePlatform]
+    val `SUSE Linux`               = "SUSE Linux".asInstanceOf[CapacityReservationInstancePlatform]
+    val Windows                    = "Windows".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Windows with SQL Server`  = "Windows with SQL Server".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Windows with SQL Server Enterprise` =
+      "Windows with SQL Server Enterprise".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Windows with SQL Server Standard` =
+      "Windows with SQL Server Standard".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Windows with SQL Server Web` = "Windows with SQL Server Web".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Linux with SQL Server Standard` =
+      "Linux with SQL Server Standard".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Linux with SQL Server Web` = "Linux with SQL Server Web".asInstanceOf[CapacityReservationInstancePlatform]
+    val `Linux with SQL Server Enterprise` =
+      "Linux with SQL Server Enterprise".asInstanceOf[CapacityReservationInstancePlatform]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5151,10 +4979,11 @@ package ec2 {
       __obj.asInstanceOf[CapacityReservationOptionsRequest]
     }
   }
-
-  object CapacityReservationPreferenceEnum {
-    val open = "open"
-    val none = "none"
+  @js.native
+  sealed trait CapacityReservationPreference extends js.Any
+  object CapacityReservationPreference extends js.Object {
+    val open = "open".asInstanceOf[CapacityReservationPreference]
+    val none = "none".asInstanceOf[CapacityReservationPreference]
 
     val values = js.Object.freeze(js.Array(open, none))
   }
@@ -5211,13 +5040,14 @@ package ec2 {
       __obj.asInstanceOf[CapacityReservationSpecificationResponse]
     }
   }
-
-  object CapacityReservationStateEnum {
-    val active    = "active"
-    val expired   = "expired"
-    val cancelled = "cancelled"
-    val pending   = "pending"
-    val failed    = "failed"
+  @js.native
+  sealed trait CapacityReservationState extends js.Any
+  object CapacityReservationState extends js.Object {
+    val active    = "active".asInstanceOf[CapacityReservationState]
+    val expired   = "expired".asInstanceOf[CapacityReservationState]
+    val cancelled = "cancelled".asInstanceOf[CapacityReservationState]
+    val pending   = "pending".asInstanceOf[CapacityReservationState]
+    val failed    = "failed".asInstanceOf[CapacityReservationState]
 
     val values = js.Object.freeze(js.Array(active, expired, cancelled, pending, failed))
   }
@@ -5259,10 +5089,11 @@ package ec2 {
       __obj.asInstanceOf[CapacityReservationTargetResponse]
     }
   }
-
-  object CapacityReservationTenancyEnum {
-    val default   = "default"
-    val dedicated = "dedicated"
+  @js.native
+  sealed trait CapacityReservationTenancy extends js.Any
+  object CapacityReservationTenancy extends js.Object {
+    val default   = "default".asInstanceOf[CapacityReservationTenancy]
+    val dedicated = "dedicated".asInstanceOf[CapacityReservationTenancy]
 
     val values = js.Object.freeze(js.Array(default, dedicated))
   }
@@ -5461,10 +5292,11 @@ package ec2 {
       __obj.asInstanceOf[ClientCertificateRevocationListStatus]
     }
   }
-
-  object ClientCertificateRevocationListStatusCodeEnum {
-    val pending = "pending"
-    val active  = "active"
+  @js.native
+  sealed trait ClientCertificateRevocationListStatusCode extends js.Any
+  object ClientCertificateRevocationListStatusCode extends js.Object {
+    val pending = "pending".asInstanceOf[ClientCertificateRevocationListStatusCode]
+    val active  = "active".asInstanceOf[ClientCertificateRevocationListStatusCode]
 
     val values = js.Object.freeze(js.Array(pending, active))
   }
@@ -5546,10 +5378,12 @@ package ec2 {
       __obj.asInstanceOf[ClientVpnAuthenticationRequest]
     }
   }
-
-  object ClientVpnAuthenticationTypeEnum {
-    val `certificate-authentication`       = "certificate-authentication"
-    val `directory-service-authentication` = "directory-service-authentication"
+  @js.native
+  sealed trait ClientVpnAuthenticationType extends js.Any
+  object ClientVpnAuthenticationType extends js.Object {
+    val `certificate-authentication` = "certificate-authentication".asInstanceOf[ClientVpnAuthenticationType]
+    val `directory-service-authentication` =
+      "directory-service-authentication".asInstanceOf[ClientVpnAuthenticationType]
 
     val values = js.Object.freeze(js.Array(`certificate-authentication`, `directory-service-authentication`))
   }
@@ -5575,12 +5409,13 @@ package ec2 {
       __obj.asInstanceOf[ClientVpnAuthorizationRuleStatus]
     }
   }
-
-  object ClientVpnAuthorizationRuleStatusCodeEnum {
-    val authorizing = "authorizing"
-    val active      = "active"
-    val failed      = "failed"
-    val revoking    = "revoking"
+  @js.native
+  sealed trait ClientVpnAuthorizationRuleStatusCode extends js.Any
+  object ClientVpnAuthorizationRuleStatusCode extends js.Object {
+    val authorizing = "authorizing".asInstanceOf[ClientVpnAuthorizationRuleStatusCode]
+    val active      = "active".asInstanceOf[ClientVpnAuthorizationRuleStatusCode]
+    val failed      = "failed".asInstanceOf[ClientVpnAuthorizationRuleStatusCode]
+    val revoking    = "revoking".asInstanceOf[ClientVpnAuthorizationRuleStatusCode]
 
     val values = js.Object.freeze(js.Array(authorizing, active, failed, revoking))
   }
@@ -5663,12 +5498,13 @@ package ec2 {
       __obj.asInstanceOf[ClientVpnConnectionStatus]
     }
   }
-
-  object ClientVpnConnectionStatusCodeEnum {
-    val active                = "active"
-    val `failed-to-terminate` = "failed-to-terminate"
-    val terminating           = "terminating"
-    val terminated            = "terminated"
+  @js.native
+  sealed trait ClientVpnConnectionStatusCode extends js.Any
+  object ClientVpnConnectionStatusCode extends js.Object {
+    val active                = "active".asInstanceOf[ClientVpnConnectionStatusCode]
+    val `failed-to-terminate` = "failed-to-terminate".asInstanceOf[ClientVpnConnectionStatusCode]
+    val terminating           = "terminating".asInstanceOf[ClientVpnConnectionStatusCode]
+    val terminated            = "terminated".asInstanceOf[ClientVpnConnectionStatusCode]
 
     val values = js.Object.freeze(js.Array(active, `failed-to-terminate`, terminating, terminated))
   }
@@ -5761,12 +5597,13 @@ package ec2 {
       __obj.asInstanceOf[ClientVpnEndpointStatus]
     }
   }
-
-  object ClientVpnEndpointStatusCodeEnum {
-    val `pending-associate` = "pending-associate"
-    val available           = "available"
-    val deleting            = "deleting"
-    val deleted             = "deleted"
+  @js.native
+  sealed trait ClientVpnEndpointStatusCode extends js.Any
+  object ClientVpnEndpointStatusCode extends js.Object {
+    val `pending-associate` = "pending-associate".asInstanceOf[ClientVpnEndpointStatusCode]
+    val available           = "available".asInstanceOf[ClientVpnEndpointStatusCode]
+    val deleting            = "deleting".asInstanceOf[ClientVpnEndpointStatusCode]
+    val deleted             = "deleted".asInstanceOf[ClientVpnEndpointStatusCode]
 
     val values = js.Object.freeze(js.Array(`pending-associate`, available, deleting, deleted))
   }
@@ -5829,12 +5666,13 @@ package ec2 {
       __obj.asInstanceOf[ClientVpnRouteStatus]
     }
   }
-
-  object ClientVpnRouteStatusCodeEnum {
-    val creating = "creating"
-    val active   = "active"
-    val failed   = "failed"
-    val deleting = "deleting"
+  @js.native
+  sealed trait ClientVpnRouteStatusCode extends js.Any
+  object ClientVpnRouteStatusCode extends js.Object {
+    val creating = "creating".asInstanceOf[ClientVpnRouteStatusCode]
+    val active   = "active".asInstanceOf[ClientVpnRouteStatusCode]
+    val failed   = "failed".asInstanceOf[ClientVpnRouteStatusCode]
+    val deleting = "deleting".asInstanceOf[ClientVpnRouteStatusCode]
 
     val values = js.Object.freeze(js.Array(creating, active, failed, deleting))
   }
@@ -6030,22 +5868,25 @@ package ec2 {
       __obj.asInstanceOf[ConnectionNotification]
     }
   }
-
-  object ConnectionNotificationStateEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait ConnectionNotificationState extends js.Any
+  object ConnectionNotificationState extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[ConnectionNotificationState]
+    val Disabled = "Disabled".asInstanceOf[ConnectionNotificationState]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
-
-  object ConnectionNotificationTypeEnum {
-    val Topic = "Topic"
+  @js.native
+  sealed trait ConnectionNotificationType extends js.Any
+  object ConnectionNotificationType extends js.Object {
+    val Topic = "Topic".asInstanceOf[ConnectionNotificationType]
 
     val values = js.Object.freeze(js.Array(Topic))
   }
-
-  object ContainerFormatEnum {
-    val ova = "ova"
+  @js.native
+  sealed trait ContainerFormat extends js.Any
+  object ContainerFormat extends js.Object {
+    val ova = "ova".asInstanceOf[ContainerFormat]
 
     val values = js.Object.freeze(js.Array(ova))
   }
@@ -6086,12 +5927,13 @@ package ec2 {
       __obj.asInstanceOf[ConversionTask]
     }
   }
-
-  object ConversionTaskStateEnum {
-    val active     = "active"
-    val cancelling = "cancelling"
-    val cancelled  = "cancelled"
-    val completed  = "completed"
+  @js.native
+  sealed trait ConversionTaskState extends js.Any
+  object ConversionTaskState extends js.Object {
+    val active     = "active".asInstanceOf[ConversionTaskState]
+    val cancelling = "cancelling".asInstanceOf[ConversionTaskState]
+    val cancelled  = "cancelled".asInstanceOf[ConversionTaskState]
+    val completed  = "completed".asInstanceOf[ConversionTaskState]
 
     val values = js.Object.freeze(js.Array(active, cancelling, cancelled, completed))
   }
@@ -6266,9 +6108,10 @@ package ec2 {
       __obj.asInstanceOf[CopySnapshotResult]
     }
   }
-
-  object CopyTagsFromSourceEnum {
-    val volume = "volume"
+  @js.native
+  sealed trait CopyTagsFromSource extends js.Any
+  object CopyTagsFromSource extends js.Object {
+    val volume = "volume".asInstanceOf[CopyTagsFromSource]
 
     val values = js.Object.freeze(js.Array(volume))
   }
@@ -9044,9 +8887,10 @@ package ec2 {
       __obj.asInstanceOf[CreditSpecificationRequest]
     }
   }
-
-  object CurrencyCodeValuesEnum {
-    val USD = "USD"
+  @js.native
+  sealed trait CurrencyCodeValues extends js.Any
+  object CurrencyCodeValues extends js.Object {
+    val USD = "USD".asInstanceOf[CurrencyCodeValues]
 
     val values = js.Object.freeze(js.Array(USD))
   }
@@ -9090,31 +8934,35 @@ package ec2 {
       __obj.asInstanceOf[CustomerGateway]
     }
   }
-
-  object DatafeedSubscriptionStateEnum {
-    val Active   = "Active"
-    val Inactive = "Inactive"
+  @js.native
+  sealed trait DatafeedSubscriptionState extends js.Any
+  object DatafeedSubscriptionState extends js.Object {
+    val Active   = "Active".asInstanceOf[DatafeedSubscriptionState]
+    val Inactive = "Inactive".asInstanceOf[DatafeedSubscriptionState]
 
     val values = js.Object.freeze(js.Array(Active, Inactive))
   }
-
-  object DefaultRouteTableAssociationValueEnum {
-    val enable  = "enable"
-    val disable = "disable"
-
-    val values = js.Object.freeze(js.Array(enable, disable))
-  }
-
-  object DefaultRouteTablePropagationValueEnum {
-    val enable  = "enable"
-    val disable = "disable"
+  @js.native
+  sealed trait DefaultRouteTableAssociationValue extends js.Any
+  object DefaultRouteTableAssociationValue extends js.Object {
+    val enable  = "enable".asInstanceOf[DefaultRouteTableAssociationValue]
+    val disable = "disable".asInstanceOf[DefaultRouteTableAssociationValue]
 
     val values = js.Object.freeze(js.Array(enable, disable))
   }
+  @js.native
+  sealed trait DefaultRouteTablePropagationValue extends js.Any
+  object DefaultRouteTablePropagationValue extends js.Object {
+    val enable  = "enable".asInstanceOf[DefaultRouteTablePropagationValue]
+    val disable = "disable".asInstanceOf[DefaultRouteTablePropagationValue]
 
-  object DefaultTargetCapacityTypeEnum {
-    val spot        = "spot"
-    val `on-demand` = "on-demand"
+    val values = js.Object.freeze(js.Array(enable, disable))
+  }
+  @js.native
+  sealed trait DefaultTargetCapacityType extends js.Any
+  object DefaultTargetCapacityType extends js.Object {
+    val spot        = "spot".asInstanceOf[DefaultTargetCapacityType]
+    val `on-demand` = "on-demand".asInstanceOf[DefaultTargetCapacityType]
 
     val values = js.Object.freeze(js.Array(spot, `on-demand`))
   }
@@ -9302,12 +9150,13 @@ package ec2 {
       __obj.asInstanceOf[DeleteFleetError]
     }
   }
-
-  object DeleteFleetErrorCodeEnum {
-    val fleetIdDoesNotExist      = "fleetIdDoesNotExist"
-    val fleetIdMalformed         = "fleetIdMalformed"
-    val fleetNotInDeletableState = "fleetNotInDeletableState"
-    val unexpectedError          = "unexpectedError"
+  @js.native
+  sealed trait DeleteFleetErrorCode extends js.Any
+  object DeleteFleetErrorCode extends js.Object {
+    val fleetIdDoesNotExist      = "fleetIdDoesNotExist".asInstanceOf[DeleteFleetErrorCode]
+    val fleetIdMalformed         = "fleetIdMalformed".asInstanceOf[DeleteFleetErrorCode]
+    val fleetNotInDeletableState = "fleetNotInDeletableState".asInstanceOf[DeleteFleetErrorCode]
+    val unexpectedError          = "unexpectedError".asInstanceOf[DeleteFleetErrorCode]
 
     val values =
       js.Object.freeze(js.Array(fleetIdDoesNotExist, fleetIdMalformed, fleetNotInDeletableState, unexpectedError))
@@ -9937,11 +9786,14 @@ package ec2 {
       __obj.asInstanceOf[DeleteQueuedReservedInstancesError]
     }
   }
-
-  object DeleteQueuedReservedInstancesErrorCodeEnum {
-    val `reserved-instances-id-invalid`          = "reserved-instances-id-invalid"
-    val `reserved-instances-not-in-queued-state` = "reserved-instances-not-in-queued-state"
-    val `unexpected-error`                       = "unexpected-error"
+  @js.native
+  sealed trait DeleteQueuedReservedInstancesErrorCode extends js.Any
+  object DeleteQueuedReservedInstancesErrorCode extends js.Object {
+    val `reserved-instances-id-invalid` =
+      "reserved-instances-id-invalid".asInstanceOf[DeleteQueuedReservedInstancesErrorCode]
+    val `reserved-instances-not-in-queued-state` =
+      "reserved-instances-not-in-queued-state".asInstanceOf[DeleteQueuedReservedInstancesErrorCode]
+    val `unexpected-error` = "unexpected-error".asInstanceOf[DeleteQueuedReservedInstancesErrorCode]
 
     val values = js.Object.freeze(
       js.Array(`reserved-instances-id-invalid`, `reserved-instances-not-in-queued-state`, `unexpected-error`)
@@ -16529,10 +16381,11 @@ package ec2 {
       __obj.asInstanceOf[DetachVpnGatewayRequest]
     }
   }
-
-  object DeviceTypeEnum {
-    val ebs              = "ebs"
-    val `instance-store` = "instance-store"
+  @js.native
+  sealed trait DeviceType extends js.Any
+  object DeviceType extends js.Object {
+    val ebs              = "ebs".asInstanceOf[DeviceType]
+    val `instance-store` = "instance-store".asInstanceOf[DeviceType]
 
     val values = js.Object.freeze(js.Array(ebs, `instance-store`))
   }
@@ -17316,11 +17169,12 @@ package ec2 {
       __obj.asInstanceOf[DiskImageDetail]
     }
   }
-
-  object DiskImageFormatEnum {
-    val VMDK = "VMDK"
-    val RAW  = "RAW"
-    val VHD  = "VHD"
+  @js.native
+  sealed trait DiskImageFormat extends js.Any
+  object DiskImageFormat extends js.Object {
+    val VMDK = "VMDK".asInstanceOf[DiskImageFormat]
+    val RAW  = "RAW".asInstanceOf[DiskImageFormat]
+    val VHD  = "VHD".asInstanceOf[DiskImageFormat]
 
     val values = js.Object.freeze(js.Array(VMDK, RAW, VHD))
   }
@@ -17371,10 +17225,11 @@ package ec2 {
       __obj.asInstanceOf[DiskInfo]
     }
   }
-
-  object DiskTypeEnum {
-    val hdd = "hdd"
-    val ssd = "ssd"
+  @js.native
+  sealed trait DiskType extends js.Any
+  object DiskType extends js.Object {
+    val hdd = "hdd".asInstanceOf[DiskType]
+    val ssd = "ssd".asInstanceOf[DiskType]
 
     val values = js.Object.freeze(js.Array(hdd, ssd))
   }
@@ -17400,11 +17255,12 @@ package ec2 {
       __obj.asInstanceOf[DnsEntry]
     }
   }
-
-  object DnsNameStateEnum {
-    val pendingVerification = "pendingVerification"
-    val verified            = "verified"
-    val failed              = "failed"
+  @js.native
+  sealed trait DnsNameState extends js.Any
+  object DnsNameState extends js.Object {
+    val pendingVerification = "pendingVerification".asInstanceOf[DnsNameState]
+    val verified            = "verified".asInstanceOf[DnsNameState]
+    val failed              = "failed".asInstanceOf[DnsNameState]
 
     val values = js.Object.freeze(js.Array(pendingVerification, verified, failed))
   }
@@ -17430,17 +17286,19 @@ package ec2 {
       __obj.asInstanceOf[DnsServersOptionsModifyStructure]
     }
   }
-
-  object DnsSupportValueEnum {
-    val enable  = "enable"
-    val disable = "disable"
+  @js.native
+  sealed trait DnsSupportValue extends js.Any
+  object DnsSupportValue extends js.Object {
+    val enable  = "enable".asInstanceOf[DnsSupportValue]
+    val disable = "disable".asInstanceOf[DnsSupportValue]
 
     val values = js.Object.freeze(js.Array(enable, disable))
   }
-
-  object DomainTypeEnum {
-    val vpc      = "vpc"
-    val standard = "standard"
+  @js.native
+  sealed trait DomainType extends js.Any
+  object DomainType extends js.Object {
+    val vpc      = "vpc".asInstanceOf[DomainType]
+    val standard = "standard".asInstanceOf[DomainType]
 
     val values = js.Object.freeze(js.Array(vpc, standard))
   }
@@ -17481,10 +17339,11 @@ package ec2 {
       __obj.asInstanceOf[EbsBlockDevice]
     }
   }
-
-  object EbsEncryptionSupportEnum {
-    val unsupported = "unsupported"
-    val supported   = "supported"
+  @js.native
+  sealed trait EbsEncryptionSupport extends js.Any
+  object EbsEncryptionSupport extends js.Object {
+    val unsupported = "unsupported".asInstanceOf[EbsEncryptionSupport]
+    val supported   = "supported".asInstanceOf[EbsEncryptionSupport]
 
     val values = js.Object.freeze(js.Array(unsupported, supported))
   }
@@ -17560,11 +17419,12 @@ package ec2 {
       __obj.asInstanceOf[EbsInstanceBlockDeviceSpecification]
     }
   }
-
-  object EbsOptimizedSupportEnum {
-    val unsupported = "unsupported"
-    val supported   = "supported"
-    val default     = "default"
+  @js.native
+  sealed trait EbsOptimizedSupport extends js.Any
+  object EbsOptimizedSupport extends js.Object {
+    val unsupported = "unsupported".asInstanceOf[EbsOptimizedSupport]
+    val supported   = "supported".asInstanceOf[EbsOptimizedSupport]
+    val default     = "default".asInstanceOf[EbsOptimizedSupport]
 
     val values = js.Object.freeze(js.Array(unsupported, supported, default))
   }
@@ -17686,16 +17546,18 @@ package ec2 {
       __obj.asInstanceOf[ElasticGpuSpecificationResponse]
     }
   }
-
-  object ElasticGpuStateEnum {
-    val ATTACHED = "ATTACHED"
+  @js.native
+  sealed trait ElasticGpuState extends js.Any
+  object ElasticGpuState extends js.Object {
+    val ATTACHED = "ATTACHED".asInstanceOf[ElasticGpuState]
 
     val values = js.Object.freeze(js.Array(ATTACHED))
   }
-
-  object ElasticGpuStatusEnum {
-    val OK       = "OK"
-    val IMPAIRED = "IMPAIRED"
+  @js.native
+  sealed trait ElasticGpuStatus extends js.Any
+  object ElasticGpuStatus extends js.Object {
+    val OK       = "OK".asInstanceOf[ElasticGpuStatus]
+    val IMPAIRED = "IMPAIRED".asInstanceOf[ElasticGpuStatus]
 
     val values = js.Object.freeze(js.Array(OK, IMPAIRED))
   }
@@ -17796,11 +17658,12 @@ package ec2 {
       __obj.asInstanceOf[ElasticInferenceAcceleratorAssociation]
     }
   }
-
-  object EnaSupportEnum {
-    val unsupported = "unsupported"
-    val supported   = "supported"
-    val required    = "required"
+  @js.native
+  sealed trait EnaSupport extends js.Any
+  object EnaSupport extends js.Object {
+    val unsupported = "unsupported".asInstanceOf[EnaSupport]
+    val supported   = "supported".asInstanceOf[EnaSupport]
+    val required    = "required".asInstanceOf[EnaSupport]
 
     val values = js.Object.freeze(js.Array(unsupported, supported, required))
   }
@@ -18153,20 +18016,22 @@ package ec2 {
       __obj.asInstanceOf[EnableVpcClassicLinkResult]
     }
   }
-
-  object EndDateTypeEnum {
-    val unlimited = "unlimited"
-    val limited   = "limited"
+  @js.native
+  sealed trait EndDateType extends js.Any
+  object EndDateType extends js.Object {
+    val unlimited = "unlimited".asInstanceOf[EndDateType]
+    val limited   = "limited".asInstanceOf[EndDateType]
 
     val values = js.Object.freeze(js.Array(unlimited, limited))
   }
-
-  object EventCodeEnum {
-    val `instance-reboot`     = "instance-reboot"
-    val `system-reboot`       = "system-reboot"
-    val `system-maintenance`  = "system-maintenance"
-    val `instance-retirement` = "instance-retirement"
-    val `instance-stop`       = "instance-stop"
+  @js.native
+  sealed trait EventCode extends js.Any
+  object EventCode extends js.Object {
+    val `instance-reboot`     = "instance-reboot".asInstanceOf[EventCode]
+    val `system-reboot`       = "system-reboot".asInstanceOf[EventCode]
+    val `system-maintenance`  = "system-maintenance".asInstanceOf[EventCode]
+    val `instance-retirement` = "instance-retirement".asInstanceOf[EventCode]
+    val `instance-stop`       = "instance-stop".asInstanceOf[EventCode]
 
     val values = js.Object.freeze(
       js.Array(`instance-reboot`, `system-reboot`, `system-maintenance`, `instance-retirement`, `instance-stop`)
@@ -18197,19 +18062,21 @@ package ec2 {
       __obj.asInstanceOf[EventInformation]
     }
   }
-
-  object EventTypeEnum {
-    val instanceChange     = "instanceChange"
-    val fleetRequestChange = "fleetRequestChange"
-    val error              = "error"
-    val information        = "information"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val instanceChange     = "instanceChange".asInstanceOf[EventType]
+    val fleetRequestChange = "fleetRequestChange".asInstanceOf[EventType]
+    val error              = "error".asInstanceOf[EventType]
+    val information        = "information".asInstanceOf[EventType]
 
     val values = js.Object.freeze(js.Array(instanceChange, fleetRequestChange, error, information))
   }
-
-  object ExcessCapacityTerminationPolicyEnum {
-    val noTermination = "noTermination"
-    val default       = "default"
+  @js.native
+  sealed trait ExcessCapacityTerminationPolicy extends js.Any
+  object ExcessCapacityTerminationPolicy extends js.Object {
+    val noTermination = "noTermination".asInstanceOf[ExcessCapacityTerminationPolicy]
+    val default       = "default".asInstanceOf[ExcessCapacityTerminationPolicy]
 
     val values = js.Object.freeze(js.Array(noTermination, default))
   }
@@ -18292,11 +18159,12 @@ package ec2 {
       __obj.asInstanceOf[ExportClientVpnClientConfigurationResult]
     }
   }
-
-  object ExportEnvironmentEnum {
-    val citrix    = "citrix"
-    val vmware    = "vmware"
-    val microsoft = "microsoft"
+  @js.native
+  sealed trait ExportEnvironment extends js.Any
+  object ExportEnvironment extends js.Object {
+    val citrix    = "citrix".asInstanceOf[ExportEnvironment]
+    val vmware    = "vmware".asInstanceOf[ExportEnvironment]
+    val microsoft = "microsoft".asInstanceOf[ExportEnvironment]
 
     val values = js.Object.freeze(js.Array(citrix, vmware, microsoft))
   }
@@ -18496,12 +18364,13 @@ package ec2 {
       __obj.asInstanceOf[ExportTaskS3LocationRequest]
     }
   }
-
-  object ExportTaskStateEnum {
-    val active     = "active"
-    val cancelling = "cancelling"
-    val cancelled  = "cancelled"
-    val completed  = "completed"
+  @js.native
+  sealed trait ExportTaskState extends js.Any
+  object ExportTaskState extends js.Object {
+    val active     = "active".asInstanceOf[ExportTaskState]
+    val cancelling = "cancelling".asInstanceOf[ExportTaskState]
+    val cancelled  = "cancelled".asInstanceOf[ExportTaskState]
+    val completed  = "completed".asInstanceOf[ExportTaskState]
 
     val values = js.Object.freeze(js.Array(active, cancelling, cancelled, completed))
   }
@@ -18626,13 +18495,14 @@ package ec2 {
       __obj.asInstanceOf[FailedQueuedPurchaseDeletion]
     }
   }
-
-  object FastSnapshotRestoreStateCodeEnum {
-    val enabling   = "enabling"
-    val optimizing = "optimizing"
-    val enabled    = "enabled"
-    val disabling  = "disabling"
-    val disabled   = "disabled"
+  @js.native
+  sealed trait FastSnapshotRestoreStateCode extends js.Any
+  object FastSnapshotRestoreStateCode extends js.Object {
+    val enabling   = "enabling".asInstanceOf[FastSnapshotRestoreStateCode]
+    val optimizing = "optimizing".asInstanceOf[FastSnapshotRestoreStateCode]
+    val enabled    = "enabled".asInstanceOf[FastSnapshotRestoreStateCode]
+    val disabling  = "disabling".asInstanceOf[FastSnapshotRestoreStateCode]
+    val disabled   = "disabled".asInstanceOf[FastSnapshotRestoreStateCode]
 
     val values = js.Object.freeze(js.Array(enabling, optimizing, enabled, disabling, disabled))
   }
@@ -18668,18 +18538,21 @@ package ec2 {
       __obj.asInstanceOf[Filter]
     }
   }
-
-  object FleetActivityStatusEnum {
-    val error               = "error"
-    val pending_fulfillment = "pending_fulfillment"
-    val pending_termination = "pending_termination"
-    val fulfilled           = "fulfilled"
+  @js.native
+  sealed trait FleetActivityStatus extends js.Any
+  object FleetActivityStatus extends js.Object {
+    val error               = "error".asInstanceOf[FleetActivityStatus]
+    val pending_fulfillment = "pending_fulfillment".asInstanceOf[FleetActivityStatus]
+    val pending_termination = "pending_termination".asInstanceOf[FleetActivityStatus]
+    val fulfilled           = "fulfilled".asInstanceOf[FleetActivityStatus]
 
     val values = js.Object.freeze(js.Array(error, pending_fulfillment, pending_termination, fulfilled))
   }
-
-  object FleetCapacityReservationUsageStrategyEnum {
-    val `use-capacity-reservations-first` = "use-capacity-reservations-first"
+  @js.native
+  sealed trait FleetCapacityReservationUsageStrategy extends js.Any
+  object FleetCapacityReservationUsageStrategy extends js.Object {
+    val `use-capacity-reservations-first` =
+      "use-capacity-reservations-first".asInstanceOf[FleetCapacityReservationUsageStrategy]
 
     val values = js.Object.freeze(js.Array(`use-capacity-reservations-first`))
   }
@@ -18769,18 +18642,20 @@ package ec2 {
       __obj.asInstanceOf[FleetData]
     }
   }
-
-  object FleetEventTypeEnum {
-    val `instance-change` = "instance-change"
-    val `fleet-change`    = "fleet-change"
-    val `service-error`   = "service-error"
+  @js.native
+  sealed trait FleetEventType extends js.Any
+  object FleetEventType extends js.Object {
+    val `instance-change` = "instance-change".asInstanceOf[FleetEventType]
+    val `fleet-change`    = "fleet-change".asInstanceOf[FleetEventType]
+    val `service-error`   = "service-error".asInstanceOf[FleetEventType]
 
     val values = js.Object.freeze(js.Array(`instance-change`, `fleet-change`, `service-error`))
   }
-
-  object FleetExcessCapacityTerminationPolicyEnum {
-    val `no-termination` = "no-termination"
-    val termination      = "termination"
+  @js.native
+  sealed trait FleetExcessCapacityTerminationPolicy extends js.Any
+  object FleetExcessCapacityTerminationPolicy extends js.Object {
+    val `no-termination` = "no-termination".asInstanceOf[FleetExcessCapacityTerminationPolicy]
+    val termination      = "termination".asInstanceOf[FleetExcessCapacityTerminationPolicy]
 
     val values = js.Object.freeze(js.Array(`no-termination`, termination))
   }
@@ -18956,31 +18831,34 @@ package ec2 {
       __obj.asInstanceOf[FleetLaunchTemplateSpecificationRequest]
     }
   }
-
-  object FleetOnDemandAllocationStrategyEnum {
-    val `lowest-price` = "lowest-price"
-    val prioritized    = "prioritized"
+  @js.native
+  sealed trait FleetOnDemandAllocationStrategy extends js.Any
+  object FleetOnDemandAllocationStrategy extends js.Object {
+    val `lowest-price` = "lowest-price".asInstanceOf[FleetOnDemandAllocationStrategy]
+    val prioritized    = "prioritized".asInstanceOf[FleetOnDemandAllocationStrategy]
 
     val values = js.Object.freeze(js.Array(`lowest-price`, prioritized))
   }
-
-  object FleetStateCodeEnum {
-    val submitted           = "submitted"
-    val active              = "active"
-    val deleted             = "deleted"
-    val failed              = "failed"
-    val deleted_running     = "deleted_running"
-    val deleted_terminating = "deleted_terminating"
-    val modifying           = "modifying"
+  @js.native
+  sealed trait FleetStateCode extends js.Any
+  object FleetStateCode extends js.Object {
+    val submitted           = "submitted".asInstanceOf[FleetStateCode]
+    val active              = "active".asInstanceOf[FleetStateCode]
+    val deleted             = "deleted".asInstanceOf[FleetStateCode]
+    val failed              = "failed".asInstanceOf[FleetStateCode]
+    val deleted_running     = "deleted_running".asInstanceOf[FleetStateCode]
+    val deleted_terminating = "deleted_terminating".asInstanceOf[FleetStateCode]
+    val modifying           = "modifying".asInstanceOf[FleetStateCode]
 
     val values =
       js.Object.freeze(js.Array(submitted, active, deleted, failed, deleted_running, deleted_terminating, modifying))
   }
-
-  object FleetTypeEnum {
-    val request  = "request"
-    val maintain = "maintain"
-    val instant  = "instant"
+  @js.native
+  sealed trait FleetType extends js.Any
+  object FleetType extends js.Object {
+    val request  = "request".asInstanceOf[FleetType]
+    val maintain = "maintain".asInstanceOf[FleetType]
+    val instant  = "instant".asInstanceOf[FleetType]
 
     val values = js.Object.freeze(js.Array(request, maintain, instant))
   }
@@ -19039,11 +18917,12 @@ package ec2 {
       __obj.asInstanceOf[FlowLog]
     }
   }
-
-  object FlowLogsResourceTypeEnum {
-    val VPC              = "VPC"
-    val Subnet           = "Subnet"
-    val NetworkInterface = "NetworkInterface"
+  @js.native
+  sealed trait FlowLogsResourceType extends js.Any
+  object FlowLogsResourceType extends js.Object {
+    val VPC              = "VPC".asInstanceOf[FlowLogsResourceType]
+    val Subnet           = "Subnet".asInstanceOf[FlowLogsResourceType]
+    val NetworkInterface = "NetworkInterface".asInstanceOf[FlowLogsResourceType]
 
     val values = js.Object.freeze(js.Array(VPC, Subnet, NetworkInterface))
   }
@@ -19186,12 +19065,13 @@ package ec2 {
       __obj.asInstanceOf[FpgaImageAttribute]
     }
   }
-
-  object FpgaImageAttributeNameEnum {
-    val description    = "description"
-    val name           = "name"
-    val loadPermission = "loadPermission"
-    val productCodes   = "productCodes"
+  @js.native
+  sealed trait FpgaImageAttributeName extends js.Any
+  object FpgaImageAttributeName extends js.Object {
+    val description    = "description".asInstanceOf[FpgaImageAttributeName]
+    val name           = "name".asInstanceOf[FpgaImageAttributeName]
+    val loadPermission = "loadPermission".asInstanceOf[FpgaImageAttributeName]
+    val productCodes   = "productCodes".asInstanceOf[FpgaImageAttributeName]
 
     val values = js.Object.freeze(js.Array(description, name, loadPermission, productCodes))
   }
@@ -19217,12 +19097,13 @@ package ec2 {
       __obj.asInstanceOf[FpgaImageState]
     }
   }
-
-  object FpgaImageStateCodeEnum {
-    val pending     = "pending"
-    val failed      = "failed"
-    val available   = "available"
-    val unavailable = "unavailable"
+  @js.native
+  sealed trait FpgaImageStateCode extends js.Any
+  object FpgaImageStateCode extends js.Object {
+    val pending     = "pending".asInstanceOf[FpgaImageStateCode]
+    val failed      = "failed".asInstanceOf[FpgaImageStateCode]
+    val available   = "available".asInstanceOf[FpgaImageStateCode]
+    val unavailable = "unavailable".asInstanceOf[FpgaImageStateCode]
 
     val values = js.Object.freeze(js.Array(pending, failed, available, unavailable))
   }
@@ -19248,9 +19129,10 @@ package ec2 {
       __obj.asInstanceOf[FpgaInfo]
     }
   }
-
-  object GatewayTypeEnum {
-    val `ipsec.1` = "ipsec.1"
+  @js.native
+  sealed trait GatewayType extends js.Any
+  object GatewayType extends js.Object {
+    val `ipsec.1` = "ipsec.1".asInstanceOf[GatewayType]
 
     val values = js.Object.freeze(js.Array(`ipsec.1`))
   }
@@ -20354,10 +20236,11 @@ package ec2 {
       __obj.asInstanceOf[HostProperties]
     }
   }
-
-  object HostRecoveryEnum {
-    val on  = "on"
-    val off = "off"
+  @js.native
+  sealed trait HostRecovery extends js.Any
+  object HostRecovery extends js.Object {
+    val on  = "on".asInstanceOf[HostRecovery]
+    val off = "off".asInstanceOf[HostRecovery]
 
     val values = js.Object.freeze(js.Array(on, off))
   }
@@ -20419,24 +20302,27 @@ package ec2 {
       __obj.asInstanceOf[HostReservation]
     }
   }
-
-  object HostTenancyEnum {
-    val dedicated = "dedicated"
-    val host      = "host"
+  @js.native
+  sealed trait HostTenancy extends js.Any
+  object HostTenancy extends js.Object {
+    val dedicated = "dedicated".asInstanceOf[HostTenancy]
+    val host      = "host".asInstanceOf[HostTenancy]
 
     val values = js.Object.freeze(js.Array(dedicated, host))
   }
-
-  object HttpTokensStateEnum {
-    val optional = "optional"
-    val required = "required"
+  @js.native
+  sealed trait HttpTokensState extends js.Any
+  object HttpTokensState extends js.Object {
+    val optional = "optional".asInstanceOf[HttpTokensState]
+    val required = "required".asInstanceOf[HttpTokensState]
 
     val values = js.Object.freeze(js.Array(optional, required))
   }
-
-  object HypervisorTypeEnum {
-    val ovm = "ovm"
-    val xen = "xen"
+  @js.native
+  sealed trait HypervisorType extends js.Any
+  object HypervisorType extends js.Object {
+    val ovm = "ovm".asInstanceOf[HypervisorType]
+    val xen = "xen".asInstanceOf[HypervisorType]
 
     val values = js.Object.freeze(js.Array(ovm, xen))
   }
@@ -20531,12 +20417,13 @@ package ec2 {
       __obj.asInstanceOf[IamInstanceProfileAssociation]
     }
   }
-
-  object IamInstanceProfileAssociationStateEnum {
-    val associating    = "associating"
-    val associated     = "associated"
-    val disassociating = "disassociating"
-    val disassociated  = "disassociated"
+  @js.native
+  sealed trait IamInstanceProfileAssociationState extends js.Any
+  object IamInstanceProfileAssociationState extends js.Object {
+    val associating    = "associating".asInstanceOf[IamInstanceProfileAssociationState]
+    val associated     = "associated".asInstanceOf[IamInstanceProfileAssociationState]
+    val disassociating = "disassociating".asInstanceOf[IamInstanceProfileAssociationState]
+    val disassociated  = "disassociated".asInstanceOf[IamInstanceProfileAssociationState]
 
     val values = js.Object.freeze(js.Array(associating, associated, disassociating, disassociated))
   }
@@ -20743,15 +20630,16 @@ package ec2 {
       __obj.asInstanceOf[ImageAttribute]
     }
   }
-
-  object ImageAttributeNameEnum {
-    val description        = "description"
-    val kernel             = "kernel"
-    val ramdisk            = "ramdisk"
-    val launchPermission   = "launchPermission"
-    val productCodes       = "productCodes"
-    val blockDeviceMapping = "blockDeviceMapping"
-    val sriovNetSupport    = "sriovNetSupport"
+  @js.native
+  sealed trait ImageAttributeName extends js.Any
+  object ImageAttributeName extends js.Object {
+    val description        = "description".asInstanceOf[ImageAttributeName]
+    val kernel             = "kernel".asInstanceOf[ImageAttributeName]
+    val ramdisk            = "ramdisk".asInstanceOf[ImageAttributeName]
+    val launchPermission   = "launchPermission".asInstanceOf[ImageAttributeName]
+    val productCodes       = "productCodes".asInstanceOf[ImageAttributeName]
+    val blockDeviceMapping = "blockDeviceMapping".asInstanceOf[ImageAttributeName]
+    val sriovNetSupport    = "sriovNetSupport".asInstanceOf[ImageAttributeName]
 
     val values = js.Object.freeze(
       js.Array(description, kernel, ramdisk, launchPermission, productCodes, blockDeviceMapping, sriovNetSupport)
@@ -20791,23 +20679,25 @@ package ec2 {
       __obj.asInstanceOf[ImageDiskContainer]
     }
   }
-
-  object ImageStateEnum {
-    val pending      = "pending"
-    val available    = "available"
-    val invalid      = "invalid"
-    val deregistered = "deregistered"
-    val transient    = "transient"
-    val failed       = "failed"
-    val error        = "error"
+  @js.native
+  sealed trait ImageState extends js.Any
+  object ImageState extends js.Object {
+    val pending      = "pending".asInstanceOf[ImageState]
+    val available    = "available".asInstanceOf[ImageState]
+    val invalid      = "invalid".asInstanceOf[ImageState]
+    val deregistered = "deregistered".asInstanceOf[ImageState]
+    val transient    = "transient".asInstanceOf[ImageState]
+    val failed       = "failed".asInstanceOf[ImageState]
+    val error        = "error".asInstanceOf[ImageState]
 
     val values = js.Object.freeze(js.Array(pending, available, invalid, deregistered, transient, failed, error))
   }
-
-  object ImageTypeValuesEnum {
-    val machine = "machine"
-    val kernel  = "kernel"
-    val ramdisk = "ramdisk"
+  @js.native
+  sealed trait ImageTypeValues extends js.Any
+  object ImageTypeValues extends js.Object {
+    val machine = "machine".asInstanceOf[ImageTypeValues]
+    val kernel  = "kernel".asInstanceOf[ImageTypeValues]
+    val ramdisk = "ramdisk".asInstanceOf[ImageTypeValues]
 
     val values = js.Object.freeze(js.Array(machine, kernel, ramdisk))
   }
@@ -21694,22 +21584,23 @@ package ec2 {
       __obj.asInstanceOf[InstanceAttribute]
     }
   }
-
-  object InstanceAttributeNameEnum {
-    val instanceType                      = "instanceType"
-    val kernel                            = "kernel"
-    val ramdisk                           = "ramdisk"
-    val userData                          = "userData"
-    val disableApiTermination             = "disableApiTermination"
-    val instanceInitiatedShutdownBehavior = "instanceInitiatedShutdownBehavior"
-    val rootDeviceName                    = "rootDeviceName"
-    val blockDeviceMapping                = "blockDeviceMapping"
-    val productCodes                      = "productCodes"
-    val sourceDestCheck                   = "sourceDestCheck"
-    val groupSet                          = "groupSet"
-    val ebsOptimized                      = "ebsOptimized"
-    val sriovNetSupport                   = "sriovNetSupport"
-    val enaSupport                        = "enaSupport"
+  @js.native
+  sealed trait InstanceAttributeName extends js.Any
+  object InstanceAttributeName extends js.Object {
+    val instanceType                      = "instanceType".asInstanceOf[InstanceAttributeName]
+    val kernel                            = "kernel".asInstanceOf[InstanceAttributeName]
+    val ramdisk                           = "ramdisk".asInstanceOf[InstanceAttributeName]
+    val userData                          = "userData".asInstanceOf[InstanceAttributeName]
+    val disableApiTermination             = "disableApiTermination".asInstanceOf[InstanceAttributeName]
+    val instanceInitiatedShutdownBehavior = "instanceInitiatedShutdownBehavior".asInstanceOf[InstanceAttributeName]
+    val rootDeviceName                    = "rootDeviceName".asInstanceOf[InstanceAttributeName]
+    val blockDeviceMapping                = "blockDeviceMapping".asInstanceOf[InstanceAttributeName]
+    val productCodes                      = "productCodes".asInstanceOf[InstanceAttributeName]
+    val sourceDestCheck                   = "sourceDestCheck".asInstanceOf[InstanceAttributeName]
+    val groupSet                          = "groupSet".asInstanceOf[InstanceAttributeName]
+    val ebsOptimized                      = "ebsOptimized".asInstanceOf[InstanceAttributeName]
+    val sriovNetSupport                   = "sriovNetSupport".asInstanceOf[InstanceAttributeName]
+    val enaSupport                        = "enaSupport".asInstanceOf[InstanceAttributeName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -21915,18 +21806,20 @@ package ec2 {
       __obj.asInstanceOf[InstanceFamilyCreditSpecification]
     }
   }
-
-  object InstanceHealthStatusEnum {
-    val healthy   = "healthy"
-    val unhealthy = "unhealthy"
+  @js.native
+  sealed trait InstanceHealthStatus extends js.Any
+  object InstanceHealthStatus extends js.Object {
+    val healthy   = "healthy".asInstanceOf[InstanceHealthStatus]
+    val unhealthy = "unhealthy".asInstanceOf[InstanceHealthStatus]
 
     val values = js.Object.freeze(js.Array(healthy, unhealthy))
   }
-
-  object InstanceInterruptionBehaviorEnum {
-    val hibernate = "hibernate"
-    val stop      = "stop"
-    val terminate = "terminate"
+  @js.native
+  sealed trait InstanceInterruptionBehavior extends js.Any
+  object InstanceInterruptionBehavior extends js.Object {
+    val hibernate = "hibernate".asInstanceOf[InstanceInterruptionBehavior]
+    val stop      = "stop".asInstanceOf[InstanceInterruptionBehavior]
+    val terminate = "terminate".asInstanceOf[InstanceInterruptionBehavior]
 
     val values = js.Object.freeze(js.Array(hibernate, stop, terminate))
   }
@@ -21968,17 +21861,19 @@ package ec2 {
       __obj.asInstanceOf[InstanceIpv6AddressRequest]
     }
   }
-
-  object InstanceLifecycleEnum {
-    val spot        = "spot"
-    val `on-demand` = "on-demand"
+  @js.native
+  sealed trait InstanceLifecycle extends js.Any
+  object InstanceLifecycle extends js.Object {
+    val spot        = "spot".asInstanceOf[InstanceLifecycle]
+    val `on-demand` = "on-demand".asInstanceOf[InstanceLifecycle]
 
     val values = js.Object.freeze(js.Array(spot, `on-demand`))
   }
-
-  object InstanceLifecycleTypeEnum {
-    val spot      = "spot"
-    val scheduled = "scheduled"
+  @js.native
+  sealed trait InstanceLifecycleType extends js.Any
+  object InstanceLifecycleType extends js.Object {
+    val spot      = "spot".asInstanceOf[InstanceLifecycleType]
+    val scheduled = "scheduled".asInstanceOf[InstanceLifecycleType]
 
     val values = js.Object.freeze(js.Array(spot, scheduled))
   }
@@ -22004,17 +21899,19 @@ package ec2 {
       __obj.asInstanceOf[InstanceMarketOptionsRequest]
     }
   }
-
-  object InstanceMatchCriteriaEnum {
-    val open     = "open"
-    val targeted = "targeted"
+  @js.native
+  sealed trait InstanceMatchCriteria extends js.Any
+  object InstanceMatchCriteria extends js.Object {
+    val open     = "open".asInstanceOf[InstanceMatchCriteria]
+    val targeted = "targeted".asInstanceOf[InstanceMatchCriteria]
 
     val values = js.Object.freeze(js.Array(open, targeted))
   }
-
-  object InstanceMetadataEndpointStateEnum {
-    val disabled = "disabled"
-    val enabled  = "enabled"
+  @js.native
+  sealed trait InstanceMetadataEndpointState extends js.Any
+  object InstanceMetadataEndpointState extends js.Object {
+    val disabled = "disabled".asInstanceOf[InstanceMetadataEndpointState]
+    val enabled  = "enabled".asInstanceOf[InstanceMetadataEndpointState]
 
     val values = js.Object.freeze(js.Array(disabled, enabled))
   }
@@ -22071,10 +21968,11 @@ package ec2 {
       __obj.asInstanceOf[InstanceMetadataOptionsResponse]
     }
   }
-
-  object InstanceMetadataOptionsStateEnum {
-    val pending = "pending"
-    val applied = "applied"
+  @js.native
+  sealed trait InstanceMetadataOptionsState extends js.Any
+  object InstanceMetadataOptionsState extends js.Object {
+    val pending = "pending".asInstanceOf[InstanceMetadataOptionsState]
+    val applied = "applied".asInstanceOf[InstanceMetadataOptionsState]
 
     val values = js.Object.freeze(js.Array(pending, applied))
   }
@@ -22374,14 +22272,15 @@ package ec2 {
       __obj.asInstanceOf[InstanceStateChange]
     }
   }
-
-  object InstanceStateNameEnum {
-    val pending         = "pending"
-    val running         = "running"
-    val `shutting-down` = "shutting-down"
-    val terminated      = "terminated"
-    val stopping        = "stopping"
-    val stopped         = "stopped"
+  @js.native
+  sealed trait InstanceStateName extends js.Any
+  object InstanceStateName extends js.Object {
+    val pending         = "pending".asInstanceOf[InstanceStateName]
+    val running         = "running".asInstanceOf[InstanceStateName]
+    val `shutting-down` = "shutting-down".asInstanceOf[InstanceStateName]
+    val terminated      = "terminated".asInstanceOf[InstanceStateName]
+    val stopping        = "stopping".asInstanceOf[InstanceStateName]
+    val stopped         = "stopped".asInstanceOf[InstanceStateName]
 
     val values = js.Object.freeze(js.Array(pending, running, `shutting-down`, terminated, stopping, stopped))
   }
@@ -22525,279 +22424,280 @@ package ec2 {
       __obj.asInstanceOf[InstanceStorageInfo]
     }
   }
-
-  object InstanceTypeEnum {
-    val `t1.micro`      = "t1.micro"
-    val `t2.nano`       = "t2.nano"
-    val `t2.micro`      = "t2.micro"
-    val `t2.small`      = "t2.small"
-    val `t2.medium`     = "t2.medium"
-    val `t2.large`      = "t2.large"
-    val `t2.xlarge`     = "t2.xlarge"
-    val `t2.2xlarge`    = "t2.2xlarge"
-    val `t3.nano`       = "t3.nano"
-    val `t3.micro`      = "t3.micro"
-    val `t3.small`      = "t3.small"
-    val `t3.medium`     = "t3.medium"
-    val `t3.large`      = "t3.large"
-    val `t3.xlarge`     = "t3.xlarge"
-    val `t3.2xlarge`    = "t3.2xlarge"
-    val `t3a.nano`      = "t3a.nano"
-    val `t3a.micro`     = "t3a.micro"
-    val `t3a.small`     = "t3a.small"
-    val `t3a.medium`    = "t3a.medium"
-    val `t3a.large`     = "t3a.large"
-    val `t3a.xlarge`    = "t3a.xlarge"
-    val `t3a.2xlarge`   = "t3a.2xlarge"
-    val `m1.small`      = "m1.small"
-    val `m1.medium`     = "m1.medium"
-    val `m1.large`      = "m1.large"
-    val `m1.xlarge`     = "m1.xlarge"
-    val `m3.medium`     = "m3.medium"
-    val `m3.large`      = "m3.large"
-    val `m3.xlarge`     = "m3.xlarge"
-    val `m3.2xlarge`    = "m3.2xlarge"
-    val `m4.large`      = "m4.large"
-    val `m4.xlarge`     = "m4.xlarge"
-    val `m4.2xlarge`    = "m4.2xlarge"
-    val `m4.4xlarge`    = "m4.4xlarge"
-    val `m4.10xlarge`   = "m4.10xlarge"
-    val `m4.16xlarge`   = "m4.16xlarge"
-    val `m2.xlarge`     = "m2.xlarge"
-    val `m2.2xlarge`    = "m2.2xlarge"
-    val `m2.4xlarge`    = "m2.4xlarge"
-    val `cr1.8xlarge`   = "cr1.8xlarge"
-    val `r3.large`      = "r3.large"
-    val `r3.xlarge`     = "r3.xlarge"
-    val `r3.2xlarge`    = "r3.2xlarge"
-    val `r3.4xlarge`    = "r3.4xlarge"
-    val `r3.8xlarge`    = "r3.8xlarge"
-    val `r4.large`      = "r4.large"
-    val `r4.xlarge`     = "r4.xlarge"
-    val `r4.2xlarge`    = "r4.2xlarge"
-    val `r4.4xlarge`    = "r4.4xlarge"
-    val `r4.8xlarge`    = "r4.8xlarge"
-    val `r4.16xlarge`   = "r4.16xlarge"
-    val `r5.large`      = "r5.large"
-    val `r5.xlarge`     = "r5.xlarge"
-    val `r5.2xlarge`    = "r5.2xlarge"
-    val `r5.4xlarge`    = "r5.4xlarge"
-    val `r5.8xlarge`    = "r5.8xlarge"
-    val `r5.12xlarge`   = "r5.12xlarge"
-    val `r5.16xlarge`   = "r5.16xlarge"
-    val `r5.24xlarge`   = "r5.24xlarge"
-    val `r5.metal`      = "r5.metal"
-    val `r5a.large`     = "r5a.large"
-    val `r5a.xlarge`    = "r5a.xlarge"
-    val `r5a.2xlarge`   = "r5a.2xlarge"
-    val `r5a.4xlarge`   = "r5a.4xlarge"
-    val `r5a.8xlarge`   = "r5a.8xlarge"
-    val `r5a.12xlarge`  = "r5a.12xlarge"
-    val `r5a.16xlarge`  = "r5a.16xlarge"
-    val `r5a.24xlarge`  = "r5a.24xlarge"
-    val `r5d.large`     = "r5d.large"
-    val `r5d.xlarge`    = "r5d.xlarge"
-    val `r5d.2xlarge`   = "r5d.2xlarge"
-    val `r5d.4xlarge`   = "r5d.4xlarge"
-    val `r5d.8xlarge`   = "r5d.8xlarge"
-    val `r5d.12xlarge`  = "r5d.12xlarge"
-    val `r5d.16xlarge`  = "r5d.16xlarge"
-    val `r5d.24xlarge`  = "r5d.24xlarge"
-    val `r5d.metal`     = "r5d.metal"
-    val `r5ad.large`    = "r5ad.large"
-    val `r5ad.xlarge`   = "r5ad.xlarge"
-    val `r5ad.2xlarge`  = "r5ad.2xlarge"
-    val `r5ad.4xlarge`  = "r5ad.4xlarge"
-    val `r5ad.8xlarge`  = "r5ad.8xlarge"
-    val `r5ad.12xlarge` = "r5ad.12xlarge"
-    val `r5ad.16xlarge` = "r5ad.16xlarge"
-    val `r5ad.24xlarge` = "r5ad.24xlarge"
-    val `x1.16xlarge`   = "x1.16xlarge"
-    val `x1.32xlarge`   = "x1.32xlarge"
-    val `x1e.xlarge`    = "x1e.xlarge"
-    val `x1e.2xlarge`   = "x1e.2xlarge"
-    val `x1e.4xlarge`   = "x1e.4xlarge"
-    val `x1e.8xlarge`   = "x1e.8xlarge"
-    val `x1e.16xlarge`  = "x1e.16xlarge"
-    val `x1e.32xlarge`  = "x1e.32xlarge"
-    val `i2.xlarge`     = "i2.xlarge"
-    val `i2.2xlarge`    = "i2.2xlarge"
-    val `i2.4xlarge`    = "i2.4xlarge"
-    val `i2.8xlarge`    = "i2.8xlarge"
-    val `i3.large`      = "i3.large"
-    val `i3.xlarge`     = "i3.xlarge"
-    val `i3.2xlarge`    = "i3.2xlarge"
-    val `i3.4xlarge`    = "i3.4xlarge"
-    val `i3.8xlarge`    = "i3.8xlarge"
-    val `i3.16xlarge`   = "i3.16xlarge"
-    val `i3.metal`      = "i3.metal"
-    val `i3en.large`    = "i3en.large"
-    val `i3en.xlarge`   = "i3en.xlarge"
-    val `i3en.2xlarge`  = "i3en.2xlarge"
-    val `i3en.3xlarge`  = "i3en.3xlarge"
-    val `i3en.6xlarge`  = "i3en.6xlarge"
-    val `i3en.12xlarge` = "i3en.12xlarge"
-    val `i3en.24xlarge` = "i3en.24xlarge"
-    val `i3en.metal`    = "i3en.metal"
-    val `hi1.4xlarge`   = "hi1.4xlarge"
-    val `hs1.8xlarge`   = "hs1.8xlarge"
-    val `c1.medium`     = "c1.medium"
-    val `c1.xlarge`     = "c1.xlarge"
-    val `c3.large`      = "c3.large"
-    val `c3.xlarge`     = "c3.xlarge"
-    val `c3.2xlarge`    = "c3.2xlarge"
-    val `c3.4xlarge`    = "c3.4xlarge"
-    val `c3.8xlarge`    = "c3.8xlarge"
-    val `c4.large`      = "c4.large"
-    val `c4.xlarge`     = "c4.xlarge"
-    val `c4.2xlarge`    = "c4.2xlarge"
-    val `c4.4xlarge`    = "c4.4xlarge"
-    val `c4.8xlarge`    = "c4.8xlarge"
-    val `c5.large`      = "c5.large"
-    val `c5.xlarge`     = "c5.xlarge"
-    val `c5.2xlarge`    = "c5.2xlarge"
-    val `c5.4xlarge`    = "c5.4xlarge"
-    val `c5.9xlarge`    = "c5.9xlarge"
-    val `c5.12xlarge`   = "c5.12xlarge"
-    val `c5.18xlarge`   = "c5.18xlarge"
-    val `c5.24xlarge`   = "c5.24xlarge"
-    val `c5.metal`      = "c5.metal"
-    val `c5d.large`     = "c5d.large"
-    val `c5d.xlarge`    = "c5d.xlarge"
-    val `c5d.2xlarge`   = "c5d.2xlarge"
-    val `c5d.4xlarge`   = "c5d.4xlarge"
-    val `c5d.9xlarge`   = "c5d.9xlarge"
-    val `c5d.12xlarge`  = "c5d.12xlarge"
-    val `c5d.18xlarge`  = "c5d.18xlarge"
-    val `c5d.24xlarge`  = "c5d.24xlarge"
-    val `c5d.metal`     = "c5d.metal"
-    val `c5n.large`     = "c5n.large"
-    val `c5n.xlarge`    = "c5n.xlarge"
-    val `c5n.2xlarge`   = "c5n.2xlarge"
-    val `c5n.4xlarge`   = "c5n.4xlarge"
-    val `c5n.9xlarge`   = "c5n.9xlarge"
-    val `c5n.18xlarge`  = "c5n.18xlarge"
-    val `cc1.4xlarge`   = "cc1.4xlarge"
-    val `cc2.8xlarge`   = "cc2.8xlarge"
-    val `g2.2xlarge`    = "g2.2xlarge"
-    val `g2.8xlarge`    = "g2.8xlarge"
-    val `g3.4xlarge`    = "g3.4xlarge"
-    val `g3.8xlarge`    = "g3.8xlarge"
-    val `g3.16xlarge`   = "g3.16xlarge"
-    val `g3s.xlarge`    = "g3s.xlarge"
-    val `g4dn.xlarge`   = "g4dn.xlarge"
-    val `g4dn.2xlarge`  = "g4dn.2xlarge"
-    val `g4dn.4xlarge`  = "g4dn.4xlarge"
-    val `g4dn.8xlarge`  = "g4dn.8xlarge"
-    val `g4dn.12xlarge` = "g4dn.12xlarge"
-    val `g4dn.16xlarge` = "g4dn.16xlarge"
-    val `cg1.4xlarge`   = "cg1.4xlarge"
-    val `p2.xlarge`     = "p2.xlarge"
-    val `p2.8xlarge`    = "p2.8xlarge"
-    val `p2.16xlarge`   = "p2.16xlarge"
-    val `p3.2xlarge`    = "p3.2xlarge"
-    val `p3.8xlarge`    = "p3.8xlarge"
-    val `p3.16xlarge`   = "p3.16xlarge"
-    val `p3dn.24xlarge` = "p3dn.24xlarge"
-    val `d2.xlarge`     = "d2.xlarge"
-    val `d2.2xlarge`    = "d2.2xlarge"
-    val `d2.4xlarge`    = "d2.4xlarge"
-    val `d2.8xlarge`    = "d2.8xlarge"
-    val `f1.2xlarge`    = "f1.2xlarge"
-    val `f1.4xlarge`    = "f1.4xlarge"
-    val `f1.16xlarge`   = "f1.16xlarge"
-    val `m5.large`      = "m5.large"
-    val `m5.xlarge`     = "m5.xlarge"
-    val `m5.2xlarge`    = "m5.2xlarge"
-    val `m5.4xlarge`    = "m5.4xlarge"
-    val `m5.8xlarge`    = "m5.8xlarge"
-    val `m5.12xlarge`   = "m5.12xlarge"
-    val `m5.16xlarge`   = "m5.16xlarge"
-    val `m5.24xlarge`   = "m5.24xlarge"
-    val `m5.metal`      = "m5.metal"
-    val `m5a.large`     = "m5a.large"
-    val `m5a.xlarge`    = "m5a.xlarge"
-    val `m5a.2xlarge`   = "m5a.2xlarge"
-    val `m5a.4xlarge`   = "m5a.4xlarge"
-    val `m5a.8xlarge`   = "m5a.8xlarge"
-    val `m5a.12xlarge`  = "m5a.12xlarge"
-    val `m5a.16xlarge`  = "m5a.16xlarge"
-    val `m5a.24xlarge`  = "m5a.24xlarge"
-    val `m5d.large`     = "m5d.large"
-    val `m5d.xlarge`    = "m5d.xlarge"
-    val `m5d.2xlarge`   = "m5d.2xlarge"
-    val `m5d.4xlarge`   = "m5d.4xlarge"
-    val `m5d.8xlarge`   = "m5d.8xlarge"
-    val `m5d.12xlarge`  = "m5d.12xlarge"
-    val `m5d.16xlarge`  = "m5d.16xlarge"
-    val `m5d.24xlarge`  = "m5d.24xlarge"
-    val `m5d.metal`     = "m5d.metal"
-    val `m5ad.large`    = "m5ad.large"
-    val `m5ad.xlarge`   = "m5ad.xlarge"
-    val `m5ad.2xlarge`  = "m5ad.2xlarge"
-    val `m5ad.4xlarge`  = "m5ad.4xlarge"
-    val `m5ad.8xlarge`  = "m5ad.8xlarge"
-    val `m5ad.12xlarge` = "m5ad.12xlarge"
-    val `m5ad.16xlarge` = "m5ad.16xlarge"
-    val `m5ad.24xlarge` = "m5ad.24xlarge"
-    val `h1.2xlarge`    = "h1.2xlarge"
-    val `h1.4xlarge`    = "h1.4xlarge"
-    val `h1.8xlarge`    = "h1.8xlarge"
-    val `h1.16xlarge`   = "h1.16xlarge"
-    val `z1d.large`     = "z1d.large"
-    val `z1d.xlarge`    = "z1d.xlarge"
-    val `z1d.2xlarge`   = "z1d.2xlarge"
-    val `z1d.3xlarge`   = "z1d.3xlarge"
-    val `z1d.6xlarge`   = "z1d.6xlarge"
-    val `z1d.12xlarge`  = "z1d.12xlarge"
-    val `z1d.metal`     = "z1d.metal"
-    val `u-6tb1.metal`  = "u-6tb1.metal"
-    val `u-9tb1.metal`  = "u-9tb1.metal"
-    val `u-12tb1.metal` = "u-12tb1.metal"
-    val `u-18tb1.metal` = "u-18tb1.metal"
-    val `u-24tb1.metal` = "u-24tb1.metal"
-    val `a1.medium`     = "a1.medium"
-    val `a1.large`      = "a1.large"
-    val `a1.xlarge`     = "a1.xlarge"
-    val `a1.2xlarge`    = "a1.2xlarge"
-    val `a1.4xlarge`    = "a1.4xlarge"
-    val `a1.metal`      = "a1.metal"
-    val `m5dn.large`    = "m5dn.large"
-    val `m5dn.xlarge`   = "m5dn.xlarge"
-    val `m5dn.2xlarge`  = "m5dn.2xlarge"
-    val `m5dn.4xlarge`  = "m5dn.4xlarge"
-    val `m5dn.8xlarge`  = "m5dn.8xlarge"
-    val `m5dn.12xlarge` = "m5dn.12xlarge"
-    val `m5dn.16xlarge` = "m5dn.16xlarge"
-    val `m5dn.24xlarge` = "m5dn.24xlarge"
-    val `m5n.large`     = "m5n.large"
-    val `m5n.xlarge`    = "m5n.xlarge"
-    val `m5n.2xlarge`   = "m5n.2xlarge"
-    val `m5n.4xlarge`   = "m5n.4xlarge"
-    val `m5n.8xlarge`   = "m5n.8xlarge"
-    val `m5n.12xlarge`  = "m5n.12xlarge"
-    val `m5n.16xlarge`  = "m5n.16xlarge"
-    val `m5n.24xlarge`  = "m5n.24xlarge"
-    val `r5dn.large`    = "r5dn.large"
-    val `r5dn.xlarge`   = "r5dn.xlarge"
-    val `r5dn.2xlarge`  = "r5dn.2xlarge"
-    val `r5dn.4xlarge`  = "r5dn.4xlarge"
-    val `r5dn.8xlarge`  = "r5dn.8xlarge"
-    val `r5dn.12xlarge` = "r5dn.12xlarge"
-    val `r5dn.16xlarge` = "r5dn.16xlarge"
-    val `r5dn.24xlarge` = "r5dn.24xlarge"
-    val `r5n.large`     = "r5n.large"
-    val `r5n.xlarge`    = "r5n.xlarge"
-    val `r5n.2xlarge`   = "r5n.2xlarge"
-    val `r5n.4xlarge`   = "r5n.4xlarge"
-    val `r5n.8xlarge`   = "r5n.8xlarge"
-    val `r5n.12xlarge`  = "r5n.12xlarge"
-    val `r5n.16xlarge`  = "r5n.16xlarge"
-    val `r5n.24xlarge`  = "r5n.24xlarge"
-    val `inf1.xlarge`   = "inf1.xlarge"
-    val `inf1.2xlarge`  = "inf1.2xlarge"
-    val `inf1.6xlarge`  = "inf1.6xlarge"
-    val `inf1.24xlarge` = "inf1.24xlarge"
+  @js.native
+  sealed trait InstanceType extends js.Any
+  object InstanceType extends js.Object {
+    val `t1.micro`      = "t1.micro".asInstanceOf[InstanceType]
+    val `t2.nano`       = "t2.nano".asInstanceOf[InstanceType]
+    val `t2.micro`      = "t2.micro".asInstanceOf[InstanceType]
+    val `t2.small`      = "t2.small".asInstanceOf[InstanceType]
+    val `t2.medium`     = "t2.medium".asInstanceOf[InstanceType]
+    val `t2.large`      = "t2.large".asInstanceOf[InstanceType]
+    val `t2.xlarge`     = "t2.xlarge".asInstanceOf[InstanceType]
+    val `t2.2xlarge`    = "t2.2xlarge".asInstanceOf[InstanceType]
+    val `t3.nano`       = "t3.nano".asInstanceOf[InstanceType]
+    val `t3.micro`      = "t3.micro".asInstanceOf[InstanceType]
+    val `t3.small`      = "t3.small".asInstanceOf[InstanceType]
+    val `t3.medium`     = "t3.medium".asInstanceOf[InstanceType]
+    val `t3.large`      = "t3.large".asInstanceOf[InstanceType]
+    val `t3.xlarge`     = "t3.xlarge".asInstanceOf[InstanceType]
+    val `t3.2xlarge`    = "t3.2xlarge".asInstanceOf[InstanceType]
+    val `t3a.nano`      = "t3a.nano".asInstanceOf[InstanceType]
+    val `t3a.micro`     = "t3a.micro".asInstanceOf[InstanceType]
+    val `t3a.small`     = "t3a.small".asInstanceOf[InstanceType]
+    val `t3a.medium`    = "t3a.medium".asInstanceOf[InstanceType]
+    val `t3a.large`     = "t3a.large".asInstanceOf[InstanceType]
+    val `t3a.xlarge`    = "t3a.xlarge".asInstanceOf[InstanceType]
+    val `t3a.2xlarge`   = "t3a.2xlarge".asInstanceOf[InstanceType]
+    val `m1.small`      = "m1.small".asInstanceOf[InstanceType]
+    val `m1.medium`     = "m1.medium".asInstanceOf[InstanceType]
+    val `m1.large`      = "m1.large".asInstanceOf[InstanceType]
+    val `m1.xlarge`     = "m1.xlarge".asInstanceOf[InstanceType]
+    val `m3.medium`     = "m3.medium".asInstanceOf[InstanceType]
+    val `m3.large`      = "m3.large".asInstanceOf[InstanceType]
+    val `m3.xlarge`     = "m3.xlarge".asInstanceOf[InstanceType]
+    val `m3.2xlarge`    = "m3.2xlarge".asInstanceOf[InstanceType]
+    val `m4.large`      = "m4.large".asInstanceOf[InstanceType]
+    val `m4.xlarge`     = "m4.xlarge".asInstanceOf[InstanceType]
+    val `m4.2xlarge`    = "m4.2xlarge".asInstanceOf[InstanceType]
+    val `m4.4xlarge`    = "m4.4xlarge".asInstanceOf[InstanceType]
+    val `m4.10xlarge`   = "m4.10xlarge".asInstanceOf[InstanceType]
+    val `m4.16xlarge`   = "m4.16xlarge".asInstanceOf[InstanceType]
+    val `m2.xlarge`     = "m2.xlarge".asInstanceOf[InstanceType]
+    val `m2.2xlarge`    = "m2.2xlarge".asInstanceOf[InstanceType]
+    val `m2.4xlarge`    = "m2.4xlarge".asInstanceOf[InstanceType]
+    val `cr1.8xlarge`   = "cr1.8xlarge".asInstanceOf[InstanceType]
+    val `r3.large`      = "r3.large".asInstanceOf[InstanceType]
+    val `r3.xlarge`     = "r3.xlarge".asInstanceOf[InstanceType]
+    val `r3.2xlarge`    = "r3.2xlarge".asInstanceOf[InstanceType]
+    val `r3.4xlarge`    = "r3.4xlarge".asInstanceOf[InstanceType]
+    val `r3.8xlarge`    = "r3.8xlarge".asInstanceOf[InstanceType]
+    val `r4.large`      = "r4.large".asInstanceOf[InstanceType]
+    val `r4.xlarge`     = "r4.xlarge".asInstanceOf[InstanceType]
+    val `r4.2xlarge`    = "r4.2xlarge".asInstanceOf[InstanceType]
+    val `r4.4xlarge`    = "r4.4xlarge".asInstanceOf[InstanceType]
+    val `r4.8xlarge`    = "r4.8xlarge".asInstanceOf[InstanceType]
+    val `r4.16xlarge`   = "r4.16xlarge".asInstanceOf[InstanceType]
+    val `r5.large`      = "r5.large".asInstanceOf[InstanceType]
+    val `r5.xlarge`     = "r5.xlarge".asInstanceOf[InstanceType]
+    val `r5.2xlarge`    = "r5.2xlarge".asInstanceOf[InstanceType]
+    val `r5.4xlarge`    = "r5.4xlarge".asInstanceOf[InstanceType]
+    val `r5.8xlarge`    = "r5.8xlarge".asInstanceOf[InstanceType]
+    val `r5.12xlarge`   = "r5.12xlarge".asInstanceOf[InstanceType]
+    val `r5.16xlarge`   = "r5.16xlarge".asInstanceOf[InstanceType]
+    val `r5.24xlarge`   = "r5.24xlarge".asInstanceOf[InstanceType]
+    val `r5.metal`      = "r5.metal".asInstanceOf[InstanceType]
+    val `r5a.large`     = "r5a.large".asInstanceOf[InstanceType]
+    val `r5a.xlarge`    = "r5a.xlarge".asInstanceOf[InstanceType]
+    val `r5a.2xlarge`   = "r5a.2xlarge".asInstanceOf[InstanceType]
+    val `r5a.4xlarge`   = "r5a.4xlarge".asInstanceOf[InstanceType]
+    val `r5a.8xlarge`   = "r5a.8xlarge".asInstanceOf[InstanceType]
+    val `r5a.12xlarge`  = "r5a.12xlarge".asInstanceOf[InstanceType]
+    val `r5a.16xlarge`  = "r5a.16xlarge".asInstanceOf[InstanceType]
+    val `r5a.24xlarge`  = "r5a.24xlarge".asInstanceOf[InstanceType]
+    val `r5d.large`     = "r5d.large".asInstanceOf[InstanceType]
+    val `r5d.xlarge`    = "r5d.xlarge".asInstanceOf[InstanceType]
+    val `r5d.2xlarge`   = "r5d.2xlarge".asInstanceOf[InstanceType]
+    val `r5d.4xlarge`   = "r5d.4xlarge".asInstanceOf[InstanceType]
+    val `r5d.8xlarge`   = "r5d.8xlarge".asInstanceOf[InstanceType]
+    val `r5d.12xlarge`  = "r5d.12xlarge".asInstanceOf[InstanceType]
+    val `r5d.16xlarge`  = "r5d.16xlarge".asInstanceOf[InstanceType]
+    val `r5d.24xlarge`  = "r5d.24xlarge".asInstanceOf[InstanceType]
+    val `r5d.metal`     = "r5d.metal".asInstanceOf[InstanceType]
+    val `r5ad.large`    = "r5ad.large".asInstanceOf[InstanceType]
+    val `r5ad.xlarge`   = "r5ad.xlarge".asInstanceOf[InstanceType]
+    val `r5ad.2xlarge`  = "r5ad.2xlarge".asInstanceOf[InstanceType]
+    val `r5ad.4xlarge`  = "r5ad.4xlarge".asInstanceOf[InstanceType]
+    val `r5ad.8xlarge`  = "r5ad.8xlarge".asInstanceOf[InstanceType]
+    val `r5ad.12xlarge` = "r5ad.12xlarge".asInstanceOf[InstanceType]
+    val `r5ad.16xlarge` = "r5ad.16xlarge".asInstanceOf[InstanceType]
+    val `r5ad.24xlarge` = "r5ad.24xlarge".asInstanceOf[InstanceType]
+    val `x1.16xlarge`   = "x1.16xlarge".asInstanceOf[InstanceType]
+    val `x1.32xlarge`   = "x1.32xlarge".asInstanceOf[InstanceType]
+    val `x1e.xlarge`    = "x1e.xlarge".asInstanceOf[InstanceType]
+    val `x1e.2xlarge`   = "x1e.2xlarge".asInstanceOf[InstanceType]
+    val `x1e.4xlarge`   = "x1e.4xlarge".asInstanceOf[InstanceType]
+    val `x1e.8xlarge`   = "x1e.8xlarge".asInstanceOf[InstanceType]
+    val `x1e.16xlarge`  = "x1e.16xlarge".asInstanceOf[InstanceType]
+    val `x1e.32xlarge`  = "x1e.32xlarge".asInstanceOf[InstanceType]
+    val `i2.xlarge`     = "i2.xlarge".asInstanceOf[InstanceType]
+    val `i2.2xlarge`    = "i2.2xlarge".asInstanceOf[InstanceType]
+    val `i2.4xlarge`    = "i2.4xlarge".asInstanceOf[InstanceType]
+    val `i2.8xlarge`    = "i2.8xlarge".asInstanceOf[InstanceType]
+    val `i3.large`      = "i3.large".asInstanceOf[InstanceType]
+    val `i3.xlarge`     = "i3.xlarge".asInstanceOf[InstanceType]
+    val `i3.2xlarge`    = "i3.2xlarge".asInstanceOf[InstanceType]
+    val `i3.4xlarge`    = "i3.4xlarge".asInstanceOf[InstanceType]
+    val `i3.8xlarge`    = "i3.8xlarge".asInstanceOf[InstanceType]
+    val `i3.16xlarge`   = "i3.16xlarge".asInstanceOf[InstanceType]
+    val `i3.metal`      = "i3.metal".asInstanceOf[InstanceType]
+    val `i3en.large`    = "i3en.large".asInstanceOf[InstanceType]
+    val `i3en.xlarge`   = "i3en.xlarge".asInstanceOf[InstanceType]
+    val `i3en.2xlarge`  = "i3en.2xlarge".asInstanceOf[InstanceType]
+    val `i3en.3xlarge`  = "i3en.3xlarge".asInstanceOf[InstanceType]
+    val `i3en.6xlarge`  = "i3en.6xlarge".asInstanceOf[InstanceType]
+    val `i3en.12xlarge` = "i3en.12xlarge".asInstanceOf[InstanceType]
+    val `i3en.24xlarge` = "i3en.24xlarge".asInstanceOf[InstanceType]
+    val `i3en.metal`    = "i3en.metal".asInstanceOf[InstanceType]
+    val `hi1.4xlarge`   = "hi1.4xlarge".asInstanceOf[InstanceType]
+    val `hs1.8xlarge`   = "hs1.8xlarge".asInstanceOf[InstanceType]
+    val `c1.medium`     = "c1.medium".asInstanceOf[InstanceType]
+    val `c1.xlarge`     = "c1.xlarge".asInstanceOf[InstanceType]
+    val `c3.large`      = "c3.large".asInstanceOf[InstanceType]
+    val `c3.xlarge`     = "c3.xlarge".asInstanceOf[InstanceType]
+    val `c3.2xlarge`    = "c3.2xlarge".asInstanceOf[InstanceType]
+    val `c3.4xlarge`    = "c3.4xlarge".asInstanceOf[InstanceType]
+    val `c3.8xlarge`    = "c3.8xlarge".asInstanceOf[InstanceType]
+    val `c4.large`      = "c4.large".asInstanceOf[InstanceType]
+    val `c4.xlarge`     = "c4.xlarge".asInstanceOf[InstanceType]
+    val `c4.2xlarge`    = "c4.2xlarge".asInstanceOf[InstanceType]
+    val `c4.4xlarge`    = "c4.4xlarge".asInstanceOf[InstanceType]
+    val `c4.8xlarge`    = "c4.8xlarge".asInstanceOf[InstanceType]
+    val `c5.large`      = "c5.large".asInstanceOf[InstanceType]
+    val `c5.xlarge`     = "c5.xlarge".asInstanceOf[InstanceType]
+    val `c5.2xlarge`    = "c5.2xlarge".asInstanceOf[InstanceType]
+    val `c5.4xlarge`    = "c5.4xlarge".asInstanceOf[InstanceType]
+    val `c5.9xlarge`    = "c5.9xlarge".asInstanceOf[InstanceType]
+    val `c5.12xlarge`   = "c5.12xlarge".asInstanceOf[InstanceType]
+    val `c5.18xlarge`   = "c5.18xlarge".asInstanceOf[InstanceType]
+    val `c5.24xlarge`   = "c5.24xlarge".asInstanceOf[InstanceType]
+    val `c5.metal`      = "c5.metal".asInstanceOf[InstanceType]
+    val `c5d.large`     = "c5d.large".asInstanceOf[InstanceType]
+    val `c5d.xlarge`    = "c5d.xlarge".asInstanceOf[InstanceType]
+    val `c5d.2xlarge`   = "c5d.2xlarge".asInstanceOf[InstanceType]
+    val `c5d.4xlarge`   = "c5d.4xlarge".asInstanceOf[InstanceType]
+    val `c5d.9xlarge`   = "c5d.9xlarge".asInstanceOf[InstanceType]
+    val `c5d.12xlarge`  = "c5d.12xlarge".asInstanceOf[InstanceType]
+    val `c5d.18xlarge`  = "c5d.18xlarge".asInstanceOf[InstanceType]
+    val `c5d.24xlarge`  = "c5d.24xlarge".asInstanceOf[InstanceType]
+    val `c5d.metal`     = "c5d.metal".asInstanceOf[InstanceType]
+    val `c5n.large`     = "c5n.large".asInstanceOf[InstanceType]
+    val `c5n.xlarge`    = "c5n.xlarge".asInstanceOf[InstanceType]
+    val `c5n.2xlarge`   = "c5n.2xlarge".asInstanceOf[InstanceType]
+    val `c5n.4xlarge`   = "c5n.4xlarge".asInstanceOf[InstanceType]
+    val `c5n.9xlarge`   = "c5n.9xlarge".asInstanceOf[InstanceType]
+    val `c5n.18xlarge`  = "c5n.18xlarge".asInstanceOf[InstanceType]
+    val `cc1.4xlarge`   = "cc1.4xlarge".asInstanceOf[InstanceType]
+    val `cc2.8xlarge`   = "cc2.8xlarge".asInstanceOf[InstanceType]
+    val `g2.2xlarge`    = "g2.2xlarge".asInstanceOf[InstanceType]
+    val `g2.8xlarge`    = "g2.8xlarge".asInstanceOf[InstanceType]
+    val `g3.4xlarge`    = "g3.4xlarge".asInstanceOf[InstanceType]
+    val `g3.8xlarge`    = "g3.8xlarge".asInstanceOf[InstanceType]
+    val `g3.16xlarge`   = "g3.16xlarge".asInstanceOf[InstanceType]
+    val `g3s.xlarge`    = "g3s.xlarge".asInstanceOf[InstanceType]
+    val `g4dn.xlarge`   = "g4dn.xlarge".asInstanceOf[InstanceType]
+    val `g4dn.2xlarge`  = "g4dn.2xlarge".asInstanceOf[InstanceType]
+    val `g4dn.4xlarge`  = "g4dn.4xlarge".asInstanceOf[InstanceType]
+    val `g4dn.8xlarge`  = "g4dn.8xlarge".asInstanceOf[InstanceType]
+    val `g4dn.12xlarge` = "g4dn.12xlarge".asInstanceOf[InstanceType]
+    val `g4dn.16xlarge` = "g4dn.16xlarge".asInstanceOf[InstanceType]
+    val `cg1.4xlarge`   = "cg1.4xlarge".asInstanceOf[InstanceType]
+    val `p2.xlarge`     = "p2.xlarge".asInstanceOf[InstanceType]
+    val `p2.8xlarge`    = "p2.8xlarge".asInstanceOf[InstanceType]
+    val `p2.16xlarge`   = "p2.16xlarge".asInstanceOf[InstanceType]
+    val `p3.2xlarge`    = "p3.2xlarge".asInstanceOf[InstanceType]
+    val `p3.8xlarge`    = "p3.8xlarge".asInstanceOf[InstanceType]
+    val `p3.16xlarge`   = "p3.16xlarge".asInstanceOf[InstanceType]
+    val `p3dn.24xlarge` = "p3dn.24xlarge".asInstanceOf[InstanceType]
+    val `d2.xlarge`     = "d2.xlarge".asInstanceOf[InstanceType]
+    val `d2.2xlarge`    = "d2.2xlarge".asInstanceOf[InstanceType]
+    val `d2.4xlarge`    = "d2.4xlarge".asInstanceOf[InstanceType]
+    val `d2.8xlarge`    = "d2.8xlarge".asInstanceOf[InstanceType]
+    val `f1.2xlarge`    = "f1.2xlarge".asInstanceOf[InstanceType]
+    val `f1.4xlarge`    = "f1.4xlarge".asInstanceOf[InstanceType]
+    val `f1.16xlarge`   = "f1.16xlarge".asInstanceOf[InstanceType]
+    val `m5.large`      = "m5.large".asInstanceOf[InstanceType]
+    val `m5.xlarge`     = "m5.xlarge".asInstanceOf[InstanceType]
+    val `m5.2xlarge`    = "m5.2xlarge".asInstanceOf[InstanceType]
+    val `m5.4xlarge`    = "m5.4xlarge".asInstanceOf[InstanceType]
+    val `m5.8xlarge`    = "m5.8xlarge".asInstanceOf[InstanceType]
+    val `m5.12xlarge`   = "m5.12xlarge".asInstanceOf[InstanceType]
+    val `m5.16xlarge`   = "m5.16xlarge".asInstanceOf[InstanceType]
+    val `m5.24xlarge`   = "m5.24xlarge".asInstanceOf[InstanceType]
+    val `m5.metal`      = "m5.metal".asInstanceOf[InstanceType]
+    val `m5a.large`     = "m5a.large".asInstanceOf[InstanceType]
+    val `m5a.xlarge`    = "m5a.xlarge".asInstanceOf[InstanceType]
+    val `m5a.2xlarge`   = "m5a.2xlarge".asInstanceOf[InstanceType]
+    val `m5a.4xlarge`   = "m5a.4xlarge".asInstanceOf[InstanceType]
+    val `m5a.8xlarge`   = "m5a.8xlarge".asInstanceOf[InstanceType]
+    val `m5a.12xlarge`  = "m5a.12xlarge".asInstanceOf[InstanceType]
+    val `m5a.16xlarge`  = "m5a.16xlarge".asInstanceOf[InstanceType]
+    val `m5a.24xlarge`  = "m5a.24xlarge".asInstanceOf[InstanceType]
+    val `m5d.large`     = "m5d.large".asInstanceOf[InstanceType]
+    val `m5d.xlarge`    = "m5d.xlarge".asInstanceOf[InstanceType]
+    val `m5d.2xlarge`   = "m5d.2xlarge".asInstanceOf[InstanceType]
+    val `m5d.4xlarge`   = "m5d.4xlarge".asInstanceOf[InstanceType]
+    val `m5d.8xlarge`   = "m5d.8xlarge".asInstanceOf[InstanceType]
+    val `m5d.12xlarge`  = "m5d.12xlarge".asInstanceOf[InstanceType]
+    val `m5d.16xlarge`  = "m5d.16xlarge".asInstanceOf[InstanceType]
+    val `m5d.24xlarge`  = "m5d.24xlarge".asInstanceOf[InstanceType]
+    val `m5d.metal`     = "m5d.metal".asInstanceOf[InstanceType]
+    val `m5ad.large`    = "m5ad.large".asInstanceOf[InstanceType]
+    val `m5ad.xlarge`   = "m5ad.xlarge".asInstanceOf[InstanceType]
+    val `m5ad.2xlarge`  = "m5ad.2xlarge".asInstanceOf[InstanceType]
+    val `m5ad.4xlarge`  = "m5ad.4xlarge".asInstanceOf[InstanceType]
+    val `m5ad.8xlarge`  = "m5ad.8xlarge".asInstanceOf[InstanceType]
+    val `m5ad.12xlarge` = "m5ad.12xlarge".asInstanceOf[InstanceType]
+    val `m5ad.16xlarge` = "m5ad.16xlarge".asInstanceOf[InstanceType]
+    val `m5ad.24xlarge` = "m5ad.24xlarge".asInstanceOf[InstanceType]
+    val `h1.2xlarge`    = "h1.2xlarge".asInstanceOf[InstanceType]
+    val `h1.4xlarge`    = "h1.4xlarge".asInstanceOf[InstanceType]
+    val `h1.8xlarge`    = "h1.8xlarge".asInstanceOf[InstanceType]
+    val `h1.16xlarge`   = "h1.16xlarge".asInstanceOf[InstanceType]
+    val `z1d.large`     = "z1d.large".asInstanceOf[InstanceType]
+    val `z1d.xlarge`    = "z1d.xlarge".asInstanceOf[InstanceType]
+    val `z1d.2xlarge`   = "z1d.2xlarge".asInstanceOf[InstanceType]
+    val `z1d.3xlarge`   = "z1d.3xlarge".asInstanceOf[InstanceType]
+    val `z1d.6xlarge`   = "z1d.6xlarge".asInstanceOf[InstanceType]
+    val `z1d.12xlarge`  = "z1d.12xlarge".asInstanceOf[InstanceType]
+    val `z1d.metal`     = "z1d.metal".asInstanceOf[InstanceType]
+    val `u-6tb1.metal`  = "u-6tb1.metal".asInstanceOf[InstanceType]
+    val `u-9tb1.metal`  = "u-9tb1.metal".asInstanceOf[InstanceType]
+    val `u-12tb1.metal` = "u-12tb1.metal".asInstanceOf[InstanceType]
+    val `u-18tb1.metal` = "u-18tb1.metal".asInstanceOf[InstanceType]
+    val `u-24tb1.metal` = "u-24tb1.metal".asInstanceOf[InstanceType]
+    val `a1.medium`     = "a1.medium".asInstanceOf[InstanceType]
+    val `a1.large`      = "a1.large".asInstanceOf[InstanceType]
+    val `a1.xlarge`     = "a1.xlarge".asInstanceOf[InstanceType]
+    val `a1.2xlarge`    = "a1.2xlarge".asInstanceOf[InstanceType]
+    val `a1.4xlarge`    = "a1.4xlarge".asInstanceOf[InstanceType]
+    val `a1.metal`      = "a1.metal".asInstanceOf[InstanceType]
+    val `m5dn.large`    = "m5dn.large".asInstanceOf[InstanceType]
+    val `m5dn.xlarge`   = "m5dn.xlarge".asInstanceOf[InstanceType]
+    val `m5dn.2xlarge`  = "m5dn.2xlarge".asInstanceOf[InstanceType]
+    val `m5dn.4xlarge`  = "m5dn.4xlarge".asInstanceOf[InstanceType]
+    val `m5dn.8xlarge`  = "m5dn.8xlarge".asInstanceOf[InstanceType]
+    val `m5dn.12xlarge` = "m5dn.12xlarge".asInstanceOf[InstanceType]
+    val `m5dn.16xlarge` = "m5dn.16xlarge".asInstanceOf[InstanceType]
+    val `m5dn.24xlarge` = "m5dn.24xlarge".asInstanceOf[InstanceType]
+    val `m5n.large`     = "m5n.large".asInstanceOf[InstanceType]
+    val `m5n.xlarge`    = "m5n.xlarge".asInstanceOf[InstanceType]
+    val `m5n.2xlarge`   = "m5n.2xlarge".asInstanceOf[InstanceType]
+    val `m5n.4xlarge`   = "m5n.4xlarge".asInstanceOf[InstanceType]
+    val `m5n.8xlarge`   = "m5n.8xlarge".asInstanceOf[InstanceType]
+    val `m5n.12xlarge`  = "m5n.12xlarge".asInstanceOf[InstanceType]
+    val `m5n.16xlarge`  = "m5n.16xlarge".asInstanceOf[InstanceType]
+    val `m5n.24xlarge`  = "m5n.24xlarge".asInstanceOf[InstanceType]
+    val `r5dn.large`    = "r5dn.large".asInstanceOf[InstanceType]
+    val `r5dn.xlarge`   = "r5dn.xlarge".asInstanceOf[InstanceType]
+    val `r5dn.2xlarge`  = "r5dn.2xlarge".asInstanceOf[InstanceType]
+    val `r5dn.4xlarge`  = "r5dn.4xlarge".asInstanceOf[InstanceType]
+    val `r5dn.8xlarge`  = "r5dn.8xlarge".asInstanceOf[InstanceType]
+    val `r5dn.12xlarge` = "r5dn.12xlarge".asInstanceOf[InstanceType]
+    val `r5dn.16xlarge` = "r5dn.16xlarge".asInstanceOf[InstanceType]
+    val `r5dn.24xlarge` = "r5dn.24xlarge".asInstanceOf[InstanceType]
+    val `r5n.large`     = "r5n.large".asInstanceOf[InstanceType]
+    val `r5n.xlarge`    = "r5n.xlarge".asInstanceOf[InstanceType]
+    val `r5n.2xlarge`   = "r5n.2xlarge".asInstanceOf[InstanceType]
+    val `r5n.4xlarge`   = "r5n.4xlarge".asInstanceOf[InstanceType]
+    val `r5n.8xlarge`   = "r5n.8xlarge".asInstanceOf[InstanceType]
+    val `r5n.12xlarge`  = "r5n.12xlarge".asInstanceOf[InstanceType]
+    val `r5n.16xlarge`  = "r5n.16xlarge".asInstanceOf[InstanceType]
+    val `r5n.24xlarge`  = "r5n.24xlarge".asInstanceOf[InstanceType]
+    val `inf1.xlarge`   = "inf1.xlarge".asInstanceOf[InstanceType]
+    val `inf1.2xlarge`  = "inf1.2xlarge".asInstanceOf[InstanceType]
+    val `inf1.6xlarge`  = "inf1.6xlarge".asInstanceOf[InstanceType]
+    val `inf1.24xlarge` = "inf1.24xlarge".asInstanceOf[InstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -23075,10 +22975,11 @@ package ec2 {
       )
     )
   }
-
-  object InstanceTypeHypervisorEnum {
-    val nitro = "nitro"
-    val xen   = "xen"
+  @js.native
+  sealed trait InstanceTypeHypervisor extends js.Any
+  object InstanceTypeHypervisor extends js.Object {
+    val nitro = "nitro".asInstanceOf[InstanceTypeHypervisor]
+    val xen   = "xen".asInstanceOf[InstanceTypeHypervisor]
 
     val values = js.Object.freeze(js.Array(nitro, xen))
   }
@@ -23213,10 +23114,11 @@ package ec2 {
       __obj.asInstanceOf[InstanceUsage]
     }
   }
-
-  object InterfacePermissionTypeEnum {
-    val `INSTANCE-ATTACH` = "INSTANCE-ATTACH"
-    val `EIP-ASSOCIATE`   = "EIP-ASSOCIATE"
+  @js.native
+  sealed trait InterfacePermissionType extends js.Any
+  object InterfacePermissionType extends js.Object {
+    val `INSTANCE-ATTACH` = "INSTANCE-ATTACH".asInstanceOf[InterfacePermissionType]
+    val `EIP-ASSOCIATE`   = "EIP-ASSOCIATE".asInstanceOf[InterfacePermissionType]
 
     val values = js.Object.freeze(js.Array(`INSTANCE-ATTACH`, `EIP-ASSOCIATE`))
   }
@@ -23420,10 +23322,11 @@ package ec2 {
       __obj.asInstanceOf[Ipv6Range]
     }
   }
-
-  object Ipv6SupportValueEnum {
-    val enable  = "enable"
-    val disable = "disable"
+  @js.native
+  sealed trait Ipv6SupportValue extends js.Any
+  object Ipv6SupportValue extends js.Object {
+    val enable  = "enable".asInstanceOf[Ipv6SupportValue]
+    val disable = "disable".asInstanceOf[Ipv6SupportValue]
 
     val values = js.Object.freeze(js.Array(enable, disable))
   }
@@ -23967,14 +23870,15 @@ package ec2 {
       __obj.asInstanceOf[LaunchTemplateElasticInferenceAcceleratorResponse]
     }
   }
-
-  object LaunchTemplateErrorCodeEnum {
-    val launchTemplateIdDoesNotExist      = "launchTemplateIdDoesNotExist"
-    val launchTemplateIdMalformed         = "launchTemplateIdMalformed"
-    val launchTemplateNameDoesNotExist    = "launchTemplateNameDoesNotExist"
-    val launchTemplateNameMalformed       = "launchTemplateNameMalformed"
-    val launchTemplateVersionDoesNotExist = "launchTemplateVersionDoesNotExist"
-    val unexpectedError                   = "unexpectedError"
+  @js.native
+  sealed trait LaunchTemplateErrorCode extends js.Any
+  object LaunchTemplateErrorCode extends js.Object {
+    val launchTemplateIdDoesNotExist      = "launchTemplateIdDoesNotExist".asInstanceOf[LaunchTemplateErrorCode]
+    val launchTemplateIdMalformed         = "launchTemplateIdMalformed".asInstanceOf[LaunchTemplateErrorCode]
+    val launchTemplateNameDoesNotExist    = "launchTemplateNameDoesNotExist".asInstanceOf[LaunchTemplateErrorCode]
+    val launchTemplateNameMalformed       = "launchTemplateNameMalformed".asInstanceOf[LaunchTemplateErrorCode]
+    val launchTemplateVersionDoesNotExist = "launchTemplateVersionDoesNotExist".asInstanceOf[LaunchTemplateErrorCode]
+    val unexpectedError                   = "unexpectedError".asInstanceOf[LaunchTemplateErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -24025,10 +23929,11 @@ package ec2 {
       __obj.asInstanceOf[LaunchTemplateHibernationOptionsRequest]
     }
   }
-
-  object LaunchTemplateHttpTokensStateEnum {
-    val optional = "optional"
-    val required = "required"
+  @js.native
+  sealed trait LaunchTemplateHttpTokensState extends js.Any
+  object LaunchTemplateHttpTokensState extends js.Object {
+    val optional = "optional".asInstanceOf[LaunchTemplateHttpTokensState]
+    val required = "required".asInstanceOf[LaunchTemplateHttpTokensState]
 
     val values = js.Object.freeze(js.Array(optional, required))
   }
@@ -24120,10 +24025,11 @@ package ec2 {
       __obj.asInstanceOf[LaunchTemplateInstanceMarketOptionsRequest]
     }
   }
-
-  object LaunchTemplateInstanceMetadataEndpointStateEnum {
-    val disabled = "disabled"
-    val enabled  = "enabled"
+  @js.native
+  sealed trait LaunchTemplateInstanceMetadataEndpointState extends js.Any
+  object LaunchTemplateInstanceMetadataEndpointState extends js.Object {
+    val disabled = "disabled".asInstanceOf[LaunchTemplateInstanceMetadataEndpointState]
+    val enabled  = "enabled".asInstanceOf[LaunchTemplateInstanceMetadataEndpointState]
 
     val values = js.Object.freeze(js.Array(disabled, enabled))
   }
@@ -24180,10 +24086,11 @@ package ec2 {
       __obj.asInstanceOf[LaunchTemplateInstanceMetadataOptionsRequest]
     }
   }
-
-  object LaunchTemplateInstanceMetadataOptionsStateEnum {
-    val pending = "pending"
-    val applied = "applied"
+  @js.native
+  sealed trait LaunchTemplateInstanceMetadataOptionsState extends js.Any
+  object LaunchTemplateInstanceMetadataOptionsState extends js.Object {
+    val pending = "pending".asInstanceOf[LaunchTemplateInstanceMetadataOptionsState]
+    val applied = "applied".asInstanceOf[LaunchTemplateInstanceMetadataOptionsState]
 
     val values = js.Object.freeze(js.Array(pending, applied))
   }
@@ -24704,21 +24611,23 @@ package ec2 {
       __obj.asInstanceOf[LicenseConfigurationRequest]
     }
   }
-
-  object ListingStateEnum {
-    val available = "available"
-    val sold      = "sold"
-    val cancelled = "cancelled"
-    val pending   = "pending"
+  @js.native
+  sealed trait ListingState extends js.Any
+  object ListingState extends js.Object {
+    val available = "available".asInstanceOf[ListingState]
+    val sold      = "sold".asInstanceOf[ListingState]
+    val cancelled = "cancelled".asInstanceOf[ListingState]
+    val pending   = "pending".asInstanceOf[ListingState]
 
     val values = js.Object.freeze(js.Array(available, sold, cancelled, pending))
   }
-
-  object ListingStatusEnum {
-    val active    = "active"
-    val pending   = "pending"
-    val cancelled = "cancelled"
-    val closed    = "closed"
+  @js.native
+  sealed trait ListingStatus extends js.Any
+  object ListingStatus extends js.Object {
+    val active    = "active".asInstanceOf[ListingStatus]
+    val pending   = "pending".asInstanceOf[ListingStatus]
+    val cancelled = "cancelled".asInstanceOf[ListingStatus]
+    val closed    = "closed".asInstanceOf[ListingStatus]
 
     val values = js.Object.freeze(js.Array(active, pending, cancelled, closed))
   }
@@ -24876,13 +24785,14 @@ package ec2 {
       __obj.asInstanceOf[LocalGatewayRoute]
     }
   }
-
-  object LocalGatewayRouteStateEnum {
-    val pending   = "pending"
-    val active    = "active"
-    val blackhole = "blackhole"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait LocalGatewayRouteState extends js.Any
+  object LocalGatewayRouteState extends js.Object {
+    val pending   = "pending".asInstanceOf[LocalGatewayRouteState]
+    val active    = "active".asInstanceOf[LocalGatewayRouteState]
+    val blackhole = "blackhole".asInstanceOf[LocalGatewayRouteState]
+    val deleting  = "deleting".asInstanceOf[LocalGatewayRouteState]
+    val deleted   = "deleted".asInstanceOf[LocalGatewayRouteState]
 
     val values = js.Object.freeze(js.Array(pending, active, blackhole, deleting, deleted))
   }
@@ -24995,10 +24905,11 @@ package ec2 {
       __obj.asInstanceOf[LocalGatewayRouteTableVpcAssociation]
     }
   }
-
-  object LocalGatewayRouteTypeEnum {
-    val static     = "static"
-    val propagated = "propagated"
+  @js.native
+  sealed trait LocalGatewayRouteType extends js.Any
+  object LocalGatewayRouteType extends js.Object {
+    val static     = "static".asInstanceOf[LocalGatewayRouteType]
+    val propagated = "propagated".asInstanceOf[LocalGatewayRouteType]
 
     val values = js.Object.freeze(js.Array(static, propagated))
   }
@@ -25076,31 +24987,35 @@ package ec2 {
       __obj.asInstanceOf[LocalGatewayVirtualInterfaceGroup]
     }
   }
-
-  object LocationTypeEnum {
-    val region                 = "region"
-    val `availability-zone`    = "availability-zone"
-    val `availability-zone-id` = "availability-zone-id"
+  @js.native
+  sealed trait LocationType extends js.Any
+  object LocationType extends js.Object {
+    val region                 = "region".asInstanceOf[LocationType]
+    val `availability-zone`    = "availability-zone".asInstanceOf[LocationType]
+    val `availability-zone-id` = "availability-zone-id".asInstanceOf[LocationType]
 
     val values = js.Object.freeze(js.Array(region, `availability-zone`, `availability-zone-id`))
   }
-
-  object LogDestinationTypeEnum {
-    val `cloud-watch-logs` = "cloud-watch-logs"
-    val s3                 = "s3"
+  @js.native
+  sealed trait LogDestinationType extends js.Any
+  object LogDestinationType extends js.Object {
+    val `cloud-watch-logs` = "cloud-watch-logs".asInstanceOf[LogDestinationType]
+    val s3                 = "s3".asInstanceOf[LogDestinationType]
 
     val values = js.Object.freeze(js.Array(`cloud-watch-logs`, s3))
   }
-
-  object MarketTypeEnum {
-    val spot = "spot"
+  @js.native
+  sealed trait MarketType extends js.Any
+  object MarketType extends js.Object {
+    val spot = "spot".asInstanceOf[MarketType]
 
     val values = js.Object.freeze(js.Array(spot))
   }
-
-  object MembershipTypeEnum {
-    val static = "static"
-    val igmp   = "igmp"
+  @js.native
+  sealed trait MembershipType extends js.Any
+  object MembershipType extends js.Object {
+    val static = "static".asInstanceOf[MembershipType]
+    val igmp   = "igmp".asInstanceOf[MembershipType]
 
     val values = js.Object.freeze(js.Array(static, igmp))
   }
@@ -26979,12 +26894,13 @@ package ec2 {
       __obj.asInstanceOf[Monitoring]
     }
   }
-
-  object MonitoringStateEnum {
-    val disabled  = "disabled"
-    val disabling = "disabling"
-    val enabled   = "enabled"
-    val pending   = "pending"
+  @js.native
+  sealed trait MonitoringState extends js.Any
+  object MonitoringState extends js.Object {
+    val disabled  = "disabled".asInstanceOf[MonitoringState]
+    val disabling = "disabling".asInstanceOf[MonitoringState]
+    val enabled   = "enabled".asInstanceOf[MonitoringState]
+    val pending   = "pending".asInstanceOf[MonitoringState]
 
     val values = js.Object.freeze(js.Array(disabled, disabling, enabled, pending))
   }
@@ -27028,10 +26944,11 @@ package ec2 {
       __obj.asInstanceOf[MoveAddressToVpcResult]
     }
   }
-
-  object MoveStatusEnum {
-    val movingToVpc        = "movingToVpc"
-    val restoringToClassic = "restoringToClassic"
+  @js.native
+  sealed trait MoveStatus extends js.Any
+  object MoveStatus extends js.Object {
+    val movingToVpc        = "movingToVpc".asInstanceOf[MoveStatus]
+    val restoringToClassic = "restoringToClassic".asInstanceOf[MoveStatus]
 
     val values = js.Object.freeze(js.Array(movingToVpc, restoringToClassic))
   }
@@ -27057,10 +26974,11 @@ package ec2 {
       __obj.asInstanceOf[MovingAddressStatus]
     }
   }
-
-  object MulticastSupportValueEnum {
-    val enable  = "enable"
-    val disable = "disable"
+  @js.native
+  sealed trait MulticastSupportValue extends js.Any
+  object MulticastSupportValue extends js.Object {
+    val enable  = "enable".asInstanceOf[MulticastSupportValue]
+    val disable = "disable".asInstanceOf[MulticastSupportValue]
 
     val values = js.Object.freeze(js.Array(enable, disable))
   }
@@ -27141,13 +27059,14 @@ package ec2 {
       __obj.asInstanceOf[NatGatewayAddress]
     }
   }
-
-  object NatGatewayStateEnum {
-    val pending   = "pending"
-    val failed    = "failed"
-    val available = "available"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait NatGatewayState extends js.Any
+  object NatGatewayState extends js.Object {
+    val pending   = "pending".asInstanceOf[NatGatewayState]
+    val failed    = "failed".asInstanceOf[NatGatewayState]
+    val available = "available".asInstanceOf[NatGatewayState]
+    val deleting  = "deleting".asInstanceOf[NatGatewayState]
+    val deleted   = "deleted".asInstanceOf[NatGatewayState]
 
     val values = js.Object.freeze(js.Array(pending, failed, available, deleting, deleted))
   }
@@ -27460,18 +27379,20 @@ package ec2 {
       __obj.asInstanceOf[NetworkInterfaceAttachmentChanges]
     }
   }
-
-  object NetworkInterfaceAttributeEnum {
-    val description     = "description"
-    val groupSet        = "groupSet"
-    val sourceDestCheck = "sourceDestCheck"
-    val attachment      = "attachment"
+  @js.native
+  sealed trait NetworkInterfaceAttribute extends js.Any
+  object NetworkInterfaceAttribute extends js.Object {
+    val description     = "description".asInstanceOf[NetworkInterfaceAttribute]
+    val groupSet        = "groupSet".asInstanceOf[NetworkInterfaceAttribute]
+    val sourceDestCheck = "sourceDestCheck".asInstanceOf[NetworkInterfaceAttribute]
+    val attachment      = "attachment".asInstanceOf[NetworkInterfaceAttribute]
 
     val values = js.Object.freeze(js.Array(description, groupSet, sourceDestCheck, attachment))
   }
-
-  object NetworkInterfaceCreationTypeEnum {
-    val efa = "efa"
+  @js.native
+  sealed trait NetworkInterfaceCreationType extends js.Any
+  object NetworkInterfaceCreationType extends js.Object {
+    val efa = "efa".asInstanceOf[NetworkInterfaceCreationType]
 
     val values = js.Object.freeze(js.Array(efa))
   }
@@ -27552,12 +27473,13 @@ package ec2 {
       __obj.asInstanceOf[NetworkInterfacePermissionState]
     }
   }
-
-  object NetworkInterfacePermissionStateCodeEnum {
-    val pending  = "pending"
-    val granted  = "granted"
-    val revoking = "revoking"
-    val revoked  = "revoked"
+  @js.native
+  sealed trait NetworkInterfacePermissionStateCode extends js.Any
+  object NetworkInterfacePermissionStateCode extends js.Object {
+    val pending  = "pending".asInstanceOf[NetworkInterfacePermissionStateCode]
+    val granted  = "granted".asInstanceOf[NetworkInterfacePermissionStateCode]
+    val revoking = "revoking".asInstanceOf[NetworkInterfacePermissionStateCode]
+    val revoked  = "revoked".asInstanceOf[NetworkInterfacePermissionStateCode]
 
     val values = js.Object.freeze(js.Array(pending, granted, revoking, revoked))
   }
@@ -27589,21 +27511,23 @@ package ec2 {
       __obj.asInstanceOf[NetworkInterfacePrivateIpAddress]
     }
   }
-
-  object NetworkInterfaceStatusEnum {
-    val available  = "available"
-    val associated = "associated"
-    val attaching  = "attaching"
-    val `in-use`   = "in-use"
-    val detaching  = "detaching"
+  @js.native
+  sealed trait NetworkInterfaceStatus extends js.Any
+  object NetworkInterfaceStatus extends js.Object {
+    val available  = "available".asInstanceOf[NetworkInterfaceStatus]
+    val associated = "associated".asInstanceOf[NetworkInterfaceStatus]
+    val attaching  = "attaching".asInstanceOf[NetworkInterfaceStatus]
+    val `in-use`   = "in-use".asInstanceOf[NetworkInterfaceStatus]
+    val detaching  = "detaching".asInstanceOf[NetworkInterfaceStatus]
 
     val values = js.Object.freeze(js.Array(available, associated, attaching, `in-use`, detaching))
   }
-
-  object NetworkInterfaceTypeEnum {
-    val interface  = "interface"
-    val natGateway = "natGateway"
-    val efa        = "efa"
+  @js.native
+  sealed trait NetworkInterfaceType extends js.Any
+  object NetworkInterfaceType extends js.Object {
+    val interface  = "interface".asInstanceOf[NetworkInterfaceType]
+    val natGateway = "natGateway".asInstanceOf[NetworkInterfaceType]
+    val efa        = "efa".asInstanceOf[NetworkInterfaceType]
 
     val values = js.Object.freeze(js.Array(interface, natGateway, efa))
   }
@@ -27626,21 +27550,23 @@ package ec2 {
       __obj.asInstanceOf[NewDhcpConfiguration]
     }
   }
-
-  object OfferingClassTypeEnum {
-    val standard    = "standard"
-    val convertible = "convertible"
+  @js.native
+  sealed trait OfferingClassType extends js.Any
+  object OfferingClassType extends js.Object {
+    val standard    = "standard".asInstanceOf[OfferingClassType]
+    val convertible = "convertible".asInstanceOf[OfferingClassType]
 
     val values = js.Object.freeze(js.Array(standard, convertible))
   }
-
-  object OfferingTypeValuesEnum {
-    val `Heavy Utilization`  = "Heavy Utilization"
-    val `Medium Utilization` = "Medium Utilization"
-    val `Light Utilization`  = "Light Utilization"
-    val `No Upfront`         = "No Upfront"
-    val `Partial Upfront`    = "Partial Upfront"
-    val `All Upfront`        = "All Upfront"
+  @js.native
+  sealed trait OfferingTypeValues extends js.Any
+  object OfferingTypeValues extends js.Object {
+    val `Heavy Utilization`  = "Heavy Utilization".asInstanceOf[OfferingTypeValues]
+    val `Medium Utilization` = "Medium Utilization".asInstanceOf[OfferingTypeValues]
+    val `Light Utilization`  = "Light Utilization".asInstanceOf[OfferingTypeValues]
+    val `No Upfront`         = "No Upfront".asInstanceOf[OfferingTypeValues]
+    val `Partial Upfront`    = "Partial Upfront".asInstanceOf[OfferingTypeValues]
+    val `All Upfront`        = "All Upfront".asInstanceOf[OfferingTypeValues]
 
     val values = js.Object.freeze(
       js.Array(
@@ -27653,10 +27579,11 @@ package ec2 {
       )
     )
   }
-
-  object OnDemandAllocationStrategyEnum {
-    val lowestPrice = "lowestPrice"
-    val prioritized = "prioritized"
+  @js.native
+  sealed trait OnDemandAllocationStrategy extends js.Any
+  object OnDemandAllocationStrategy extends js.Object {
+    val lowestPrice = "lowestPrice".asInstanceOf[OnDemandAllocationStrategy]
+    val prioritized = "prioritized".asInstanceOf[OnDemandAllocationStrategy]
 
     val values = js.Object.freeze(js.Array(lowestPrice, prioritized))
   }
@@ -27732,18 +27659,20 @@ package ec2 {
       __obj.asInstanceOf[OnDemandOptionsRequest]
     }
   }
-
-  object OperationTypeEnum {
-    val add    = "add"
-    val remove = "remove"
+  @js.native
+  sealed trait OperationType extends js.Any
+  object OperationType extends js.Object {
+    val add    = "add".asInstanceOf[OperationType]
+    val remove = "remove".asInstanceOf[OperationType]
 
     val values = js.Object.freeze(js.Array(add, remove))
   }
-
-  object PaymentOptionEnum {
-    val AllUpfront     = "AllUpfront"
-    val PartialUpfront = "PartialUpfront"
-    val NoUpfront      = "NoUpfront"
+  @js.native
+  sealed trait PaymentOption extends js.Any
+  object PaymentOption extends js.Object {
+    val AllUpfront     = "AllUpfront".asInstanceOf[PaymentOption]
+    val PartialUpfront = "PartialUpfront".asInstanceOf[PaymentOption]
+    val NoUpfront      = "NoUpfront".asInstanceOf[PaymentOption]
 
     val values = js.Object.freeze(js.Array(AllUpfront, PartialUpfront, NoUpfront))
   }
@@ -27884,9 +27813,10 @@ package ec2 {
       __obj.asInstanceOf[PeeringTgwInfo]
     }
   }
-
-  object PermissionGroupEnum {
-    val all = "all"
+  @js.native
+  sealed trait PermissionGroup extends js.Any
+  object PermissionGroup extends js.Object {
+    val all = "all".asInstanceOf[PermissionGroup]
 
     val values = js.Object.freeze(js.Array(all))
   }
@@ -28211,20 +28141,22 @@ package ec2 {
       __obj.asInstanceOf[PlacementGroupInfo]
     }
   }
-
-  object PlacementGroupStateEnum {
-    val pending   = "pending"
-    val available = "available"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait PlacementGroupState extends js.Any
+  object PlacementGroupState extends js.Object {
+    val pending   = "pending".asInstanceOf[PlacementGroupState]
+    val available = "available".asInstanceOf[PlacementGroupState]
+    val deleting  = "deleting".asInstanceOf[PlacementGroupState]
+    val deleted   = "deleted".asInstanceOf[PlacementGroupState]
 
     val values = js.Object.freeze(js.Array(pending, available, deleting, deleted))
   }
-
-  object PlacementGroupStrategyEnum {
-    val cluster   = "cluster"
-    val partition = "partition"
-    val spread    = "spread"
+  @js.native
+  sealed trait PlacementGroupStrategy extends js.Any
+  object PlacementGroupStrategy extends js.Object {
+    val cluster   = "cluster".asInstanceOf[PlacementGroupStrategy]
+    val partition = "partition".asInstanceOf[PlacementGroupStrategy]
+    val spread    = "spread".asInstanceOf[PlacementGroupStrategy]
 
     val values = js.Object.freeze(js.Array(cluster, partition, spread))
   }
@@ -28247,17 +28179,19 @@ package ec2 {
       __obj.asInstanceOf[PlacementResponse]
     }
   }
-
-  object PlacementStrategyEnum {
-    val cluster   = "cluster"
-    val spread    = "spread"
-    val partition = "partition"
+  @js.native
+  sealed trait PlacementStrategy extends js.Any
+  object PlacementStrategy extends js.Object {
+    val cluster   = "cluster".asInstanceOf[PlacementStrategy]
+    val spread    = "spread".asInstanceOf[PlacementStrategy]
+    val partition = "partition".asInstanceOf[PlacementStrategy]
 
     val values = js.Object.freeze(js.Array(cluster, spread, partition))
   }
-
-  object PlatformValuesEnum {
-    val Windows = "Windows"
+  @js.native
+  sealed trait PlatformValues extends js.Any
+  object PlatformValues extends js.Object {
+    val Windows = "Windows".asInstanceOf[PlatformValues]
 
     val values = js.Object.freeze(js.Array(Windows))
   }
@@ -28446,14 +28380,15 @@ package ec2 {
       __obj.asInstanceOf[PrincipalIdFormat]
     }
   }
-
-  object PrincipalTypeEnum {
-    val All              = "All"
-    val Service          = "Service"
-    val OrganizationUnit = "OrganizationUnit"
-    val Account          = "Account"
-    val User             = "User"
-    val Role             = "Role"
+  @js.native
+  sealed trait PrincipalType extends js.Any
+  object PrincipalType extends js.Object {
+    val All              = "All".asInstanceOf[PrincipalType]
+    val Service          = "Service".asInstanceOf[PrincipalType]
+    val OrganizationUnit = "OrganizationUnit".asInstanceOf[PrincipalType]
+    val Account          = "Account".asInstanceOf[PrincipalType]
+    val User             = "User".asInstanceOf[PrincipalType]
+    val Role             = "Role".asInstanceOf[PrincipalType]
 
     val values = js.Object.freeze(js.Array(All, Service, OrganizationUnit, Account, User, Role))
   }
@@ -28551,10 +28486,11 @@ package ec2 {
       __obj.asInstanceOf[ProductCode]
     }
   }
-
-  object ProductCodeValuesEnum {
-    val devpay      = "devpay"
-    val marketplace = "marketplace"
+  @js.native
+  sealed trait ProductCodeValues extends js.Any
+  object ProductCodeValues extends js.Object {
+    val devpay      = "devpay".asInstanceOf[ProductCodeValues]
+    val marketplace = "marketplace".asInstanceOf[ProductCodeValues]
 
     val values = js.Object.freeze(js.Array(devpay, marketplace))
   }
@@ -28938,12 +28874,13 @@ package ec2 {
       __obj.asInstanceOf[PurchaseScheduledInstancesResult]
     }
   }
-
-  object RIProductDescriptionEnum {
-    val `Linux/UNIX`              = "Linux/UNIX"
-    val `Linux/UNIX (Amazon VPC)` = "Linux/UNIX (Amazon VPC)"
-    val Windows                   = "Windows"
-    val `Windows (Amazon VPC)`    = "Windows (Amazon VPC)"
+  @js.native
+  sealed trait RIProductDescription extends js.Any
+  object RIProductDescription extends js.Object {
+    val `Linux/UNIX`              = "Linux/UNIX".asInstanceOf[RIProductDescription]
+    val `Linux/UNIX (Amazon VPC)` = "Linux/UNIX (Amazon VPC)".asInstanceOf[RIProductDescription]
+    val Windows                   = "Windows".asInstanceOf[RIProductDescription]
+    val `Windows (Amazon VPC)`    = "Windows (Amazon VPC)".asInstanceOf[RIProductDescription]
 
     val values = js.Object.freeze(js.Array(`Linux/UNIX`, `Linux/UNIX (Amazon VPC)`, Windows, `Windows (Amazon VPC)`))
   }
@@ -28990,9 +28927,10 @@ package ec2 {
       __obj.asInstanceOf[RecurringCharge]
     }
   }
-
-  object RecurringChargeFrequencyEnum {
-    val Hourly = "Hourly"
+  @js.native
+  sealed trait RecurringChargeFrequency extends js.Any
+  object RecurringChargeFrequency extends js.Object {
+    val Hourly = "Hourly".asInstanceOf[RecurringChargeFrequency]
 
     val values = js.Object.freeze(js.Array(Hourly))
   }
@@ -29675,17 +29613,18 @@ package ec2 {
       __obj.asInstanceOf[ReplaceTransitGatewayRouteResult]
     }
   }
-
-  object ReportInstanceReasonCodesEnum {
-    val `instance-stuck-in-state`    = "instance-stuck-in-state"
-    val unresponsive                 = "unresponsive"
-    val `not-accepting-credentials`  = "not-accepting-credentials"
-    val `password-not-available`     = "password-not-available"
-    val `performance-network`        = "performance-network"
-    val `performance-instance-store` = "performance-instance-store"
-    val `performance-ebs-volume`     = "performance-ebs-volume"
-    val `performance-other`          = "performance-other"
-    val other                        = "other"
+  @js.native
+  sealed trait ReportInstanceReasonCodes extends js.Any
+  object ReportInstanceReasonCodes extends js.Object {
+    val `instance-stuck-in-state`    = "instance-stuck-in-state".asInstanceOf[ReportInstanceReasonCodes]
+    val unresponsive                 = "unresponsive".asInstanceOf[ReportInstanceReasonCodes]
+    val `not-accepting-credentials`  = "not-accepting-credentials".asInstanceOf[ReportInstanceReasonCodes]
+    val `password-not-available`     = "password-not-available".asInstanceOf[ReportInstanceReasonCodes]
+    val `performance-network`        = "performance-network".asInstanceOf[ReportInstanceReasonCodes]
+    val `performance-instance-store` = "performance-instance-store".asInstanceOf[ReportInstanceReasonCodes]
+    val `performance-ebs-volume`     = "performance-ebs-volume".asInstanceOf[ReportInstanceReasonCodes]
+    val `performance-other`          = "performance-other".asInstanceOf[ReportInstanceReasonCodes]
+    val other                        = "other".asInstanceOf[ReportInstanceReasonCodes]
 
     val values = js.Object.freeze(
       js.Array(
@@ -29737,10 +29676,11 @@ package ec2 {
       __obj.asInstanceOf[ReportInstanceStatusRequest]
     }
   }
-
-  object ReportStatusTypeEnum {
-    val ok       = "ok"
-    val impaired = "impaired"
+  @js.native
+  sealed trait ReportStatusType extends js.Any
+  object ReportStatusType extends js.Object {
+    val ok       = "ok".asInstanceOf[ReportStatusType]
+    val impaired = "impaired".asInstanceOf[ReportStatusType]
 
     val values = js.Object.freeze(js.Array(ok, impaired))
   }
@@ -30056,12 +29996,13 @@ package ec2 {
       __obj.asInstanceOf[Reservation]
     }
   }
-
-  object ReservationStateEnum {
-    val `payment-pending` = "payment-pending"
-    val `payment-failed`  = "payment-failed"
-    val active            = "active"
-    val retired           = "retired"
+  @js.native
+  sealed trait ReservationState extends js.Any
+  object ReservationState extends js.Object {
+    val `payment-pending` = "payment-pending".asInstanceOf[ReservationState]
+    val `payment-failed`  = "payment-failed".asInstanceOf[ReservationState]
+    val active            = "active".asInstanceOf[ReservationState]
+    val retired           = "retired".asInstanceOf[ReservationState]
 
     val values = js.Object.freeze(js.Array(`payment-pending`, `payment-failed`, active, retired))
   }
@@ -30134,14 +30075,15 @@ package ec2 {
       __obj.asInstanceOf[ReservedInstanceReservationValue]
     }
   }
-
-  object ReservedInstanceStateEnum {
-    val `payment-pending` = "payment-pending"
-    val active            = "active"
-    val `payment-failed`  = "payment-failed"
-    val retired           = "retired"
-    val queued            = "queued"
-    val `queued-deleted`  = "queued-deleted"
+  @js.native
+  sealed trait ReservedInstanceState extends js.Any
+  object ReservedInstanceState extends js.Object {
+    val `payment-pending` = "payment-pending".asInstanceOf[ReservedInstanceState]
+    val active            = "active".asInstanceOf[ReservedInstanceState]
+    val `payment-failed`  = "payment-failed".asInstanceOf[ReservedInstanceState]
+    val retired           = "retired".asInstanceOf[ReservedInstanceState]
+    val queued            = "queued".asInstanceOf[ReservedInstanceState]
+    val `queued-deleted`  = "queued-deleted".asInstanceOf[ReservedInstanceState]
 
     val values =
       js.Object.freeze(js.Array(`payment-pending`, active, `payment-failed`, retired, queued, `queued-deleted`))
@@ -30476,9 +30418,10 @@ package ec2 {
       __obj.asInstanceOf[ResetEbsDefaultKmsKeyIdResult]
     }
   }
-
-  object ResetFpgaImageAttributeNameEnum {
-    val loadPermission = "loadPermission"
+  @js.native
+  sealed trait ResetFpgaImageAttributeName extends js.Any
+  object ResetFpgaImageAttributeName extends js.Object {
+    val loadPermission = "loadPermission".asInstanceOf[ResetFpgaImageAttributeName]
 
     val values = js.Object.freeze(js.Array(loadPermission))
   }
@@ -30522,9 +30465,10 @@ package ec2 {
       __obj.asInstanceOf[ResetFpgaImageAttributeResult]
     }
   }
-
-  object ResetImageAttributeNameEnum {
-    val launchPermission = "launchPermission"
+  @js.native
+  sealed trait ResetImageAttributeName extends js.Any
+  object ResetImageAttributeName extends js.Object {
+    val launchPermission = "launchPermission".asInstanceOf[ResetImageAttributeName]
 
     val values = js.Object.freeze(js.Array(launchPermission))
   }
@@ -30630,44 +30574,45 @@ package ec2 {
       __obj.asInstanceOf[ResetSnapshotAttributeRequest]
     }
   }
-
-  object ResourceTypeEnum {
-    val `client-vpn-endpoint`              = "client-vpn-endpoint"
-    val `customer-gateway`                 = "customer-gateway"
-    val `dedicated-host`                   = "dedicated-host"
-    val `dhcp-options`                     = "dhcp-options"
-    val `elastic-ip`                       = "elastic-ip"
-    val fleet                              = "fleet"
-    val `fpga-image`                       = "fpga-image"
-    val `host-reservation`                 = "host-reservation"
-    val image                              = "image"
-    val instance                           = "instance"
-    val `internet-gateway`                 = "internet-gateway"
-    val `key-pair`                         = "key-pair"
-    val `launch-template`                  = "launch-template"
-    val natgateway                         = "natgateway"
-    val `network-acl`                      = "network-acl"
-    val `network-interface`                = "network-interface"
-    val `placement-group`                  = "placement-group"
-    val `reserved-instances`               = "reserved-instances"
-    val `route-table`                      = "route-table"
-    val `security-group`                   = "security-group"
-    val snapshot                           = "snapshot"
-    val `spot-fleet-request`               = "spot-fleet-request"
-    val `spot-instances-request`           = "spot-instances-request"
-    val subnet                             = "subnet"
-    val `traffic-mirror-filter`            = "traffic-mirror-filter"
-    val `traffic-mirror-session`           = "traffic-mirror-session"
-    val `traffic-mirror-target`            = "traffic-mirror-target"
-    val `transit-gateway`                  = "transit-gateway"
-    val `transit-gateway-attachment`       = "transit-gateway-attachment"
-    val `transit-gateway-multicast-domain` = "transit-gateway-multicast-domain"
-    val `transit-gateway-route-table`      = "transit-gateway-route-table"
-    val volume                             = "volume"
-    val vpc                                = "vpc"
-    val `vpc-peering-connection`           = "vpc-peering-connection"
-    val `vpn-connection`                   = "vpn-connection"
-    val `vpn-gateway`                      = "vpn-gateway"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val `client-vpn-endpoint`              = "client-vpn-endpoint".asInstanceOf[ResourceType]
+    val `customer-gateway`                 = "customer-gateway".asInstanceOf[ResourceType]
+    val `dedicated-host`                   = "dedicated-host".asInstanceOf[ResourceType]
+    val `dhcp-options`                     = "dhcp-options".asInstanceOf[ResourceType]
+    val `elastic-ip`                       = "elastic-ip".asInstanceOf[ResourceType]
+    val fleet                              = "fleet".asInstanceOf[ResourceType]
+    val `fpga-image`                       = "fpga-image".asInstanceOf[ResourceType]
+    val `host-reservation`                 = "host-reservation".asInstanceOf[ResourceType]
+    val image                              = "image".asInstanceOf[ResourceType]
+    val instance                           = "instance".asInstanceOf[ResourceType]
+    val `internet-gateway`                 = "internet-gateway".asInstanceOf[ResourceType]
+    val `key-pair`                         = "key-pair".asInstanceOf[ResourceType]
+    val `launch-template`                  = "launch-template".asInstanceOf[ResourceType]
+    val natgateway                         = "natgateway".asInstanceOf[ResourceType]
+    val `network-acl`                      = "network-acl".asInstanceOf[ResourceType]
+    val `network-interface`                = "network-interface".asInstanceOf[ResourceType]
+    val `placement-group`                  = "placement-group".asInstanceOf[ResourceType]
+    val `reserved-instances`               = "reserved-instances".asInstanceOf[ResourceType]
+    val `route-table`                      = "route-table".asInstanceOf[ResourceType]
+    val `security-group`                   = "security-group".asInstanceOf[ResourceType]
+    val snapshot                           = "snapshot".asInstanceOf[ResourceType]
+    val `spot-fleet-request`               = "spot-fleet-request".asInstanceOf[ResourceType]
+    val `spot-instances-request`           = "spot-instances-request".asInstanceOf[ResourceType]
+    val subnet                             = "subnet".asInstanceOf[ResourceType]
+    val `traffic-mirror-filter`            = "traffic-mirror-filter".asInstanceOf[ResourceType]
+    val `traffic-mirror-session`           = "traffic-mirror-session".asInstanceOf[ResourceType]
+    val `traffic-mirror-target`            = "traffic-mirror-target".asInstanceOf[ResourceType]
+    val `transit-gateway`                  = "transit-gateway".asInstanceOf[ResourceType]
+    val `transit-gateway-attachment`       = "transit-gateway-attachment".asInstanceOf[ResourceType]
+    val `transit-gateway-multicast-domain` = "transit-gateway-multicast-domain".asInstanceOf[ResourceType]
+    val `transit-gateway-route-table`      = "transit-gateway-route-table".asInstanceOf[ResourceType]
+    val volume                             = "volume".asInstanceOf[ResourceType]
+    val vpc                                = "vpc".asInstanceOf[ResourceType]
+    val `vpc-peering-connection`           = "vpc-peering-connection".asInstanceOf[ResourceType]
+    val `vpn-connection`                   = "vpn-connection".asInstanceOf[ResourceType]
+    val `vpn-gateway`                      = "vpn-gateway".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -31008,10 +30953,11 @@ package ec2 {
       __obj.asInstanceOf[RevokeSecurityGroupIngressRequest]
     }
   }
-
-  object RootDeviceTypeEnum {
-    val ebs              = "ebs"
-    val `instance-store` = "instance-store"
+  @js.native
+  sealed trait RootDeviceType extends js.Any
+  object RootDeviceType extends js.Object {
+    val ebs              = "ebs".asInstanceOf[RootDeviceType]
+    val `instance-store` = "instance-store".asInstanceOf[RootDeviceType]
 
     val values = js.Object.freeze(js.Array(ebs, `instance-store`))
   }
@@ -31075,18 +31021,20 @@ package ec2 {
       __obj.asInstanceOf[Route]
     }
   }
-
-  object RouteOriginEnum {
-    val CreateRouteTable          = "CreateRouteTable"
-    val CreateRoute               = "CreateRoute"
-    val EnableVgwRoutePropagation = "EnableVgwRoutePropagation"
+  @js.native
+  sealed trait RouteOrigin extends js.Any
+  object RouteOrigin extends js.Object {
+    val CreateRouteTable          = "CreateRouteTable".asInstanceOf[RouteOrigin]
+    val CreateRoute               = "CreateRoute".asInstanceOf[RouteOrigin]
+    val EnableVgwRoutePropagation = "EnableVgwRoutePropagation".asInstanceOf[RouteOrigin]
 
     val values = js.Object.freeze(js.Array(CreateRouteTable, CreateRoute, EnableVgwRoutePropagation))
   }
-
-  object RouteStateEnum {
-    val active    = "active"
-    val blackhole = "blackhole"
+  @js.native
+  sealed trait RouteState extends js.Any
+  object RouteState extends js.Object {
+    val active    = "active".asInstanceOf[RouteState]
+    val blackhole = "blackhole".asInstanceOf[RouteState]
 
     val values = js.Object.freeze(js.Array(active, blackhole))
   }
@@ -31183,20 +31131,22 @@ package ec2 {
       __obj.asInstanceOf[RouteTableAssociationState]
     }
   }
-
-  object RouteTableAssociationStateCodeEnum {
-    val associating    = "associating"
-    val associated     = "associated"
-    val disassociating = "disassociating"
-    val disassociated  = "disassociated"
-    val failed         = "failed"
+  @js.native
+  sealed trait RouteTableAssociationStateCode extends js.Any
+  object RouteTableAssociationStateCode extends js.Object {
+    val associating    = "associating".asInstanceOf[RouteTableAssociationStateCode]
+    val associated     = "associated".asInstanceOf[RouteTableAssociationStateCode]
+    val disassociating = "disassociating".asInstanceOf[RouteTableAssociationStateCode]
+    val disassociated  = "disassociated".asInstanceOf[RouteTableAssociationStateCode]
+    val failed         = "failed".asInstanceOf[RouteTableAssociationStateCode]
 
     val values = js.Object.freeze(js.Array(associating, associated, disassociating, disassociated, failed))
   }
-
-  object RuleActionEnum {
-    val allow = "allow"
-    val deny  = "deny"
+  @js.native
+  sealed trait RuleAction extends js.Any
+  object RuleAction extends js.Object {
+    val allow = "allow".asInstanceOf[RuleAction]
+    val deny  = "deny".asInstanceOf[RuleAction]
 
     val values = js.Object.freeze(js.Array(allow, deny))
   }
@@ -32260,20 +32210,22 @@ package ec2 {
       __obj.asInstanceOf[ServiceDetail]
     }
   }
-
-  object ServiceStateEnum {
-    val Pending   = "Pending"
-    val Available = "Available"
-    val Deleting  = "Deleting"
-    val Deleted   = "Deleted"
-    val Failed    = "Failed"
+  @js.native
+  sealed trait ServiceState extends js.Any
+  object ServiceState extends js.Object {
+    val Pending   = "Pending".asInstanceOf[ServiceState]
+    val Available = "Available".asInstanceOf[ServiceState]
+    val Deleting  = "Deleting".asInstanceOf[ServiceState]
+    val Deleted   = "Deleted".asInstanceOf[ServiceState]
+    val Failed    = "Failed".asInstanceOf[ServiceState]
 
     val values = js.Object.freeze(js.Array(Pending, Available, Deleting, Deleted, Failed))
   }
-
-  object ServiceTypeEnum {
-    val Interface = "Interface"
-    val Gateway   = "Gateway"
+  @js.native
+  sealed trait ServiceType extends js.Any
+  object ServiceType extends js.Object {
+    val Interface = "Interface".asInstanceOf[ServiceType]
+    val Gateway   = "Gateway".asInstanceOf[ServiceType]
 
     val values = js.Object.freeze(js.Array(Interface, Gateway))
   }
@@ -32296,10 +32248,11 @@ package ec2 {
       __obj.asInstanceOf[ServiceTypeDetail]
     }
   }
-
-  object ShutdownBehaviorEnum {
-    val stop      = "stop"
-    val terminate = "terminate"
+  @js.native
+  sealed trait ShutdownBehavior extends js.Any
+  object ShutdownBehavior extends js.Object {
+    val stop      = "stop".asInstanceOf[ShutdownBehavior]
+    val terminate = "terminate".asInstanceOf[ShutdownBehavior]
 
     val values = js.Object.freeze(js.Array(stop, terminate))
   }
@@ -32407,10 +32360,11 @@ package ec2 {
       __obj.asInstanceOf[Snapshot]
     }
   }
-
-  object SnapshotAttributeNameEnum {
-    val productCodes           = "productCodes"
-    val createVolumePermission = "createVolumePermission"
+  @js.native
+  sealed trait SnapshotAttributeName extends js.Any
+  object SnapshotAttributeName extends js.Object {
+    val productCodes           = "productCodes".asInstanceOf[SnapshotAttributeName]
+    val createVolumePermission = "createVolumePermission".asInstanceOf[SnapshotAttributeName]
 
     val values = js.Object.freeze(js.Array(productCodes, createVolumePermission))
   }
@@ -32534,11 +32488,12 @@ package ec2 {
       __obj.asInstanceOf[SnapshotInfo]
     }
   }
-
-  object SnapshotStateEnum {
-    val pending   = "pending"
-    val completed = "completed"
-    val error     = "error"
+  @js.native
+  sealed trait SnapshotState extends js.Any
+  object SnapshotState extends js.Object {
+    val pending   = "pending".asInstanceOf[SnapshotState]
+    val completed = "completed".asInstanceOf[SnapshotState]
+    val error     = "error".asInstanceOf[SnapshotState]
 
     val values = js.Object.freeze(js.Array(pending, completed, error))
   }
@@ -32591,11 +32546,12 @@ package ec2 {
       __obj.asInstanceOf[SnapshotTaskDetail]
     }
   }
-
-  object SpotAllocationStrategyEnum {
-    val `lowest-price`       = "lowest-price"
-    val diversified          = "diversified"
-    val `capacity-optimized` = "capacity-optimized"
+  @js.native
+  sealed trait SpotAllocationStrategy extends js.Any
+  object SpotAllocationStrategy extends js.Object {
+    val `lowest-price`       = "lowest-price".asInstanceOf[SpotAllocationStrategy]
+    val diversified          = "diversified".asInstanceOf[SpotAllocationStrategy]
+    val `capacity-optimized` = "capacity-optimized".asInstanceOf[SpotAllocationStrategy]
 
     val values = js.Object.freeze(js.Array(`lowest-price`, diversified, `capacity-optimized`))
   }
@@ -32874,11 +32830,12 @@ package ec2 {
       __obj.asInstanceOf[SpotFleetTagSpecification]
     }
   }
-
-  object SpotInstanceInterruptionBehaviorEnum {
-    val hibernate = "hibernate"
-    val stop      = "stop"
-    val terminate = "terminate"
+  @js.native
+  sealed trait SpotInstanceInterruptionBehavior extends js.Any
+  object SpotInstanceInterruptionBehavior extends js.Object {
+    val hibernate = "hibernate".asInstanceOf[SpotInstanceInterruptionBehavior]
+    val stop      = "stop".asInstanceOf[SpotInstanceInterruptionBehavior]
+    val terminate = "terminate".asInstanceOf[SpotInstanceInterruptionBehavior]
 
     val values = js.Object.freeze(js.Array(hibernate, stop, terminate))
   }
@@ -32957,13 +32914,14 @@ package ec2 {
       __obj.asInstanceOf[SpotInstanceRequest]
     }
   }
-
-  object SpotInstanceStateEnum {
-    val open      = "open"
-    val active    = "active"
-    val closed    = "closed"
-    val cancelled = "cancelled"
-    val failed    = "failed"
+  @js.native
+  sealed trait SpotInstanceState extends js.Any
+  object SpotInstanceState extends js.Object {
+    val open      = "open".asInstanceOf[SpotInstanceState]
+    val active    = "active".asInstanceOf[SpotInstanceState]
+    val closed    = "closed".asInstanceOf[SpotInstanceState]
+    val cancelled = "cancelled".asInstanceOf[SpotInstanceState]
+    val failed    = "failed".asInstanceOf[SpotInstanceState]
 
     val values = js.Object.freeze(js.Array(open, active, closed, cancelled, failed))
   }
@@ -33014,10 +32972,11 @@ package ec2 {
       __obj.asInstanceOf[SpotInstanceStatus]
     }
   }
-
-  object SpotInstanceTypeEnum {
-    val `one-time` = "one-time"
-    val persistent = "persistent"
+  @js.native
+  sealed trait SpotInstanceType extends js.Any
+  object SpotInstanceType extends js.Object {
+    val `one-time` = "one-time".asInstanceOf[SpotInstanceType]
+    val persistent = "persistent".asInstanceOf[SpotInstanceType]
 
     val values = js.Object.freeze(js.Array(`one-time`, persistent))
   }
@@ -33333,16 +33292,17 @@ package ec2 {
       __obj.asInstanceOf[StartVpcEndpointServicePrivateDnsVerificationResult]
     }
   }
-
-  object StateEnum {
-    val PendingAcceptance = "PendingAcceptance"
-    val Pending           = "Pending"
-    val Available         = "Available"
-    val Deleting          = "Deleting"
-    val Deleted           = "Deleted"
-    val Rejected          = "Rejected"
-    val Failed            = "Failed"
-    val Expired           = "Expired"
+  @js.native
+  sealed trait State extends js.Any
+  object State extends js.Object {
+    val PendingAcceptance = "PendingAcceptance".asInstanceOf[State]
+    val Pending           = "Pending".asInstanceOf[State]
+    val Available         = "Available".asInstanceOf[State]
+    val Deleting          = "Deleting".asInstanceOf[State]
+    val Deleted           = "Deleted".asInstanceOf[State]
+    val Rejected          = "Rejected".asInstanceOf[State]
+    val Failed            = "Failed".asInstanceOf[State]
+    val Expired           = "Expired".asInstanceOf[State]
 
     val values =
       js.Object.freeze(js.Array(PendingAcceptance, Pending, Available, Deleting, Deleted, Rejected, Failed, Expired))
@@ -33369,26 +33329,29 @@ package ec2 {
       __obj.asInstanceOf[StateReason]
     }
   }
-
-  object StatusEnum {
-    val MoveInProgress = "MoveInProgress"
-    val InVpc          = "InVpc"
-    val InClassic      = "InClassic"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val MoveInProgress = "MoveInProgress".asInstanceOf[Status]
+    val InVpc          = "InVpc".asInstanceOf[Status]
+    val InClassic      = "InClassic".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(MoveInProgress, InVpc, InClassic))
   }
-
-  object StatusNameEnum {
-    val reachability = "reachability"
+  @js.native
+  sealed trait StatusName extends js.Any
+  object StatusName extends js.Object {
+    val reachability = "reachability".asInstanceOf[StatusName]
 
     val values = js.Object.freeze(js.Array(reachability))
   }
-
-  object StatusTypeEnum {
-    val passed              = "passed"
-    val failed              = "failed"
-    val `insufficient-data` = "insufficient-data"
-    val initializing        = "initializing"
+  @js.native
+  sealed trait StatusType extends js.Any
+  object StatusType extends js.Object {
+    val passed              = "passed".asInstanceOf[StatusType]
+    val failed              = "failed".asInstanceOf[StatusType]
+    val `insufficient-data` = "insufficient-data".asInstanceOf[StatusType]
+    val initializing        = "initializing".asInstanceOf[StatusType]
 
     val values = js.Object.freeze(js.Array(passed, failed, `insufficient-data`, initializing))
   }
@@ -33585,14 +33548,15 @@ package ec2 {
       __obj.asInstanceOf[SubnetCidrBlockState]
     }
   }
-
-  object SubnetCidrBlockStateCodeEnum {
-    val associating    = "associating"
-    val associated     = "associated"
-    val disassociating = "disassociating"
-    val disassociated  = "disassociated"
-    val failing        = "failing"
-    val failed         = "failed"
+  @js.native
+  sealed trait SubnetCidrBlockStateCode extends js.Any
+  object SubnetCidrBlockStateCode extends js.Object {
+    val associating    = "associating".asInstanceOf[SubnetCidrBlockStateCode]
+    val associated     = "associated".asInstanceOf[SubnetCidrBlockStateCode]
+    val disassociating = "disassociating".asInstanceOf[SubnetCidrBlockStateCode]
+    val disassociated  = "disassociated".asInstanceOf[SubnetCidrBlockStateCode]
+    val failing        = "failing".asInstanceOf[SubnetCidrBlockStateCode]
+    val failed         = "failed".asInstanceOf[SubnetCidrBlockStateCode]
 
     val values = js.Object.freeze(js.Array(associating, associated, disassociating, disassociated, failing, failed))
   }
@@ -33621,10 +33585,11 @@ package ec2 {
       __obj.asInstanceOf[SubnetIpv6CidrBlockAssociation]
     }
   }
-
-  object SubnetStateEnum {
-    val pending   = "pending"
-    val available = "available"
+  @js.native
+  sealed trait SubnetState extends js.Any
+  object SubnetState extends js.Object {
+    val pending   = "pending".asInstanceOf[SubnetState]
+    val available = "available".asInstanceOf[SubnetState]
 
     val values = js.Object.freeze(js.Array(pending, available))
   }
@@ -33666,13 +33631,14 @@ package ec2 {
       __obj.asInstanceOf[SuccessfulQueuedPurchaseDeletion]
     }
   }
-
-  object SummaryStatusEnum {
-    val ok                  = "ok"
-    val impaired            = "impaired"
-    val `insufficient-data` = "insufficient-data"
-    val `not-applicable`    = "not-applicable"
-    val initializing        = "initializing"
+  @js.native
+  sealed trait SummaryStatus extends js.Any
+  object SummaryStatus extends js.Object {
+    val ok                  = "ok".asInstanceOf[SummaryStatus]
+    val impaired            = "impaired".asInstanceOf[SummaryStatus]
+    val `insufficient-data` = "insufficient-data".asInstanceOf[SummaryStatus]
+    val `not-applicable`    = "not-applicable".asInstanceOf[SummaryStatus]
+    val initializing        = "initializing".asInstanceOf[SummaryStatus]
 
     val values = js.Object.freeze(js.Array(ok, impaired, `insufficient-data`, `not-applicable`, initializing))
   }
@@ -33952,18 +33918,20 @@ package ec2 {
       __obj.asInstanceOf[TargetReservationValue]
     }
   }
-
-  object TelemetryStatusEnum {
-    val UP   = "UP"
-    val DOWN = "DOWN"
+  @js.native
+  sealed trait TelemetryStatus extends js.Any
+  object TelemetryStatus extends js.Object {
+    val UP   = "UP".asInstanceOf[TelemetryStatus]
+    val DOWN = "DOWN".asInstanceOf[TelemetryStatus]
 
     val values = js.Object.freeze(js.Array(UP, DOWN))
   }
-
-  object TenancyEnum {
-    val default   = "default"
-    val dedicated = "dedicated"
-    val host      = "host"
+  @js.native
+  sealed trait Tenancy extends js.Any
+  object Tenancy extends js.Object {
+    val default   = "default".asInstanceOf[Tenancy]
+    val dedicated = "dedicated".asInstanceOf[Tenancy]
+    val host      = "host".asInstanceOf[Tenancy]
 
     val values = js.Object.freeze(js.Array(default, dedicated, host))
   }
@@ -34078,10 +34046,11 @@ package ec2 {
       __obj.asInstanceOf[TerminateInstancesResult]
     }
   }
-
-  object TrafficDirectionEnum {
-    val ingress = "ingress"
-    val egress  = "egress"
+  @js.native
+  sealed trait TrafficDirection extends js.Any
+  object TrafficDirection extends js.Object {
+    val ingress = "ingress".asInstanceOf[TrafficDirection]
+    val egress  = "egress".asInstanceOf[TrafficDirection]
 
     val values = js.Object.freeze(js.Array(ingress, egress))
   }
@@ -34170,18 +34139,20 @@ package ec2 {
       __obj.asInstanceOf[TrafficMirrorFilterRule]
     }
   }
-
-  object TrafficMirrorFilterRuleFieldEnum {
-    val `destination-port-range` = "destination-port-range"
-    val `source-port-range`      = "source-port-range"
-    val protocol                 = "protocol"
-    val description              = "description"
+  @js.native
+  sealed trait TrafficMirrorFilterRuleField extends js.Any
+  object TrafficMirrorFilterRuleField extends js.Object {
+    val `destination-port-range` = "destination-port-range".asInstanceOf[TrafficMirrorFilterRuleField]
+    val `source-port-range`      = "source-port-range".asInstanceOf[TrafficMirrorFilterRuleField]
+    val protocol                 = "protocol".asInstanceOf[TrafficMirrorFilterRuleField]
+    val description              = "description".asInstanceOf[TrafficMirrorFilterRuleField]
 
     val values = js.Object.freeze(js.Array(`destination-port-range`, `source-port-range`, protocol, description))
   }
-
-  object TrafficMirrorNetworkServiceEnum {
-    val `amazon-dns` = "amazon-dns"
+  @js.native
+  sealed trait TrafficMirrorNetworkService extends js.Any
+  object TrafficMirrorNetworkService extends js.Object {
+    val `amazon-dns` = "amazon-dns".asInstanceOf[TrafficMirrorNetworkService]
 
     val values = js.Object.freeze(js.Array(`amazon-dns`))
   }
@@ -34229,10 +34200,11 @@ package ec2 {
       __obj.asInstanceOf[TrafficMirrorPortRangeRequest]
     }
   }
-
-  object TrafficMirrorRuleActionEnum {
-    val accept = "accept"
-    val reject = "reject"
+  @js.native
+  sealed trait TrafficMirrorRuleAction extends js.Any
+  object TrafficMirrorRuleAction extends js.Object {
+    val accept = "accept".asInstanceOf[TrafficMirrorRuleAction]
+    val reject = "reject".asInstanceOf[TrafficMirrorRuleAction]
 
     val values = js.Object.freeze(js.Array(accept, reject))
   }
@@ -34282,11 +34254,12 @@ package ec2 {
       __obj.asInstanceOf[TrafficMirrorSession]
     }
   }
-
-  object TrafficMirrorSessionFieldEnum {
-    val `packet-length`      = "packet-length"
-    val description          = "description"
-    val `virtual-network-id` = "virtual-network-id"
+  @js.native
+  sealed trait TrafficMirrorSessionField extends js.Any
+  object TrafficMirrorSessionField extends js.Object {
+    val `packet-length`      = "packet-length".asInstanceOf[TrafficMirrorSessionField]
+    val description          = "description".asInstanceOf[TrafficMirrorSessionField]
+    val `virtual-network-id` = "virtual-network-id".asInstanceOf[TrafficMirrorSessionField]
 
     val values = js.Object.freeze(js.Array(`packet-length`, description, `virtual-network-id`))
   }
@@ -34327,18 +34300,20 @@ package ec2 {
       __obj.asInstanceOf[TrafficMirrorTarget]
     }
   }
-
-  object TrafficMirrorTargetTypeEnum {
-    val `network-interface`     = "network-interface"
-    val `network-load-balancer` = "network-load-balancer"
+  @js.native
+  sealed trait TrafficMirrorTargetType extends js.Any
+  object TrafficMirrorTargetType extends js.Object {
+    val `network-interface`     = "network-interface".asInstanceOf[TrafficMirrorTargetType]
+    val `network-load-balancer` = "network-load-balancer".asInstanceOf[TrafficMirrorTargetType]
 
     val values = js.Object.freeze(js.Array(`network-interface`, `network-load-balancer`))
   }
-
-  object TrafficTypeEnum {
-    val ACCEPT = "ACCEPT"
-    val REJECT = "REJECT"
-    val ALL    = "ALL"
+  @js.native
+  sealed trait TrafficType extends js.Any
+  object TrafficType extends js.Object {
+    val ACCEPT = "ACCEPT".asInstanceOf[TrafficType]
+    val REJECT = "REJECT".asInstanceOf[TrafficType]
+    val ALL    = "ALL".asInstanceOf[TrafficType]
 
     val values = js.Object.freeze(js.Array(ACCEPT, REJECT, ALL))
   }
@@ -34417,12 +34392,13 @@ package ec2 {
       __obj.asInstanceOf[TransitGatewayAssociation]
     }
   }
-
-  object TransitGatewayAssociationStateEnum {
-    val associating    = "associating"
-    val associated     = "associated"
-    val disassociating = "disassociating"
-    val disassociated  = "disassociated"
+  @js.native
+  sealed trait TransitGatewayAssociationState extends js.Any
+  object TransitGatewayAssociationState extends js.Object {
+    val associating    = "associating".asInstanceOf[TransitGatewayAssociationState]
+    val associated     = "associated".asInstanceOf[TransitGatewayAssociationState]
+    val disassociating = "disassociating".asInstanceOf[TransitGatewayAssociationState]
+    val disassociated  = "disassociated".asInstanceOf[TransitGatewayAssociationState]
 
     val values = js.Object.freeze(js.Array(associating, associated, disassociating, disassociated))
   }
@@ -34522,29 +34498,31 @@ package ec2 {
       __obj.asInstanceOf[TransitGatewayAttachmentPropagation]
     }
   }
-
-  object TransitGatewayAttachmentResourceTypeEnum {
-    val vpc                      = "vpc"
-    val vpn                      = "vpn"
-    val `direct-connect-gateway` = "direct-connect-gateway"
-    val `tgw-peering`            = "tgw-peering"
+  @js.native
+  sealed trait TransitGatewayAttachmentResourceType extends js.Any
+  object TransitGatewayAttachmentResourceType extends js.Object {
+    val vpc                      = "vpc".asInstanceOf[TransitGatewayAttachmentResourceType]
+    val vpn                      = "vpn".asInstanceOf[TransitGatewayAttachmentResourceType]
+    val `direct-connect-gateway` = "direct-connect-gateway".asInstanceOf[TransitGatewayAttachmentResourceType]
+    val `tgw-peering`            = "tgw-peering".asInstanceOf[TransitGatewayAttachmentResourceType]
 
     val values = js.Object.freeze(js.Array(vpc, vpn, `direct-connect-gateway`, `tgw-peering`))
   }
-
-  object TransitGatewayAttachmentStateEnum {
-    val initiating        = "initiating"
-    val pendingAcceptance = "pendingAcceptance"
-    val rollingBack       = "rollingBack"
-    val pending           = "pending"
-    val available         = "available"
-    val modifying         = "modifying"
-    val deleting          = "deleting"
-    val deleted           = "deleted"
-    val failed            = "failed"
-    val rejected          = "rejected"
-    val rejecting         = "rejecting"
-    val failing           = "failing"
+  @js.native
+  sealed trait TransitGatewayAttachmentState extends js.Any
+  object TransitGatewayAttachmentState extends js.Object {
+    val initiating        = "initiating".asInstanceOf[TransitGatewayAttachmentState]
+    val pendingAcceptance = "pendingAcceptance".asInstanceOf[TransitGatewayAttachmentState]
+    val rollingBack       = "rollingBack".asInstanceOf[TransitGatewayAttachmentState]
+    val pending           = "pending".asInstanceOf[TransitGatewayAttachmentState]
+    val available         = "available".asInstanceOf[TransitGatewayAttachmentState]
+    val modifying         = "modifying".asInstanceOf[TransitGatewayAttachmentState]
+    val deleting          = "deleting".asInstanceOf[TransitGatewayAttachmentState]
+    val deleted           = "deleted".asInstanceOf[TransitGatewayAttachmentState]
+    val failed            = "failed".asInstanceOf[TransitGatewayAttachmentState]
+    val rejected          = "rejected".asInstanceOf[TransitGatewayAttachmentState]
+    val rejecting         = "rejecting".asInstanceOf[TransitGatewayAttachmentState]
+    val failing           = "failing".asInstanceOf[TransitGatewayAttachmentState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -34563,12 +34541,13 @@ package ec2 {
       )
     )
   }
-
-  object TransitGatewayMulitcastDomainAssociationStateEnum {
-    val associating    = "associating"
-    val associated     = "associated"
-    val disassociating = "disassociating"
-    val disassociated  = "disassociated"
+  @js.native
+  sealed trait TransitGatewayMulitcastDomainAssociationState extends js.Any
+  object TransitGatewayMulitcastDomainAssociationState extends js.Object {
+    val associating    = "associating".asInstanceOf[TransitGatewayMulitcastDomainAssociationState]
+    val associated     = "associated".asInstanceOf[TransitGatewayMulitcastDomainAssociationState]
+    val disassociating = "disassociating".asInstanceOf[TransitGatewayMulitcastDomainAssociationState]
+    val disassociated  = "disassociated".asInstanceOf[TransitGatewayMulitcastDomainAssociationState]
 
     val values = js.Object.freeze(js.Array(associating, associated, disassociating, disassociated))
   }
@@ -34728,12 +34707,13 @@ package ec2 {
       __obj.asInstanceOf[TransitGatewayMulticastDomainAssociations]
     }
   }
-
-  object TransitGatewayMulticastDomainStateEnum {
-    val pending   = "pending"
-    val available = "available"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait TransitGatewayMulticastDomainState extends js.Any
+  object TransitGatewayMulticastDomainState extends js.Object {
+    val pending   = "pending".asInstanceOf[TransitGatewayMulticastDomainState]
+    val available = "available".asInstanceOf[TransitGatewayMulticastDomainState]
+    val deleting  = "deleting".asInstanceOf[TransitGatewayMulticastDomainState]
+    val deleted   = "deleted".asInstanceOf[TransitGatewayMulticastDomainState]
 
     val values = js.Object.freeze(js.Array(pending, available, deleting, deleted))
   }
@@ -34970,12 +34950,13 @@ package ec2 {
       __obj.asInstanceOf[TransitGatewayPropagation]
     }
   }
-
-  object TransitGatewayPropagationStateEnum {
-    val enabling  = "enabling"
-    val enabled   = "enabled"
-    val disabling = "disabling"
-    val disabled  = "disabled"
+  @js.native
+  sealed trait TransitGatewayPropagationState extends js.Any
+  object TransitGatewayPropagationState extends js.Object {
+    val enabling  = "enabling".asInstanceOf[TransitGatewayPropagationState]
+    val enabled   = "enabled".asInstanceOf[TransitGatewayPropagationState]
+    val disabling = "disabling".asInstanceOf[TransitGatewayPropagationState]
+    val disabled  = "disabled".asInstanceOf[TransitGatewayPropagationState]
 
     val values = js.Object.freeze(js.Array(enabling, enabled, disabling, disabled))
   }
@@ -35079,13 +35060,14 @@ package ec2 {
       __obj.asInstanceOf[TransitGatewayRouteAttachment]
     }
   }
-
-  object TransitGatewayRouteStateEnum {
-    val pending   = "pending"
-    val active    = "active"
-    val blackhole = "blackhole"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait TransitGatewayRouteState extends js.Any
+  object TransitGatewayRouteState extends js.Object {
+    val pending   = "pending".asInstanceOf[TransitGatewayRouteState]
+    val active    = "active".asInstanceOf[TransitGatewayRouteState]
+    val blackhole = "blackhole".asInstanceOf[TransitGatewayRouteState]
+    val deleting  = "deleting".asInstanceOf[TransitGatewayRouteState]
+    val deleted   = "deleted".asInstanceOf[TransitGatewayRouteState]
 
     val values = js.Object.freeze(js.Array(pending, active, blackhole, deleting, deleted))
   }
@@ -35192,29 +35174,32 @@ package ec2 {
       __obj.asInstanceOf[TransitGatewayRouteTablePropagation]
     }
   }
-
-  object TransitGatewayRouteTableStateEnum {
-    val pending   = "pending"
-    val available = "available"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait TransitGatewayRouteTableState extends js.Any
+  object TransitGatewayRouteTableState extends js.Object {
+    val pending   = "pending".asInstanceOf[TransitGatewayRouteTableState]
+    val available = "available".asInstanceOf[TransitGatewayRouteTableState]
+    val deleting  = "deleting".asInstanceOf[TransitGatewayRouteTableState]
+    val deleted   = "deleted".asInstanceOf[TransitGatewayRouteTableState]
 
     val values = js.Object.freeze(js.Array(pending, available, deleting, deleted))
   }
-
-  object TransitGatewayRouteTypeEnum {
-    val static     = "static"
-    val propagated = "propagated"
+  @js.native
+  sealed trait TransitGatewayRouteType extends js.Any
+  object TransitGatewayRouteType extends js.Object {
+    val static     = "static".asInstanceOf[TransitGatewayRouteType]
+    val propagated = "propagated".asInstanceOf[TransitGatewayRouteType]
 
     val values = js.Object.freeze(js.Array(static, propagated))
   }
-
-  object TransitGatewayStateEnum {
-    val pending   = "pending"
-    val available = "available"
-    val modifying = "modifying"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait TransitGatewayState extends js.Any
+  object TransitGatewayState extends js.Object {
+    val pending   = "pending".asInstanceOf[TransitGatewayState]
+    val available = "available".asInstanceOf[TransitGatewayState]
+    val modifying = "modifying".asInstanceOf[TransitGatewayState]
+    val deleting  = "deleting".asInstanceOf[TransitGatewayState]
+    val deleted   = "deleted".asInstanceOf[TransitGatewayState]
 
     val values = js.Object.freeze(js.Array(pending, available, modifying, deleting, deleted))
   }
@@ -35285,10 +35270,11 @@ package ec2 {
       __obj.asInstanceOf[TransitGatewayVpcAttachmentOptions]
     }
   }
-
-  object TransportProtocolEnum {
-    val tcp = "tcp"
-    val udp = "udp"
+  @js.native
+  sealed trait TransportProtocol extends js.Any
+  object TransportProtocol extends js.Object {
+    val tcp = "tcp".asInstanceOf[TransportProtocol]
+    val udp = "udp".asInstanceOf[TransportProtocol]
 
     val values = js.Object.freeze(js.Array(tcp, udp))
   }
@@ -35428,11 +35414,12 @@ package ec2 {
       __obj.asInstanceOf[UnassignPrivateIpAddressesRequest]
     }
   }
-
-  object UnlimitedSupportedInstanceFamilyEnum {
-    val t2  = "t2"
-    val t3  = "t3"
-    val t3a = "t3a"
+  @js.native
+  sealed trait UnlimitedSupportedInstanceFamily extends js.Any
+  object UnlimitedSupportedInstanceFamily extends js.Object {
+    val t2  = "t2".asInstanceOf[UnlimitedSupportedInstanceFamily]
+    val t3  = "t3".asInstanceOf[UnlimitedSupportedInstanceFamily]
+    val t3a = "t3a".asInstanceOf[UnlimitedSupportedInstanceFamily]
 
     val values = js.Object.freeze(js.Array(t2, t3, t3a))
   }
@@ -35473,12 +35460,16 @@ package ec2 {
       __obj.asInstanceOf[UnmonitorInstancesResult]
     }
   }
-
-  object UnsuccessfulInstanceCreditSpecificationErrorCodeEnum {
-    val `InvalidInstanceID.Malformed`              = "InvalidInstanceID.Malformed"
-    val `InvalidInstanceID.NotFound`               = "InvalidInstanceID.NotFound"
-    val IncorrectInstanceState                     = "IncorrectInstanceState"
-    val `InstanceCreditSpecification.NotSupported` = "InstanceCreditSpecification.NotSupported"
+  @js.native
+  sealed trait UnsuccessfulInstanceCreditSpecificationErrorCode extends js.Any
+  object UnsuccessfulInstanceCreditSpecificationErrorCode extends js.Object {
+    val `InvalidInstanceID.Malformed` =
+      "InvalidInstanceID.Malformed".asInstanceOf[UnsuccessfulInstanceCreditSpecificationErrorCode]
+    val `InvalidInstanceID.NotFound` =
+      "InvalidInstanceID.NotFound".asInstanceOf[UnsuccessfulInstanceCreditSpecificationErrorCode]
+    val IncorrectInstanceState = "IncorrectInstanceState".asInstanceOf[UnsuccessfulInstanceCreditSpecificationErrorCode]
+    val `InstanceCreditSpecification.NotSupported` =
+      "InstanceCreditSpecification.NotSupported".asInstanceOf[UnsuccessfulInstanceCreditSpecificationErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -35663,10 +35654,11 @@ package ec2 {
       __obj.asInstanceOf[UpdateSecurityGroupRuleDescriptionsIngressResult]
     }
   }
-
-  object UsageClassTypeEnum {
-    val spot        = "spot"
-    val `on-demand` = "on-demand"
+  @js.native
+  sealed trait UsageClassType extends js.Any
+  object UsageClassType extends js.Object {
+    val spot        = "spot".asInstanceOf[UsageClassType]
+    val `on-demand` = "on-demand".asInstanceOf[UsageClassType]
 
     val values = js.Object.freeze(js.Array(spot, `on-demand`))
   }
@@ -35835,10 +35827,11 @@ package ec2 {
       __obj.asInstanceOf[VgwTelemetry]
     }
   }
-
-  object VirtualizationTypeEnum {
-    val hvm         = "hvm"
-    val paravirtual = "paravirtual"
+  @js.native
+  sealed trait VirtualizationType extends js.Any
+  object VirtualizationType extends js.Object {
+    val hvm         = "hvm".asInstanceOf[VirtualizationType]
+    val paravirtual = "paravirtual".asInstanceOf[VirtualizationType]
 
     val values = js.Object.freeze(js.Array(hvm, paravirtual))
   }
@@ -35937,20 +35930,22 @@ package ec2 {
       __obj.asInstanceOf[VolumeAttachment]
     }
   }
-
-  object VolumeAttachmentStateEnum {
-    val attaching = "attaching"
-    val attached  = "attached"
-    val detaching = "detaching"
-    val detached  = "detached"
-    val busy      = "busy"
+  @js.native
+  sealed trait VolumeAttachmentState extends js.Any
+  object VolumeAttachmentState extends js.Object {
+    val attaching = "attaching".asInstanceOf[VolumeAttachmentState]
+    val attached  = "attached".asInstanceOf[VolumeAttachmentState]
+    val detaching = "detaching".asInstanceOf[VolumeAttachmentState]
+    val detached  = "detached".asInstanceOf[VolumeAttachmentState]
+    val busy      = "busy".asInstanceOf[VolumeAttachmentState]
 
     val values = js.Object.freeze(js.Array(attaching, attached, detaching, detached, busy))
   }
-
-  object VolumeAttributeNameEnum {
-    val autoEnableIO = "autoEnableIO"
-    val productCodes = "productCodes"
+  @js.native
+  sealed trait VolumeAttributeName extends js.Any
+  object VolumeAttributeName extends js.Object {
+    val autoEnableIO = "autoEnableIO".asInstanceOf[VolumeAttributeName]
+    val productCodes = "productCodes".asInstanceOf[VolumeAttributeName]
 
     val values = js.Object.freeze(js.Array(autoEnableIO, productCodes))
   }
@@ -36028,23 +36023,25 @@ package ec2 {
       __obj.asInstanceOf[VolumeModification]
     }
   }
-
-  object VolumeModificationStateEnum {
-    val modifying  = "modifying"
-    val optimizing = "optimizing"
-    val completed  = "completed"
-    val failed     = "failed"
+  @js.native
+  sealed trait VolumeModificationState extends js.Any
+  object VolumeModificationState extends js.Object {
+    val modifying  = "modifying".asInstanceOf[VolumeModificationState]
+    val optimizing = "optimizing".asInstanceOf[VolumeModificationState]
+    val completed  = "completed".asInstanceOf[VolumeModificationState]
+    val failed     = "failed".asInstanceOf[VolumeModificationState]
 
     val values = js.Object.freeze(js.Array(modifying, optimizing, completed, failed))
   }
-
-  object VolumeStateEnum {
-    val creating  = "creating"
-    val available = "available"
-    val `in-use`  = "in-use"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
-    val error     = "error"
+  @js.native
+  sealed trait VolumeState extends js.Any
+  object VolumeState extends js.Object {
+    val creating  = "creating".asInstanceOf[VolumeState]
+    val available = "available".asInstanceOf[VolumeState]
+    val `in-use`  = "in-use".asInstanceOf[VolumeState]
+    val deleting  = "deleting".asInstanceOf[VolumeState]
+    val deleted   = "deleted".asInstanceOf[VolumeState]
+    val error     = "error".asInstanceOf[VolumeState]
 
     val values = js.Object.freeze(js.Array(creating, available, `in-use`, deleting, deleted, error))
   }
@@ -36176,11 +36173,12 @@ package ec2 {
       __obj.asInstanceOf[VolumeStatusInfo]
     }
   }
-
-  object VolumeStatusInfoStatusEnum {
-    val ok                  = "ok"
-    val impaired            = "impaired"
-    val `insufficient-data` = "insufficient-data"
+  @js.native
+  sealed trait VolumeStatusInfoStatus extends js.Any
+  object VolumeStatusInfoStatus extends js.Object {
+    val ok                  = "ok".asInstanceOf[VolumeStatusInfoStatus]
+    val impaired            = "impaired".asInstanceOf[VolumeStatusInfoStatus]
+    val `insufficient-data` = "insufficient-data".asInstanceOf[VolumeStatusInfoStatus]
 
     val values = js.Object.freeze(js.Array(ok, impaired, `insufficient-data`))
   }
@@ -36221,20 +36219,22 @@ package ec2 {
       __obj.asInstanceOf[VolumeStatusItem]
     }
   }
-
-  object VolumeStatusNameEnum {
-    val `io-enabled`     = "io-enabled"
-    val `io-performance` = "io-performance"
+  @js.native
+  sealed trait VolumeStatusName extends js.Any
+  object VolumeStatusName extends js.Object {
+    val `io-enabled`     = "io-enabled".asInstanceOf[VolumeStatusName]
+    val `io-performance` = "io-performance".asInstanceOf[VolumeStatusName]
 
     val values = js.Object.freeze(js.Array(`io-enabled`, `io-performance`))
   }
-
-  object VolumeTypeEnum {
-    val standard = "standard"
-    val io1      = "io1"
-    val gp2      = "gp2"
-    val sc1      = "sc1"
-    val st1      = "st1"
+  @js.native
+  sealed trait VolumeType extends js.Any
+  object VolumeType extends js.Object {
+    val standard = "standard".asInstanceOf[VolumeType]
+    val io1      = "io1".asInstanceOf[VolumeType]
+    val gp2      = "gp2".asInstanceOf[VolumeType]
+    val sc1      = "sc1".asInstanceOf[VolumeType]
+    val st1      = "st1".asInstanceOf[VolumeType]
 
     val values = js.Object.freeze(js.Array(standard, io1, gp2, sc1, st1))
   }
@@ -36308,10 +36308,11 @@ package ec2 {
       __obj.asInstanceOf[VpcAttachment]
     }
   }
-
-  object VpcAttributeNameEnum {
-    val enableDnsSupport   = "enableDnsSupport"
-    val enableDnsHostnames = "enableDnsHostnames"
+  @js.native
+  sealed trait VpcAttributeName extends js.Any
+  object VpcAttributeName extends js.Object {
+    val enableDnsSupport   = "enableDnsSupport".asInstanceOf[VpcAttributeName]
+    val enableDnsHostnames = "enableDnsHostnames".asInstanceOf[VpcAttributeName]
 
     val values = js.Object.freeze(js.Array(enableDnsSupport, enableDnsHostnames))
   }
@@ -36362,14 +36363,15 @@ package ec2 {
       __obj.asInstanceOf[VpcCidrBlockState]
     }
   }
-
-  object VpcCidrBlockStateCodeEnum {
-    val associating    = "associating"
-    val associated     = "associated"
-    val disassociating = "disassociating"
-    val disassociated  = "disassociated"
-    val failing        = "failing"
-    val failed         = "failed"
+  @js.native
+  sealed trait VpcCidrBlockStateCode extends js.Any
+  object VpcCidrBlockStateCode extends js.Object {
+    val associating    = "associating".asInstanceOf[VpcCidrBlockStateCode]
+    val associated     = "associated".asInstanceOf[VpcCidrBlockStateCode]
+    val disassociating = "disassociating".asInstanceOf[VpcCidrBlockStateCode]
+    val disassociated  = "disassociated".asInstanceOf[VpcCidrBlockStateCode]
+    val failing        = "failing".asInstanceOf[VpcCidrBlockStateCode]
+    val failed         = "failed".asInstanceOf[VpcCidrBlockStateCode]
 
     val values = js.Object.freeze(js.Array(associating, associated, disassociating, disassociated, failing, failed))
   }
@@ -36502,10 +36504,11 @@ package ec2 {
       __obj.asInstanceOf[VpcEndpointConnection]
     }
   }
-
-  object VpcEndpointTypeEnum {
-    val Interface = "Interface"
-    val Gateway   = "Gateway"
+  @js.native
+  sealed trait VpcEndpointType extends js.Any
+  object VpcEndpointType extends js.Object {
+    val Interface = "Interface".asInstanceOf[VpcEndpointType]
+    val Gateway   = "Gateway".asInstanceOf[VpcEndpointType]
 
     val values = js.Object.freeze(js.Array(Interface, Gateway))
   }
@@ -36627,17 +36630,18 @@ package ec2 {
       __obj.asInstanceOf[VpcPeeringConnectionStateReason]
     }
   }
-
-  object VpcPeeringConnectionStateReasonCodeEnum {
-    val `initiating-request` = "initiating-request"
-    val `pending-acceptance` = "pending-acceptance"
-    val active               = "active"
-    val deleted              = "deleted"
-    val rejected             = "rejected"
-    val failed               = "failed"
-    val expired              = "expired"
-    val provisioning         = "provisioning"
-    val deleting             = "deleting"
+  @js.native
+  sealed trait VpcPeeringConnectionStateReasonCode extends js.Any
+  object VpcPeeringConnectionStateReasonCode extends js.Object {
+    val `initiating-request` = "initiating-request".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val `pending-acceptance` = "pending-acceptance".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val active               = "active".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val deleted              = "deleted".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val rejected             = "rejected".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val failed               = "failed".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val expired              = "expired".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val provisioning         = "provisioning".asInstanceOf[VpcPeeringConnectionStateReasonCode]
+    val deleting             = "deleting".asInstanceOf[VpcPeeringConnectionStateReasonCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -36690,16 +36694,18 @@ package ec2 {
       __obj.asInstanceOf[VpcPeeringConnectionVpcInfo]
     }
   }
-
-  object VpcStateEnum {
-    val pending   = "pending"
-    val available = "available"
+  @js.native
+  sealed trait VpcState extends js.Any
+  object VpcState extends js.Object {
+    val pending   = "pending".asInstanceOf[VpcState]
+    val available = "available".asInstanceOf[VpcState]
 
     val values = js.Object.freeze(js.Array(pending, available))
   }
-
-  object VpcTenancyEnum {
-    val default = "default"
+  @js.native
+  sealed trait VpcTenancy extends js.Any
+  object VpcTenancy extends js.Object {
+    val default = "default".asInstanceOf[VpcTenancy]
 
     val values = js.Object.freeze(js.Array(default))
   }
@@ -36807,10 +36813,11 @@ package ec2 {
       __obj.asInstanceOf[VpnConnectionOptionsSpecification]
     }
   }
-
-  object VpnEcmpSupportValueEnum {
-    val enable  = "enable"
-    val disable = "disable"
+  @js.native
+  sealed trait VpnEcmpSupportValue extends js.Any
+  object VpnEcmpSupportValue extends js.Object {
+    val enable  = "enable".asInstanceOf[VpnEcmpSupportValue]
+    val disable = "disable".asInstanceOf[VpnEcmpSupportValue]
 
     val values = js.Object.freeze(js.Array(enable, disable))
   }
@@ -36851,18 +36858,20 @@ package ec2 {
       __obj.asInstanceOf[VpnGateway]
     }
   }
-
-  object VpnProtocolEnum {
-    val openvpn = "openvpn"
+  @js.native
+  sealed trait VpnProtocol extends js.Any
+  object VpnProtocol extends js.Object {
+    val openvpn = "openvpn".asInstanceOf[VpnProtocol]
 
     val values = js.Object.freeze(js.Array(openvpn))
   }
-
-  object VpnStateEnum {
-    val pending   = "pending"
-    val available = "available"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait VpnState extends js.Any
+  object VpnState extends js.Object {
+    val pending   = "pending".asInstanceOf[VpnState]
+    val available = "available".asInstanceOf[VpnState]
+    val deleting  = "deleting".asInstanceOf[VpnState]
+    val deleted   = "deleted".asInstanceOf[VpnState]
 
     val values = js.Object.freeze(js.Array(pending, available, deleting, deleted))
   }
@@ -36891,9 +36900,10 @@ package ec2 {
       __obj.asInstanceOf[VpnStaticRoute]
     }
   }
-
-  object VpnStaticRouteSourceEnum {
-    val Static = "Static"
+  @js.native
+  sealed trait VpnStaticRouteSource extends js.Any
+  object VpnStaticRouteSource extends js.Object {
+    val Static = "Static".asInstanceOf[VpnStaticRouteSource]
 
     val values = js.Object.freeze(js.Array(Static))
   }
@@ -37003,10 +37013,11 @@ package ec2 {
       __obj.asInstanceOf[WithdrawByoipCidrResult]
     }
   }
-
-  object scopeEnum {
-    val `Availability Zone` = "Availability Zone"
-    val Region              = "Region"
+  @js.native
+  sealed trait scope extends js.Any
+  object scope extends js.Object {
+    val `Availability Zone` = "Availability Zone".asInstanceOf[scope]
+    val Region              = "Region".asInstanceOf[scope]
 
     val values = js.Object.freeze(js.Array(`Availability Zone`, Region))
   }

--- a/services/ecr/src/main/scala/facade/amazonaws/services/ECR.scala
+++ b/services/ecr/src/main/scala/facade/amazonaws/services/ECR.scala
@@ -20,15 +20,12 @@ package object ecr {
   type ExpirationTimestamp                 = js.Date
   type FindingDescription                  = String
   type FindingName                         = String
-  type FindingSeverity                     = String
   type FindingSeverityCounts               = js.Dictionary[SeverityCount]
   type ForceFlag                           = Boolean
   type GetAuthorizationTokenRegistryIdList = js.Array[RegistryId]
-  type ImageActionType                     = String
   type ImageCount                          = Int
   type ImageDetailList                     = js.Array[ImageDetail]
   type ImageDigest                         = String
-  type ImageFailureCode                    = String
   type ImageFailureList                    = js.Array[ImageFailure]
   type ImageFailureReason                  = String
   type ImageIdentifierList                 = js.Array[ImageIdentifier]
@@ -38,18 +35,14 @@ package object ecr {
   type ImageSizeInBytes                    = Double
   type ImageTag                            = String
   type ImageTagList                        = js.Array[ImageTag]
-  type ImageTagMutability                  = String
-  type LayerAvailability                   = String
   type LayerDigest                         = String
   type LayerDigestList                     = js.Array[LayerDigest]
-  type LayerFailureCode                    = String
   type LayerFailureList                    = js.Array[LayerFailure]
   type LayerFailureReason                  = String
   type LayerList                           = js.Array[Layer]
   type LayerPartBlob                       = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type LayerSizeInBytes                    = Double
   type LifecyclePolicyPreviewResultList    = js.Array[LifecyclePolicyPreviewResult]
-  type LifecyclePolicyPreviewStatus        = String
   type LifecyclePolicyRulePriority         = Int
   type LifecyclePolicyText                 = String
   type LifecyclePreviewMaxResults          = Int
@@ -66,14 +59,12 @@ package object ecr {
   type RepositoryNameList                  = js.Array[RepositoryName]
   type RepositoryPolicyText                = String
   type ScanOnPushFlag                      = Boolean
-  type ScanStatus                          = String
   type ScanStatusDescription               = String
   type ScanTimestamp                       = js.Date
   type SeverityCount                       = Int
   type TagKey                              = String
   type TagKeyList                          = js.Array[TagKey]
   type TagList                             = js.Array[Tag]
-  type TagStatus                           = String
   type TagValue                            = String
   type UploadId                            = String
   type Url                                 = String
@@ -786,14 +777,15 @@ package ecr {
       __obj.asInstanceOf[DescribeRepositoriesResponse]
     }
   }
-
-  object FindingSeverityEnum {
-    val INFORMATIONAL = "INFORMATIONAL"
-    val LOW           = "LOW"
-    val MEDIUM        = "MEDIUM"
-    val HIGH          = "HIGH"
-    val CRITICAL      = "CRITICAL"
-    val UNDEFINED     = "UNDEFINED"
+  @js.native
+  sealed trait FindingSeverity extends js.Any
+  object FindingSeverity extends js.Object {
+    val INFORMATIONAL = "INFORMATIONAL".asInstanceOf[FindingSeverity]
+    val LOW           = "LOW".asInstanceOf[FindingSeverity]
+    val MEDIUM        = "MEDIUM".asInstanceOf[FindingSeverity]
+    val HIGH          = "HIGH".asInstanceOf[FindingSeverity]
+    val CRITICAL      = "CRITICAL".asInstanceOf[FindingSeverity]
+    val UNDEFINED     = "UNDEFINED".asInstanceOf[FindingSeverity]
 
     val values = js.Object.freeze(js.Array(INFORMATIONAL, LOW, MEDIUM, HIGH, CRITICAL, UNDEFINED))
   }
@@ -1056,9 +1048,10 @@ package ecr {
       __obj.asInstanceOf[Image]
     }
   }
-
-  object ImageActionTypeEnum {
-    val EXPIRE = "EXPIRE"
+  @js.native
+  sealed trait ImageActionType extends js.Any
+  object ImageActionType extends js.Object {
+    val EXPIRE = "EXPIRE".asInstanceOf[ImageActionType]
 
     val values = js.Object.freeze(js.Array(EXPIRE))
   }
@@ -1127,13 +1120,14 @@ package ecr {
       __obj.asInstanceOf[ImageFailure]
     }
   }
-
-  object ImageFailureCodeEnum {
-    val InvalidImageDigest         = "InvalidImageDigest"
-    val InvalidImageTag            = "InvalidImageTag"
-    val ImageTagDoesNotMatchDigest = "ImageTagDoesNotMatchDigest"
-    val ImageNotFound              = "ImageNotFound"
-    val MissingDigestAndTag        = "MissingDigestAndTag"
+  @js.native
+  sealed trait ImageFailureCode extends js.Any
+  object ImageFailureCode extends js.Object {
+    val InvalidImageDigest         = "InvalidImageDigest".asInstanceOf[ImageFailureCode]
+    val InvalidImageTag            = "InvalidImageTag".asInstanceOf[ImageFailureCode]
+    val ImageTagDoesNotMatchDigest = "ImageTagDoesNotMatchDigest".asInstanceOf[ImageFailureCode]
+    val ImageNotFound              = "ImageNotFound".asInstanceOf[ImageFailureCode]
+    val MissingDigestAndTag        = "MissingDigestAndTag".asInstanceOf[ImageFailureCode]
 
     val values = js.Object.freeze(
       js.Array(InvalidImageDigest, InvalidImageTag, ImageTagDoesNotMatchDigest, ImageNotFound, MissingDigestAndTag)
@@ -1290,10 +1284,11 @@ package ecr {
       __obj.asInstanceOf[ImageScanningConfiguration]
     }
   }
-
-  object ImageTagMutabilityEnum {
-    val MUTABLE   = "MUTABLE"
-    val IMMUTABLE = "IMMUTABLE"
+  @js.native
+  sealed trait ImageTagMutability extends js.Any
+  object ImageTagMutability extends js.Object {
+    val MUTABLE   = "MUTABLE".asInstanceOf[ImageTagMutability]
+    val IMMUTABLE = "IMMUTABLE".asInstanceOf[ImageTagMutability]
 
     val values = js.Object.freeze(js.Array(MUTABLE, IMMUTABLE))
   }
@@ -1365,10 +1360,11 @@ package ecr {
       __obj.asInstanceOf[Layer]
     }
   }
-
-  object LayerAvailabilityEnum {
-    val AVAILABLE   = "AVAILABLE"
-    val UNAVAILABLE = "UNAVAILABLE"
+  @js.native
+  sealed trait LayerAvailability extends js.Any
+  object LayerAvailability extends js.Object {
+    val AVAILABLE   = "AVAILABLE".asInstanceOf[LayerAvailability]
+    val UNAVAILABLE = "UNAVAILABLE".asInstanceOf[LayerAvailability]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, UNAVAILABLE))
   }
@@ -1397,10 +1393,11 @@ package ecr {
       __obj.asInstanceOf[LayerFailure]
     }
   }
-
-  object LayerFailureCodeEnum {
-    val InvalidLayerDigest = "InvalidLayerDigest"
-    val MissingLayerDigest = "MissingLayerDigest"
+  @js.native
+  sealed trait LayerFailureCode extends js.Any
+  object LayerFailureCode extends js.Object {
+    val InvalidLayerDigest = "InvalidLayerDigest".asInstanceOf[LayerFailureCode]
+    val MissingLayerDigest = "MissingLayerDigest".asInstanceOf[LayerFailureCode]
 
     val values = js.Object.freeze(js.Array(InvalidLayerDigest, MissingLayerDigest))
   }
@@ -1454,12 +1451,13 @@ package ecr {
       __obj.asInstanceOf[LifecyclePolicyPreviewResult]
     }
   }
-
-  object LifecyclePolicyPreviewStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETE    = "COMPLETE"
-    val EXPIRED     = "EXPIRED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait LifecyclePolicyPreviewStatus extends js.Any
+  object LifecyclePolicyPreviewStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[LifecyclePolicyPreviewStatus]
+    val COMPLETE    = "COMPLETE".asInstanceOf[LifecyclePolicyPreviewStatus]
+    val EXPIRED     = "EXPIRED".asInstanceOf[LifecyclePolicyPreviewStatus]
+    val FAILED      = "FAILED".asInstanceOf[LifecyclePolicyPreviewStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETE, EXPIRED, FAILED))
   }
@@ -1825,11 +1823,12 @@ package ecr {
       __obj.asInstanceOf[Repository]
     }
   }
-
-  object ScanStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETE    = "COMPLETE"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait ScanStatus extends js.Any
+  object ScanStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ScanStatus]
+    val COMPLETE    = "COMPLETE".asInstanceOf[ScanStatus]
+    val FAILED      = "FAILED".asInstanceOf[ScanStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETE, FAILED))
   }
@@ -2036,11 +2035,12 @@ package ecr {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TagStatusEnum {
-    val TAGGED   = "TAGGED"
-    val UNTAGGED = "UNTAGGED"
-    val ANY      = "ANY"
+  @js.native
+  sealed trait TagStatus extends js.Any
+  object TagStatus extends js.Object {
+    val TAGGED   = "TAGGED".asInstanceOf[TagStatus]
+    val UNTAGGED = "UNTAGGED".asInstanceOf[TagStatus]
+    val ANY      = "ANY".asInstanceOf[TagStatus]
 
     val values = js.Object.freeze(js.Array(TAGGED, UNTAGGED, ANY))
   }

--- a/services/ecs/src/main/scala/facade/amazonaws/services/ECS.scala
+++ b/services/ecs/src/main/scala/facade/amazonaws/services/ECS.scala
@@ -7,125 +7,79 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object ecs {
-  type AgentUpdateStatus                     = String
-  type AssignPublicIp                        = String
-  type AttachmentDetails                     = js.Array[KeyValuePair]
-  type AttachmentStateChanges                = js.Array[AttachmentStateChange]
-  type Attachments                           = js.Array[Attachment]
-  type Attributes                            = js.Array[Attribute]
-  type BoxedBoolean                          = Boolean
-  type BoxedInteger                          = Int
-  type CapacityProviderField                 = String
-  type CapacityProviderFieldList             = js.Array[CapacityProviderField]
-  type CapacityProviderStatus                = String
-  type CapacityProviderStrategy              = js.Array[CapacityProviderStrategyItem]
-  type CapacityProviderStrategyItemBase      = Int
-  type CapacityProviderStrategyItemWeight    = Int
-  type CapacityProviders                     = js.Array[CapacityProvider]
-  type ClusterField                          = String
-  type ClusterFieldList                      = js.Array[ClusterField]
-  type ClusterSettingName                    = String
-  type ClusterSettings                       = js.Array[ClusterSetting]
-  type Clusters                              = js.Array[Cluster]
-  type Compatibility                         = String
-  type CompatibilityList                     = js.Array[Compatibility]
-  type Connectivity                          = String
-  type ContainerCondition                    = String
-  type ContainerDefinitions                  = js.Array[ContainerDefinition]
-  type ContainerDependencies                 = js.Array[ContainerDependency]
-  type ContainerInstanceField                = String
-  type ContainerInstanceFieldList            = js.Array[ContainerInstanceField]
-  type ContainerInstanceStatus               = String
-  type ContainerInstances                    = js.Array[ContainerInstance]
-  type ContainerOverrides                    = js.Array[ContainerOverride]
-  type ContainerStateChanges                 = js.Array[ContainerStateChange]
-  type Containers                            = js.Array[Container]
-  type DeploymentControllerType              = String
-  type Deployments                           = js.Array[Deployment]
-  type DesiredStatus                         = String
-  type DeviceCgroupPermission                = String
-  type DeviceCgroupPermissions               = js.Array[DeviceCgroupPermission]
-  type DevicesList                           = js.Array[Device]
-  type DockerLabelsMap                       = js.Dictionary[String]
-  type EnvironmentVariables                  = js.Array[KeyValuePair]
-  type Failures                              = js.Array[Failure]
-  type FirelensConfigurationOptionsMap       = js.Dictionary[String]
-  type FirelensConfigurationType             = String
-  type GpuIds                                = js.Array[String]
-  type HealthStatus                          = String
-  type HostEntryList                         = js.Array[HostEntry]
-  type InferenceAcceleratorOverrides         = js.Array[InferenceAcceleratorOverride]
-  type InferenceAccelerators                 = js.Array[InferenceAccelerator]
-  type IpcMode                               = String
-  type LaunchType                            = String
-  type LoadBalancers                         = js.Array[LoadBalancer]
-  type LogConfigurationOptionsMap            = js.Dictionary[String]
-  type LogDriver                             = String
-  type ManagedScalingStatus                  = String
-  type ManagedScalingStepSize                = Int
-  type ManagedScalingTargetCapacity          = Int
-  type ManagedTerminationProtection          = String
-  type MountPointList                        = js.Array[MountPoint]
-  type NetworkBindings                       = js.Array[NetworkBinding]
-  type NetworkInterfaces                     = js.Array[NetworkInterface]
-  type NetworkMode                           = String
-  type PidMode                               = String
-  type PlacementConstraintType               = String
-  type PlacementConstraints                  = js.Array[PlacementConstraint]
-  type PlacementStrategies                   = js.Array[PlacementStrategy]
-  type PlacementStrategyType                 = String
-  type PlatformDeviceType                    = String
-  type PlatformDevices                       = js.Array[PlatformDevice]
-  type PortMappingList                       = js.Array[PortMapping]
-  type PropagateTags                         = String
-  type ProxyConfigurationProperties          = js.Array[KeyValuePair]
-  type ProxyConfigurationType                = String
-  type RequiresAttributes                    = js.Array[Attribute]
-  type ResourceRequirements                  = js.Array[ResourceRequirement]
-  type ResourceType                          = String
-  type Resources                             = js.Array[Resource]
-  type ScaleUnit                             = String
-  type SchedulingStrategy                    = String
-  type Scope                                 = String
-  type SecretList                            = js.Array[Secret]
-  type ServiceEvents                         = js.Array[ServiceEvent]
-  type ServiceField                          = String
-  type ServiceFieldList                      = js.Array[ServiceField]
-  type ServiceRegistries                     = js.Array[ServiceRegistry]
-  type Services                              = js.Array[Service]
-  type SettingName                           = String
-  type Settings                              = js.Array[Setting]
-  type SortOrder                             = String
-  type StabilityStatus                       = String
-  type Statistics                            = js.Array[KeyValuePair]
-  type StringList                            = js.Array[String]
-  type StringMap                             = js.Dictionary[String]
-  type SystemControls                        = js.Array[SystemControl]
-  type TagKey                                = String
-  type TagKeys                               = js.Array[TagKey]
-  type TagValue                              = String
-  type Tags                                  = js.Array[Tag]
-  type TargetType                            = String
-  type TaskDefinitionFamilyStatus            = String
-  type TaskDefinitionField                   = String
-  type TaskDefinitionFieldList               = js.Array[TaskDefinitionField]
-  type TaskDefinitionPlacementConstraintType = String
-  type TaskDefinitionPlacementConstraints    = js.Array[TaskDefinitionPlacementConstraint]
-  type TaskDefinitionStatus                  = String
-  type TaskField                             = String
-  type TaskFieldList                         = js.Array[TaskField]
-  type TaskSetField                          = String
-  type TaskSetFieldList                      = js.Array[TaskSetField]
-  type TaskSets                              = js.Array[TaskSet]
-  type TaskStopCode                          = String
-  type Tasks                                 = js.Array[Task]
-  type Timestamp                             = js.Date
-  type TmpfsList                             = js.Array[Tmpfs]
-  type TransportProtocol                     = String
-  type UlimitList                            = js.Array[Ulimit]
-  type UlimitName                            = String
-  type VolumeFromList                        = js.Array[VolumeFrom]
-  type VolumeList                            = js.Array[Volume]
+  type AttachmentDetails                  = js.Array[KeyValuePair]
+  type AttachmentStateChanges             = js.Array[AttachmentStateChange]
+  type Attachments                        = js.Array[Attachment]
+  type Attributes                         = js.Array[Attribute]
+  type BoxedBoolean                       = Boolean
+  type BoxedInteger                       = Int
+  type CapacityProviderFieldList          = js.Array[CapacityProviderField]
+  type CapacityProviderStrategy           = js.Array[CapacityProviderStrategyItem]
+  type CapacityProviderStrategyItemBase   = Int
+  type CapacityProviderStrategyItemWeight = Int
+  type CapacityProviders                  = js.Array[CapacityProvider]
+  type ClusterFieldList                   = js.Array[ClusterField]
+  type ClusterSettings                    = js.Array[ClusterSetting]
+  type Clusters                           = js.Array[Cluster]
+  type CompatibilityList                  = js.Array[Compatibility]
+  type ContainerDefinitions               = js.Array[ContainerDefinition]
+  type ContainerDependencies              = js.Array[ContainerDependency]
+  type ContainerInstanceFieldList         = js.Array[ContainerInstanceField]
+  type ContainerInstances                 = js.Array[ContainerInstance]
+  type ContainerOverrides                 = js.Array[ContainerOverride]
+  type ContainerStateChanges              = js.Array[ContainerStateChange]
+  type Containers                         = js.Array[Container]
+  type Deployments                        = js.Array[Deployment]
+  type DeviceCgroupPermissions            = js.Array[DeviceCgroupPermission]
+  type DevicesList                        = js.Array[Device]
+  type DockerLabelsMap                    = js.Dictionary[String]
+  type EnvironmentVariables               = js.Array[KeyValuePair]
+  type Failures                           = js.Array[Failure]
+  type FirelensConfigurationOptionsMap    = js.Dictionary[String]
+  type GpuIds                             = js.Array[String]
+  type HostEntryList                      = js.Array[HostEntry]
+  type InferenceAcceleratorOverrides      = js.Array[InferenceAcceleratorOverride]
+  type InferenceAccelerators              = js.Array[InferenceAccelerator]
+  type LoadBalancers                      = js.Array[LoadBalancer]
+  type LogConfigurationOptionsMap         = js.Dictionary[String]
+  type ManagedScalingStepSize             = Int
+  type ManagedScalingTargetCapacity       = Int
+  type MountPointList                     = js.Array[MountPoint]
+  type NetworkBindings                    = js.Array[NetworkBinding]
+  type NetworkInterfaces                  = js.Array[NetworkInterface]
+  type PlacementConstraints               = js.Array[PlacementConstraint]
+  type PlacementStrategies                = js.Array[PlacementStrategy]
+  type PlatformDevices                    = js.Array[PlatformDevice]
+  type PortMappingList                    = js.Array[PortMapping]
+  type ProxyConfigurationProperties       = js.Array[KeyValuePair]
+  type RequiresAttributes                 = js.Array[Attribute]
+  type ResourceRequirements               = js.Array[ResourceRequirement]
+  type Resources                          = js.Array[Resource]
+  type SecretList                         = js.Array[Secret]
+  type ServiceEvents                      = js.Array[ServiceEvent]
+  type ServiceFieldList                   = js.Array[ServiceField]
+  type ServiceRegistries                  = js.Array[ServiceRegistry]
+  type Services                           = js.Array[Service]
+  type Settings                           = js.Array[Setting]
+  type Statistics                         = js.Array[KeyValuePair]
+  type StringList                         = js.Array[String]
+  type StringMap                          = js.Dictionary[String]
+  type SystemControls                     = js.Array[SystemControl]
+  type TagKey                             = String
+  type TagKeys                            = js.Array[TagKey]
+  type TagValue                           = String
+  type Tags                               = js.Array[Tag]
+  type TaskDefinitionFieldList            = js.Array[TaskDefinitionField]
+  type TaskDefinitionPlacementConstraints = js.Array[TaskDefinitionPlacementConstraint]
+  type TaskFieldList                      = js.Array[TaskField]
+  type TaskSetFieldList                   = js.Array[TaskSetField]
+  type TaskSets                           = js.Array[TaskSet]
+  type Tasks                              = js.Array[Task]
+  type Timestamp                          = js.Date
+  type TmpfsList                          = js.Array[Tmpfs]
+  type UlimitList                         = js.Array[Ulimit]
+  type VolumeFromList                     = js.Array[VolumeFrom]
+  type VolumeList                         = js.Array[Volume]
 
   implicit final class ECSOps(private val service: ECS) extends AnyVal {
 
@@ -327,21 +281,23 @@ package ecs {
     ): Request[UpdateServicePrimaryTaskSetResponse]                                 = js.native
     def updateTaskSet(params: UpdateTaskSetRequest): Request[UpdateTaskSetResponse] = js.native
   }
-
-  object AgentUpdateStatusEnum {
-    val PENDING  = "PENDING"
-    val STAGING  = "STAGING"
-    val STAGED   = "STAGED"
-    val UPDATING = "UPDATING"
-    val UPDATED  = "UPDATED"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait AgentUpdateStatus extends js.Any
+  object AgentUpdateStatus extends js.Object {
+    val PENDING  = "PENDING".asInstanceOf[AgentUpdateStatus]
+    val STAGING  = "STAGING".asInstanceOf[AgentUpdateStatus]
+    val STAGED   = "STAGED".asInstanceOf[AgentUpdateStatus]
+    val UPDATING = "UPDATING".asInstanceOf[AgentUpdateStatus]
+    val UPDATED  = "UPDATED".asInstanceOf[AgentUpdateStatus]
+    val FAILED   = "FAILED".asInstanceOf[AgentUpdateStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, STAGING, STAGED, UPDATING, UPDATED, FAILED))
   }
-
-  object AssignPublicIpEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait AssignPublicIp extends js.Any
+  object AssignPublicIp extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[AssignPublicIp]
+    val DISABLED = "DISABLED".asInstanceOf[AssignPublicIp]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -514,15 +470,17 @@ package ecs {
       __obj.asInstanceOf[CapacityProvider]
     }
   }
-
-  object CapacityProviderFieldEnum {
-    val TAGS = "TAGS"
+  @js.native
+  sealed trait CapacityProviderField extends js.Any
+  object CapacityProviderField extends js.Object {
+    val TAGS = "TAGS".asInstanceOf[CapacityProviderField]
 
     val values = js.Object.freeze(js.Array(TAGS))
   }
-
-  object CapacityProviderStatusEnum {
-    val ACTIVE = "ACTIVE"
+  @js.native
+  sealed trait CapacityProviderStatus extends js.Any
+  object CapacityProviderStatus extends js.Object {
+    val ACTIVE = "ACTIVE".asInstanceOf[CapacityProviderStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE))
   }
@@ -615,12 +573,13 @@ package ecs {
       __obj.asInstanceOf[Cluster]
     }
   }
-
-  object ClusterFieldEnum {
-    val ATTACHMENTS = "ATTACHMENTS"
-    val SETTINGS    = "SETTINGS"
-    val STATISTICS  = "STATISTICS"
-    val TAGS        = "TAGS"
+  @js.native
+  sealed trait ClusterField extends js.Any
+  object ClusterField extends js.Object {
+    val ATTACHMENTS = "ATTACHMENTS".asInstanceOf[ClusterField]
+    val SETTINGS    = "SETTINGS".asInstanceOf[ClusterField]
+    val STATISTICS  = "STATISTICS".asInstanceOf[ClusterField]
+    val TAGS        = "TAGS".asInstanceOf[ClusterField]
 
     val values = js.Object.freeze(js.Array(ATTACHMENTS, SETTINGS, STATISTICS, TAGS))
   }
@@ -646,23 +605,26 @@ package ecs {
       __obj.asInstanceOf[ClusterSetting]
     }
   }
-
-  object ClusterSettingNameEnum {
-    val containerInsights = "containerInsights"
+  @js.native
+  sealed trait ClusterSettingName extends js.Any
+  object ClusterSettingName extends js.Object {
+    val containerInsights = "containerInsights".asInstanceOf[ClusterSettingName]
 
     val values = js.Object.freeze(js.Array(containerInsights))
   }
-
-  object CompatibilityEnum {
-    val EC2     = "EC2"
-    val FARGATE = "FARGATE"
+  @js.native
+  sealed trait Compatibility extends js.Any
+  object Compatibility extends js.Object {
+    val EC2     = "EC2".asInstanceOf[Compatibility]
+    val FARGATE = "FARGATE".asInstanceOf[Compatibility]
 
     val values = js.Object.freeze(js.Array(EC2, FARGATE))
   }
-
-  object ConnectivityEnum {
-    val CONNECTED    = "CONNECTED"
-    val DISCONNECTED = "DISCONNECTED"
+  @js.native
+  sealed trait Connectivity extends js.Any
+  object Connectivity extends js.Object {
+    val CONNECTED    = "CONNECTED".asInstanceOf[Connectivity]
+    val DISCONNECTED = "DISCONNECTED".asInstanceOf[Connectivity]
 
     val values = js.Object.freeze(js.Array(CONNECTED, DISCONNECTED))
   }
@@ -730,12 +692,13 @@ package ecs {
       __obj.asInstanceOf[Container]
     }
   }
-
-  object ContainerConditionEnum {
-    val START    = "START"
-    val COMPLETE = "COMPLETE"
-    val SUCCESS  = "SUCCESS"
-    val HEALTHY  = "HEALTHY"
+  @js.native
+  sealed trait ContainerCondition extends js.Any
+  object ContainerCondition extends js.Object {
+    val START    = "START".asInstanceOf[ContainerCondition]
+    val COMPLETE = "COMPLETE".asInstanceOf[ContainerCondition]
+    val SUCCESS  = "SUCCESS".asInstanceOf[ContainerCondition]
+    val HEALTHY  = "HEALTHY".asInstanceOf[ContainerCondition]
 
     val values = js.Object.freeze(js.Array(START, COMPLETE, SUCCESS, HEALTHY))
   }
@@ -963,19 +926,21 @@ package ecs {
       __obj.asInstanceOf[ContainerInstance]
     }
   }
-
-  object ContainerInstanceFieldEnum {
-    val TAGS = "TAGS"
+  @js.native
+  sealed trait ContainerInstanceField extends js.Any
+  object ContainerInstanceField extends js.Object {
+    val TAGS = "TAGS".asInstanceOf[ContainerInstanceField]
 
     val values = js.Object.freeze(js.Array(TAGS))
   }
-
-  object ContainerInstanceStatusEnum {
-    val ACTIVE              = "ACTIVE"
-    val DRAINING            = "DRAINING"
-    val REGISTERING         = "REGISTERING"
-    val DEREGISTERING       = "DEREGISTERING"
-    val REGISTRATION_FAILED = "REGISTRATION_FAILED"
+  @js.native
+  sealed trait ContainerInstanceStatus extends js.Any
+  object ContainerInstanceStatus extends js.Object {
+    val ACTIVE              = "ACTIVE".asInstanceOf[ContainerInstanceStatus]
+    val DRAINING            = "DRAINING".asInstanceOf[ContainerInstanceStatus]
+    val REGISTERING         = "REGISTERING".asInstanceOf[ContainerInstanceStatus]
+    val DEREGISTERING       = "DEREGISTERING".asInstanceOf[ContainerInstanceStatus]
+    val REGISTRATION_FAILED = "REGISTRATION_FAILED".asInstanceOf[ContainerInstanceStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DRAINING, REGISTERING, DEREGISTERING, REGISTRATION_FAILED))
   }
@@ -1591,11 +1556,12 @@ package ecs {
       __obj.asInstanceOf[DeploymentController]
     }
   }
-
-  object DeploymentControllerTypeEnum {
-    val ECS         = "ECS"
-    val CODE_DEPLOY = "CODE_DEPLOY"
-    val EXTERNAL    = "EXTERNAL"
+  @js.native
+  sealed trait DeploymentControllerType extends js.Any
+  object DeploymentControllerType extends js.Object {
+    val ECS         = "ECS".asInstanceOf[DeploymentControllerType]
+    val CODE_DEPLOY = "CODE_DEPLOY".asInstanceOf[DeploymentControllerType]
+    val EXTERNAL    = "EXTERNAL".asInstanceOf[DeploymentControllerType]
 
     val values = js.Object.freeze(js.Array(ECS, CODE_DEPLOY, EXTERNAL))
   }
@@ -1973,11 +1939,12 @@ package ecs {
       __obj.asInstanceOf[DescribeTasksResponse]
     }
   }
-
-  object DesiredStatusEnum {
-    val RUNNING = "RUNNING"
-    val PENDING = "PENDING"
-    val STOPPED = "STOPPED"
+  @js.native
+  sealed trait DesiredStatus extends js.Any
+  object DesiredStatus extends js.Object {
+    val RUNNING = "RUNNING".asInstanceOf[DesiredStatus]
+    val PENDING = "PENDING".asInstanceOf[DesiredStatus]
+    val STOPPED = "STOPPED".asInstanceOf[DesiredStatus]
 
     val values = js.Object.freeze(js.Array(RUNNING, PENDING, STOPPED))
   }
@@ -2008,11 +1975,12 @@ package ecs {
       __obj.asInstanceOf[Device]
     }
   }
-
-  object DeviceCgroupPermissionEnum {
-    val read  = "read"
-    val write = "write"
-    val mknod = "mknod"
+  @js.native
+  sealed trait DeviceCgroupPermission extends js.Any
+  object DeviceCgroupPermission extends js.Object {
+    val read  = "read".asInstanceOf[DeviceCgroupPermission]
+    val write = "write".asInstanceOf[DeviceCgroupPermission]
+    val mknod = "mknod".asInstanceOf[DeviceCgroupPermission]
 
     val values = js.Object.freeze(js.Array(read, write, mknod))
   }
@@ -2160,10 +2128,11 @@ package ecs {
       __obj.asInstanceOf[FirelensConfiguration]
     }
   }
-
-  object FirelensConfigurationTypeEnum {
-    val fluentd   = "fluentd"
-    val fluentbit = "fluentbit"
+  @js.native
+  sealed trait FirelensConfigurationType extends js.Any
+  object FirelensConfigurationType extends js.Object {
+    val fluentd   = "fluentd".asInstanceOf[FirelensConfigurationType]
+    val fluentbit = "fluentbit".asInstanceOf[FirelensConfigurationType]
 
     val values = js.Object.freeze(js.Array(fluentd, fluentbit))
   }
@@ -2204,11 +2173,12 @@ package ecs {
       __obj.asInstanceOf[HealthCheck]
     }
   }
-
-  object HealthStatusEnum {
-    val HEALTHY   = "HEALTHY"
-    val UNHEALTHY = "UNHEALTHY"
-    val UNKNOWN   = "UNKNOWN"
+  @js.native
+  sealed trait HealthStatus extends js.Any
+  object HealthStatus extends js.Object {
+    val HEALTHY   = "HEALTHY".asInstanceOf[HealthStatus]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[HealthStatus]
+    val UNKNOWN   = "UNKNOWN".asInstanceOf[HealthStatus]
 
     val values = js.Object.freeze(js.Array(HEALTHY, UNHEALTHY, UNKNOWN))
   }
@@ -2301,11 +2271,12 @@ package ecs {
       __obj.asInstanceOf[InferenceAcceleratorOverride]
     }
   }
-
-  object IpcModeEnum {
-    val host = "host"
-    val task = "task"
-    val none = "none"
+  @js.native
+  sealed trait IpcMode extends js.Any
+  object IpcMode extends js.Object {
+    val host = "host".asInstanceOf[IpcMode]
+    val task = "task".asInstanceOf[IpcMode]
+    val none = "none".asInstanceOf[IpcMode]
 
     val values = js.Object.freeze(js.Array(host, task, none))
   }
@@ -2353,10 +2324,11 @@ package ecs {
       __obj.asInstanceOf[KeyValuePair]
     }
   }
-
-  object LaunchTypeEnum {
-    val EC2     = "EC2"
-    val FARGATE = "FARGATE"
+  @js.native
+  sealed trait LaunchType extends js.Any
+  object LaunchType extends js.Object {
+    val EC2     = "EC2".asInstanceOf[LaunchType]
+    val FARGATE = "FARGATE".asInstanceOf[LaunchType]
 
     val values = js.Object.freeze(js.Array(EC2, FARGATE))
   }
@@ -2876,16 +2848,17 @@ package ecs {
       __obj.asInstanceOf[LogConfiguration]
     }
   }
-
-  object LogDriverEnum {
-    val `json-file` = "json-file"
-    val syslog      = "syslog"
-    val journald    = "journald"
-    val gelf        = "gelf"
-    val fluentd     = "fluentd"
-    val awslogs     = "awslogs"
-    val splunk      = "splunk"
-    val awsfirelens = "awsfirelens"
+  @js.native
+  sealed trait LogDriver extends js.Any
+  object LogDriver extends js.Object {
+    val `json-file` = "json-file".asInstanceOf[LogDriver]
+    val syslog      = "syslog".asInstanceOf[LogDriver]
+    val journald    = "journald".asInstanceOf[LogDriver]
+    val gelf        = "gelf".asInstanceOf[LogDriver]
+    val fluentd     = "fluentd".asInstanceOf[LogDriver]
+    val awslogs     = "awslogs".asInstanceOf[LogDriver]
+    val splunk      = "splunk".asInstanceOf[LogDriver]
+    val awsfirelens = "awsfirelens".asInstanceOf[LogDriver]
 
     val values = js.Object.freeze(js.Array(`json-file`, syslog, journald, gelf, fluentd, awslogs, splunk, awsfirelens))
   }
@@ -2919,17 +2892,19 @@ package ecs {
       __obj.asInstanceOf[ManagedScaling]
     }
   }
-
-  object ManagedScalingStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait ManagedScalingStatus extends js.Any
+  object ManagedScalingStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[ManagedScalingStatus]
+    val DISABLED = "DISABLED".asInstanceOf[ManagedScalingStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
-
-  object ManagedTerminationProtectionEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait ManagedTerminationProtection extends js.Any
+  object ManagedTerminationProtection extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[ManagedTerminationProtection]
+    val DISABLED = "DISABLED".asInstanceOf[ManagedTerminationProtection]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -3030,19 +3005,21 @@ package ecs {
       __obj.asInstanceOf[NetworkInterface]
     }
   }
-
-  object NetworkModeEnum {
-    val bridge = "bridge"
-    val host   = "host"
-    val awsvpc = "awsvpc"
-    val none   = "none"
+  @js.native
+  sealed trait NetworkMode extends js.Any
+  object NetworkMode extends js.Object {
+    val bridge = "bridge".asInstanceOf[NetworkMode]
+    val host   = "host".asInstanceOf[NetworkMode]
+    val awsvpc = "awsvpc".asInstanceOf[NetworkMode]
+    val none   = "none".asInstanceOf[NetworkMode]
 
     val values = js.Object.freeze(js.Array(bridge, host, awsvpc, none))
   }
-
-  object PidModeEnum {
-    val host = "host"
-    val task = "task"
+  @js.native
+  sealed trait PidMode extends js.Any
+  object PidMode extends js.Object {
+    val host = "host".asInstanceOf[PidMode]
+    val task = "task".asInstanceOf[PidMode]
 
     val values = js.Object.freeze(js.Array(host, task))
   }
@@ -3070,10 +3047,11 @@ package ecs {
       __obj.asInstanceOf[PlacementConstraint]
     }
   }
-
-  object PlacementConstraintTypeEnum {
-    val distinctInstance = "distinctInstance"
-    val memberOf         = "memberOf"
+  @js.native
+  sealed trait PlacementConstraintType extends js.Any
+  object PlacementConstraintType extends js.Object {
+    val distinctInstance = "distinctInstance".asInstanceOf[PlacementConstraintType]
+    val memberOf         = "memberOf".asInstanceOf[PlacementConstraintType]
 
     val values = js.Object.freeze(js.Array(distinctInstance, memberOf))
   }
@@ -3099,11 +3077,12 @@ package ecs {
       __obj.asInstanceOf[PlacementStrategy]
     }
   }
-
-  object PlacementStrategyTypeEnum {
-    val random  = "random"
-    val spread  = "spread"
-    val binpack = "binpack"
+  @js.native
+  sealed trait PlacementStrategyType extends js.Any
+  object PlacementStrategyType extends js.Object {
+    val random  = "random".asInstanceOf[PlacementStrategyType]
+    val spread  = "spread".asInstanceOf[PlacementStrategyType]
+    val binpack = "binpack".asInstanceOf[PlacementStrategyType]
 
     val values = js.Object.freeze(js.Array(random, spread, binpack))
   }
@@ -3131,9 +3110,10 @@ package ecs {
       __obj.asInstanceOf[PlatformDevice]
     }
   }
-
-  object PlatformDeviceTypeEnum {
-    val GPU = "GPU"
+  @js.native
+  sealed trait PlatformDeviceType extends js.Any
+  object PlatformDeviceType extends js.Object {
+    val GPU = "GPU".asInstanceOf[PlatformDeviceType]
 
     val values = js.Object.freeze(js.Array(GPU))
   }
@@ -3164,10 +3144,11 @@ package ecs {
       __obj.asInstanceOf[PortMapping]
     }
   }
-
-  object PropagateTagsEnum {
-    val TASK_DEFINITION = "TASK_DEFINITION"
-    val SERVICE         = "SERVICE"
+  @js.native
+  sealed trait PropagateTags extends js.Any
+  object PropagateTags extends js.Object {
+    val TASK_DEFINITION = "TASK_DEFINITION".asInstanceOf[PropagateTags]
+    val SERVICE         = "SERVICE".asInstanceOf[PropagateTags]
 
     val values = js.Object.freeze(js.Array(TASK_DEFINITION, SERVICE))
   }
@@ -3200,9 +3181,10 @@ package ecs {
       __obj.asInstanceOf[ProxyConfiguration]
     }
   }
-
-  object ProxyConfigurationTypeEnum {
-    val APPMESH = "APPMESH"
+  @js.native
+  sealed trait ProxyConfigurationType extends js.Any
+  object ProxyConfigurationType extends js.Object {
+    val APPMESH = "APPMESH".asInstanceOf[ProxyConfigurationType]
 
     val values = js.Object.freeze(js.Array(APPMESH))
   }
@@ -3576,10 +3558,11 @@ package ecs {
       __obj.asInstanceOf[ResourceRequirement]
     }
   }
-
-  object ResourceTypeEnum {
-    val GPU                  = "GPU"
-    val InferenceAccelerator = "InferenceAccelerator"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val GPU                  = "GPU".asInstanceOf[ResourceType]
+    val InferenceAccelerator = "InferenceAccelerator".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(GPU, InferenceAccelerator))
   }
@@ -3687,23 +3670,26 @@ package ecs {
       __obj.asInstanceOf[Scale]
     }
   }
-
-  object ScaleUnitEnum {
-    val PERCENT = "PERCENT"
+  @js.native
+  sealed trait ScaleUnit extends js.Any
+  object ScaleUnit extends js.Object {
+    val PERCENT = "PERCENT".asInstanceOf[ScaleUnit]
 
     val values = js.Object.freeze(js.Array(PERCENT))
   }
-
-  object SchedulingStrategyEnum {
-    val REPLICA = "REPLICA"
-    val DAEMON  = "DAEMON"
+  @js.native
+  sealed trait SchedulingStrategy extends js.Any
+  object SchedulingStrategy extends js.Object {
+    val REPLICA = "REPLICA".asInstanceOf[SchedulingStrategy]
+    val DAEMON  = "DAEMON".asInstanceOf[SchedulingStrategy]
 
     val values = js.Object.freeze(js.Array(REPLICA, DAEMON))
   }
-
-  object ScopeEnum {
-    val task   = "task"
-    val shared = "shared"
+  @js.native
+  sealed trait Scope extends js.Any
+  object Scope extends js.Object {
+    val task   = "task".asInstanceOf[Scope]
+    val shared = "shared".asInstanceOf[Scope]
 
     val values = js.Object.freeze(js.Array(task, shared))
   }
@@ -3864,9 +3850,10 @@ package ecs {
       __obj.asInstanceOf[ServiceEvent]
     }
   }
-
-  object ServiceFieldEnum {
-    val TAGS = "TAGS"
+  @js.native
+  sealed trait ServiceField extends js.Any
+  object ServiceField extends js.Object {
+    val TAGS = "TAGS".asInstanceOf[ServiceField]
 
     val values = js.Object.freeze(js.Array(TAGS))
   }
@@ -3923,13 +3910,14 @@ package ecs {
       __obj.asInstanceOf[Setting]
     }
   }
-
-  object SettingNameEnum {
-    val serviceLongArnFormat           = "serviceLongArnFormat"
-    val taskLongArnFormat              = "taskLongArnFormat"
-    val containerInstanceLongArnFormat = "containerInstanceLongArnFormat"
-    val awsvpcTrunking                 = "awsvpcTrunking"
-    val containerInsights              = "containerInsights"
+  @js.native
+  sealed trait SettingName extends js.Any
+  object SettingName extends js.Object {
+    val serviceLongArnFormat           = "serviceLongArnFormat".asInstanceOf[SettingName]
+    val taskLongArnFormat              = "taskLongArnFormat".asInstanceOf[SettingName]
+    val containerInstanceLongArnFormat = "containerInstanceLongArnFormat".asInstanceOf[SettingName]
+    val awsvpcTrunking                 = "awsvpcTrunking".asInstanceOf[SettingName]
+    val containerInsights              = "containerInsights".asInstanceOf[SettingName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3941,17 +3929,19 @@ package ecs {
       )
     )
   }
-
-  object SortOrderEnum {
-    val ASC  = "ASC"
-    val DESC = "DESC"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val ASC  = "ASC".asInstanceOf[SortOrder]
+    val DESC = "DESC".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(ASC, DESC))
   }
-
-  object StabilityStatusEnum {
-    val STEADY_STATE = "STEADY_STATE"
-    val STABILIZING  = "STABILIZING"
+  @js.native
+  sealed trait StabilityStatus extends js.Any
+  object StabilityStatus extends js.Object {
+    val STEADY_STATE = "STEADY_STATE".asInstanceOf[StabilityStatus]
+    val STABILIZING  = "STABILIZING".asInstanceOf[StabilityStatus]
 
     val values = js.Object.freeze(js.Array(STEADY_STATE, STABILIZING))
   }
@@ -4297,9 +4287,10 @@ package ecs {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TargetTypeEnum {
-    val `container-instance` = "container-instance"
+  @js.native
+  sealed trait TargetType extends js.Any
+  object TargetType extends js.Object {
+    val `container-instance` = "container-instance".asInstanceOf[TargetType]
 
     val values = js.Object.freeze(js.Array(`container-instance`))
   }
@@ -4491,17 +4482,19 @@ package ecs {
       __obj.asInstanceOf[TaskDefinition]
     }
   }
-
-  object TaskDefinitionFamilyStatusEnum {
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
-    val ALL      = "ALL"
+  @js.native
+  sealed trait TaskDefinitionFamilyStatus extends js.Any
+  object TaskDefinitionFamilyStatus extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[TaskDefinitionFamilyStatus]
+    val INACTIVE = "INACTIVE".asInstanceOf[TaskDefinitionFamilyStatus]
+    val ALL      = "ALL".asInstanceOf[TaskDefinitionFamilyStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, INACTIVE, ALL))
   }
-
-  object TaskDefinitionFieldEnum {
-    val TAGS = "TAGS"
+  @js.native
+  sealed trait TaskDefinitionField extends js.Any
+  object TaskDefinitionField extends js.Object {
+    val TAGS = "TAGS".asInstanceOf[TaskDefinitionField]
 
     val values = js.Object.freeze(js.Array(TAGS))
   }
@@ -4529,22 +4522,25 @@ package ecs {
       __obj.asInstanceOf[TaskDefinitionPlacementConstraint]
     }
   }
-
-  object TaskDefinitionPlacementConstraintTypeEnum {
-    val memberOf = "memberOf"
+  @js.native
+  sealed trait TaskDefinitionPlacementConstraintType extends js.Any
+  object TaskDefinitionPlacementConstraintType extends js.Object {
+    val memberOf = "memberOf".asInstanceOf[TaskDefinitionPlacementConstraintType]
 
     val values = js.Object.freeze(js.Array(memberOf))
   }
-
-  object TaskDefinitionStatusEnum {
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait TaskDefinitionStatus extends js.Any
+  object TaskDefinitionStatus extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[TaskDefinitionStatus]
+    val INACTIVE = "INACTIVE".asInstanceOf[TaskDefinitionStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, INACTIVE))
   }
-
-  object TaskFieldEnum {
-    val TAGS = "TAGS"
+  @js.native
+  sealed trait TaskField extends js.Any
+  object TaskField extends js.Object {
+    val TAGS = "TAGS".asInstanceOf[TaskField]
 
     val values = js.Object.freeze(js.Array(TAGS))
   }
@@ -4669,17 +4665,19 @@ package ecs {
       __obj.asInstanceOf[TaskSet]
     }
   }
-
-  object TaskSetFieldEnum {
-    val TAGS = "TAGS"
+  @js.native
+  sealed trait TaskSetField extends js.Any
+  object TaskSetField extends js.Object {
+    val TAGS = "TAGS".asInstanceOf[TaskSetField]
 
     val values = js.Object.freeze(js.Array(TAGS))
   }
-
-  object TaskStopCodeEnum {
-    val TaskFailedToStart        = "TaskFailedToStart"
-    val EssentialContainerExited = "EssentialContainerExited"
-    val UserInitiated            = "UserInitiated"
+  @js.native
+  sealed trait TaskStopCode extends js.Any
+  object TaskStopCode extends js.Object {
+    val TaskFailedToStart        = "TaskFailedToStart".asInstanceOf[TaskStopCode]
+    val EssentialContainerExited = "EssentialContainerExited".asInstanceOf[TaskStopCode]
+    val UserInitiated            = "UserInitiated".asInstanceOf[TaskStopCode]
 
     val values = js.Object.freeze(js.Array(TaskFailedToStart, EssentialContainerExited, UserInitiated))
   }
@@ -4710,10 +4708,11 @@ package ecs {
       __obj.asInstanceOf[Tmpfs]
     }
   }
-
-  object TransportProtocolEnum {
-    val tcp = "tcp"
-    val udp = "udp"
+  @js.native
+  sealed trait TransportProtocol extends js.Any
+  object TransportProtocol extends js.Object {
+    val tcp = "tcp".asInstanceOf[TransportProtocol]
+    val udp = "udp".asInstanceOf[TransportProtocol]
 
     val values = js.Object.freeze(js.Array(tcp, udp))
   }
@@ -4744,23 +4743,24 @@ package ecs {
       __obj.asInstanceOf[Ulimit]
     }
   }
-
-  object UlimitNameEnum {
-    val core       = "core"
-    val cpu        = "cpu"
-    val data       = "data"
-    val fsize      = "fsize"
-    val locks      = "locks"
-    val memlock    = "memlock"
-    val msgqueue   = "msgqueue"
-    val nice       = "nice"
-    val nofile     = "nofile"
-    val nproc      = "nproc"
-    val rss        = "rss"
-    val rtprio     = "rtprio"
-    val rttime     = "rttime"
-    val sigpending = "sigpending"
-    val stack      = "stack"
+  @js.native
+  sealed trait UlimitName extends js.Any
+  object UlimitName extends js.Object {
+    val core       = "core".asInstanceOf[UlimitName]
+    val cpu        = "cpu".asInstanceOf[UlimitName]
+    val data       = "data".asInstanceOf[UlimitName]
+    val fsize      = "fsize".asInstanceOf[UlimitName]
+    val locks      = "locks".asInstanceOf[UlimitName]
+    val memlock    = "memlock".asInstanceOf[UlimitName]
+    val msgqueue   = "msgqueue".asInstanceOf[UlimitName]
+    val nice       = "nice".asInstanceOf[UlimitName]
+    val nofile     = "nofile".asInstanceOf[UlimitName]
+    val nproc      = "nproc".asInstanceOf[UlimitName]
+    val rss        = "rss".asInstanceOf[UlimitName]
+    val rtprio     = "rtprio".asInstanceOf[UlimitName]
+    val rttime     = "rttime".asInstanceOf[UlimitName]
+    val sigpending = "sigpending".asInstanceOf[UlimitName]
+    val stack      = "stack".asInstanceOf[UlimitName]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/efs/src/main/scala/facade/amazonaws/services/EFS.scala
+++ b/services/efs/src/main/scala/facade/amazonaws/services/EFS.scala
@@ -24,7 +24,6 @@ package object efs {
   type Gid                            = Double
   type IpAddress                      = String
   type KmsKeyId                       = String
-  type LifeCycleState                 = String
   type LifecyclePolicies              = js.Array[LifecyclePolicy]
   type Marker                         = String
   type MaxItems                       = Int
@@ -37,7 +36,6 @@ package object efs {
   type OwnerGid                       = Double
   type OwnerUid                       = Double
   type Path                           = String
-  type PerformanceMode                = String
   type Permissions                    = String
   type Policy                         = String
   type ProvisionedThroughputInMibps   = Double
@@ -50,10 +48,8 @@ package object efs {
   type TagKeys                        = js.Array[TagKey]
   type TagValue                       = String
   type Tags                           = js.Array[Tag]
-  type ThroughputMode                 = String
   type Timestamp                      = js.Date
   type Token                          = String
-  type TransitionToIARules            = String
   type Uid                            = Double
 
   implicit final class EFSOps(private val service: EFS) extends AnyVal {
@@ -836,13 +832,14 @@ package efs {
       __obj.asInstanceOf[FileSystemSize]
     }
   }
-
-  object LifeCycleStateEnum {
-    val creating  = "creating"
-    val available = "available"
-    val updating  = "updating"
-    val deleting  = "deleting"
-    val deleted   = "deleted"
+  @js.native
+  sealed trait LifeCycleState extends js.Any
+  object LifeCycleState extends js.Object {
+    val creating  = "creating".asInstanceOf[LifeCycleState]
+    val available = "available".asInstanceOf[LifeCycleState]
+    val updating  = "updating".asInstanceOf[LifeCycleState]
+    val deleting  = "deleting".asInstanceOf[LifeCycleState]
+    val deleted   = "deleted".asInstanceOf[LifeCycleState]
 
     val values = js.Object.freeze(js.Array(creating, available, updating, deleting, deleted))
   }
@@ -993,10 +990,11 @@ package efs {
       __obj.asInstanceOf[MountTargetDescription]
     }
   }
-
-  object PerformanceModeEnum {
-    val generalPurpose = "generalPurpose"
-    val maxIO          = "maxIO"
+  @js.native
+  sealed trait PerformanceMode extends js.Any
+  object PerformanceMode extends js.Object {
+    val generalPurpose = "generalPurpose".asInstanceOf[PerformanceMode]
+    val maxIO          = "maxIO".asInstanceOf[PerformanceMode]
 
     val values = js.Object.freeze(js.Array(generalPurpose, maxIO))
   }
@@ -1141,20 +1139,22 @@ package efs {
       __obj.asInstanceOf[TagResourceRequest]
     }
   }
-
-  object ThroughputModeEnum {
-    val bursting    = "bursting"
-    val provisioned = "provisioned"
+  @js.native
+  sealed trait ThroughputMode extends js.Any
+  object ThroughputMode extends js.Object {
+    val bursting    = "bursting".asInstanceOf[ThroughputMode]
+    val provisioned = "provisioned".asInstanceOf[ThroughputMode]
 
     val values = js.Object.freeze(js.Array(bursting, provisioned))
   }
-
-  object TransitionToIARulesEnum {
-    val AFTER_7_DAYS  = "AFTER_7_DAYS"
-    val AFTER_14_DAYS = "AFTER_14_DAYS"
-    val AFTER_30_DAYS = "AFTER_30_DAYS"
-    val AFTER_60_DAYS = "AFTER_60_DAYS"
-    val AFTER_90_DAYS = "AFTER_90_DAYS"
+  @js.native
+  sealed trait TransitionToIARules extends js.Any
+  object TransitionToIARules extends js.Object {
+    val AFTER_7_DAYS  = "AFTER_7_DAYS".asInstanceOf[TransitionToIARules]
+    val AFTER_14_DAYS = "AFTER_14_DAYS".asInstanceOf[TransitionToIARules]
+    val AFTER_30_DAYS = "AFTER_30_DAYS".asInstanceOf[TransitionToIARules]
+    val AFTER_60_DAYS = "AFTER_60_DAYS".asInstanceOf[TransitionToIARules]
+    val AFTER_90_DAYS = "AFTER_90_DAYS".asInstanceOf[TransitionToIARules]
 
     val values = js.Object.freeze(js.Array(AFTER_7_DAYS, AFTER_14_DAYS, AFTER_30_DAYS, AFTER_60_DAYS, AFTER_90_DAYS))
   }

--- a/services/eks/src/main/scala/facade/amazonaws/services/EKS.scala
+++ b/services/eks/src/main/scala/facade/amazonaws/services/EKS.scala
@@ -7,38 +7,28 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object eks {
-  type AMITypes                         = String
   type AutoScalingGroupList             = js.Array[AutoScalingGroup]
   type BoxedBoolean                     = Boolean
   type BoxedInteger                     = Int
   type Capacity                         = Int
   type ClusterName                      = String
-  type ClusterStatus                    = String
-  type ErrorCode                        = String
   type ErrorDetails                     = js.Array[ErrorDetail]
   type FargateProfileLabel              = js.Dictionary[String]
   type FargateProfileSelectors          = js.Array[FargateProfileSelector]
-  type FargateProfileStatus             = String
   type FargateProfilesRequestMaxResults = Int
   type IssueList                        = js.Array[Issue]
   type ListClustersRequestMaxResults    = Int
   type ListNodegroupsRequestMaxResults  = Int
   type ListUpdatesRequestMaxResults     = Int
   type LogSetups                        = js.Array[LogSetup]
-  type LogType                          = String
   type LogTypes                         = js.Array[LogType]
-  type NodegroupIssueCode               = String
-  type NodegroupStatus                  = String
   type StringList                       = js.Array[String]
   type TagKey                           = String
   type TagKeyList                       = js.Array[TagKey]
   type TagMap                           = js.Dictionary[TagValue]
   type TagValue                         = String
   type Timestamp                        = js.Date
-  type UpdateParamType                  = String
   type UpdateParams                     = js.Array[UpdateParam]
-  type UpdateStatus                     = String
-  type UpdateType                       = String
   type labelKey                         = String
   type labelValue                       = String
   type labelsKeyList                    = js.Array[String]
@@ -124,10 +114,11 @@ package eks {
     def updateNodegroupVersion(params: UpdateNodegroupVersionRequest): Request[UpdateNodegroupVersionResponse] =
       js.native
   }
-
-  object AMITypesEnum {
-    val AL2_x86_64     = "AL2_x86_64"
-    val AL2_x86_64_GPU = "AL2_x86_64_GPU"
+  @js.native
+  sealed trait AMITypes extends js.Any
+  object AMITypes extends js.Object {
+    val AL2_x86_64     = "AL2_x86_64".asInstanceOf[AMITypes]
+    val AL2_x86_64_GPU = "AL2_x86_64_GPU".asInstanceOf[AMITypes]
 
     val values = js.Object.freeze(js.Array(AL2_x86_64, AL2_x86_64_GPU))
   }
@@ -227,13 +218,14 @@ package eks {
       __obj.asInstanceOf[Cluster]
     }
   }
-
-  object ClusterStatusEnum {
-    val CREATING = "CREATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
-    val FAILED   = "FAILED"
-    val UPDATING = "UPDATING"
+  @js.native
+  sealed trait ClusterStatus extends js.Any
+  object ClusterStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[ClusterStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[ClusterStatus]
+    val DELETING = "DELETING".asInstanceOf[ClusterStatus]
+    val FAILED   = "FAILED".asInstanceOf[ClusterStatus]
+    val UPDATING = "UPDATING".asInstanceOf[ClusterStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING, FAILED, UPDATING))
   }
@@ -670,19 +662,20 @@ package eks {
       __obj.asInstanceOf[DescribeUpdateResponse]
     }
   }
-
-  object ErrorCodeEnum {
-    val SubnetNotFound            = "SubnetNotFound"
-    val SecurityGroupNotFound     = "SecurityGroupNotFound"
-    val EniLimitReached           = "EniLimitReached"
-    val IpNotAvailable            = "IpNotAvailable"
-    val AccessDenied              = "AccessDenied"
-    val OperationNotPermitted     = "OperationNotPermitted"
-    val VpcIdNotFound             = "VpcIdNotFound"
-    val Unknown                   = "Unknown"
-    val NodeCreationFailure       = "NodeCreationFailure"
-    val PodEvictionFailure        = "PodEvictionFailure"
-    val InsufficientFreeAddresses = "InsufficientFreeAddresses"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val SubnetNotFound            = "SubnetNotFound".asInstanceOf[ErrorCode]
+    val SecurityGroupNotFound     = "SecurityGroupNotFound".asInstanceOf[ErrorCode]
+    val EniLimitReached           = "EniLimitReached".asInstanceOf[ErrorCode]
+    val IpNotAvailable            = "IpNotAvailable".asInstanceOf[ErrorCode]
+    val AccessDenied              = "AccessDenied".asInstanceOf[ErrorCode]
+    val OperationNotPermitted     = "OperationNotPermitted".asInstanceOf[ErrorCode]
+    val VpcIdNotFound             = "VpcIdNotFound".asInstanceOf[ErrorCode]
+    val Unknown                   = "Unknown".asInstanceOf[ErrorCode]
+    val NodeCreationFailure       = "NodeCreationFailure".asInstanceOf[ErrorCode]
+    val PodEvictionFailure        = "PodEvictionFailure".asInstanceOf[ErrorCode]
+    val InsufficientFreeAddresses = "InsufficientFreeAddresses".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -790,13 +783,14 @@ package eks {
       __obj.asInstanceOf[FargateProfileSelector]
     }
   }
-
-  object FargateProfileStatusEnum {
-    val CREATING      = "CREATING"
-    val ACTIVE        = "ACTIVE"
-    val DELETING      = "DELETING"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val DELETE_FAILED = "DELETE_FAILED"
+  @js.native
+  sealed trait FargateProfileStatus extends js.Any
+  object FargateProfileStatus extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[FargateProfileStatus]
+    val ACTIVE        = "ACTIVE".asInstanceOf[FargateProfileStatus]
+    val DELETING      = "DELETING".asInstanceOf[FargateProfileStatus]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[FargateProfileStatus]
+    val DELETE_FAILED = "DELETE_FAILED".asInstanceOf[FargateProfileStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING, CREATE_FAILED, DELETE_FAILED))
   }
@@ -1070,13 +1064,14 @@ package eks {
       __obj.asInstanceOf[LogSetup]
     }
   }
-
-  object LogTypeEnum {
-    val api               = "api"
-    val audit             = "audit"
-    val authenticator     = "authenticator"
-    val controllerManager = "controllerManager"
-    val scheduler         = "scheduler"
+  @js.native
+  sealed trait LogType extends js.Any
+  object LogType extends js.Object {
+    val api               = "api".asInstanceOf[LogType]
+    val audit             = "audit".asInstanceOf[LogType]
+    val authenticator     = "authenticator".asInstanceOf[LogType]
+    val controllerManager = "controllerManager".asInstanceOf[LogType]
+    val scheduler         = "scheduler".asInstanceOf[LogType]
 
     val values = js.Object.freeze(js.Array(api, audit, authenticator, controllerManager, scheduler))
   }
@@ -1191,22 +1186,23 @@ package eks {
       __obj.asInstanceOf[NodegroupHealth]
     }
   }
-
-  object NodegroupIssueCodeEnum {
-    val AutoScalingGroupNotFound             = "AutoScalingGroupNotFound"
-    val AutoScalingGroupInvalidConfiguration = "AutoScalingGroupInvalidConfiguration"
-    val Ec2SecurityGroupNotFound             = "Ec2SecurityGroupNotFound"
-    val Ec2SecurityGroupDeletionFailure      = "Ec2SecurityGroupDeletionFailure"
-    val Ec2LaunchTemplateNotFound            = "Ec2LaunchTemplateNotFound"
-    val Ec2LaunchTemplateVersionMismatch     = "Ec2LaunchTemplateVersionMismatch"
-    val Ec2SubnetNotFound                    = "Ec2SubnetNotFound"
-    val IamInstanceProfileNotFound           = "IamInstanceProfileNotFound"
-    val IamNodeRoleNotFound                  = "IamNodeRoleNotFound"
-    val AsgInstanceLaunchFailures            = "AsgInstanceLaunchFailures"
-    val InstanceLimitExceeded                = "InstanceLimitExceeded"
-    val InsufficientFreeAddresses            = "InsufficientFreeAddresses"
-    val AccessDenied                         = "AccessDenied"
-    val InternalFailure                      = "InternalFailure"
+  @js.native
+  sealed trait NodegroupIssueCode extends js.Any
+  object NodegroupIssueCode extends js.Object {
+    val AutoScalingGroupNotFound             = "AutoScalingGroupNotFound".asInstanceOf[NodegroupIssueCode]
+    val AutoScalingGroupInvalidConfiguration = "AutoScalingGroupInvalidConfiguration".asInstanceOf[NodegroupIssueCode]
+    val Ec2SecurityGroupNotFound             = "Ec2SecurityGroupNotFound".asInstanceOf[NodegroupIssueCode]
+    val Ec2SecurityGroupDeletionFailure      = "Ec2SecurityGroupDeletionFailure".asInstanceOf[NodegroupIssueCode]
+    val Ec2LaunchTemplateNotFound            = "Ec2LaunchTemplateNotFound".asInstanceOf[NodegroupIssueCode]
+    val Ec2LaunchTemplateVersionMismatch     = "Ec2LaunchTemplateVersionMismatch".asInstanceOf[NodegroupIssueCode]
+    val Ec2SubnetNotFound                    = "Ec2SubnetNotFound".asInstanceOf[NodegroupIssueCode]
+    val IamInstanceProfileNotFound           = "IamInstanceProfileNotFound".asInstanceOf[NodegroupIssueCode]
+    val IamNodeRoleNotFound                  = "IamNodeRoleNotFound".asInstanceOf[NodegroupIssueCode]
+    val AsgInstanceLaunchFailures            = "AsgInstanceLaunchFailures".asInstanceOf[NodegroupIssueCode]
+    val InstanceLimitExceeded                = "InstanceLimitExceeded".asInstanceOf[NodegroupIssueCode]
+    val InsufficientFreeAddresses            = "InsufficientFreeAddresses".asInstanceOf[NodegroupIssueCode]
+    val AccessDenied                         = "AccessDenied".asInstanceOf[NodegroupIssueCode]
+    val InternalFailure                      = "InternalFailure".asInstanceOf[NodegroupIssueCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1276,15 +1272,16 @@ package eks {
       __obj.asInstanceOf[NodegroupScalingConfig]
     }
   }
-
-  object NodegroupStatusEnum {
-    val CREATING      = "CREATING"
-    val ACTIVE        = "ACTIVE"
-    val UPDATING      = "UPDATING"
-    val DELETING      = "DELETING"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val DELETE_FAILED = "DELETE_FAILED"
-    val DEGRADED      = "DEGRADED"
+  @js.native
+  sealed trait NodegroupStatus extends js.Any
+  object NodegroupStatus extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[NodegroupStatus]
+    val ACTIVE        = "ACTIVE".asInstanceOf[NodegroupStatus]
+    val UPDATING      = "UPDATING".asInstanceOf[NodegroupStatus]
+    val DELETING      = "DELETING".asInstanceOf[NodegroupStatus]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[NodegroupStatus]
+    val DELETE_FAILED = "DELETE_FAILED".asInstanceOf[NodegroupStatus]
+    val DEGRADED      = "DEGRADED".asInstanceOf[NodegroupStatus]
 
     val values =
       js.Object.freeze(js.Array(CREATING, ACTIVE, UPDATING, DELETING, CREATE_FAILED, DELETE_FAILED, DEGRADED))
@@ -1654,20 +1651,21 @@ package eks {
       __obj.asInstanceOf[UpdateParam]
     }
   }
-
-  object UpdateParamTypeEnum {
-    val Version               = "Version"
-    val PlatformVersion       = "PlatformVersion"
-    val EndpointPrivateAccess = "EndpointPrivateAccess"
-    val EndpointPublicAccess  = "EndpointPublicAccess"
-    val ClusterLogging        = "ClusterLogging"
-    val DesiredSize           = "DesiredSize"
-    val LabelsToAdd           = "LabelsToAdd"
-    val LabelsToRemove        = "LabelsToRemove"
-    val MaxSize               = "MaxSize"
-    val MinSize               = "MinSize"
-    val ReleaseVersion        = "ReleaseVersion"
-    val PublicAccessCidrs     = "PublicAccessCidrs"
+  @js.native
+  sealed trait UpdateParamType extends js.Any
+  object UpdateParamType extends js.Object {
+    val Version               = "Version".asInstanceOf[UpdateParamType]
+    val PlatformVersion       = "PlatformVersion".asInstanceOf[UpdateParamType]
+    val EndpointPrivateAccess = "EndpointPrivateAccess".asInstanceOf[UpdateParamType]
+    val EndpointPublicAccess  = "EndpointPublicAccess".asInstanceOf[UpdateParamType]
+    val ClusterLogging        = "ClusterLogging".asInstanceOf[UpdateParamType]
+    val DesiredSize           = "DesiredSize".asInstanceOf[UpdateParamType]
+    val LabelsToAdd           = "LabelsToAdd".asInstanceOf[UpdateParamType]
+    val LabelsToRemove        = "LabelsToRemove".asInstanceOf[UpdateParamType]
+    val MaxSize               = "MaxSize".asInstanceOf[UpdateParamType]
+    val MinSize               = "MinSize".asInstanceOf[UpdateParamType]
+    val ReleaseVersion        = "ReleaseVersion".asInstanceOf[UpdateParamType]
+    val PublicAccessCidrs     = "PublicAccessCidrs".asInstanceOf[UpdateParamType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1686,21 +1684,23 @@ package eks {
       )
     )
   }
-
-  object UpdateStatusEnum {
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Cancelled  = "Cancelled"
-    val Successful = "Successful"
+  @js.native
+  sealed trait UpdateStatus extends js.Any
+  object UpdateStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[UpdateStatus]
+    val Failed     = "Failed".asInstanceOf[UpdateStatus]
+    val Cancelled  = "Cancelled".asInstanceOf[UpdateStatus]
+    val Successful = "Successful".asInstanceOf[UpdateStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Failed, Cancelled, Successful))
   }
-
-  object UpdateTypeEnum {
-    val VersionUpdate        = "VersionUpdate"
-    val EndpointAccessUpdate = "EndpointAccessUpdate"
-    val LoggingUpdate        = "LoggingUpdate"
-    val ConfigUpdate         = "ConfigUpdate"
+  @js.native
+  sealed trait UpdateType extends js.Any
+  object UpdateType extends js.Object {
+    val VersionUpdate        = "VersionUpdate".asInstanceOf[UpdateType]
+    val EndpointAccessUpdate = "EndpointAccessUpdate".asInstanceOf[UpdateType]
+    val LoggingUpdate        = "LoggingUpdate".asInstanceOf[UpdateType]
+    val ConfigUpdate         = "ConfigUpdate".asInstanceOf[UpdateType]
 
     val values = js.Object.freeze(js.Array(VersionUpdate, EndpointAccessUpdate, LoggingUpdate, ConfigUpdate))
   }

--- a/services/elasticache/src/main/scala/facade/amazonaws/services/ElastiCache.scala
+++ b/services/elasticache/src/main/scala/facade/amazonaws/services/ElastiCache.scala
@@ -7,11 +7,7 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object elasticache {
-  type AZMode                              = String
   type AllowedNodeGroupId                  = String
-  type AuthTokenUpdateStatus               = String
-  type AuthTokenUpdateStrategyType         = String
-  type AutomaticFailoverStatus             = String
   type AvailabilityZonesList               = js.Array[String]
   type BooleanOptional                     = Boolean
   type CacheClusterIdList                  = js.Array[String]
@@ -27,7 +23,6 @@ package object elasticache {
   type CacheSecurityGroupNameList          = js.Array[String]
   type CacheSecurityGroups                 = js.Array[CacheSecurityGroup]
   type CacheSubnetGroups                   = js.Array[CacheSubnetGroup]
-  type ChangeType                          = String
   type ClusterIdList                       = js.Array[String]
   type CustomerNodeEndpointList            = js.Array[CustomerNodeEndpoint]
   type EC2SecurityGroupList                = js.Array[EC2SecurityGroup]
@@ -43,11 +38,8 @@ package object elasticache {
   type NodeGroupsToRetainList              = js.Array[AllowedNodeGroupId]
   type NodeSnapshotList                    = js.Array[NodeSnapshot]
   type NodeTypeList                        = js.Array[String]
-  type NodeUpdateInitiatedBy               = String
-  type NodeUpdateStatus                    = String
   type ParameterNameValueList              = js.Array[ParameterNameValue]
   type ParametersList                      = js.Array[Parameter]
-  type PendingAutomaticFailoverStatus      = String
   type PreferredAvailabilityZoneList       = js.Array[String]
   type ProcessedUpdateActionList           = js.Array[ProcessedUpdateAction]
   type RecurringChargeList                 = js.Array[RecurringCharge]
@@ -61,21 +53,15 @@ package object elasticache {
   type SecurityGroupIdsList                = js.Array[String]
   type SecurityGroupMembershipList         = js.Array[SecurityGroupMembership]
   type ServiceUpdateList                   = js.Array[ServiceUpdate]
-  type ServiceUpdateSeverity               = String
-  type ServiceUpdateStatus                 = String
   type ServiceUpdateStatusList             = js.Array[ServiceUpdateStatus]
-  type ServiceUpdateType                   = String
-  type SlaMet                              = String
   type SnapshotArnsList                    = js.Array[String]
   type SnapshotList                        = js.Array[Snapshot]
-  type SourceType                          = String
   type SubnetIdentifierList                = js.Array[String]
   type SubnetList                          = js.Array[Subnet]
   type TStamp                              = js.Date
   type TagList                             = js.Array[Tag]
   type UnprocessedUpdateActionList         = js.Array[UnprocessedUpdateAction]
   type UpdateActionList                    = js.Array[UpdateAction]
-  type UpdateActionStatus                  = String
   type UpdateActionStatusList              = js.Array[UpdateActionStatus]
 
   implicit final class ElastiCacheOps(private val service: ElastiCache) extends AnyVal {
@@ -286,10 +272,11 @@ package elasticache {
     def startMigration(params: StartMigrationMessage): Request[StartMigrationResponse] = js.native
     def testFailover(params: TestFailoverMessage): Request[TestFailoverResult]         = js.native
   }
-
-  object AZModeEnum {
-    val `single-az` = "single-az"
-    val `cross-az`  = "cross-az"
+  @js.native
+  sealed trait AZMode extends js.Any
+  object AZMode extends js.Object {
+    val `single-az` = "single-az".asInstanceOf[AZMode]
+    val `cross-az`  = "cross-az".asInstanceOf[AZMode]
 
     val values = js.Object.freeze(js.Array(`single-az`, `cross-az`))
   }
@@ -339,17 +326,19 @@ package elasticache {
       __obj.asInstanceOf[AllowedNodeTypeModificationsMessage]
     }
   }
-
-  object AuthTokenUpdateStatusEnum {
-    val SETTING  = "SETTING"
-    val ROTATING = "ROTATING"
+  @js.native
+  sealed trait AuthTokenUpdateStatus extends js.Any
+  object AuthTokenUpdateStatus extends js.Object {
+    val SETTING  = "SETTING".asInstanceOf[AuthTokenUpdateStatus]
+    val ROTATING = "ROTATING".asInstanceOf[AuthTokenUpdateStatus]
 
     val values = js.Object.freeze(js.Array(SETTING, ROTATING))
   }
-
-  object AuthTokenUpdateStrategyTypeEnum {
-    val SET    = "SET"
-    val ROTATE = "ROTATE"
+  @js.native
+  sealed trait AuthTokenUpdateStrategyType extends js.Any
+  object AuthTokenUpdateStrategyType extends js.Object {
+    val SET    = "SET".asInstanceOf[AuthTokenUpdateStrategyType]
+    val ROTATE = "ROTATE".asInstanceOf[AuthTokenUpdateStrategyType]
 
     val values = js.Object.freeze(js.Array(SET, ROTATE))
   }
@@ -396,12 +385,13 @@ package elasticache {
       __obj.asInstanceOf[AuthorizeCacheSecurityGroupIngressResult]
     }
   }
-
-  object AutomaticFailoverStatusEnum {
-    val enabled   = "enabled"
-    val disabled  = "disabled"
-    val enabling  = "enabling"
-    val disabling = "disabling"
+  @js.native
+  sealed trait AutomaticFailoverStatus extends js.Any
+  object AutomaticFailoverStatus extends js.Object {
+    val enabled   = "enabled".asInstanceOf[AutomaticFailoverStatus]
+    val disabled  = "disabled".asInstanceOf[AutomaticFailoverStatus]
+    val enabling  = "enabling".asInstanceOf[AutomaticFailoverStatus]
+    val disabling = "disabling".asInstanceOf[AutomaticFailoverStatus]
 
     val values = js.Object.freeze(js.Array(enabled, disabled, enabling, disabling))
   }
@@ -1077,10 +1067,11 @@ package elasticache {
       __obj.asInstanceOf[CacheSubnetGroupMessage]
     }
   }
-
-  object ChangeTypeEnum {
-    val immediate         = "immediate"
-    val `requires-reboot` = "requires-reboot"
+  @js.native
+  sealed trait ChangeType extends js.Any
+  object ChangeType extends js.Object {
+    val immediate         = "immediate".asInstanceOf[ChangeType]
+    val `requires-reboot` = "requires-reboot".asInstanceOf[ChangeType]
 
     val values = js.Object.freeze(js.Array(immediate, `requires-reboot`))
   }
@@ -3071,21 +3062,23 @@ package elasticache {
       __obj.asInstanceOf[NodeSnapshot]
     }
   }
-
-  object NodeUpdateInitiatedByEnum {
-    val system   = "system"
-    val customer = "customer"
+  @js.native
+  sealed trait NodeUpdateInitiatedBy extends js.Any
+  object NodeUpdateInitiatedBy extends js.Object {
+    val system   = "system".asInstanceOf[NodeUpdateInitiatedBy]
+    val customer = "customer".asInstanceOf[NodeUpdateInitiatedBy]
 
     val values = js.Object.freeze(js.Array(system, customer))
   }
-
-  object NodeUpdateStatusEnum {
-    val `not-applied`      = "not-applied"
-    val `waiting-to-start` = "waiting-to-start"
-    val `in-progress`      = "in-progress"
-    val stopping           = "stopping"
-    val stopped            = "stopped"
-    val complete           = "complete"
+  @js.native
+  sealed trait NodeUpdateStatus extends js.Any
+  object NodeUpdateStatus extends js.Object {
+    val `not-applied`      = "not-applied".asInstanceOf[NodeUpdateStatus]
+    val `waiting-to-start` = "waiting-to-start".asInstanceOf[NodeUpdateStatus]
+    val `in-progress`      = "in-progress".asInstanceOf[NodeUpdateStatus]
+    val stopping           = "stopping".asInstanceOf[NodeUpdateStatus]
+    val stopped            = "stopped".asInstanceOf[NodeUpdateStatus]
+    val complete           = "complete".asInstanceOf[NodeUpdateStatus]
 
     val values =
       js.Object.freeze(js.Array(`not-applied`, `waiting-to-start`, `in-progress`, stopping, stopped, complete))
@@ -3177,10 +3170,11 @@ package elasticache {
       __obj.asInstanceOf[ParameterNameValue]
     }
   }
-
-  object PendingAutomaticFailoverStatusEnum {
-    val enabled  = "enabled"
-    val disabled = "disabled"
+  @js.native
+  sealed trait PendingAutomaticFailoverStatus extends js.Any
+  object PendingAutomaticFailoverStatus extends js.Object {
+    val enabled  = "enabled".asInstanceOf[PendingAutomaticFailoverStatus]
+    val disabled = "disabled".asInstanceOf[PendingAutomaticFailoverStatus]
 
     val values = js.Object.freeze(js.Array(enabled, disabled))
   }
@@ -3830,26 +3824,29 @@ package elasticache {
       __obj.asInstanceOf[ServiceUpdate]
     }
   }
-
-  object ServiceUpdateSeverityEnum {
-    val critical  = "critical"
-    val important = "important"
-    val medium    = "medium"
-    val low       = "low"
+  @js.native
+  sealed trait ServiceUpdateSeverity extends js.Any
+  object ServiceUpdateSeverity extends js.Object {
+    val critical  = "critical".asInstanceOf[ServiceUpdateSeverity]
+    val important = "important".asInstanceOf[ServiceUpdateSeverity]
+    val medium    = "medium".asInstanceOf[ServiceUpdateSeverity]
+    val low       = "low".asInstanceOf[ServiceUpdateSeverity]
 
     val values = js.Object.freeze(js.Array(critical, important, medium, low))
   }
-
-  object ServiceUpdateStatusEnum {
-    val available = "available"
-    val cancelled = "cancelled"
-    val expired   = "expired"
+  @js.native
+  sealed trait ServiceUpdateStatus extends js.Any
+  object ServiceUpdateStatus extends js.Object {
+    val available = "available".asInstanceOf[ServiceUpdateStatus]
+    val cancelled = "cancelled".asInstanceOf[ServiceUpdateStatus]
+    val expired   = "expired".asInstanceOf[ServiceUpdateStatus]
 
     val values = js.Object.freeze(js.Array(available, cancelled, expired))
   }
-
-  object ServiceUpdateTypeEnum {
-    val `security-update` = "security-update"
+  @js.native
+  sealed trait ServiceUpdateType extends js.Any
+  object ServiceUpdateType extends js.Object {
+    val `security-update` = "security-update".asInstanceOf[ServiceUpdateType]
 
     val values = js.Object.freeze(js.Array(`security-update`))
   }
@@ -3872,11 +3869,12 @@ package elasticache {
       __obj.asInstanceOf[ServiceUpdatesMessage]
     }
   }
-
-  object SlaMetEnum {
-    val yes   = "yes"
-    val no    = "no"
-    val `n/a` = "n/a"
+  @js.native
+  sealed trait SlaMet extends js.Any
+  object SlaMet extends js.Object {
+    val yes   = "yes".asInstanceOf[SlaMet]
+    val no    = "no".asInstanceOf[SlaMet]
+    val `n/a` = "n/a".asInstanceOf[SlaMet]
 
     val values = js.Object.freeze(js.Array(yes, no, `n/a`))
   }
@@ -3996,13 +3994,14 @@ package elasticache {
       __obj.asInstanceOf[Snapshot]
     }
   }
-
-  object SourceTypeEnum {
-    val `cache-cluster`         = "cache-cluster"
-    val `cache-parameter-group` = "cache-parameter-group"
-    val `cache-security-group`  = "cache-security-group"
-    val `cache-subnet-group`    = "cache-subnet-group"
-    val `replication-group`     = "replication-group"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val `cache-cluster`         = "cache-cluster".asInstanceOf[SourceType]
+    val `cache-parameter-group` = "cache-parameter-group".asInstanceOf[SourceType]
+    val `cache-security-group`  = "cache-security-group".asInstanceOf[SourceType]
+    val `cache-subnet-group`    = "cache-subnet-group".asInstanceOf[SourceType]
+    val `replication-group`     = "replication-group".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4296,14 +4295,15 @@ package elasticache {
       __obj.asInstanceOf[UpdateActionResultsMessage]
     }
   }
-
-  object UpdateActionStatusEnum {
-    val `not-applied`      = "not-applied"
-    val `waiting-to-start` = "waiting-to-start"
-    val `in-progress`      = "in-progress"
-    val stopping           = "stopping"
-    val stopped            = "stopped"
-    val complete           = "complete"
+  @js.native
+  sealed trait UpdateActionStatus extends js.Any
+  object UpdateActionStatus extends js.Object {
+    val `not-applied`      = "not-applied".asInstanceOf[UpdateActionStatus]
+    val `waiting-to-start` = "waiting-to-start".asInstanceOf[UpdateActionStatus]
+    val `in-progress`      = "in-progress".asInstanceOf[UpdateActionStatus]
+    val stopping           = "stopping".asInstanceOf[UpdateActionStatus]
+    val stopped            = "stopped".asInstanceOf[UpdateActionStatus]
+    val complete           = "complete".asInstanceOf[UpdateActionStatus]
 
     val values =
       js.Object.freeze(js.Array(`not-applied`, `waiting-to-start`, `in-progress`, stopping, stopped, complete))

--- a/services/elasticbeanstalk/src/main/scala/facade/amazonaws/services/ElasticBeanstalk.scala
+++ b/services/elasticbeanstalk/src/main/scala/facade/amazonaws/services/ElasticBeanstalk.scala
@@ -9,9 +9,6 @@ import facade.amazonaws._
 package object elasticbeanstalk {
   type ARN                                  = String
   type AbortableOperationInProgress         = Boolean
-  type ActionHistoryStatus                  = String
-  type ActionStatus                         = String
-  type ActionType                           = String
   type ApplicationArn                       = String
   type ApplicationDescriptionList           = js.Array[ApplicationDescription]
   type ApplicationName                      = String
@@ -19,7 +16,6 @@ package object elasticbeanstalk {
   type ApplicationVersionArn                = String
   type ApplicationVersionDescriptionList    = js.Array[ApplicationVersionDescription]
   type ApplicationVersionProccess           = Boolean
-  type ApplicationVersionStatus             = String
   type AutoCreateApplication                = Boolean
   type AutoScalingGroupList                 = js.Array[AutoScalingGroup]
   type AvailableSolutionStackDetailsList    = js.Array[SolutionStackDescription]
@@ -29,8 +25,6 @@ package object elasticbeanstalk {
   type Cause                                = String
   type Causes                               = js.Array[Cause]
   type CnameAvailability                    = Boolean
-  type ComputeType                          = String
-  type ConfigurationDeploymentStatus        = String
   type ConfigurationOptionDefaultValue      = String
   type ConfigurationOptionDescriptionsList  = js.Array[ConfigurationOptionDescription]
   type ConfigurationOptionName              = String
@@ -39,7 +33,6 @@ package object elasticbeanstalk {
   type ConfigurationOptionSettingsList      = js.Array[ConfigurationOptionSetting]
   type ConfigurationOptionSeverity          = String
   type ConfigurationOptionValue             = String
-  type ConfigurationOptionValueType         = String
   type ConfigurationSettingsDescriptionList = js.Array[ConfigurationSettingsDescription]
   type ConfigurationTemplateName            = String
   type ConfigurationTemplateNamesList       = js.Array[ConfigurationTemplateName]
@@ -54,23 +47,16 @@ package object elasticbeanstalk {
   type EndpointURL                          = String
   type EnvironmentArn                       = String
   type EnvironmentDescriptionsList          = js.Array[EnvironmentDescription]
-  type EnvironmentHealth                    = String
-  type EnvironmentHealthAttribute           = String
   type EnvironmentHealthAttributes          = js.Array[EnvironmentHealthAttribute]
-  type EnvironmentHealthStatus              = String
   type EnvironmentId                        = String
   type EnvironmentIdList                    = js.Array[EnvironmentId]
   type EnvironmentInfoDescriptionList       = js.Array[EnvironmentInfoDescription]
-  type EnvironmentInfoType                  = String
   type EnvironmentLinks                     = js.Array[EnvironmentLink]
   type EnvironmentName                      = String
   type EnvironmentNamesList                 = js.Array[EnvironmentName]
-  type EnvironmentStatus                    = String
   type EventDate                            = js.Date
   type EventDescriptionList                 = js.Array[EventDescription]
   type EventMessage                         = String
-  type EventSeverity                        = String
-  type FailureType                          = String
   type FileTypeExtension                    = String
   type ForceTerminate                       = Boolean
   type GroupName                            = String
@@ -80,7 +66,6 @@ package object elasticbeanstalk {
   type InstanceHealthList                   = js.Array[SingleInstanceHealth]
   type InstanceId                           = String
   type InstanceList                         = js.Array[Instance]
-  type InstancesHealthAttribute             = String
   type InstancesHealthAttributes            = js.Array[InstancesHealthAttribute]
   type LaunchConfigurationList              = js.Array[LaunchConfiguration]
   type LaunchTemplateList                   = js.Array[LaunchTemplate]
@@ -118,7 +103,6 @@ package object elasticbeanstalk {
   type PlatformName                         = String
   type PlatformOwner                        = String
   type PlatformProgrammingLanguages         = js.Array[PlatformProgrammingLanguage]
-  type PlatformStatus                       = String
   type PlatformSummaryList                  = js.Array[PlatformSummary]
   type PlatformVersion                      = String
   type QueueList                            = js.Array[Queue]
@@ -136,8 +120,6 @@ package object elasticbeanstalk {
   type SolutionStackFileTypeList            = js.Array[FileTypeExtension]
   type SolutionStackName                    = String
   type SourceLocation                       = String
-  type SourceRepository                     = String
-  type SourceType                           = String
   type SupportedAddon                       = String
   type SupportedAddonList                   = js.Array[SupportedAddon]
   type SupportedTier                        = String
@@ -158,7 +140,6 @@ package object elasticbeanstalk {
   type UserDefinedOption                    = Boolean
   type ValidationMessageString              = String
   type ValidationMessagesList               = js.Array[ValidationMessage]
-  type ValidationSeverity                   = String
   type VersionLabel                         = String
   type VersionLabels                        = js.Array[VersionLabel]
   type VersionLabelsList                    = js.Array[VersionLabel]
@@ -384,28 +365,31 @@ package elasticbeanstalk {
       __obj.asInstanceOf[AbortEnvironmentUpdateMessage]
     }
   }
-
-  object ActionHistoryStatusEnum {
-    val Completed = "Completed"
-    val Failed    = "Failed"
-    val Unknown   = "Unknown"
+  @js.native
+  sealed trait ActionHistoryStatus extends js.Any
+  object ActionHistoryStatus extends js.Object {
+    val Completed = "Completed".asInstanceOf[ActionHistoryStatus]
+    val Failed    = "Failed".asInstanceOf[ActionHistoryStatus]
+    val Unknown   = "Unknown".asInstanceOf[ActionHistoryStatus]
 
     val values = js.Object.freeze(js.Array(Completed, Failed, Unknown))
   }
-
-  object ActionStatusEnum {
-    val Scheduled = "Scheduled"
-    val Pending   = "Pending"
-    val Running   = "Running"
-    val Unknown   = "Unknown"
+  @js.native
+  sealed trait ActionStatus extends js.Any
+  object ActionStatus extends js.Object {
+    val Scheduled = "Scheduled".asInstanceOf[ActionStatus]
+    val Pending   = "Pending".asInstanceOf[ActionStatus]
+    val Running   = "Running".asInstanceOf[ActionStatus]
+    val Unknown   = "Unknown".asInstanceOf[ActionStatus]
 
     val values = js.Object.freeze(js.Array(Scheduled, Pending, Running, Unknown))
   }
-
-  object ActionTypeEnum {
-    val InstanceRefresh = "InstanceRefresh"
-    val PlatformUpdate  = "PlatformUpdate"
-    val Unknown         = "Unknown"
+  @js.native
+  sealed trait ActionType extends js.Any
+  object ActionType extends js.Object {
+    val InstanceRefresh = "InstanceRefresh".asInstanceOf[ActionType]
+    val PlatformUpdate  = "PlatformUpdate".asInstanceOf[ActionType]
+    val Unknown         = "Unknown".asInstanceOf[ActionType]
 
     val values = js.Object.freeze(js.Array(InstanceRefresh, PlatformUpdate, Unknown))
   }
@@ -666,13 +650,14 @@ package elasticbeanstalk {
       __obj.asInstanceOf[ApplicationVersionLifecycleConfig]
     }
   }
-
-  object ApplicationVersionStatusEnum {
-    val Processed   = "Processed"
-    val Unprocessed = "Unprocessed"
-    val Failed      = "Failed"
-    val Processing  = "Processing"
-    val Building    = "Building"
+  @js.native
+  sealed trait ApplicationVersionStatus extends js.Any
+  object ApplicationVersionStatus extends js.Object {
+    val Processed   = "Processed".asInstanceOf[ApplicationVersionStatus]
+    val Unprocessed = "Unprocessed".asInstanceOf[ApplicationVersionStatus]
+    val Failed      = "Failed".asInstanceOf[ApplicationVersionStatus]
+    val Processing  = "Processing".asInstanceOf[ApplicationVersionStatus]
+    val Building    = "Building".asInstanceOf[ApplicationVersionStatus]
 
     val values = js.Object.freeze(js.Array(Processed, Unprocessed, Failed, Processing, Building))
   }
@@ -910,19 +895,21 @@ package elasticbeanstalk {
       __obj.asInstanceOf[ComposeEnvironmentsMessage]
     }
   }
-
-  object ComputeTypeEnum {
-    val BUILD_GENERAL1_SMALL  = "BUILD_GENERAL1_SMALL"
-    val BUILD_GENERAL1_MEDIUM = "BUILD_GENERAL1_MEDIUM"
-    val BUILD_GENERAL1_LARGE  = "BUILD_GENERAL1_LARGE"
+  @js.native
+  sealed trait ComputeType extends js.Any
+  object ComputeType extends js.Object {
+    val BUILD_GENERAL1_SMALL  = "BUILD_GENERAL1_SMALL".asInstanceOf[ComputeType]
+    val BUILD_GENERAL1_MEDIUM = "BUILD_GENERAL1_MEDIUM".asInstanceOf[ComputeType]
+    val BUILD_GENERAL1_LARGE  = "BUILD_GENERAL1_LARGE".asInstanceOf[ComputeType]
 
     val values = js.Object.freeze(js.Array(BUILD_GENERAL1_SMALL, BUILD_GENERAL1_MEDIUM, BUILD_GENERAL1_LARGE))
   }
-
-  object ConfigurationDeploymentStatusEnum {
-    val deployed = "deployed"
-    val pending  = "pending"
-    val failed   = "failed"
+  @js.native
+  sealed trait ConfigurationDeploymentStatus extends js.Any
+  object ConfigurationDeploymentStatus extends js.Object {
+    val deployed = "deployed".asInstanceOf[ConfigurationDeploymentStatus]
+    val pending  = "pending".asInstanceOf[ConfigurationDeploymentStatus]
+    val failed   = "failed".asInstanceOf[ConfigurationDeploymentStatus]
 
     val values = js.Object.freeze(js.Array(deployed, pending, failed))
   }
@@ -1003,10 +990,11 @@ package elasticbeanstalk {
       __obj.asInstanceOf[ConfigurationOptionSetting]
     }
   }
-
-  object ConfigurationOptionValueTypeEnum {
-    val Scalar = "Scalar"
-    val List   = "List"
+  @js.native
+  sealed trait ConfigurationOptionValueType extends js.Any
+  object ConfigurationOptionValueType extends js.Object {
+    val Scalar = "Scalar".asInstanceOf[ConfigurationOptionValueType]
+    val List   = "List".asInstanceOf[ConfigurationOptionValueType]
 
     val values = js.Object.freeze(js.Array(Scalar, List))
   }
@@ -2135,41 +2123,44 @@ package elasticbeanstalk {
       __obj.asInstanceOf[EnvironmentDescriptionsMessage]
     }
   }
-
-  object EnvironmentHealthEnum {
-    val Green  = "Green"
-    val Yellow = "Yellow"
-    val Red    = "Red"
-    val Grey   = "Grey"
+  @js.native
+  sealed trait EnvironmentHealth extends js.Any
+  object EnvironmentHealth extends js.Object {
+    val Green  = "Green".asInstanceOf[EnvironmentHealth]
+    val Yellow = "Yellow".asInstanceOf[EnvironmentHealth]
+    val Red    = "Red".asInstanceOf[EnvironmentHealth]
+    val Grey   = "Grey".asInstanceOf[EnvironmentHealth]
 
     val values = js.Object.freeze(js.Array(Green, Yellow, Red, Grey))
   }
-
-  object EnvironmentHealthAttributeEnum {
-    val Status             = "Status"
-    val Color              = "Color"
-    val Causes             = "Causes"
-    val ApplicationMetrics = "ApplicationMetrics"
-    val InstancesHealth    = "InstancesHealth"
-    val All                = "All"
-    val HealthStatus       = "HealthStatus"
-    val RefreshedAt        = "RefreshedAt"
+  @js.native
+  sealed trait EnvironmentHealthAttribute extends js.Any
+  object EnvironmentHealthAttribute extends js.Object {
+    val Status             = "Status".asInstanceOf[EnvironmentHealthAttribute]
+    val Color              = "Color".asInstanceOf[EnvironmentHealthAttribute]
+    val Causes             = "Causes".asInstanceOf[EnvironmentHealthAttribute]
+    val ApplicationMetrics = "ApplicationMetrics".asInstanceOf[EnvironmentHealthAttribute]
+    val InstancesHealth    = "InstancesHealth".asInstanceOf[EnvironmentHealthAttribute]
+    val All                = "All".asInstanceOf[EnvironmentHealthAttribute]
+    val HealthStatus       = "HealthStatus".asInstanceOf[EnvironmentHealthAttribute]
+    val RefreshedAt        = "RefreshedAt".asInstanceOf[EnvironmentHealthAttribute]
 
     val values = js.Object.freeze(
       js.Array(Status, Color, Causes, ApplicationMetrics, InstancesHealth, All, HealthStatus, RefreshedAt)
     )
   }
-
-  object EnvironmentHealthStatusEnum {
-    val NoData    = "NoData"
-    val Unknown   = "Unknown"
-    val Pending   = "Pending"
-    val Ok        = "Ok"
-    val Info      = "Info"
-    val Warning   = "Warning"
-    val Degraded  = "Degraded"
-    val Severe    = "Severe"
-    val Suspended = "Suspended"
+  @js.native
+  sealed trait EnvironmentHealthStatus extends js.Any
+  object EnvironmentHealthStatus extends js.Object {
+    val NoData    = "NoData".asInstanceOf[EnvironmentHealthStatus]
+    val Unknown   = "Unknown".asInstanceOf[EnvironmentHealthStatus]
+    val Pending   = "Pending".asInstanceOf[EnvironmentHealthStatus]
+    val Ok        = "Ok".asInstanceOf[EnvironmentHealthStatus]
+    val Info      = "Info".asInstanceOf[EnvironmentHealthStatus]
+    val Warning   = "Warning".asInstanceOf[EnvironmentHealthStatus]
+    val Degraded  = "Degraded".asInstanceOf[EnvironmentHealthStatus]
+    val Severe    = "Severe".asInstanceOf[EnvironmentHealthStatus]
+    val Suspended = "Suspended".asInstanceOf[EnvironmentHealthStatus]
 
     val values = js.Object.freeze(js.Array(NoData, Unknown, Pending, Ok, Info, Warning, Degraded, Severe, Suspended))
   }
@@ -2201,10 +2192,11 @@ package elasticbeanstalk {
       __obj.asInstanceOf[EnvironmentInfoDescription]
     }
   }
-
-  object EnvironmentInfoTypeEnum {
-    val tail   = "tail"
-    val bundle = "bundle"
+  @js.native
+  sealed trait EnvironmentInfoType extends js.Any
+  object EnvironmentInfoType extends js.Object {
+    val tail   = "tail".asInstanceOf[EnvironmentInfoType]
+    val bundle = "bundle".asInstanceOf[EnvironmentInfoType]
 
     val values = js.Object.freeze(js.Array(tail, bundle))
   }
@@ -2308,13 +2300,14 @@ package elasticbeanstalk {
       __obj.asInstanceOf[EnvironmentResourcesDescription]
     }
   }
-
-  object EnvironmentStatusEnum {
-    val Launching   = "Launching"
-    val Updating    = "Updating"
-    val Ready       = "Ready"
-    val Terminating = "Terminating"
-    val Terminated  = "Terminated"
+  @js.native
+  sealed trait EnvironmentStatus extends js.Any
+  object EnvironmentStatus extends js.Object {
+    val Launching   = "Launching".asInstanceOf[EnvironmentStatus]
+    val Updating    = "Updating".asInstanceOf[EnvironmentStatus]
+    val Ready       = "Ready".asInstanceOf[EnvironmentStatus]
+    val Terminating = "Terminating".asInstanceOf[EnvironmentStatus]
+    val Terminated  = "Terminated".asInstanceOf[EnvironmentStatus]
 
     val values = js.Object.freeze(js.Array(Launching, Updating, Ready, Terminating, Terminated))
   }
@@ -2408,26 +2401,28 @@ package elasticbeanstalk {
       __obj.asInstanceOf[EventDescriptionsMessage]
     }
   }
-
-  object EventSeverityEnum {
-    val TRACE = "TRACE"
-    val DEBUG = "DEBUG"
-    val INFO  = "INFO"
-    val WARN  = "WARN"
-    val ERROR = "ERROR"
-    val FATAL = "FATAL"
+  @js.native
+  sealed trait EventSeverity extends js.Any
+  object EventSeverity extends js.Object {
+    val TRACE = "TRACE".asInstanceOf[EventSeverity]
+    val DEBUG = "DEBUG".asInstanceOf[EventSeverity]
+    val INFO  = "INFO".asInstanceOf[EventSeverity]
+    val WARN  = "WARN".asInstanceOf[EventSeverity]
+    val ERROR = "ERROR".asInstanceOf[EventSeverity]
+    val FATAL = "FATAL".asInstanceOf[EventSeverity]
 
     val values = js.Object.freeze(js.Array(TRACE, DEBUG, INFO, WARN, ERROR, FATAL))
   }
-
-  object FailureTypeEnum {
-    val UpdateCancelled         = "UpdateCancelled"
-    val CancellationFailed      = "CancellationFailed"
-    val RollbackFailed          = "RollbackFailed"
-    val RollbackSuccessful      = "RollbackSuccessful"
-    val InternalFailure         = "InternalFailure"
-    val InvalidEnvironmentState = "InvalidEnvironmentState"
-    val PermissionsError        = "PermissionsError"
+  @js.native
+  sealed trait FailureType extends js.Any
+  object FailureType extends js.Object {
+    val UpdateCancelled         = "UpdateCancelled".asInstanceOf[FailureType]
+    val CancellationFailed      = "CancellationFailed".asInstanceOf[FailureType]
+    val RollbackFailed          = "RollbackFailed".asInstanceOf[FailureType]
+    val RollbackSuccessful      = "RollbackSuccessful".asInstanceOf[FailureType]
+    val InternalFailure         = "InternalFailure".asInstanceOf[FailureType]
+    val InvalidEnvironmentState = "InvalidEnvironmentState".asInstanceOf[FailureType]
+    val PermissionsError        = "PermissionsError".asInstanceOf[FailureType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2500,19 +2495,20 @@ package elasticbeanstalk {
       __obj.asInstanceOf[InstanceHealthSummary]
     }
   }
-
-  object InstancesHealthAttributeEnum {
-    val HealthStatus       = "HealthStatus"
-    val Color              = "Color"
-    val Causes             = "Causes"
-    val ApplicationMetrics = "ApplicationMetrics"
-    val RefreshedAt        = "RefreshedAt"
-    val LaunchedAt         = "LaunchedAt"
-    val System             = "System"
-    val Deployment         = "Deployment"
-    val AvailabilityZone   = "AvailabilityZone"
-    val InstanceType       = "InstanceType"
-    val All                = "All"
+  @js.native
+  sealed trait InstancesHealthAttribute extends js.Any
+  object InstancesHealthAttribute extends js.Object {
+    val HealthStatus       = "HealthStatus".asInstanceOf[InstancesHealthAttribute]
+    val Color              = "Color".asInstanceOf[InstancesHealthAttribute]
+    val Causes             = "Causes".asInstanceOf[InstancesHealthAttribute]
+    val ApplicationMetrics = "ApplicationMetrics".asInstanceOf[InstancesHealthAttribute]
+    val RefreshedAt        = "RefreshedAt".asInstanceOf[InstancesHealthAttribute]
+    val LaunchedAt         = "LaunchedAt".asInstanceOf[InstancesHealthAttribute]
+    val System             = "System".asInstanceOf[InstancesHealthAttribute]
+    val Deployment         = "Deployment".asInstanceOf[InstancesHealthAttribute]
+    val AvailabilityZone   = "AvailabilityZone".asInstanceOf[InstancesHealthAttribute]
+    val InstanceType       = "InstanceType".asInstanceOf[InstancesHealthAttribute]
+    val All                = "All".asInstanceOf[InstancesHealthAttribute]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3068,13 +3064,14 @@ package elasticbeanstalk {
       __obj.asInstanceOf[PlatformProgrammingLanguage]
     }
   }
-
-  object PlatformStatusEnum {
-    val Creating = "Creating"
-    val Failed   = "Failed"
-    val Ready    = "Ready"
-    val Deleting = "Deleting"
-    val Deleted  = "Deleted"
+  @js.native
+  sealed trait PlatformStatus extends js.Any
+  object PlatformStatus extends js.Object {
+    val Creating = "Creating".asInstanceOf[PlatformStatus]
+    val Failed   = "Failed".asInstanceOf[PlatformStatus]
+    val Ready    = "Ready".asInstanceOf[PlatformStatus]
+    val Deleting = "Deleting".asInstanceOf[PlatformStatus]
+    val Deleted  = "Deleted".asInstanceOf[PlatformStatus]
 
     val values = js.Object.freeze(js.Array(Creating, Failed, Ready, Deleting, Deleted))
   }
@@ -3467,17 +3464,19 @@ package elasticbeanstalk {
       __obj.asInstanceOf[SourceConfiguration]
     }
   }
-
-  object SourceRepositoryEnum {
-    val CodeCommit = "CodeCommit"
-    val S3         = "S3"
+  @js.native
+  sealed trait SourceRepository extends js.Any
+  object SourceRepository extends js.Object {
+    val CodeCommit = "CodeCommit".asInstanceOf[SourceRepository]
+    val S3         = "S3".asInstanceOf[SourceRepository]
 
     val values = js.Object.freeze(js.Array(CodeCommit, S3))
   }
-
-  object SourceTypeEnum {
-    val Git = "Git"
-    val Zip = "Zip"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val Git = "Git".asInstanceOf[SourceType]
+    val Zip = "Zip".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(js.Array(Git, Zip))
   }
@@ -3869,10 +3868,11 @@ package elasticbeanstalk {
       __obj.asInstanceOf[ValidationMessage]
     }
   }
-
-  object ValidationSeverityEnum {
-    val error   = "error"
-    val warning = "warning"
+  @js.native
+  sealed trait ValidationSeverity extends js.Any
+  object ValidationSeverity extends js.Object {
+    val error   = "error".asInstanceOf[ValidationSeverity]
+    val warning = "warning".asInstanceOf[ValidationSeverity]
 
     val values = js.Object.freeze(js.Array(error, warning))
   }

--- a/services/elbv2/src/main/scala/facade/amazonaws/services/ELBv2.scala
+++ b/services/elbv2/src/main/scala/facade/amazonaws/services/ELBv2.scala
@@ -7,15 +7,13 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object elbv2 {
-  type ActionOrder    = Int
-  type ActionTypeEnum = String
-  type Actions        = js.Array[Action]
-  type AllocationId   = String
+  type ActionOrder  = Int
+  type Actions      = js.Array[Action]
+  type AllocationId = String
   type AuthenticateCognitoActionAuthenticationRequestExtraParams =
     js.Dictionary[AuthenticateCognitoActionAuthenticationRequestParamValue]
   type AuthenticateCognitoActionAuthenticationRequestParamName  = String
   type AuthenticateCognitoActionAuthenticationRequestParamValue = String
-  type AuthenticateCognitoActionConditionalBehaviorEnum         = String
   type AuthenticateCognitoActionScope                           = String
   type AuthenticateCognitoActionSessionCookieName               = String
   type AuthenticateCognitoActionSessionTimeout                  = Double
@@ -29,7 +27,6 @@ package object elbv2 {
   type AuthenticateOidcActionAuthorizationEndpoint           = String
   type AuthenticateOidcActionClientId                        = String
   type AuthenticateOidcActionClientSecret                    = String
-  type AuthenticateOidcActionConditionalBehaviorEnum         = String
   type AuthenticateOidcActionIssuer                          = String
   type AuthenticateOidcActionScope                           = String
   type AuthenticateOidcActionSessionCookieName               = String
@@ -60,7 +57,6 @@ package object elbv2 {
   type HttpCode                                              = String
   type HttpHeaderConditionName                               = String
   type IpAddress                                             = String
-  type IpAddressType                                         = String
   type IsDefault                                             = Boolean
   type Limits                                                = js.Array[Limit]
   type ListOfString                                          = js.Array[StringValue]
@@ -75,9 +71,6 @@ package object elbv2 {
   type LoadBalancerAttributes                                = js.Array[LoadBalancerAttribute]
   type LoadBalancerName                                      = String
   type LoadBalancerNames                                     = js.Array[LoadBalancerName]
-  type LoadBalancerSchemeEnum                                = String
-  type LoadBalancerStateEnum                                 = String
-  type LoadBalancerTypeEnum                                  = String
   type LoadBalancers                                         = js.Array[LoadBalancer]
   type Marker                                                = String
   type Max                                                   = String
@@ -86,14 +79,12 @@ package object elbv2 {
   type Path                                                  = String
   type Port                                                  = Int
   type PrivateIPv4Address                                    = String
-  type ProtocolEnum                                          = String
   type QueryStringKeyValuePairList                           = js.Array[QueryStringKeyValuePair]
   type RedirectActionHost                                    = String
   type RedirectActionPath                                    = String
   type RedirectActionPort                                    = String
   type RedirectActionProtocol                                = String
   type RedirectActionQuery                                   = String
-  type RedirectActionStatusCodeEnum                          = String
   type ResourceArn                                           = String
   type ResourceArns                                          = js.Array[ResourceArn]
   type RuleArn                                               = String
@@ -133,10 +124,7 @@ package object elbv2 {
   type TargetGroupWeight                                     = Int
   type TargetGroups                                          = js.Array[TargetGroup]
   type TargetHealthDescriptions                              = js.Array[TargetHealthDescription]
-  type TargetHealthReasonEnum                                = String
-  type TargetHealthStateEnum                                 = String
   type TargetId                                              = String
-  type TargetTypeEnum                                        = String
   type VpcId                                                 = String
   type ZoneName                                              = String
 
@@ -316,13 +304,14 @@ package elbv2 {
       __obj.asInstanceOf[Action]
     }
   }
-
-  object ActionTypeEnumEnum {
-    val forward                = "forward"
-    val `authenticate-oidc`    = "authenticate-oidc"
-    val `authenticate-cognito` = "authenticate-cognito"
-    val redirect               = "redirect"
-    val `fixed-response`       = "fixed-response"
+  @js.native
+  sealed trait ActionTypeEnum extends js.Any
+  object ActionTypeEnum extends js.Object {
+    val forward                = "forward".asInstanceOf[ActionTypeEnum]
+    val `authenticate-oidc`    = "authenticate-oidc".asInstanceOf[ActionTypeEnum]
+    val `authenticate-cognito` = "authenticate-cognito".asInstanceOf[ActionTypeEnum]
+    val redirect               = "redirect".asInstanceOf[ActionTypeEnum]
+    val `fixed-response`       = "fixed-response".asInstanceOf[ActionTypeEnum]
 
     val values =
       js.Object.freeze(js.Array(forward, `authenticate-oidc`, `authenticate-cognito`, redirect, `fixed-response`))
@@ -398,11 +387,12 @@ package elbv2 {
       __obj.asInstanceOf[AddTagsOutput]
     }
   }
-
-  object AuthenticateCognitoActionConditionalBehaviorEnumEnum {
-    val deny         = "deny"
-    val allow        = "allow"
-    val authenticate = "authenticate"
+  @js.native
+  sealed trait AuthenticateCognitoActionConditionalBehaviorEnum extends js.Any
+  object AuthenticateCognitoActionConditionalBehaviorEnum extends js.Object {
+    val deny         = "deny".asInstanceOf[AuthenticateCognitoActionConditionalBehaviorEnum]
+    val allow        = "allow".asInstanceOf[AuthenticateCognitoActionConditionalBehaviorEnum]
+    val authenticate = "authenticate".asInstanceOf[AuthenticateCognitoActionConditionalBehaviorEnum]
 
     val values = js.Object.freeze(js.Array(deny, allow, authenticate))
   }
@@ -451,11 +441,12 @@ package elbv2 {
       __obj.asInstanceOf[AuthenticateCognitoActionConfig]
     }
   }
-
-  object AuthenticateOidcActionConditionalBehaviorEnumEnum {
-    val deny         = "deny"
-    val allow        = "allow"
-    val authenticate = "authenticate"
+  @js.native
+  sealed trait AuthenticateOidcActionConditionalBehaviorEnum extends js.Any
+  object AuthenticateOidcActionConditionalBehaviorEnum extends js.Object {
+    val deny         = "deny".asInstanceOf[AuthenticateOidcActionConditionalBehaviorEnum]
+    val allow        = "allow".asInstanceOf[AuthenticateOidcActionConditionalBehaviorEnum]
+    val authenticate = "authenticate".asInstanceOf[AuthenticateOidcActionConditionalBehaviorEnum]
 
     val values = js.Object.freeze(js.Array(deny, allow, authenticate))
   }
@@ -1520,10 +1511,11 @@ package elbv2 {
       __obj.asInstanceOf[HttpRequestMethodConditionConfig]
     }
   }
-
-  object IpAddressTypeEnum {
-    val ipv4      = "ipv4"
-    val dualstack = "dualstack"
+  @js.native
+  sealed trait IpAddressType extends js.Any
+  object IpAddressType extends js.Object {
+    val ipv4      = "ipv4".asInstanceOf[IpAddressType]
+    val dualstack = "dualstack".asInstanceOf[IpAddressType]
 
     val values = js.Object.freeze(js.Array(ipv4, dualstack))
   }
@@ -1685,10 +1677,11 @@ package elbv2 {
       __obj.asInstanceOf[LoadBalancerAttribute]
     }
   }
-
-  object LoadBalancerSchemeEnumEnum {
-    val `internet-facing` = "internet-facing"
-    val internal          = "internal"
+  @js.native
+  sealed trait LoadBalancerSchemeEnum extends js.Any
+  object LoadBalancerSchemeEnum extends js.Object {
+    val `internet-facing` = "internet-facing".asInstanceOf[LoadBalancerSchemeEnum]
+    val internal          = "internal".asInstanceOf[LoadBalancerSchemeEnum]
 
     val values = js.Object.freeze(js.Array(`internet-facing`, internal))
   }
@@ -1714,19 +1707,21 @@ package elbv2 {
       __obj.asInstanceOf[LoadBalancerState]
     }
   }
-
-  object LoadBalancerStateEnumEnum {
-    val active          = "active"
-    val provisioning    = "provisioning"
-    val active_impaired = "active_impaired"
-    val failed          = "failed"
+  @js.native
+  sealed trait LoadBalancerStateEnum extends js.Any
+  object LoadBalancerStateEnum extends js.Object {
+    val active          = "active".asInstanceOf[LoadBalancerStateEnum]
+    val provisioning    = "provisioning".asInstanceOf[LoadBalancerStateEnum]
+    val active_impaired = "active_impaired".asInstanceOf[LoadBalancerStateEnum]
+    val failed          = "failed".asInstanceOf[LoadBalancerStateEnum]
 
     val values = js.Object.freeze(js.Array(active, provisioning, active_impaired, failed))
   }
-
-  object LoadBalancerTypeEnumEnum {
-    val application = "application"
-    val network     = "network"
+  @js.native
+  sealed trait LoadBalancerTypeEnum extends js.Any
+  object LoadBalancerTypeEnum extends js.Object {
+    val application = "application".asInstanceOf[LoadBalancerTypeEnum]
+    val network     = "network".asInstanceOf[LoadBalancerTypeEnum]
 
     val values = js.Object.freeze(js.Array(application, network))
   }
@@ -1998,14 +1993,15 @@ package elbv2 {
       __obj.asInstanceOf[PathPatternConditionConfig]
     }
   }
-
-  object ProtocolEnumEnum {
-    val HTTP    = "HTTP"
-    val HTTPS   = "HTTPS"
-    val TCP     = "TCP"
-    val TLS     = "TLS"
-    val UDP     = "UDP"
-    val TCP_UDP = "TCP_UDP"
+  @js.native
+  sealed trait ProtocolEnum extends js.Any
+  object ProtocolEnum extends js.Object {
+    val HTTP    = "HTTP".asInstanceOf[ProtocolEnum]
+    val HTTPS   = "HTTPS".asInstanceOf[ProtocolEnum]
+    val TCP     = "TCP".asInstanceOf[ProtocolEnum]
+    val TLS     = "TLS".asInstanceOf[ProtocolEnum]
+    val UDP     = "UDP".asInstanceOf[ProtocolEnum]
+    val TCP_UDP = "TCP_UDP".asInstanceOf[ProtocolEnum]
 
     val values = js.Object.freeze(js.Array(HTTP, HTTPS, TCP, TLS, UDP, TCP_UDP))
   }
@@ -2095,10 +2091,11 @@ package elbv2 {
       __obj.asInstanceOf[RedirectActionConfig]
     }
   }
-
-  object RedirectActionStatusCodeEnumEnum {
-    val HTTP_301 = "HTTP_301"
-    val HTTP_302 = "HTTP_302"
+  @js.native
+  sealed trait RedirectActionStatusCodeEnum extends js.Any
+  object RedirectActionStatusCodeEnum extends js.Object {
+    val HTTP_301 = "HTTP_301".asInstanceOf[RedirectActionStatusCodeEnum]
+    val HTTP_302 = "HTTP_302".asInstanceOf[RedirectActionStatusCodeEnum]
 
     val values = js.Object.freeze(js.Array(HTTP_301, HTTP_302))
   }
@@ -2772,20 +2769,21 @@ package elbv2 {
       __obj.asInstanceOf[TargetHealthDescription]
     }
   }
-
-  object TargetHealthReasonEnumEnum {
-    val `Elb.RegistrationInProgress`      = "Elb.RegistrationInProgress"
-    val `Elb.InitialHealthChecking`       = "Elb.InitialHealthChecking"
-    val `Target.ResponseCodeMismatch`     = "Target.ResponseCodeMismatch"
-    val `Target.Timeout`                  = "Target.Timeout"
-    val `Target.FailedHealthChecks`       = "Target.FailedHealthChecks"
-    val `Target.NotRegistered`            = "Target.NotRegistered"
-    val `Target.NotInUse`                 = "Target.NotInUse"
-    val `Target.DeregistrationInProgress` = "Target.DeregistrationInProgress"
-    val `Target.InvalidState`             = "Target.InvalidState"
-    val `Target.IpUnusable`               = "Target.IpUnusable"
-    val `Target.HealthCheckDisabled`      = "Target.HealthCheckDisabled"
-    val `Elb.InternalError`               = "Elb.InternalError"
+  @js.native
+  sealed trait TargetHealthReasonEnum extends js.Any
+  object TargetHealthReasonEnum extends js.Object {
+    val `Elb.RegistrationInProgress`      = "Elb.RegistrationInProgress".asInstanceOf[TargetHealthReasonEnum]
+    val `Elb.InitialHealthChecking`       = "Elb.InitialHealthChecking".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.ResponseCodeMismatch`     = "Target.ResponseCodeMismatch".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.Timeout`                  = "Target.Timeout".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.FailedHealthChecks`       = "Target.FailedHealthChecks".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.NotRegistered`            = "Target.NotRegistered".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.NotInUse`                 = "Target.NotInUse".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.DeregistrationInProgress` = "Target.DeregistrationInProgress".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.InvalidState`             = "Target.InvalidState".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.IpUnusable`               = "Target.IpUnusable".asInstanceOf[TargetHealthReasonEnum]
+    val `Target.HealthCheckDisabled`      = "Target.HealthCheckDisabled".asInstanceOf[TargetHealthReasonEnum]
+    val `Elb.InternalError`               = "Elb.InternalError".asInstanceOf[TargetHealthReasonEnum]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2804,22 +2802,24 @@ package elbv2 {
       )
     )
   }
-
-  object TargetHealthStateEnumEnum {
-    val initial     = "initial"
-    val healthy     = "healthy"
-    val unhealthy   = "unhealthy"
-    val unused      = "unused"
-    val draining    = "draining"
-    val unavailable = "unavailable"
+  @js.native
+  sealed trait TargetHealthStateEnum extends js.Any
+  object TargetHealthStateEnum extends js.Object {
+    val initial     = "initial".asInstanceOf[TargetHealthStateEnum]
+    val healthy     = "healthy".asInstanceOf[TargetHealthStateEnum]
+    val unhealthy   = "unhealthy".asInstanceOf[TargetHealthStateEnum]
+    val unused      = "unused".asInstanceOf[TargetHealthStateEnum]
+    val draining    = "draining".asInstanceOf[TargetHealthStateEnum]
+    val unavailable = "unavailable".asInstanceOf[TargetHealthStateEnum]
 
     val values = js.Object.freeze(js.Array(initial, healthy, unhealthy, unused, draining, unavailable))
   }
-
-  object TargetTypeEnumEnum {
-    val instance = "instance"
-    val ip       = "ip"
-    val lambda   = "lambda"
+  @js.native
+  sealed trait TargetTypeEnum extends js.Any
+  object TargetTypeEnum extends js.Object {
+    val instance = "instance".asInstanceOf[TargetTypeEnum]
+    val ip       = "ip".asInstanceOf[TargetTypeEnum]
+    val lambda   = "lambda".asInstanceOf[TargetTypeEnum]
 
     val values = js.Object.freeze(js.Array(instance, ip, lambda))
   }

--- a/services/emr/src/main/scala/facade/amazonaws/services/EMR.scala
+++ b/services/emr/src/main/scala/facade/amazonaws/services/EMR.scala
@@ -7,97 +7,68 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object emr {
-  type ActionOnFailure                        = String
-  type AdjustmentType                         = String
-  type ApplicationList                        = js.Array[Application]
-  type ArnType                                = String
-  type AutoScalingPolicyState                 = String
-  type AutoScalingPolicyStateChangeReasonCode = String
-  type BooleanObject                          = Boolean
-  type BootstrapActionConfigList              = js.Array[BootstrapActionConfig]
-  type BootstrapActionDetailList              = js.Array[BootstrapActionDetail]
-  type CancelStepsInfoList                    = js.Array[CancelStepsInfo]
-  type CancelStepsRequestStatus               = String
-  type ClusterId                              = String
-  type ClusterState                           = String
-  type ClusterStateChangeReasonCode           = String
-  type ClusterStateList                       = js.Array[ClusterState]
-  type ClusterSummaryList                     = js.Array[ClusterSummary]
-  type CommandList                            = js.Array[Command]
-  type ComparisonOperator                     = String
-  type ConfigurationList                      = js.Array[Configuration]
-  type Date                                   = js.Date
-  type EC2InstanceIdsList                     = js.Array[InstanceId]
-  type EC2InstanceIdsToTerminateList          = js.Array[InstanceId]
-  type EbsBlockDeviceConfigList               = js.Array[EbsBlockDeviceConfig]
-  type EbsBlockDeviceList                     = js.Array[EbsBlockDevice]
-  type EbsVolumeList                          = js.Array[EbsVolume]
-  type InstanceCollectionType                 = String
-  type InstanceFleetConfigList                = js.Array[InstanceFleetConfig]
-  type InstanceFleetId                        = String
-  type InstanceFleetList                      = js.Array[InstanceFleet]
-  type InstanceFleetState                     = String
-  type InstanceFleetStateChangeReasonCode     = String
-  type InstanceFleetType                      = String
-  type InstanceGroupConfigList                = js.Array[InstanceGroupConfig]
-  type InstanceGroupDetailList                = js.Array[InstanceGroupDetail]
-  type InstanceGroupId                        = String
-  type InstanceGroupIdsList                   = js.Array[XmlStringMaxLen256]
-  type InstanceGroupList                      = js.Array[InstanceGroup]
-  type InstanceGroupModifyConfigList          = js.Array[InstanceGroupModifyConfig]
-  type InstanceGroupState                     = String
-  type InstanceGroupStateChangeReasonCode     = String
-  type InstanceGroupType                      = String
-  type InstanceGroupTypeList                  = js.Array[InstanceGroupType]
-  type InstanceId                             = String
-  type InstanceList                           = js.Array[Instance]
-  type InstanceRoleType                       = String
-  type InstanceState                          = String
-  type InstanceStateChangeReasonCode          = String
-  type InstanceStateList                      = js.Array[InstanceState]
-  type InstanceType                           = String
-  type InstanceTypeConfigList                 = js.Array[InstanceTypeConfig]
-  type InstanceTypeSpecificationList          = js.Array[InstanceTypeSpecification]
-  type JobFlowDetailList                      = js.Array[JobFlowDetail]
-  type JobFlowExecutionState                  = String
-  type JobFlowExecutionStateList              = js.Array[JobFlowExecutionState]
-  type KeyValueList                           = js.Array[KeyValue]
-  type Marker                                 = String
-  type MarketType                             = String
-  type MetricDimensionList                    = js.Array[MetricDimension]
-  type NewSupportedProductsList               = js.Array[SupportedProductConfig]
-  type NonNegativeDouble                      = Double
-  type OptionalArnType                        = String
-  type Port                                   = Int
-  type PortRanges                             = js.Array[PortRange]
-  type RepoUpgradeOnBoot                      = String
-  type ResourceId                             = String
-  type ScaleDownBehavior                      = String
-  type ScalingRuleList                        = js.Array[ScalingRule]
-  type SecurityConfigurationList              = js.Array[SecurityConfigurationSummary]
-  type SecurityGroupsList                     = js.Array[XmlStringMaxLen256]
-  type SpotProvisioningTimeoutAction          = String
-  type Statistic                              = String
-  type StepCancellationOption                 = String
-  type StepConfigList                         = js.Array[StepConfig]
-  type StepDetailList                         = js.Array[StepDetail]
-  type StepExecutionState                     = String
-  type StepId                                 = String
-  type StepIdsList                            = js.Array[XmlStringMaxLen256]
-  type StepState                              = String
-  type StepStateChangeReasonCode              = String
-  type StepStateList                          = js.Array[StepState]
-  type StepSummaryList                        = js.Array[StepSummary]
-  type StringList                             = js.Array[String]
-  type StringMap                              = js.Dictionary[String]
-  type SupportedProductsList                  = js.Array[XmlStringMaxLen256]
-  type TagList                                = js.Array[Tag]
-  type Unit                                   = String
-  type WholeNumber                            = Int
-  type XmlString                              = String
-  type XmlStringList                          = js.Array[XmlString]
-  type XmlStringMaxLen256                     = String
-  type XmlStringMaxLen256List                 = js.Array[XmlStringMaxLen256]
+  type ApplicationList               = js.Array[Application]
+  type ArnType                       = String
+  type BooleanObject                 = Boolean
+  type BootstrapActionConfigList     = js.Array[BootstrapActionConfig]
+  type BootstrapActionDetailList     = js.Array[BootstrapActionDetail]
+  type CancelStepsInfoList           = js.Array[CancelStepsInfo]
+  type ClusterId                     = String
+  type ClusterStateList              = js.Array[ClusterState]
+  type ClusterSummaryList            = js.Array[ClusterSummary]
+  type CommandList                   = js.Array[Command]
+  type ConfigurationList             = js.Array[Configuration]
+  type Date                          = js.Date
+  type EC2InstanceIdsList            = js.Array[InstanceId]
+  type EC2InstanceIdsToTerminateList = js.Array[InstanceId]
+  type EbsBlockDeviceConfigList      = js.Array[EbsBlockDeviceConfig]
+  type EbsBlockDeviceList            = js.Array[EbsBlockDevice]
+  type EbsVolumeList                 = js.Array[EbsVolume]
+  type InstanceFleetConfigList       = js.Array[InstanceFleetConfig]
+  type InstanceFleetId               = String
+  type InstanceFleetList             = js.Array[InstanceFleet]
+  type InstanceGroupConfigList       = js.Array[InstanceGroupConfig]
+  type InstanceGroupDetailList       = js.Array[InstanceGroupDetail]
+  type InstanceGroupId               = String
+  type InstanceGroupIdsList          = js.Array[XmlStringMaxLen256]
+  type InstanceGroupList             = js.Array[InstanceGroup]
+  type InstanceGroupModifyConfigList = js.Array[InstanceGroupModifyConfig]
+  type InstanceGroupTypeList         = js.Array[InstanceGroupType]
+  type InstanceId                    = String
+  type InstanceList                  = js.Array[Instance]
+  type InstanceStateList             = js.Array[InstanceState]
+  type InstanceType                  = String
+  type InstanceTypeConfigList        = js.Array[InstanceTypeConfig]
+  type InstanceTypeSpecificationList = js.Array[InstanceTypeSpecification]
+  type JobFlowDetailList             = js.Array[JobFlowDetail]
+  type JobFlowExecutionStateList     = js.Array[JobFlowExecutionState]
+  type KeyValueList                  = js.Array[KeyValue]
+  type Marker                        = String
+  type MetricDimensionList           = js.Array[MetricDimension]
+  type NewSupportedProductsList      = js.Array[SupportedProductConfig]
+  type NonNegativeDouble             = Double
+  type OptionalArnType               = String
+  type Port                          = Int
+  type PortRanges                    = js.Array[PortRange]
+  type ResourceId                    = String
+  type ScalingRuleList               = js.Array[ScalingRule]
+  type SecurityConfigurationList     = js.Array[SecurityConfigurationSummary]
+  type SecurityGroupsList            = js.Array[XmlStringMaxLen256]
+  type StepConfigList                = js.Array[StepConfig]
+  type StepDetailList                = js.Array[StepDetail]
+  type StepId                        = String
+  type StepIdsList                   = js.Array[XmlStringMaxLen256]
+  type StepStateList                 = js.Array[StepState]
+  type StepSummaryList               = js.Array[StepSummary]
+  type StringList                    = js.Array[String]
+  type StringMap                     = js.Dictionary[String]
+  type SupportedProductsList         = js.Array[XmlStringMaxLen256]
+  type TagList                       = js.Array[Tag]
+  type WholeNumber                   = Int
+  type XmlString                     = String
+  type XmlStringList                 = js.Array[XmlString]
+  type XmlStringMaxLen256            = String
+  type XmlStringMaxLen256List        = js.Array[XmlStringMaxLen256]
 
   implicit final class EMROps(private val service: EMR) extends AnyVal {
 
@@ -221,12 +192,13 @@ package emr {
         params: DescribeJobFlowsInput
     ): Request[DescribeJobFlowsOutput] = js.native
   }
-
-  object ActionOnFailureEnum {
-    val TERMINATE_JOB_FLOW = "TERMINATE_JOB_FLOW"
-    val TERMINATE_CLUSTER  = "TERMINATE_CLUSTER"
-    val CANCEL_AND_WAIT    = "CANCEL_AND_WAIT"
-    val CONTINUE           = "CONTINUE"
+  @js.native
+  sealed trait ActionOnFailure extends js.Any
+  object ActionOnFailure extends js.Object {
+    val TERMINATE_JOB_FLOW = "TERMINATE_JOB_FLOW".asInstanceOf[ActionOnFailure]
+    val TERMINATE_CLUSTER  = "TERMINATE_CLUSTER".asInstanceOf[ActionOnFailure]
+    val CANCEL_AND_WAIT    = "CANCEL_AND_WAIT".asInstanceOf[ActionOnFailure]
+    val CONTINUE           = "CONTINUE".asInstanceOf[ActionOnFailure]
 
     val values = js.Object.freeze(js.Array(TERMINATE_JOB_FLOW, TERMINATE_CLUSTER, CANCEL_AND_WAIT, CONTINUE))
   }
@@ -405,11 +377,12 @@ package emr {
       __obj.asInstanceOf[AddTagsOutput]
     }
   }
-
-  object AdjustmentTypeEnum {
-    val CHANGE_IN_CAPACITY         = "CHANGE_IN_CAPACITY"
-    val PERCENT_CHANGE_IN_CAPACITY = "PERCENT_CHANGE_IN_CAPACITY"
-    val EXACT_CAPACITY             = "EXACT_CAPACITY"
+  @js.native
+  sealed trait AdjustmentType extends js.Any
+  object AdjustmentType extends js.Object {
+    val CHANGE_IN_CAPACITY         = "CHANGE_IN_CAPACITY".asInstanceOf[AdjustmentType]
+    val PERCENT_CHANGE_IN_CAPACITY = "PERCENT_CHANGE_IN_CAPACITY".asInstanceOf[AdjustmentType]
+    val EXACT_CAPACITY             = "EXACT_CAPACITY".asInstanceOf[AdjustmentType]
 
     val values = js.Object.freeze(js.Array(CHANGE_IN_CAPACITY, PERCENT_CHANGE_IN_CAPACITY, EXACT_CAPACITY))
   }
@@ -491,14 +464,15 @@ package emr {
       __obj.asInstanceOf[AutoScalingPolicyDescription]
     }
   }
-
-  object AutoScalingPolicyStateEnum {
-    val PENDING   = "PENDING"
-    val ATTACHING = "ATTACHING"
-    val ATTACHED  = "ATTACHED"
-    val DETACHING = "DETACHING"
-    val DETACHED  = "DETACHED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait AutoScalingPolicyState extends js.Any
+  object AutoScalingPolicyState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[AutoScalingPolicyState]
+    val ATTACHING = "ATTACHING".asInstanceOf[AutoScalingPolicyState]
+    val ATTACHED  = "ATTACHED".asInstanceOf[AutoScalingPolicyState]
+    val DETACHING = "DETACHING".asInstanceOf[AutoScalingPolicyState]
+    val DETACHED  = "DETACHED".asInstanceOf[AutoScalingPolicyState]
+    val FAILED    = "FAILED".asInstanceOf[AutoScalingPolicyState]
 
     val values = js.Object.freeze(js.Array(PENDING, ATTACHING, ATTACHED, DETACHING, DETACHED, FAILED))
   }
@@ -524,11 +498,12 @@ package emr {
       __obj.asInstanceOf[AutoScalingPolicyStateChangeReason]
     }
   }
-
-  object AutoScalingPolicyStateChangeReasonCodeEnum {
-    val USER_REQUEST      = "USER_REQUEST"
-    val PROVISION_FAILURE = "PROVISION_FAILURE"
-    val CLEANUP_FAILURE   = "CLEANUP_FAILURE"
+  @js.native
+  sealed trait AutoScalingPolicyStateChangeReasonCode extends js.Any
+  object AutoScalingPolicyStateChangeReasonCode extends js.Object {
+    val USER_REQUEST      = "USER_REQUEST".asInstanceOf[AutoScalingPolicyStateChangeReasonCode]
+    val PROVISION_FAILURE = "PROVISION_FAILURE".asInstanceOf[AutoScalingPolicyStateChangeReasonCode]
+    val CLEANUP_FAILURE   = "CLEANUP_FAILURE".asInstanceOf[AutoScalingPolicyStateChangeReasonCode]
 
     val values = js.Object.freeze(js.Array(USER_REQUEST, PROVISION_FAILURE, CLEANUP_FAILURE))
   }
@@ -718,10 +693,11 @@ package emr {
       __obj.asInstanceOf[CancelStepsOutput]
     }
   }
-
-  object CancelStepsRequestStatusEnum {
-    val SUBMITTED = "SUBMITTED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait CancelStepsRequestStatus extends js.Any
+  object CancelStepsRequestStatus extends js.Object {
+    val SUBMITTED = "SUBMITTED".asInstanceOf[CancelStepsRequestStatus]
+    val FAILED    = "FAILED".asInstanceOf[CancelStepsRequestStatus]
 
     val values = js.Object.freeze(js.Array(SUBMITTED, FAILED))
   }
@@ -870,15 +846,16 @@ package emr {
       __obj.asInstanceOf[Cluster]
     }
   }
-
-  object ClusterStateEnum {
-    val STARTING               = "STARTING"
-    val BOOTSTRAPPING          = "BOOTSTRAPPING"
-    val RUNNING                = "RUNNING"
-    val WAITING                = "WAITING"
-    val TERMINATING            = "TERMINATING"
-    val TERMINATED             = "TERMINATED"
-    val TERMINATED_WITH_ERRORS = "TERMINATED_WITH_ERRORS"
+  @js.native
+  sealed trait ClusterState extends js.Any
+  object ClusterState extends js.Object {
+    val STARTING               = "STARTING".asInstanceOf[ClusterState]
+    val BOOTSTRAPPING          = "BOOTSTRAPPING".asInstanceOf[ClusterState]
+    val RUNNING                = "RUNNING".asInstanceOf[ClusterState]
+    val WAITING                = "WAITING".asInstanceOf[ClusterState]
+    val TERMINATING            = "TERMINATING".asInstanceOf[ClusterState]
+    val TERMINATED             = "TERMINATED".asInstanceOf[ClusterState]
+    val TERMINATED_WITH_ERRORS = "TERMINATED_WITH_ERRORS".asInstanceOf[ClusterState]
 
     val values = js.Object.freeze(
       js.Array(STARTING, BOOTSTRAPPING, RUNNING, WAITING, TERMINATING, TERMINATED, TERMINATED_WITH_ERRORS)
@@ -906,16 +883,17 @@ package emr {
       __obj.asInstanceOf[ClusterStateChangeReason]
     }
   }
-
-  object ClusterStateChangeReasonCodeEnum {
-    val INTERNAL_ERROR         = "INTERNAL_ERROR"
-    val VALIDATION_ERROR       = "VALIDATION_ERROR"
-    val INSTANCE_FAILURE       = "INSTANCE_FAILURE"
-    val INSTANCE_FLEET_TIMEOUT = "INSTANCE_FLEET_TIMEOUT"
-    val BOOTSTRAP_FAILURE      = "BOOTSTRAP_FAILURE"
-    val USER_REQUEST           = "USER_REQUEST"
-    val STEP_FAILURE           = "STEP_FAILURE"
-    val ALL_STEPS_COMPLETED    = "ALL_STEPS_COMPLETED"
+  @js.native
+  sealed trait ClusterStateChangeReasonCode extends js.Any
+  object ClusterStateChangeReasonCode extends js.Object {
+    val INTERNAL_ERROR         = "INTERNAL_ERROR".asInstanceOf[ClusterStateChangeReasonCode]
+    val VALIDATION_ERROR       = "VALIDATION_ERROR".asInstanceOf[ClusterStateChangeReasonCode]
+    val INSTANCE_FAILURE       = "INSTANCE_FAILURE".asInstanceOf[ClusterStateChangeReasonCode]
+    val INSTANCE_FLEET_TIMEOUT = "INSTANCE_FLEET_TIMEOUT".asInstanceOf[ClusterStateChangeReasonCode]
+    val BOOTSTRAP_FAILURE      = "BOOTSTRAP_FAILURE".asInstanceOf[ClusterStateChangeReasonCode]
+    val USER_REQUEST           = "USER_REQUEST".asInstanceOf[ClusterStateChangeReasonCode]
+    val STEP_FAILURE           = "STEP_FAILURE".asInstanceOf[ClusterStateChangeReasonCode]
+    val ALL_STEPS_COMPLETED    = "ALL_STEPS_COMPLETED".asInstanceOf[ClusterStateChangeReasonCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1039,12 +1017,13 @@ package emr {
       __obj.asInstanceOf[Command]
     }
   }
-
-  object ComparisonOperatorEnum {
-    val GREATER_THAN_OR_EQUAL = "GREATER_THAN_OR_EQUAL"
-    val GREATER_THAN          = "GREATER_THAN"
-    val LESS_THAN             = "LESS_THAN"
-    val LESS_THAN_OR_EQUAL    = "LESS_THAN_OR_EQUAL"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val GREATER_THAN_OR_EQUAL = "GREATER_THAN_OR_EQUAL".asInstanceOf[ComparisonOperator]
+    val GREATER_THAN          = "GREATER_THAN".asInstanceOf[ComparisonOperator]
+    val LESS_THAN             = "LESS_THAN".asInstanceOf[ComparisonOperator]
+    val LESS_THAN_OR_EQUAL    = "LESS_THAN_OR_EQUAL".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(js.Array(GREATER_THAN_OR_EQUAL, GREATER_THAN, LESS_THAN, LESS_THAN_OR_EQUAL))
   }
@@ -1637,10 +1616,11 @@ package emr {
       __obj.asInstanceOf[Instance]
     }
   }
-
-  object InstanceCollectionTypeEnum {
-    val INSTANCE_FLEET = "INSTANCE_FLEET"
-    val INSTANCE_GROUP = "INSTANCE_GROUP"
+  @js.native
+  sealed trait InstanceCollectionType extends js.Any
+  object InstanceCollectionType extends js.Object {
+    val INSTANCE_FLEET = "INSTANCE_FLEET".asInstanceOf[InstanceCollectionType]
+    val INSTANCE_GROUP = "INSTANCE_GROUP".asInstanceOf[InstanceCollectionType]
 
     val values = js.Object.freeze(js.Array(INSTANCE_FLEET, INSTANCE_GROUP))
   }
@@ -1786,15 +1766,16 @@ package emr {
       __obj.asInstanceOf[InstanceFleetProvisioningSpecifications]
     }
   }
-
-  object InstanceFleetStateEnum {
-    val PROVISIONING  = "PROVISIONING"
-    val BOOTSTRAPPING = "BOOTSTRAPPING"
-    val RUNNING       = "RUNNING"
-    val RESIZING      = "RESIZING"
-    val SUSPENDED     = "SUSPENDED"
-    val TERMINATING   = "TERMINATING"
-    val TERMINATED    = "TERMINATED"
+  @js.native
+  sealed trait InstanceFleetState extends js.Any
+  object InstanceFleetState extends js.Object {
+    val PROVISIONING  = "PROVISIONING".asInstanceOf[InstanceFleetState]
+    val BOOTSTRAPPING = "BOOTSTRAPPING".asInstanceOf[InstanceFleetState]
+    val RUNNING       = "RUNNING".asInstanceOf[InstanceFleetState]
+    val RESIZING      = "RESIZING".asInstanceOf[InstanceFleetState]
+    val SUSPENDED     = "SUSPENDED".asInstanceOf[InstanceFleetState]
+    val TERMINATING   = "TERMINATING".asInstanceOf[InstanceFleetState]
+    val TERMINATED    = "TERMINATED".asInstanceOf[InstanceFleetState]
 
     val values =
       js.Object.freeze(js.Array(PROVISIONING, BOOTSTRAPPING, RUNNING, RESIZING, SUSPENDED, TERMINATING, TERMINATED))
@@ -1823,12 +1804,13 @@ package emr {
       __obj.asInstanceOf[InstanceFleetStateChangeReason]
     }
   }
-
-  object InstanceFleetStateChangeReasonCodeEnum {
-    val INTERNAL_ERROR     = "INTERNAL_ERROR"
-    val VALIDATION_ERROR   = "VALIDATION_ERROR"
-    val INSTANCE_FAILURE   = "INSTANCE_FAILURE"
-    val CLUSTER_TERMINATED = "CLUSTER_TERMINATED"
+  @js.native
+  sealed trait InstanceFleetStateChangeReasonCode extends js.Any
+  object InstanceFleetStateChangeReasonCode extends js.Object {
+    val INTERNAL_ERROR     = "INTERNAL_ERROR".asInstanceOf[InstanceFleetStateChangeReasonCode]
+    val VALIDATION_ERROR   = "VALIDATION_ERROR".asInstanceOf[InstanceFleetStateChangeReasonCode]
+    val INSTANCE_FAILURE   = "INSTANCE_FAILURE".asInstanceOf[InstanceFleetStateChangeReasonCode]
+    val CLUSTER_TERMINATED = "CLUSTER_TERMINATED".asInstanceOf[InstanceFleetStateChangeReasonCode]
 
     val values = js.Object.freeze(js.Array(INTERNAL_ERROR, VALIDATION_ERROR, INSTANCE_FAILURE, CLUSTER_TERMINATED))
   }
@@ -1886,11 +1868,12 @@ package emr {
       __obj.asInstanceOf[InstanceFleetTimeline]
     }
   }
-
-  object InstanceFleetTypeEnum {
-    val MASTER = "MASTER"
-    val CORE   = "CORE"
-    val TASK   = "TASK"
+  @js.native
+  sealed trait InstanceFleetType extends js.Any
+  object InstanceFleetType extends js.Object {
+    val MASTER = "MASTER".asInstanceOf[InstanceFleetType]
+    val CORE   = "CORE".asInstanceOf[InstanceFleetType]
+    val TASK   = "TASK".asInstanceOf[InstanceFleetType]
 
     val values = js.Object.freeze(js.Array(MASTER, CORE, TASK))
   }
@@ -2105,19 +2088,20 @@ package emr {
       __obj.asInstanceOf[InstanceGroupModifyConfig]
     }
   }
-
-  object InstanceGroupStateEnum {
-    val PROVISIONING  = "PROVISIONING"
-    val BOOTSTRAPPING = "BOOTSTRAPPING"
-    val RUNNING       = "RUNNING"
-    val RECONFIGURING = "RECONFIGURING"
-    val RESIZING      = "RESIZING"
-    val SUSPENDED     = "SUSPENDED"
-    val TERMINATING   = "TERMINATING"
-    val TERMINATED    = "TERMINATED"
-    val ARRESTED      = "ARRESTED"
-    val SHUTTING_DOWN = "SHUTTING_DOWN"
-    val ENDED         = "ENDED"
+  @js.native
+  sealed trait InstanceGroupState extends js.Any
+  object InstanceGroupState extends js.Object {
+    val PROVISIONING  = "PROVISIONING".asInstanceOf[InstanceGroupState]
+    val BOOTSTRAPPING = "BOOTSTRAPPING".asInstanceOf[InstanceGroupState]
+    val RUNNING       = "RUNNING".asInstanceOf[InstanceGroupState]
+    val RECONFIGURING = "RECONFIGURING".asInstanceOf[InstanceGroupState]
+    val RESIZING      = "RESIZING".asInstanceOf[InstanceGroupState]
+    val SUSPENDED     = "SUSPENDED".asInstanceOf[InstanceGroupState]
+    val TERMINATING   = "TERMINATING".asInstanceOf[InstanceGroupState]
+    val TERMINATED    = "TERMINATED".asInstanceOf[InstanceGroupState]
+    val ARRESTED      = "ARRESTED".asInstanceOf[InstanceGroupState]
+    val SHUTTING_DOWN = "SHUTTING_DOWN".asInstanceOf[InstanceGroupState]
+    val ENDED         = "ENDED".asInstanceOf[InstanceGroupState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2157,12 +2141,13 @@ package emr {
       __obj.asInstanceOf[InstanceGroupStateChangeReason]
     }
   }
-
-  object InstanceGroupStateChangeReasonCodeEnum {
-    val INTERNAL_ERROR     = "INTERNAL_ERROR"
-    val VALIDATION_ERROR   = "VALIDATION_ERROR"
-    val INSTANCE_FAILURE   = "INSTANCE_FAILURE"
-    val CLUSTER_TERMINATED = "CLUSTER_TERMINATED"
+  @js.native
+  sealed trait InstanceGroupStateChangeReasonCode extends js.Any
+  object InstanceGroupStateChangeReasonCode extends js.Object {
+    val INTERNAL_ERROR     = "INTERNAL_ERROR".asInstanceOf[InstanceGroupStateChangeReasonCode]
+    val VALIDATION_ERROR   = "VALIDATION_ERROR".asInstanceOf[InstanceGroupStateChangeReasonCode]
+    val INSTANCE_FAILURE   = "INSTANCE_FAILURE".asInstanceOf[InstanceGroupStateChangeReasonCode]
+    val CLUSTER_TERMINATED = "CLUSTER_TERMINATED".asInstanceOf[InstanceGroupStateChangeReasonCode]
 
     val values = js.Object.freeze(js.Array(INTERNAL_ERROR, VALIDATION_ERROR, INSTANCE_FAILURE, CLUSTER_TERMINATED))
   }
@@ -2216,11 +2201,12 @@ package emr {
       __obj.asInstanceOf[InstanceGroupTimeline]
     }
   }
-
-  object InstanceGroupTypeEnum {
-    val MASTER = "MASTER"
-    val CORE   = "CORE"
-    val TASK   = "TASK"
+  @js.native
+  sealed trait InstanceGroupType extends js.Any
+  object InstanceGroupType extends js.Object {
+    val MASTER = "MASTER".asInstanceOf[InstanceGroupType]
+    val CORE   = "CORE".asInstanceOf[InstanceGroupType]
+    val TASK   = "TASK".asInstanceOf[InstanceGroupType]
 
     val values = js.Object.freeze(js.Array(MASTER, CORE, TASK))
   }
@@ -2251,21 +2237,23 @@ package emr {
       __obj.asInstanceOf[InstanceResizePolicy]
     }
   }
-
-  object InstanceRoleTypeEnum {
-    val MASTER = "MASTER"
-    val CORE   = "CORE"
-    val TASK   = "TASK"
+  @js.native
+  sealed trait InstanceRoleType extends js.Any
+  object InstanceRoleType extends js.Object {
+    val MASTER = "MASTER".asInstanceOf[InstanceRoleType]
+    val CORE   = "CORE".asInstanceOf[InstanceRoleType]
+    val TASK   = "TASK".asInstanceOf[InstanceRoleType]
 
     val values = js.Object.freeze(js.Array(MASTER, CORE, TASK))
   }
-
-  object InstanceStateEnum {
-    val AWAITING_FULFILLMENT = "AWAITING_FULFILLMENT"
-    val PROVISIONING         = "PROVISIONING"
-    val BOOTSTRAPPING        = "BOOTSTRAPPING"
-    val RUNNING              = "RUNNING"
-    val TERMINATED           = "TERMINATED"
+  @js.native
+  sealed trait InstanceState extends js.Any
+  object InstanceState extends js.Object {
+    val AWAITING_FULFILLMENT = "AWAITING_FULFILLMENT".asInstanceOf[InstanceState]
+    val PROVISIONING         = "PROVISIONING".asInstanceOf[InstanceState]
+    val BOOTSTRAPPING        = "BOOTSTRAPPING".asInstanceOf[InstanceState]
+    val RUNNING              = "RUNNING".asInstanceOf[InstanceState]
+    val TERMINATED           = "TERMINATED".asInstanceOf[InstanceState]
 
     val values = js.Object.freeze(js.Array(AWAITING_FULFILLMENT, PROVISIONING, BOOTSTRAPPING, RUNNING, TERMINATED))
   }
@@ -2291,13 +2279,14 @@ package emr {
       __obj.asInstanceOf[InstanceStateChangeReason]
     }
   }
-
-  object InstanceStateChangeReasonCodeEnum {
-    val INTERNAL_ERROR     = "INTERNAL_ERROR"
-    val VALIDATION_ERROR   = "VALIDATION_ERROR"
-    val INSTANCE_FAILURE   = "INSTANCE_FAILURE"
-    val BOOTSTRAP_FAILURE  = "BOOTSTRAP_FAILURE"
-    val CLUSTER_TERMINATED = "CLUSTER_TERMINATED"
+  @js.native
+  sealed trait InstanceStateChangeReasonCode extends js.Any
+  object InstanceStateChangeReasonCode extends js.Object {
+    val INTERNAL_ERROR     = "INTERNAL_ERROR".asInstanceOf[InstanceStateChangeReasonCode]
+    val VALIDATION_ERROR   = "VALIDATION_ERROR".asInstanceOf[InstanceStateChangeReasonCode]
+    val INSTANCE_FAILURE   = "INSTANCE_FAILURE".asInstanceOf[InstanceStateChangeReasonCode]
+    val BOOTSTRAP_FAILURE  = "BOOTSTRAP_FAILURE".asInstanceOf[InstanceStateChangeReasonCode]
+    val CLUSTER_TERMINATED = "CLUSTER_TERMINATED".asInstanceOf[InstanceStateChangeReasonCode]
 
     val values = js.Object.freeze(
       js.Array(INTERNAL_ERROR, VALIDATION_ERROR, INSTANCE_FAILURE, BOOTSTRAP_FAILURE, CLUSTER_TERMINATED)
@@ -2498,15 +2487,17 @@ package emr {
   /**
     * The type of instance.
     */
-  object JobFlowExecutionStateEnum {
-    val STARTING      = "STARTING"
-    val BOOTSTRAPPING = "BOOTSTRAPPING"
-    val RUNNING       = "RUNNING"
-    val WAITING       = "WAITING"
-    val SHUTTING_DOWN = "SHUTTING_DOWN"
-    val TERMINATED    = "TERMINATED"
-    val COMPLETED     = "COMPLETED"
-    val FAILED        = "FAILED"
+  @js.native
+  sealed trait JobFlowExecutionState extends js.Any
+  object JobFlowExecutionState extends js.Object {
+    val STARTING      = "STARTING".asInstanceOf[JobFlowExecutionState]
+    val BOOTSTRAPPING = "BOOTSTRAPPING".asInstanceOf[JobFlowExecutionState]
+    val RUNNING       = "RUNNING".asInstanceOf[JobFlowExecutionState]
+    val WAITING       = "WAITING".asInstanceOf[JobFlowExecutionState]
+    val SHUTTING_DOWN = "SHUTTING_DOWN".asInstanceOf[JobFlowExecutionState]
+    val TERMINATED    = "TERMINATED".asInstanceOf[JobFlowExecutionState]
+    val COMPLETED     = "COMPLETED".asInstanceOf[JobFlowExecutionState]
+    val FAILED        = "FAILED".asInstanceOf[JobFlowExecutionState]
 
     val values = js.Object.freeze(
       js.Array(STARTING, BOOTSTRAPPING, RUNNING, WAITING, SHUTTING_DOWN, TERMINATED, COMPLETED, FAILED)
@@ -3073,10 +3064,11 @@ package emr {
       __obj.asInstanceOf[ListStepsOutput]
     }
   }
-
-  object MarketTypeEnum {
-    val ON_DEMAND = "ON_DEMAND"
-    val SPOT      = "SPOT"
+  @js.native
+  sealed trait MarketType extends js.Any
+  object MarketType extends js.Object {
+    val ON_DEMAND = "ON_DEMAND".asInstanceOf[MarketType]
+    val SPOT      = "SPOT".asInstanceOf[MarketType]
 
     val values = js.Object.freeze(js.Array(ON_DEMAND, SPOT))
   }
@@ -3382,10 +3374,11 @@ package emr {
       __obj.asInstanceOf[RemoveTagsOutput]
     }
   }
-
-  object RepoUpgradeOnBootEnum {
-    val SECURITY = "SECURITY"
-    val NONE     = "NONE"
+  @js.native
+  sealed trait RepoUpgradeOnBoot extends js.Any
+  object RepoUpgradeOnBoot extends js.Object {
+    val SECURITY = "SECURITY".asInstanceOf[RepoUpgradeOnBoot]
+    val NONE     = "NONE".asInstanceOf[RepoUpgradeOnBoot]
 
     val values = js.Object.freeze(js.Array(SECURITY, NONE))
   }
@@ -3501,10 +3494,11 @@ package emr {
       __obj.asInstanceOf[RunJobFlowOutput]
     }
   }
-
-  object ScaleDownBehaviorEnum {
-    val TERMINATE_AT_INSTANCE_HOUR   = "TERMINATE_AT_INSTANCE_HOUR"
-    val TERMINATE_AT_TASK_COMPLETION = "TERMINATE_AT_TASK_COMPLETION"
+  @js.native
+  sealed trait ScaleDownBehavior extends js.Any
+  object ScaleDownBehavior extends js.Object {
+    val TERMINATE_AT_INSTANCE_HOUR   = "TERMINATE_AT_INSTANCE_HOUR".asInstanceOf[ScaleDownBehavior]
+    val TERMINATE_AT_TASK_COMPLETION = "TERMINATE_AT_TASK_COMPLETION".asInstanceOf[ScaleDownBehavior]
 
     val values = js.Object.freeze(js.Array(TERMINATE_AT_INSTANCE_HOUR, TERMINATE_AT_TASK_COMPLETION))
   }
@@ -3779,20 +3773,22 @@ package emr {
       __obj.asInstanceOf[SpotProvisioningSpecification]
     }
   }
-
-  object SpotProvisioningTimeoutActionEnum {
-    val SWITCH_TO_ON_DEMAND = "SWITCH_TO_ON_DEMAND"
-    val TERMINATE_CLUSTER   = "TERMINATE_CLUSTER"
+  @js.native
+  sealed trait SpotProvisioningTimeoutAction extends js.Any
+  object SpotProvisioningTimeoutAction extends js.Object {
+    val SWITCH_TO_ON_DEMAND = "SWITCH_TO_ON_DEMAND".asInstanceOf[SpotProvisioningTimeoutAction]
+    val TERMINATE_CLUSTER   = "TERMINATE_CLUSTER".asInstanceOf[SpotProvisioningTimeoutAction]
 
     val values = js.Object.freeze(js.Array(SWITCH_TO_ON_DEMAND, TERMINATE_CLUSTER))
   }
-
-  object StatisticEnum {
-    val SAMPLE_COUNT = "SAMPLE_COUNT"
-    val AVERAGE      = "AVERAGE"
-    val SUM          = "SUM"
-    val MINIMUM      = "MINIMUM"
-    val MAXIMUM      = "MAXIMUM"
+  @js.native
+  sealed trait Statistic extends js.Any
+  object Statistic extends js.Object {
+    val SAMPLE_COUNT = "SAMPLE_COUNT".asInstanceOf[Statistic]
+    val AVERAGE      = "AVERAGE".asInstanceOf[Statistic]
+    val SUM          = "SUM".asInstanceOf[Statistic]
+    val MINIMUM      = "MINIMUM".asInstanceOf[Statistic]
+    val MAXIMUM      = "MAXIMUM".asInstanceOf[Statistic]
 
     val values = js.Object.freeze(js.Array(SAMPLE_COUNT, AVERAGE, SUM, MINIMUM, MAXIMUM))
   }
@@ -3827,10 +3823,11 @@ package emr {
       __obj.asInstanceOf[Step]
     }
   }
-
-  object StepCancellationOptionEnum {
-    val SEND_INTERRUPT    = "SEND_INTERRUPT"
-    val TERMINATE_PROCESS = "TERMINATE_PROCESS"
+  @js.native
+  sealed trait StepCancellationOption extends js.Any
+  object StepCancellationOption extends js.Object {
+    val SEND_INTERRUPT    = "SEND_INTERRUPT".asInstanceOf[StepCancellationOption]
+    val TERMINATE_PROCESS = "TERMINATE_PROCESS".asInstanceOf[StepCancellationOption]
 
     val values = js.Object.freeze(js.Array(SEND_INTERRUPT, TERMINATE_PROCESS))
   }
@@ -3885,15 +3882,16 @@ package emr {
       __obj.asInstanceOf[StepDetail]
     }
   }
-
-  object StepExecutionStateEnum {
-    val PENDING     = "PENDING"
-    val RUNNING     = "RUNNING"
-    val CONTINUE    = "CONTINUE"
-    val COMPLETED   = "COMPLETED"
-    val CANCELLED   = "CANCELLED"
-    val FAILED      = "FAILED"
-    val INTERRUPTED = "INTERRUPTED"
+  @js.native
+  sealed trait StepExecutionState extends js.Any
+  object StepExecutionState extends js.Object {
+    val PENDING     = "PENDING".asInstanceOf[StepExecutionState]
+    val RUNNING     = "RUNNING".asInstanceOf[StepExecutionState]
+    val CONTINUE    = "CONTINUE".asInstanceOf[StepExecutionState]
+    val COMPLETED   = "COMPLETED".asInstanceOf[StepExecutionState]
+    val CANCELLED   = "CANCELLED".asInstanceOf[StepExecutionState]
+    val FAILED      = "FAILED".asInstanceOf[StepExecutionState]
+    val INTERRUPTED = "INTERRUPTED".asInstanceOf[StepExecutionState]
 
     val values = js.Object.freeze(js.Array(PENDING, RUNNING, CONTINUE, COMPLETED, CANCELLED, FAILED, INTERRUPTED))
   }
@@ -3930,15 +3928,16 @@ package emr {
       __obj.asInstanceOf[StepExecutionStatusDetail]
     }
   }
-
-  object StepStateEnum {
-    val PENDING        = "PENDING"
-    val CANCEL_PENDING = "CANCEL_PENDING"
-    val RUNNING        = "RUNNING"
-    val COMPLETED      = "COMPLETED"
-    val CANCELLED      = "CANCELLED"
-    val FAILED         = "FAILED"
-    val INTERRUPTED    = "INTERRUPTED"
+  @js.native
+  sealed trait StepState extends js.Any
+  object StepState extends js.Object {
+    val PENDING        = "PENDING".asInstanceOf[StepState]
+    val CANCEL_PENDING = "CANCEL_PENDING".asInstanceOf[StepState]
+    val RUNNING        = "RUNNING".asInstanceOf[StepState]
+    val COMPLETED      = "COMPLETED".asInstanceOf[StepState]
+    val CANCELLED      = "CANCELLED".asInstanceOf[StepState]
+    val FAILED         = "FAILED".asInstanceOf[StepState]
+    val INTERRUPTED    = "INTERRUPTED".asInstanceOf[StepState]
 
     val values = js.Object.freeze(js.Array(PENDING, CANCEL_PENDING, RUNNING, COMPLETED, CANCELLED, FAILED, INTERRUPTED))
   }
@@ -3964,9 +3963,10 @@ package emr {
       __obj.asInstanceOf[StepStateChangeReason]
     }
   }
-
-  object StepStateChangeReasonCodeEnum {
-    val NONE = "NONE"
+  @js.native
+  sealed trait StepStateChangeReasonCode extends js.Any
+  object StepStateChangeReasonCode extends js.Object {
+    val NONE = "NONE".asInstanceOf[StepStateChangeReasonCode]
 
     val values = js.Object.freeze(js.Array(NONE))
   }
@@ -4119,35 +4119,36 @@ package emr {
       __obj.asInstanceOf[TerminateJobFlowsInput]
     }
   }
-
-  object UnitEnum {
-    val NONE                  = "NONE"
-    val SECONDS               = "SECONDS"
-    val MICRO_SECONDS         = "MICRO_SECONDS"
-    val MILLI_SECONDS         = "MILLI_SECONDS"
-    val BYTES                 = "BYTES"
-    val KILO_BYTES            = "KILO_BYTES"
-    val MEGA_BYTES            = "MEGA_BYTES"
-    val GIGA_BYTES            = "GIGA_BYTES"
-    val TERA_BYTES            = "TERA_BYTES"
-    val BITS                  = "BITS"
-    val KILO_BITS             = "KILO_BITS"
-    val MEGA_BITS             = "MEGA_BITS"
-    val GIGA_BITS             = "GIGA_BITS"
-    val TERA_BITS             = "TERA_BITS"
-    val PERCENT               = "PERCENT"
-    val COUNT                 = "COUNT"
-    val BYTES_PER_SECOND      = "BYTES_PER_SECOND"
-    val KILO_BYTES_PER_SECOND = "KILO_BYTES_PER_SECOND"
-    val MEGA_BYTES_PER_SECOND = "MEGA_BYTES_PER_SECOND"
-    val GIGA_BYTES_PER_SECOND = "GIGA_BYTES_PER_SECOND"
-    val TERA_BYTES_PER_SECOND = "TERA_BYTES_PER_SECOND"
-    val BITS_PER_SECOND       = "BITS_PER_SECOND"
-    val KILO_BITS_PER_SECOND  = "KILO_BITS_PER_SECOND"
-    val MEGA_BITS_PER_SECOND  = "MEGA_BITS_PER_SECOND"
-    val GIGA_BITS_PER_SECOND  = "GIGA_BITS_PER_SECOND"
-    val TERA_BITS_PER_SECOND  = "TERA_BITS_PER_SECOND"
-    val COUNT_PER_SECOND      = "COUNT_PER_SECOND"
+  @js.native
+  sealed trait Unit extends js.Any
+  object Unit extends js.Object {
+    val NONE                  = "NONE".asInstanceOf[Unit]
+    val SECONDS               = "SECONDS".asInstanceOf[Unit]
+    val MICRO_SECONDS         = "MICRO_SECONDS".asInstanceOf[Unit]
+    val MILLI_SECONDS         = "MILLI_SECONDS".asInstanceOf[Unit]
+    val BYTES                 = "BYTES".asInstanceOf[Unit]
+    val KILO_BYTES            = "KILO_BYTES".asInstanceOf[Unit]
+    val MEGA_BYTES            = "MEGA_BYTES".asInstanceOf[Unit]
+    val GIGA_BYTES            = "GIGA_BYTES".asInstanceOf[Unit]
+    val TERA_BYTES            = "TERA_BYTES".asInstanceOf[Unit]
+    val BITS                  = "BITS".asInstanceOf[Unit]
+    val KILO_BITS             = "KILO_BITS".asInstanceOf[Unit]
+    val MEGA_BITS             = "MEGA_BITS".asInstanceOf[Unit]
+    val GIGA_BITS             = "GIGA_BITS".asInstanceOf[Unit]
+    val TERA_BITS             = "TERA_BITS".asInstanceOf[Unit]
+    val PERCENT               = "PERCENT".asInstanceOf[Unit]
+    val COUNT                 = "COUNT".asInstanceOf[Unit]
+    val BYTES_PER_SECOND      = "BYTES_PER_SECOND".asInstanceOf[Unit]
+    val KILO_BYTES_PER_SECOND = "KILO_BYTES_PER_SECOND".asInstanceOf[Unit]
+    val MEGA_BYTES_PER_SECOND = "MEGA_BYTES_PER_SECOND".asInstanceOf[Unit]
+    val GIGA_BYTES_PER_SECOND = "GIGA_BYTES_PER_SECOND".asInstanceOf[Unit]
+    val TERA_BYTES_PER_SECOND = "TERA_BYTES_PER_SECOND".asInstanceOf[Unit]
+    val BITS_PER_SECOND       = "BITS_PER_SECOND".asInstanceOf[Unit]
+    val KILO_BITS_PER_SECOND  = "KILO_BITS_PER_SECOND".asInstanceOf[Unit]
+    val MEGA_BITS_PER_SECOND  = "MEGA_BITS_PER_SECOND".asInstanceOf[Unit]
+    val GIGA_BITS_PER_SECOND  = "GIGA_BITS_PER_SECOND".asInstanceOf[Unit]
+    val TERA_BITS_PER_SECOND  = "TERA_BITS_PER_SECOND".asInstanceOf[Unit]
+    val COUNT_PER_SECOND      = "COUNT_PER_SECOND".asInstanceOf[Unit]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/es/src/main/scala/facade/amazonaws/services/ES.scala
+++ b/services/es/src/main/scala/facade/amazonaws/services/ES.scala
@@ -7,72 +7,62 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object es {
-  type ARN                                        = String
-  type AdditionalLimitList                        = js.Array[AdditionalLimit]
-  type AdvancedOptions                            = js.Dictionary[String]
-  type CloudWatchLogsLogGroupArn                  = String
-  type CompatibleElasticsearchVersionsList        = js.Array[CompatibleVersionsMap]
-  type DeploymentCloseDateTimeStamp               = js.Date
-  type DeploymentStatus                           = String
-  type DomainId                                   = String
-  type DomainInfoList                             = js.Array[DomainInfo]
-  type DomainName                                 = String
-  type DomainNameList                             = js.Array[DomainName]
-  type ESPartitionInstanceType                    = String
-  type ESWarmPartitionInstanceType                = String
-  type ElasticsearchDomainStatusList              = js.Array[ElasticsearchDomainStatus]
-  type ElasticsearchInstanceTypeList              = js.Array[ESPartitionInstanceType]
-  type ElasticsearchVersionList                   = js.Array[ElasticsearchVersionString]
-  type ElasticsearchVersionString                 = String
-  type EndpointsMap                               = js.Dictionary[ServiceUrl]
-  type GUID                                       = String
-  type IdentityPoolId                             = String
-  type InstanceCount                              = Int
-  type InstanceRole                               = String
-  type IntegerClass                               = Int
-  type Issue                                      = String
-  type Issues                                     = js.Array[Issue]
-  type KmsKeyId                                   = String
-  type LimitName                                  = String
-  type LimitValue                                 = String
-  type LimitValueList                             = js.Array[LimitValue]
-  type LimitsByRole                               = js.Dictionary[Limits]
-  type LogPublishingOptions                       = js.Dictionary[LogPublishingOption]
-  type LogType                                    = String
-  type MaxResults                                 = Int
-  type MaximumInstanceCount                       = Int
-  type MinimumInstanceCount                       = Int
-  type NextToken                                  = String
-  type OptionState                                = String
-  type Password                                   = String
-  type PolicyDocument                             = String
-  type RecurringChargeList                        = js.Array[RecurringCharge]
-  type ReservationToken                           = String
-  type ReservedElasticsearchInstanceList          = js.Array[ReservedElasticsearchInstance]
-  type ReservedElasticsearchInstanceOfferingList  = js.Array[ReservedElasticsearchInstanceOffering]
-  type ReservedElasticsearchInstancePaymentOption = String
-  type RoleArn                                    = String
-  type ServiceUrl                                 = String
-  type StartTimestamp                             = js.Date
-  type StorageSubTypeName                         = String
-  type StorageTypeLimitList                       = js.Array[StorageTypeLimit]
-  type StorageTypeList                            = js.Array[StorageType]
-  type StorageTypeName                            = String
-  type StringList                                 = js.Array[String]
-  type TLSSecurityPolicy                          = String
-  type TagKey                                     = String
-  type TagList                                    = js.Array[Tag]
-  type TagValue                                   = String
-  type UIntValue                                  = Int
-  type UpdateTimestamp                            = js.Date
-  type UpgradeHistoryList                         = js.Array[UpgradeHistory]
-  type UpgradeName                                = String
-  type UpgradeStatus                              = String
-  type UpgradeStep                                = String
-  type UpgradeStepsList                           = js.Array[UpgradeStepItem]
-  type UserPoolId                                 = String
-  type Username                                   = String
-  type VolumeType                                 = String
+  type ARN                                       = String
+  type AdditionalLimitList                       = js.Array[AdditionalLimit]
+  type AdvancedOptions                           = js.Dictionary[String]
+  type CloudWatchLogsLogGroupArn                 = String
+  type CompatibleElasticsearchVersionsList       = js.Array[CompatibleVersionsMap]
+  type DeploymentCloseDateTimeStamp              = js.Date
+  type DomainId                                  = String
+  type DomainInfoList                            = js.Array[DomainInfo]
+  type DomainName                                = String
+  type DomainNameList                            = js.Array[DomainName]
+  type ElasticsearchDomainStatusList             = js.Array[ElasticsearchDomainStatus]
+  type ElasticsearchInstanceTypeList             = js.Array[ESPartitionInstanceType]
+  type ElasticsearchVersionList                  = js.Array[ElasticsearchVersionString]
+  type ElasticsearchVersionString                = String
+  type EndpointsMap                              = js.Dictionary[ServiceUrl]
+  type GUID                                      = String
+  type IdentityPoolId                            = String
+  type InstanceCount                             = Int
+  type InstanceRole                              = String
+  type IntegerClass                              = Int
+  type Issue                                     = String
+  type Issues                                    = js.Array[Issue]
+  type KmsKeyId                                  = String
+  type LimitName                                 = String
+  type LimitValue                                = String
+  type LimitValueList                            = js.Array[LimitValue]
+  type LimitsByRole                              = js.Dictionary[Limits]
+  type LogPublishingOptions                      = js.Dictionary[LogPublishingOption]
+  type MaxResults                                = Int
+  type MaximumInstanceCount                      = Int
+  type MinimumInstanceCount                      = Int
+  type NextToken                                 = String
+  type Password                                  = String
+  type PolicyDocument                            = String
+  type RecurringChargeList                       = js.Array[RecurringCharge]
+  type ReservationToken                          = String
+  type ReservedElasticsearchInstanceList         = js.Array[ReservedElasticsearchInstance]
+  type ReservedElasticsearchInstanceOfferingList = js.Array[ReservedElasticsearchInstanceOffering]
+  type RoleArn                                   = String
+  type ServiceUrl                                = String
+  type StartTimestamp                            = js.Date
+  type StorageSubTypeName                        = String
+  type StorageTypeLimitList                      = js.Array[StorageTypeLimit]
+  type StorageTypeList                           = js.Array[StorageType]
+  type StorageTypeName                           = String
+  type StringList                                = js.Array[String]
+  type TagKey                                    = String
+  type TagList                                   = js.Array[Tag]
+  type TagValue                                  = String
+  type UIntValue                                 = Int
+  type UpdateTimestamp                           = js.Date
+  type UpgradeHistoryList                        = js.Array[UpgradeHistory]
+  type UpgradeName                               = String
+  type UpgradeStepsList                          = js.Array[UpgradeStepItem]
+  type UserPoolId                                = String
+  type Username                                  = String
 
   implicit final class ESOps(private val service: ES) extends AnyVal {
 
@@ -616,13 +606,14 @@ package es {
       __obj.asInstanceOf[DeleteElasticsearchDomainResponse]
     }
   }
-
-  object DeploymentStatusEnum {
-    val PENDING_UPDATE = "PENDING_UPDATE"
-    val IN_PROGRESS    = "IN_PROGRESS"
-    val COMPLETED      = "COMPLETED"
-    val NOT_ELIGIBLE   = "NOT_ELIGIBLE"
-    val ELIGIBLE       = "ELIGIBLE"
+  @js.native
+  sealed trait DeploymentStatus extends js.Any
+  object DeploymentStatus extends js.Object {
+    val PENDING_UPDATE = "PENDING_UPDATE".asInstanceOf[DeploymentStatus]
+    val IN_PROGRESS    = "IN_PROGRESS".asInstanceOf[DeploymentStatus]
+    val COMPLETED      = "COMPLETED".asInstanceOf[DeploymentStatus]
+    val NOT_ELIGIBLE   = "NOT_ELIGIBLE".asInstanceOf[DeploymentStatus]
+    val ELIGIBLE       = "ELIGIBLE".asInstanceOf[DeploymentStatus]
 
     val values = js.Object.freeze(js.Array(PENDING_UPDATE, IN_PROGRESS, COMPLETED, NOT_ELIGIBLE, ELIGIBLE))
   }
@@ -1014,66 +1005,67 @@ package es {
       __obj.asInstanceOf[EBSOptionsStatus]
     }
   }
-
-  object ESPartitionInstanceTypeEnum {
-    val `m3.medium.elasticsearch`         = "m3.medium.elasticsearch"
-    val `m3.large.elasticsearch`          = "m3.large.elasticsearch"
-    val `m3.xlarge.elasticsearch`         = "m3.xlarge.elasticsearch"
-    val `m3.2xlarge.elasticsearch`        = "m3.2xlarge.elasticsearch"
-    val `m4.large.elasticsearch`          = "m4.large.elasticsearch"
-    val `m4.xlarge.elasticsearch`         = "m4.xlarge.elasticsearch"
-    val `m4.2xlarge.elasticsearch`        = "m4.2xlarge.elasticsearch"
-    val `m4.4xlarge.elasticsearch`        = "m4.4xlarge.elasticsearch"
-    val `m4.10xlarge.elasticsearch`       = "m4.10xlarge.elasticsearch"
-    val `m5.large.elasticsearch`          = "m5.large.elasticsearch"
-    val `m5.xlarge.elasticsearch`         = "m5.xlarge.elasticsearch"
-    val `m5.2xlarge.elasticsearch`        = "m5.2xlarge.elasticsearch"
-    val `m5.4xlarge.elasticsearch`        = "m5.4xlarge.elasticsearch"
-    val `m5.12xlarge.elasticsearch`       = "m5.12xlarge.elasticsearch"
-    val `r5.large.elasticsearch`          = "r5.large.elasticsearch"
-    val `r5.xlarge.elasticsearch`         = "r5.xlarge.elasticsearch"
-    val `r5.2xlarge.elasticsearch`        = "r5.2xlarge.elasticsearch"
-    val `r5.4xlarge.elasticsearch`        = "r5.4xlarge.elasticsearch"
-    val `r5.12xlarge.elasticsearch`       = "r5.12xlarge.elasticsearch"
-    val `c5.large.elasticsearch`          = "c5.large.elasticsearch"
-    val `c5.xlarge.elasticsearch`         = "c5.xlarge.elasticsearch"
-    val `c5.2xlarge.elasticsearch`        = "c5.2xlarge.elasticsearch"
-    val `c5.4xlarge.elasticsearch`        = "c5.4xlarge.elasticsearch"
-    val `c5.9xlarge.elasticsearch`        = "c5.9xlarge.elasticsearch"
-    val `c5.18xlarge.elasticsearch`       = "c5.18xlarge.elasticsearch"
-    val `ultrawarm1.medium.elasticsearch` = "ultrawarm1.medium.elasticsearch"
-    val `ultrawarm1.large.elasticsearch`  = "ultrawarm1.large.elasticsearch"
-    val `t2.micro.elasticsearch`          = "t2.micro.elasticsearch"
-    val `t2.small.elasticsearch`          = "t2.small.elasticsearch"
-    val `t2.medium.elasticsearch`         = "t2.medium.elasticsearch"
-    val `r3.large.elasticsearch`          = "r3.large.elasticsearch"
-    val `r3.xlarge.elasticsearch`         = "r3.xlarge.elasticsearch"
-    val `r3.2xlarge.elasticsearch`        = "r3.2xlarge.elasticsearch"
-    val `r3.4xlarge.elasticsearch`        = "r3.4xlarge.elasticsearch"
-    val `r3.8xlarge.elasticsearch`        = "r3.8xlarge.elasticsearch"
-    val `i2.xlarge.elasticsearch`         = "i2.xlarge.elasticsearch"
-    val `i2.2xlarge.elasticsearch`        = "i2.2xlarge.elasticsearch"
-    val `d2.xlarge.elasticsearch`         = "d2.xlarge.elasticsearch"
-    val `d2.2xlarge.elasticsearch`        = "d2.2xlarge.elasticsearch"
-    val `d2.4xlarge.elasticsearch`        = "d2.4xlarge.elasticsearch"
-    val `d2.8xlarge.elasticsearch`        = "d2.8xlarge.elasticsearch"
-    val `c4.large.elasticsearch`          = "c4.large.elasticsearch"
-    val `c4.xlarge.elasticsearch`         = "c4.xlarge.elasticsearch"
-    val `c4.2xlarge.elasticsearch`        = "c4.2xlarge.elasticsearch"
-    val `c4.4xlarge.elasticsearch`        = "c4.4xlarge.elasticsearch"
-    val `c4.8xlarge.elasticsearch`        = "c4.8xlarge.elasticsearch"
-    val `r4.large.elasticsearch`          = "r4.large.elasticsearch"
-    val `r4.xlarge.elasticsearch`         = "r4.xlarge.elasticsearch"
-    val `r4.2xlarge.elasticsearch`        = "r4.2xlarge.elasticsearch"
-    val `r4.4xlarge.elasticsearch`        = "r4.4xlarge.elasticsearch"
-    val `r4.8xlarge.elasticsearch`        = "r4.8xlarge.elasticsearch"
-    val `r4.16xlarge.elasticsearch`       = "r4.16xlarge.elasticsearch"
-    val `i3.large.elasticsearch`          = "i3.large.elasticsearch"
-    val `i3.xlarge.elasticsearch`         = "i3.xlarge.elasticsearch"
-    val `i3.2xlarge.elasticsearch`        = "i3.2xlarge.elasticsearch"
-    val `i3.4xlarge.elasticsearch`        = "i3.4xlarge.elasticsearch"
-    val `i3.8xlarge.elasticsearch`        = "i3.8xlarge.elasticsearch"
-    val `i3.16xlarge.elasticsearch`       = "i3.16xlarge.elasticsearch"
+  @js.native
+  sealed trait ESPartitionInstanceType extends js.Any
+  object ESPartitionInstanceType extends js.Object {
+    val `m3.medium.elasticsearch`         = "m3.medium.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m3.large.elasticsearch`          = "m3.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m3.xlarge.elasticsearch`         = "m3.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m3.2xlarge.elasticsearch`        = "m3.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m4.large.elasticsearch`          = "m4.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m4.xlarge.elasticsearch`         = "m4.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m4.2xlarge.elasticsearch`        = "m4.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m4.4xlarge.elasticsearch`        = "m4.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m4.10xlarge.elasticsearch`       = "m4.10xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m5.large.elasticsearch`          = "m5.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m5.xlarge.elasticsearch`         = "m5.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m5.2xlarge.elasticsearch`        = "m5.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m5.4xlarge.elasticsearch`        = "m5.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `m5.12xlarge.elasticsearch`       = "m5.12xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r5.large.elasticsearch`          = "r5.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r5.xlarge.elasticsearch`         = "r5.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r5.2xlarge.elasticsearch`        = "r5.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r5.4xlarge.elasticsearch`        = "r5.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r5.12xlarge.elasticsearch`       = "r5.12xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c5.large.elasticsearch`          = "c5.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c5.xlarge.elasticsearch`         = "c5.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c5.2xlarge.elasticsearch`        = "c5.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c5.4xlarge.elasticsearch`        = "c5.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c5.9xlarge.elasticsearch`        = "c5.9xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c5.18xlarge.elasticsearch`       = "c5.18xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `ultrawarm1.medium.elasticsearch` = "ultrawarm1.medium.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `ultrawarm1.large.elasticsearch`  = "ultrawarm1.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `t2.micro.elasticsearch`          = "t2.micro.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `t2.small.elasticsearch`          = "t2.small.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `t2.medium.elasticsearch`         = "t2.medium.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r3.large.elasticsearch`          = "r3.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r3.xlarge.elasticsearch`         = "r3.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r3.2xlarge.elasticsearch`        = "r3.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r3.4xlarge.elasticsearch`        = "r3.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r3.8xlarge.elasticsearch`        = "r3.8xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i2.xlarge.elasticsearch`         = "i2.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i2.2xlarge.elasticsearch`        = "i2.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `d2.xlarge.elasticsearch`         = "d2.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `d2.2xlarge.elasticsearch`        = "d2.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `d2.4xlarge.elasticsearch`        = "d2.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `d2.8xlarge.elasticsearch`        = "d2.8xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c4.large.elasticsearch`          = "c4.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c4.xlarge.elasticsearch`         = "c4.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c4.2xlarge.elasticsearch`        = "c4.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c4.4xlarge.elasticsearch`        = "c4.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `c4.8xlarge.elasticsearch`        = "c4.8xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r4.large.elasticsearch`          = "r4.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r4.xlarge.elasticsearch`         = "r4.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r4.2xlarge.elasticsearch`        = "r4.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r4.4xlarge.elasticsearch`        = "r4.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r4.8xlarge.elasticsearch`        = "r4.8xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `r4.16xlarge.elasticsearch`       = "r4.16xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i3.large.elasticsearch`          = "i3.large.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i3.xlarge.elasticsearch`         = "i3.xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i3.2xlarge.elasticsearch`        = "i3.2xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i3.4xlarge.elasticsearch`        = "i3.4xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i3.8xlarge.elasticsearch`        = "i3.8xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
+    val `i3.16xlarge.elasticsearch`       = "i3.16xlarge.elasticsearch".asInstanceOf[ESPartitionInstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1138,10 +1130,11 @@ package es {
       )
     )
   }
-
-  object ESWarmPartitionInstanceTypeEnum {
-    val `ultrawarm1.medium.elasticsearch` = "ultrawarm1.medium.elasticsearch"
-    val `ultrawarm1.large.elasticsearch`  = "ultrawarm1.large.elasticsearch"
+  @js.native
+  sealed trait ESWarmPartitionInstanceType extends js.Any
+  object ESWarmPartitionInstanceType extends js.Object {
+    val `ultrawarm1.medium.elasticsearch` = "ultrawarm1.medium.elasticsearch".asInstanceOf[ESWarmPartitionInstanceType]
+    val `ultrawarm1.large.elasticsearch`  = "ultrawarm1.large.elasticsearch".asInstanceOf[ESWarmPartitionInstanceType]
 
     val values = js.Object.freeze(js.Array(`ultrawarm1.medium.elasticsearch`, `ultrawarm1.large.elasticsearch`))
   }
@@ -1848,10 +1841,12 @@ package es {
     *  * ES_APPLICATION_LOGS: Elasticsearch application logs contain information about errors and warnings raised during the operation of the service and can be useful for troubleshooting.
     * </p>
     */
-  object LogTypeEnum {
-    val INDEX_SLOW_LOGS     = "INDEX_SLOW_LOGS"
-    val SEARCH_SLOW_LOGS    = "SEARCH_SLOW_LOGS"
-    val ES_APPLICATION_LOGS = "ES_APPLICATION_LOGS"
+  @js.native
+  sealed trait LogType extends js.Any
+  object LogType extends js.Object {
+    val INDEX_SLOW_LOGS     = "INDEX_SLOW_LOGS".asInstanceOf[LogType]
+    val SEARCH_SLOW_LOGS    = "SEARCH_SLOW_LOGS".asInstanceOf[LogType]
+    val ES_APPLICATION_LOGS = "ES_APPLICATION_LOGS".asInstanceOf[LogType]
 
     val values = js.Object.freeze(js.Array(INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS))
   }
@@ -1929,10 +1924,12 @@ package es {
     * * Processing: The request change is still in-process.
     *  * Active: The request change is processed and deployed to the Elasticsearch domain.
     */
-  object OptionStateEnum {
-    val RequiresIndexDocuments = "RequiresIndexDocuments"
-    val Processing             = "Processing"
-    val Active                 = "Active"
+  @js.native
+  sealed trait OptionState extends js.Any
+  object OptionState extends js.Object {
+    val RequiresIndexDocuments = "RequiresIndexDocuments".asInstanceOf[OptionState]
+    val Processing             = "Processing".asInstanceOf[OptionState]
+    val Active                 = "Active".asInstanceOf[OptionState]
 
     val values = js.Object.freeze(js.Array(RequiresIndexDocuments, Processing, Active))
   }
@@ -2173,11 +2170,12 @@ package es {
       __obj.asInstanceOf[ReservedElasticsearchInstanceOffering]
     }
   }
-
-  object ReservedElasticsearchInstancePaymentOptionEnum {
-    val ALL_UPFRONT     = "ALL_UPFRONT"
-    val PARTIAL_UPFRONT = "PARTIAL_UPFRONT"
-    val NO_UPFRONT      = "NO_UPFRONT"
+  @js.native
+  sealed trait ReservedElasticsearchInstancePaymentOption extends js.Any
+  object ReservedElasticsearchInstancePaymentOption extends js.Object {
+    val ALL_UPFRONT     = "ALL_UPFRONT".asInstanceOf[ReservedElasticsearchInstancePaymentOption]
+    val PARTIAL_UPFRONT = "PARTIAL_UPFRONT".asInstanceOf[ReservedElasticsearchInstancePaymentOption]
+    val NO_UPFRONT      = "NO_UPFRONT".asInstanceOf[ReservedElasticsearchInstancePaymentOption]
 
     val values = js.Object.freeze(js.Array(ALL_UPFRONT, PARTIAL_UPFRONT, NO_UPFRONT))
   }
@@ -2350,10 +2348,11 @@ package es {
       __obj.asInstanceOf[StorageTypeLimit]
     }
   }
-
-  object TLSSecurityPolicyEnum {
-    val `Policy-Min-TLS-1-0-2019-07` = "Policy-Min-TLS-1-0-2019-07"
-    val `Policy-Min-TLS-1-2-2019-07` = "Policy-Min-TLS-1-2-2019-07"
+  @js.native
+  sealed trait TLSSecurityPolicy extends js.Any
+  object TLSSecurityPolicy extends js.Object {
+    val `Policy-Min-TLS-1-0-2019-07` = "Policy-Min-TLS-1-0-2019-07".asInstanceOf[TLSSecurityPolicy]
+    val `Policy-Min-TLS-1-2-2019-07` = "Policy-Min-TLS-1-2-2019-07".asInstanceOf[TLSSecurityPolicy]
 
     val values = js.Object.freeze(js.Array(`Policy-Min-TLS-1-0-2019-07`, `Policy-Min-TLS-1-2-2019-07`))
   }
@@ -2535,20 +2534,22 @@ package es {
       __obj.asInstanceOf[UpgradeHistory]
     }
   }
-
-  object UpgradeStatusEnum {
-    val IN_PROGRESS           = "IN_PROGRESS"
-    val SUCCEEDED             = "SUCCEEDED"
-    val SUCCEEDED_WITH_ISSUES = "SUCCEEDED_WITH_ISSUES"
-    val FAILED                = "FAILED"
+  @js.native
+  sealed trait UpgradeStatus extends js.Any
+  object UpgradeStatus extends js.Object {
+    val IN_PROGRESS           = "IN_PROGRESS".asInstanceOf[UpgradeStatus]
+    val SUCCEEDED             = "SUCCEEDED".asInstanceOf[UpgradeStatus]
+    val SUCCEEDED_WITH_ISSUES = "SUCCEEDED_WITH_ISSUES".asInstanceOf[UpgradeStatus]
+    val FAILED                = "FAILED".asInstanceOf[UpgradeStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, SUCCEEDED, SUCCEEDED_WITH_ISSUES, FAILED))
   }
-
-  object UpgradeStepEnum {
-    val PRE_UPGRADE_CHECK = "PRE_UPGRADE_CHECK"
-    val SNAPSHOT          = "SNAPSHOT"
-    val UPGRADE           = "UPGRADE"
+  @js.native
+  sealed trait UpgradeStep extends js.Any
+  object UpgradeStep extends js.Object {
+    val PRE_UPGRADE_CHECK = "PRE_UPGRADE_CHECK".asInstanceOf[UpgradeStep]
+    val SNAPSHOT          = "SNAPSHOT".asInstanceOf[UpgradeStep]
+    val UPGRADE           = "UPGRADE".asInstanceOf[UpgradeStep]
 
     val values = js.Object.freeze(js.Array(PRE_UPGRADE_CHECK, SNAPSHOT, UPGRADE))
   }
@@ -2658,10 +2659,12 @@ package es {
   /**
     * The type of EBS volume, standard, gp2, or io1. See <a href="http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs" target="_blank">Configuring EBS-based Storage</a>for more information.
     */
-  object VolumeTypeEnum {
-    val standard = "standard"
-    val gp2      = "gp2"
-    val io1      = "io1"
+  @js.native
+  sealed trait VolumeType extends js.Any
+  object VolumeType extends js.Object {
+    val standard = "standard".asInstanceOf[VolumeType]
+    val gp2      = "gp2".asInstanceOf[VolumeType]
+    val io1      = "io1".asInstanceOf[VolumeType]
 
     val values = js.Object.freeze(js.Array(standard, gp2, io1))
   }

--- a/services/eventbridge/src/main/scala/facade/amazonaws/services/EventBridge.scala
+++ b/services/eventbridge/src/main/scala/facade/amazonaws/services/EventBridge.scala
@@ -10,7 +10,6 @@ package object eventbridge {
   type AccountId                        = String
   type Action                           = String
   type Arn                              = String
-  type AssignPublicIp                   = String
   type ErrorCode                        = String
   type ErrorMessage                     = String
   type EventBusList                     = js.Array[EventBus]
@@ -22,10 +21,8 @@ package object eventbridge {
   type EventSourceList                  = js.Array[EventSource]
   type EventSourceName                  = String
   type EventSourceNamePrefix            = String
-  type EventSourceState                 = String
   type EventTime                        = js.Date
   type InputTransformerPathKey          = String
-  type LaunchType                       = String
   type LimitMax100                      = Int
   type LimitMin1                        = Int
   type ManagedBy                        = String
@@ -48,7 +45,6 @@ package object eventbridge {
   type RuleName                         = String
   type RuleNameList                     = js.Array[RuleName]
   type RuleResponseList                 = js.Array[Rule]
-  type RuleState                        = String
   type RunCommandTargetKey              = String
   type RunCommandTargetValue            = String
   type RunCommandTargetValues           = js.Array[RunCommandTargetValue]
@@ -205,10 +201,11 @@ package eventbridge {
       __obj.asInstanceOf[ActivateEventSourceRequest]
     }
   }
-
-  object AssignPublicIpEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait AssignPublicIp extends js.Any
+  object AssignPublicIp extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[AssignPublicIp]
+    val DISABLED = "DISABLED".asInstanceOf[AssignPublicIp]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -812,11 +809,12 @@ package eventbridge {
       __obj.asInstanceOf[EventSource]
     }
   }
-
-  object EventSourceStateEnum {
-    val PENDING = "PENDING"
-    val ACTIVE  = "ACTIVE"
-    val DELETED = "DELETED"
+  @js.native
+  sealed trait EventSourceState extends js.Any
+  object EventSourceState extends js.Object {
+    val PENDING = "PENDING".asInstanceOf[EventSourceState]
+    val ACTIVE  = "ACTIVE".asInstanceOf[EventSourceState]
+    val DELETED = "DELETED".asInstanceOf[EventSourceState]
 
     val values = js.Object.freeze(js.Array(PENDING, ACTIVE, DELETED))
   }
@@ -865,10 +863,11 @@ package eventbridge {
       __obj.asInstanceOf[KinesisParameters]
     }
   }
-
-  object LaunchTypeEnum {
-    val EC2     = "EC2"
-    val FARGATE = "FARGATE"
+  @js.native
+  sealed trait LaunchType extends js.Any
+  object LaunchType extends js.Object {
+    val EC2     = "EC2".asInstanceOf[LaunchType]
+    val FARGATE = "FARGATE".asInstanceOf[LaunchType]
 
     val values = js.Object.freeze(js.Array(EC2, FARGATE))
   }
@@ -1758,10 +1757,11 @@ package eventbridge {
       __obj.asInstanceOf[Rule]
     }
   }
-
-  object RuleStateEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait RuleState extends js.Any
+  object RuleState extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[RuleState]
+    val DISABLED = "DISABLED".asInstanceOf[RuleState]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }

--- a/services/firehose/src/main/scala/facade/amazonaws/services/Firehose.scala
+++ b/services/firehose/src/main/scala/facade/amazonaws/services/Firehose.scala
@@ -13,19 +13,14 @@ package object firehose {
   type BucketARN                               = String
   type ClusterJDBCURL                          = String
   type ColumnToJsonKeyMappings                 = js.Dictionary[NonEmptyString]
-  type CompressionFormat                       = String
   type CopyOptions                             = String
   type Data                                    = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type DataTableColumns                        = String
   type DataTableName                           = String
   type DeliveryStartTimestamp                  = js.Date
   type DeliveryStreamARN                       = String
-  type DeliveryStreamEncryptionStatus          = String
-  type DeliveryStreamFailureType               = String
   type DeliveryStreamName                      = String
   type DeliveryStreamNameList                  = js.Array[DeliveryStreamName]
-  type DeliveryStreamStatus                    = String
-  type DeliveryStreamType                      = String
   type DeliveryStreamVersionId                 = String
   type DescribeDeliveryStreamInputLimit        = Int
   type DestinationDescriptionList              = js.Array[DestinationDescription]
@@ -35,19 +30,15 @@ package object firehose {
   type ElasticsearchClusterEndpoint            = String
   type ElasticsearchDomainARN                  = String
   type ElasticsearchIndexName                  = String
-  type ElasticsearchIndexRotationPeriod        = String
   type ElasticsearchRetryDurationInSeconds     = Int
-  type ElasticsearchS3BackupMode               = String
   type ElasticsearchTypeName                   = String
   type ErrorCode                               = String
   type ErrorMessage                            = String
   type ErrorOutputPrefix                       = String
   type HECAcknowledgmentTimeoutInSeconds       = Int
   type HECEndpoint                             = String
-  type HECEndpointType                         = String
   type HECToken                                = String
   type IntervalInSeconds                       = Int
-  type KeyType                                 = String
   type KinesisStreamARN                        = String
   type ListDeliveryStreamsInputLimit           = Int
   type ListOfNonEmptyStrings                   = js.Array[NonEmptyString]
@@ -56,35 +47,25 @@ package object firehose {
   type ListTagsForDeliveryStreamOutputTagList  = js.Array[Tag]
   type LogGroupName                            = String
   type LogStreamName                           = String
-  type NoEncryptionConfig                      = String
   type NonEmptyString                          = String
   type NonEmptyStringWithoutWhitespace         = String
   type NonNegativeIntegerObject                = Int
-  type OrcCompression                          = String
-  type OrcFormatVersion                        = String
   type OrcRowIndexStride                       = Int
   type OrcStripeSizeBytes                      = Int
-  type ParquetCompression                      = String
   type ParquetPageSizeBytes                    = Int
-  type ParquetWriterVersion                    = String
   type Password                                = String
   type Prefix                                  = String
   type ProcessorList                           = js.Array[Processor]
   type ProcessorParameterList                  = js.Array[ProcessorParameter]
-  type ProcessorParameterName                  = String
   type ProcessorParameterValue                 = String
-  type ProcessorType                           = String
   type Proportion                              = Double
   type PutRecordBatchRequestEntryList          = js.Array[Record]
   type PutRecordBatchResponseEntryList         = js.Array[PutRecordBatchResponseEntry]
   type PutResponseRecordId                     = String
   type RedshiftRetryDurationInSeconds          = Int
-  type RedshiftS3BackupMode                    = String
   type RoleARN                                 = String
-  type S3BackupMode                            = String
   type SizeInMBs                               = Int
   type SplunkRetryDurationInSeconds            = Int
-  type SplunkS3BackupMode                      = String
   type TagDeliveryStreamInputTagList           = js.Array[Tag]
   type TagKey                                  = String
   type TagKeyList                              = js.Array[TagKey]
@@ -196,12 +177,13 @@ package firehose {
       __obj.asInstanceOf[CloudWatchLoggingOptions]
     }
   }
-
-  object CompressionFormatEnum {
-    val UNCOMPRESSED = "UNCOMPRESSED"
-    val GZIP         = "GZIP"
-    val ZIP          = "ZIP"
-    val Snappy       = "Snappy"
+  @js.native
+  sealed trait CompressionFormat extends js.Any
+  object CompressionFormat extends js.Object {
+    val UNCOMPRESSED = "UNCOMPRESSED".asInstanceOf[CompressionFormat]
+    val GZIP         = "GZIP".asInstanceOf[CompressionFormat]
+    val ZIP          = "ZIP".asInstanceOf[CompressionFormat]
+    val Snappy       = "Snappy".asInstanceOf[CompressionFormat]
 
     val values = js.Object.freeze(js.Array(UNCOMPRESSED, GZIP, ZIP, Snappy))
   }
@@ -480,27 +462,29 @@ package firehose {
       __obj.asInstanceOf[DeliveryStreamEncryptionConfigurationInput]
     }
   }
-
-  object DeliveryStreamEncryptionStatusEnum {
-    val ENABLED          = "ENABLED"
-    val ENABLING         = "ENABLING"
-    val ENABLING_FAILED  = "ENABLING_FAILED"
-    val DISABLED         = "DISABLED"
-    val DISABLING        = "DISABLING"
-    val DISABLING_FAILED = "DISABLING_FAILED"
+  @js.native
+  sealed trait DeliveryStreamEncryptionStatus extends js.Any
+  object DeliveryStreamEncryptionStatus extends js.Object {
+    val ENABLED          = "ENABLED".asInstanceOf[DeliveryStreamEncryptionStatus]
+    val ENABLING         = "ENABLING".asInstanceOf[DeliveryStreamEncryptionStatus]
+    val ENABLING_FAILED  = "ENABLING_FAILED".asInstanceOf[DeliveryStreamEncryptionStatus]
+    val DISABLED         = "DISABLED".asInstanceOf[DeliveryStreamEncryptionStatus]
+    val DISABLING        = "DISABLING".asInstanceOf[DeliveryStreamEncryptionStatus]
+    val DISABLING_FAILED = "DISABLING_FAILED".asInstanceOf[DeliveryStreamEncryptionStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, ENABLING, ENABLING_FAILED, DISABLED, DISABLING, DISABLING_FAILED))
   }
-
-  object DeliveryStreamFailureTypeEnum {
-    val RETIRE_KMS_GRANT_FAILED = "RETIRE_KMS_GRANT_FAILED"
-    val CREATE_KMS_GRANT_FAILED = "CREATE_KMS_GRANT_FAILED"
-    val KMS_ACCESS_DENIED       = "KMS_ACCESS_DENIED"
-    val DISABLED_KMS_KEY        = "DISABLED_KMS_KEY"
-    val INVALID_KMS_KEY         = "INVALID_KMS_KEY"
-    val KMS_KEY_NOT_FOUND       = "KMS_KEY_NOT_FOUND"
-    val KMS_OPT_IN_REQUIRED     = "KMS_OPT_IN_REQUIRED"
-    val UNKNOWN_ERROR           = "UNKNOWN_ERROR"
+  @js.native
+  sealed trait DeliveryStreamFailureType extends js.Any
+  object DeliveryStreamFailureType extends js.Object {
+    val RETIRE_KMS_GRANT_FAILED = "RETIRE_KMS_GRANT_FAILED".asInstanceOf[DeliveryStreamFailureType]
+    val CREATE_KMS_GRANT_FAILED = "CREATE_KMS_GRANT_FAILED".asInstanceOf[DeliveryStreamFailureType]
+    val KMS_ACCESS_DENIED       = "KMS_ACCESS_DENIED".asInstanceOf[DeliveryStreamFailureType]
+    val DISABLED_KMS_KEY        = "DISABLED_KMS_KEY".asInstanceOf[DeliveryStreamFailureType]
+    val INVALID_KMS_KEY         = "INVALID_KMS_KEY".asInstanceOf[DeliveryStreamFailureType]
+    val KMS_KEY_NOT_FOUND       = "KMS_KEY_NOT_FOUND".asInstanceOf[DeliveryStreamFailureType]
+    val KMS_OPT_IN_REQUIRED     = "KMS_OPT_IN_REQUIRED".asInstanceOf[DeliveryStreamFailureType]
+    val UNKNOWN_ERROR           = "UNKNOWN_ERROR".asInstanceOf[DeliveryStreamFailureType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -515,20 +499,22 @@ package firehose {
       )
     )
   }
-
-  object DeliveryStreamStatusEnum {
-    val CREATING        = "CREATING"
-    val CREATING_FAILED = "CREATING_FAILED"
-    val DELETING        = "DELETING"
-    val DELETING_FAILED = "DELETING_FAILED"
-    val ACTIVE          = "ACTIVE"
+  @js.native
+  sealed trait DeliveryStreamStatus extends js.Any
+  object DeliveryStreamStatus extends js.Object {
+    val CREATING        = "CREATING".asInstanceOf[DeliveryStreamStatus]
+    val CREATING_FAILED = "CREATING_FAILED".asInstanceOf[DeliveryStreamStatus]
+    val DELETING        = "DELETING".asInstanceOf[DeliveryStreamStatus]
+    val DELETING_FAILED = "DELETING_FAILED".asInstanceOf[DeliveryStreamStatus]
+    val ACTIVE          = "ACTIVE".asInstanceOf[DeliveryStreamStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, CREATING_FAILED, DELETING, DELETING_FAILED, ACTIVE))
   }
-
-  object DeliveryStreamTypeEnum {
-    val DirectPut             = "DirectPut"
-    val KinesisStreamAsSource = "KinesisStreamAsSource"
+  @js.native
+  sealed trait DeliveryStreamType extends js.Any
+  object DeliveryStreamType extends js.Object {
+    val DirectPut             = "DirectPut".asInstanceOf[DeliveryStreamType]
+    val KinesisStreamAsSource = "KinesisStreamAsSource".asInstanceOf[DeliveryStreamType]
 
     val values = js.Object.freeze(js.Array(DirectPut, KinesisStreamAsSource))
   }
@@ -819,13 +805,14 @@ package firehose {
       __obj.asInstanceOf[ElasticsearchDestinationUpdate]
     }
   }
-
-  object ElasticsearchIndexRotationPeriodEnum {
-    val NoRotation = "NoRotation"
-    val OneHour    = "OneHour"
-    val OneDay     = "OneDay"
-    val OneWeek    = "OneWeek"
-    val OneMonth   = "OneMonth"
+  @js.native
+  sealed trait ElasticsearchIndexRotationPeriod extends js.Any
+  object ElasticsearchIndexRotationPeriod extends js.Object {
+    val NoRotation = "NoRotation".asInstanceOf[ElasticsearchIndexRotationPeriod]
+    val OneHour    = "OneHour".asInstanceOf[ElasticsearchIndexRotationPeriod]
+    val OneDay     = "OneDay".asInstanceOf[ElasticsearchIndexRotationPeriod]
+    val OneWeek    = "OneWeek".asInstanceOf[ElasticsearchIndexRotationPeriod]
+    val OneMonth   = "OneMonth".asInstanceOf[ElasticsearchIndexRotationPeriod]
 
     val values = js.Object.freeze(js.Array(NoRotation, OneHour, OneDay, OneWeek, OneMonth))
   }
@@ -848,10 +835,11 @@ package firehose {
       __obj.asInstanceOf[ElasticsearchRetryOptions]
     }
   }
-
-  object ElasticsearchS3BackupModeEnum {
-    val FailedDocumentsOnly = "FailedDocumentsOnly"
-    val AllDocuments        = "AllDocuments"
+  @js.native
+  sealed trait ElasticsearchS3BackupMode extends js.Any
+  object ElasticsearchS3BackupMode extends js.Object {
+    val FailedDocumentsOnly = "FailedDocumentsOnly".asInstanceOf[ElasticsearchS3BackupMode]
+    val AllDocuments        = "AllDocuments".asInstanceOf[ElasticsearchS3BackupMode]
 
     val values = js.Object.freeze(js.Array(FailedDocumentsOnly, AllDocuments))
   }
@@ -1067,10 +1055,11 @@ package firehose {
       __obj.asInstanceOf[FailureDescription]
     }
   }
-
-  object HECEndpointTypeEnum {
-    val Raw   = "Raw"
-    val Event = "Event"
+  @js.native
+  sealed trait HECEndpointType extends js.Any
+  object HECEndpointType extends js.Object {
+    val Raw   = "Raw".asInstanceOf[HECEndpointType]
+    val Event = "Event".asInstanceOf[HECEndpointType]
 
     val values = js.Object.freeze(js.Array(Raw, Event))
   }
@@ -1133,10 +1122,11 @@ package firehose {
       __obj.asInstanceOf[KMSEncryptionConfig]
     }
   }
-
-  object KeyTypeEnum {
-    val AWS_OWNED_CMK        = "AWS_OWNED_CMK"
-    val CUSTOMER_MANAGED_CMK = "CUSTOMER_MANAGED_CMK"
+  @js.native
+  sealed trait KeyType extends js.Any
+  object KeyType extends js.Object {
+    val AWS_OWNED_CMK        = "AWS_OWNED_CMK".asInstanceOf[KeyType]
+    val CUSTOMER_MANAGED_CMK = "CUSTOMER_MANAGED_CMK".asInstanceOf[KeyType]
 
     val values = js.Object.freeze(js.Array(AWS_OWNED_CMK, CUSTOMER_MANAGED_CMK))
   }
@@ -1279,9 +1269,10 @@ package firehose {
       __obj.asInstanceOf[ListTagsForDeliveryStreamOutput]
     }
   }
-
-  object NoEncryptionConfigEnum {
-    val NoEncryption = "NoEncryption"
+  @js.native
+  sealed trait NoEncryptionConfig extends js.Any
+  object NoEncryptionConfig extends js.Object {
+    val NoEncryption = "NoEncryption".asInstanceOf[NoEncryptionConfig]
 
     val values = js.Object.freeze(js.Array(NoEncryption))
   }
@@ -1312,18 +1303,20 @@ package firehose {
       __obj.asInstanceOf[OpenXJsonSerDe]
     }
   }
-
-  object OrcCompressionEnum {
-    val NONE   = "NONE"
-    val ZLIB   = "ZLIB"
-    val SNAPPY = "SNAPPY"
+  @js.native
+  sealed trait OrcCompression extends js.Any
+  object OrcCompression extends js.Object {
+    val NONE   = "NONE".asInstanceOf[OrcCompression]
+    val ZLIB   = "ZLIB".asInstanceOf[OrcCompression]
+    val SNAPPY = "SNAPPY".asInstanceOf[OrcCompression]
 
     val values = js.Object.freeze(js.Array(NONE, ZLIB, SNAPPY))
   }
-
-  object OrcFormatVersionEnum {
-    val V0_11 = "V0_11"
-    val V0_12 = "V0_12"
+  @js.native
+  sealed trait OrcFormatVersion extends js.Any
+  object OrcFormatVersion extends js.Object {
+    val V0_11 = "V0_11".asInstanceOf[OrcFormatVersion]
+    val V0_12 = "V0_12".asInstanceOf[OrcFormatVersion]
 
     val values = js.Object.freeze(js.Array(V0_11, V0_12))
   }
@@ -1394,11 +1387,12 @@ package firehose {
       __obj.asInstanceOf[OutputFormatConfiguration]
     }
   }
-
-  object ParquetCompressionEnum {
-    val UNCOMPRESSED = "UNCOMPRESSED"
-    val GZIP         = "GZIP"
-    val SNAPPY       = "SNAPPY"
+  @js.native
+  sealed trait ParquetCompression extends js.Any
+  object ParquetCompression extends js.Object {
+    val UNCOMPRESSED = "UNCOMPRESSED".asInstanceOf[ParquetCompression]
+    val GZIP         = "GZIP".asInstanceOf[ParquetCompression]
+    val SNAPPY       = "SNAPPY".asInstanceOf[ParquetCompression]
 
     val values = js.Object.freeze(js.Array(UNCOMPRESSED, GZIP, SNAPPY))
   }
@@ -1438,10 +1432,11 @@ package firehose {
       __obj.asInstanceOf[ParquetSerDe]
     }
   }
-
-  object ParquetWriterVersionEnum {
-    val V1 = "V1"
-    val V2 = "V2"
+  @js.native
+  sealed trait ParquetWriterVersion extends js.Any
+  object ParquetWriterVersion extends js.Object {
+    val V1 = "V1".asInstanceOf[ParquetWriterVersion]
+    val V2 = "V2".asInstanceOf[ParquetWriterVersion]
 
     val values = js.Object.freeze(js.Array(V1, V2))
   }
@@ -1515,20 +1510,22 @@ package firehose {
       __obj.asInstanceOf[ProcessorParameter]
     }
   }
-
-  object ProcessorParameterNameEnum {
-    val LambdaArn               = "LambdaArn"
-    val NumberOfRetries         = "NumberOfRetries"
-    val RoleArn                 = "RoleArn"
-    val BufferSizeInMBs         = "BufferSizeInMBs"
-    val BufferIntervalInSeconds = "BufferIntervalInSeconds"
+  @js.native
+  sealed trait ProcessorParameterName extends js.Any
+  object ProcessorParameterName extends js.Object {
+    val LambdaArn               = "LambdaArn".asInstanceOf[ProcessorParameterName]
+    val NumberOfRetries         = "NumberOfRetries".asInstanceOf[ProcessorParameterName]
+    val RoleArn                 = "RoleArn".asInstanceOf[ProcessorParameterName]
+    val BufferSizeInMBs         = "BufferSizeInMBs".asInstanceOf[ProcessorParameterName]
+    val BufferIntervalInSeconds = "BufferIntervalInSeconds".asInstanceOf[ProcessorParameterName]
 
     val values =
       js.Object.freeze(js.Array(LambdaArn, NumberOfRetries, RoleArn, BufferSizeInMBs, BufferIntervalInSeconds))
   }
-
-  object ProcessorTypeEnum {
-    val Lambda = "Lambda"
+  @js.native
+  sealed trait ProcessorType extends js.Any
+  object ProcessorType extends js.Object {
+    val Lambda = "Lambda".asInstanceOf[ProcessorType]
 
     val values = js.Object.freeze(js.Array(Lambda))
   }
@@ -1832,17 +1829,19 @@ package firehose {
       __obj.asInstanceOf[RedshiftRetryOptions]
     }
   }
-
-  object RedshiftS3BackupModeEnum {
-    val Disabled = "Disabled"
-    val Enabled  = "Enabled"
+  @js.native
+  sealed trait RedshiftS3BackupMode extends js.Any
+  object RedshiftS3BackupMode extends js.Object {
+    val Disabled = "Disabled".asInstanceOf[RedshiftS3BackupMode]
+    val Enabled  = "Enabled".asInstanceOf[RedshiftS3BackupMode]
 
     val values = js.Object.freeze(js.Array(Disabled, Enabled))
   }
-
-  object S3BackupModeEnum {
-    val Disabled = "Disabled"
-    val Enabled  = "Enabled"
+  @js.native
+  sealed trait S3BackupMode extends js.Any
+  object S3BackupMode extends js.Object {
+    val Disabled = "Disabled".asInstanceOf[S3BackupMode]
+    val Enabled  = "Enabled".asInstanceOf[S3BackupMode]
 
     val values = js.Object.freeze(js.Array(Disabled, Enabled))
   }
@@ -2203,10 +2202,11 @@ package firehose {
       __obj.asInstanceOf[SplunkRetryOptions]
     }
   }
-
-  object SplunkS3BackupModeEnum {
-    val FailedEventsOnly = "FailedEventsOnly"
-    val AllEvents        = "AllEvents"
+  @js.native
+  sealed trait SplunkS3BackupMode extends js.Any
+  object SplunkS3BackupMode extends js.Object {
+    val FailedEventsOnly = "FailedEventsOnly".asInstanceOf[SplunkS3BackupMode]
+    val AllEvents        = "AllEvents".asInstanceOf[SplunkS3BackupMode]
 
     val values = js.Object.freeze(js.Array(FailedEventsOnly, AllEvents))
   }

--- a/services/fms/src/main/scala/facade/amazonaws/services/FMS.scala
+++ b/services/fms/src/main/scala/facade/amazonaws/services/FMS.scala
@@ -8,13 +8,10 @@ import facade.amazonaws._
 
 package object fms {
   type AWSAccountId               = String
-  type AccountRoleStatus          = String
   type ComplianceViolators        = js.Array[ComplianceViolator]
   type CustomerPolicyScopeId      = String
   type CustomerPolicyScopeIdList  = js.Array[CustomerPolicyScopeId]
-  type CustomerPolicyScopeIdType  = String
   type CustomerPolicyScopeMap     = js.Dictionary[CustomerPolicyScopeIdList]
-  type DependentServiceName       = String
   type DetailedInfo               = String
   type EvaluationResults          = js.Array[EvaluationResult]
   type IssueInfoMap               = js.Dictionary[DetailedInfo]
@@ -23,7 +20,6 @@ package object fms {
   type PaginationMaxResults       = Int
   type PaginationToken            = String
   type PolicyComplianceStatusList = js.Array[PolicyComplianceStatus]
-  type PolicyComplianceStatusType = String
   type PolicyId                   = String
   type PolicySummaryList          = js.Array[PolicySummary]
   type PolicyUpdateToken          = String
@@ -37,13 +33,11 @@ package object fms {
   type ResourceTags               = js.Array[ResourceTag]
   type ResourceType               = String
   type ResourceTypeList           = js.Array[ResourceType]
-  type SecurityServiceType        = String
   type TagKey                     = String
   type TagKeyList                 = js.Array[TagKey]
   type TagList                    = js.Array[Tag]
   type TagValue                   = String
   type TimeStamp                  = js.Date
-  type ViolationReason            = String
 
   implicit final class FMSOps(private val service: FMS) extends AnyVal {
 
@@ -110,13 +104,14 @@ package fms {
     def tagResource(params: TagResourceRequest): Request[TagResourceResponse]                            = js.native
     def untagResource(params: UntagResourceRequest): Request[UntagResourceResponse]                      = js.native
   }
-
-  object AccountRoleStatusEnum {
-    val READY            = "READY"
-    val CREATING         = "CREATING"
-    val PENDING_DELETION = "PENDING_DELETION"
-    val DELETING         = "DELETING"
-    val DELETED          = "DELETED"
+  @js.native
+  sealed trait AccountRoleStatus extends js.Any
+  object AccountRoleStatus extends js.Object {
+    val READY            = "READY".asInstanceOf[AccountRoleStatus]
+    val CREATING         = "CREATING".asInstanceOf[AccountRoleStatus]
+    val PENDING_DELETION = "PENDING_DELETION".asInstanceOf[AccountRoleStatus]
+    val DELETING         = "DELETING".asInstanceOf[AccountRoleStatus]
+    val DELETED          = "DELETED".asInstanceOf[AccountRoleStatus]
 
     val values = js.Object.freeze(js.Array(READY, CREATING, PENDING_DELETION, DELETING, DELETED))
   }
@@ -163,9 +158,10 @@ package fms {
       __obj.asInstanceOf[ComplianceViolator]
     }
   }
-
-  object CustomerPolicyScopeIdTypeEnum {
-    val ACCOUNT = "ACCOUNT"
+  @js.native
+  sealed trait CustomerPolicyScopeIdType extends js.Any
+  object CustomerPolicyScopeIdType extends js.Object {
+    val ACCOUNT = "ACCOUNT".asInstanceOf[CustomerPolicyScopeIdType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT))
   }
@@ -203,12 +199,13 @@ package fms {
       __obj.asInstanceOf[DeletePolicyRequest]
     }
   }
-
-  object DependentServiceNameEnum {
-    val AWSCONFIG          = "AWSCONFIG"
-    val AWSWAF             = "AWSWAF"
-    val AWSSHIELD_ADVANCED = "AWSSHIELD_ADVANCED"
-    val AWSVPC             = "AWSVPC"
+  @js.native
+  sealed trait DependentServiceName extends js.Any
+  object DependentServiceName extends js.Object {
+    val AWSCONFIG          = "AWSCONFIG".asInstanceOf[DependentServiceName]
+    val AWSWAF             = "AWSWAF".asInstanceOf[DependentServiceName]
+    val AWSSHIELD_ADVANCED = "AWSSHIELD_ADVANCED".asInstanceOf[DependentServiceName]
+    val AWSVPC             = "AWSVPC".asInstanceOf[DependentServiceName]
 
     val values = js.Object.freeze(js.Array(AWSCONFIG, AWSWAF, AWSSHIELD_ADVANCED, AWSVPC))
   }
@@ -726,10 +723,11 @@ package fms {
       __obj.asInstanceOf[PolicyComplianceStatus]
     }
   }
-
-  object PolicyComplianceStatusTypeEnum {
-    val COMPLIANT     = "COMPLIANT"
-    val NON_COMPLIANT = "NON_COMPLIANT"
+  @js.native
+  sealed trait PolicyComplianceStatusType extends js.Any
+  object PolicyComplianceStatusType extends js.Object {
+    val COMPLIANT     = "COMPLIANT".asInstanceOf[PolicyComplianceStatusType]
+    val NON_COMPLIANT = "NON_COMPLIANT".asInstanceOf[PolicyComplianceStatusType]
 
     val values = js.Object.freeze(js.Array(COMPLIANT, NON_COMPLIANT))
   }
@@ -876,13 +874,14 @@ package fms {
       __obj.asInstanceOf[SecurityServicePolicyData]
     }
   }
-
-  object SecurityServiceTypeEnum {
-    val WAF                           = "WAF"
-    val SHIELD_ADVANCED               = "SHIELD_ADVANCED"
-    val SECURITY_GROUPS_COMMON        = "SECURITY_GROUPS_COMMON"
-    val SECURITY_GROUPS_CONTENT_AUDIT = "SECURITY_GROUPS_CONTENT_AUDIT"
-    val SECURITY_GROUPS_USAGE_AUDIT   = "SECURITY_GROUPS_USAGE_AUDIT"
+  @js.native
+  sealed trait SecurityServiceType extends js.Any
+  object SecurityServiceType extends js.Object {
+    val WAF                           = "WAF".asInstanceOf[SecurityServiceType]
+    val SHIELD_ADVANCED               = "SHIELD_ADVANCED".asInstanceOf[SecurityServiceType]
+    val SECURITY_GROUPS_COMMON        = "SECURITY_GROUPS_COMMON".asInstanceOf[SecurityServiceType]
+    val SECURITY_GROUPS_CONTENT_AUDIT = "SECURITY_GROUPS_CONTENT_AUDIT".asInstanceOf[SecurityServiceType]
+    val SECURITY_GROUPS_USAGE_AUDIT   = "SECURITY_GROUPS_USAGE_AUDIT".asInstanceOf[SecurityServiceType]
 
     val values = js.Object.freeze(
       js.Array(WAF, SHIELD_ADVANCED, SECURITY_GROUPS_COMMON, SECURITY_GROUPS_CONTENT_AUDIT, SECURITY_GROUPS_USAGE_AUDIT)
@@ -980,17 +979,19 @@ package fms {
       __obj.asInstanceOf[UntagResourceResponse]
     }
   }
-
-  object ViolationReasonEnum {
-    val WEB_ACL_MISSING_RULE_GROUP                    = "WEB_ACL_MISSING_RULE_GROUP"
-    val RESOURCE_MISSING_WEB_ACL                      = "RESOURCE_MISSING_WEB_ACL"
-    val RESOURCE_INCORRECT_WEB_ACL                    = "RESOURCE_INCORRECT_WEB_ACL"
-    val RESOURCE_MISSING_SHIELD_PROTECTION            = "RESOURCE_MISSING_SHIELD_PROTECTION"
-    val RESOURCE_MISSING_WEB_ACL_OR_SHIELD_PROTECTION = "RESOURCE_MISSING_WEB_ACL_OR_SHIELD_PROTECTION"
-    val RESOURCE_MISSING_SECURITY_GROUP               = "RESOURCE_MISSING_SECURITY_GROUP"
-    val RESOURCE_VIOLATES_AUDIT_SECURITY_GROUP        = "RESOURCE_VIOLATES_AUDIT_SECURITY_GROUP"
-    val SECURITY_GROUP_UNUSED                         = "SECURITY_GROUP_UNUSED"
-    val SECURITY_GROUP_REDUNDANT                      = "SECURITY_GROUP_REDUNDANT"
+  @js.native
+  sealed trait ViolationReason extends js.Any
+  object ViolationReason extends js.Object {
+    val WEB_ACL_MISSING_RULE_GROUP         = "WEB_ACL_MISSING_RULE_GROUP".asInstanceOf[ViolationReason]
+    val RESOURCE_MISSING_WEB_ACL           = "RESOURCE_MISSING_WEB_ACL".asInstanceOf[ViolationReason]
+    val RESOURCE_INCORRECT_WEB_ACL         = "RESOURCE_INCORRECT_WEB_ACL".asInstanceOf[ViolationReason]
+    val RESOURCE_MISSING_SHIELD_PROTECTION = "RESOURCE_MISSING_SHIELD_PROTECTION".asInstanceOf[ViolationReason]
+    val RESOURCE_MISSING_WEB_ACL_OR_SHIELD_PROTECTION =
+      "RESOURCE_MISSING_WEB_ACL_OR_SHIELD_PROTECTION".asInstanceOf[ViolationReason]
+    val RESOURCE_MISSING_SECURITY_GROUP        = "RESOURCE_MISSING_SECURITY_GROUP".asInstanceOf[ViolationReason]
+    val RESOURCE_VIOLATES_AUDIT_SECURITY_GROUP = "RESOURCE_VIOLATES_AUDIT_SECURITY_GROUP".asInstanceOf[ViolationReason]
+    val SECURITY_GROUP_UNUSED                  = "SECURITY_GROUP_UNUSED".asInstanceOf[ViolationReason]
+    val SECURITY_GROUP_REDUNDANT               = "SECURITY_GROUP_REDUNDANT".asInstanceOf[ViolationReason]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/forecast/src/main/scala/facade/amazonaws/services/Forecast.scala
+++ b/services/forecast/src/main/scala/facade/amazonaws/services/Forecast.scala
@@ -9,22 +9,16 @@ import facade.amazonaws._
 package object forecast {
   type Arn                           = String
   type ArnList                       = js.Array[Arn]
-  type AttributeType                 = String
   type CategoricalParameterRanges    = js.Array[CategoricalParameterRange]
   type ContinuousParameterRanges     = js.Array[ContinuousParameterRange]
   type DatasetGroups                 = js.Array[DatasetGroupSummary]
   type DatasetImportJobs             = js.Array[DatasetImportJobSummary]
-  type DatasetType                   = String
   type Datasets                      = js.Array[DatasetSummary]
-  type Domain                        = String
   type ErrorMessage                  = String
-  type EvaluationType                = String
-  type FeaturizationMethodName       = String
   type FeaturizationMethodParameters = js.Dictionary[ParameterValue]
   type FeaturizationPipeline         = js.Array[FeaturizationMethod]
   type Featurizations                = js.Array[Featurization]
   type FieldStatistics               = js.Dictionary[Statistics]
-  type FilterConditionString         = String
   type Filters                       = js.Array[Filter]
   type ForecastDimensions            = js.Array[Name]
   type ForecastExportJobs            = js.Array[ForecastExportJobSummary]
@@ -44,7 +38,6 @@ package object forecast {
   type PredictorExecutions           = js.Array[PredictorExecution]
   type Predictors                    = js.Array[PredictorSummary]
   type S3Path                        = String
-  type ScalingType                   = String
   type SchemaAttributes              = js.Array[SchemaAttribute]
   type Status                        = String
   type SupplementaryFeatures         = js.Array[SupplementaryFeature]
@@ -159,12 +152,13 @@ package forecast {
     def listPredictors(params: ListPredictorsRequest): Request[ListPredictorsResponse]             = js.native
     def updateDatasetGroup(params: UpdateDatasetGroupRequest): Request[UpdateDatasetGroupResponse] = js.native
   }
-
-  object AttributeTypeEnum {
-    val string    = "string"
-    val integer   = "integer"
-    val float     = "float"
-    val timestamp = "timestamp"
+  @js.native
+  sealed trait AttributeType extends js.Any
+  object AttributeType extends js.Object {
+    val string    = "string".asInstanceOf[AttributeType]
+    val integer   = "integer".asInstanceOf[AttributeType]
+    val float     = "float".asInstanceOf[AttributeType]
+    val timestamp = "timestamp".asInstanceOf[AttributeType]
 
     val values = js.Object.freeze(js.Array(string, integer, float, timestamp))
   }
@@ -639,11 +633,12 @@ package forecast {
       __obj.asInstanceOf[DatasetSummary]
     }
   }
-
-  object DatasetTypeEnum {
-    val TARGET_TIME_SERIES  = "TARGET_TIME_SERIES"
-    val RELATED_TIME_SERIES = "RELATED_TIME_SERIES"
-    val ITEM_METADATA       = "ITEM_METADATA"
+  @js.native
+  sealed trait DatasetType extends js.Any
+  object DatasetType extends js.Object {
+    val TARGET_TIME_SERIES  = "TARGET_TIME_SERIES".asInstanceOf[DatasetType]
+    val RELATED_TIME_SERIES = "RELATED_TIME_SERIES".asInstanceOf[DatasetType]
+    val ITEM_METADATA       = "ITEM_METADATA".asInstanceOf[DatasetType]
 
     val values = js.Object.freeze(js.Array(TARGET_TIME_SERIES, RELATED_TIME_SERIES, ITEM_METADATA))
   }
@@ -1135,15 +1130,16 @@ package forecast {
       __obj.asInstanceOf[DescribePredictorResponse]
     }
   }
-
-  object DomainEnum {
-    val RETAIL             = "RETAIL"
-    val CUSTOM             = "CUSTOM"
-    val INVENTORY_PLANNING = "INVENTORY_PLANNING"
-    val EC2_CAPACITY       = "EC2_CAPACITY"
-    val WORK_FORCE         = "WORK_FORCE"
-    val WEB_TRAFFIC        = "WEB_TRAFFIC"
-    val METRICS            = "METRICS"
+  @js.native
+  sealed trait Domain extends js.Any
+  object Domain extends js.Object {
+    val RETAIL             = "RETAIL".asInstanceOf[Domain]
+    val CUSTOM             = "CUSTOM".asInstanceOf[Domain]
+    val INVENTORY_PLANNING = "INVENTORY_PLANNING".asInstanceOf[Domain]
+    val EC2_CAPACITY       = "EC2_CAPACITY".asInstanceOf[Domain]
+    val WORK_FORCE         = "WORK_FORCE".asInstanceOf[Domain]
+    val WEB_TRAFFIC        = "WEB_TRAFFIC".asInstanceOf[Domain]
+    val METRICS            = "METRICS".asInstanceOf[Domain]
 
     val values =
       js.Object.freeze(js.Array(RETAIL, CUSTOM, INVENTORY_PLANNING, EC2_CAPACITY, WORK_FORCE, WEB_TRAFFIC, METRICS))
@@ -1216,10 +1212,11 @@ package forecast {
       __obj.asInstanceOf[EvaluationResult]
     }
   }
-
-  object EvaluationTypeEnum {
-    val SUMMARY  = "SUMMARY"
-    val COMPUTED = "COMPUTED"
+  @js.native
+  sealed trait EvaluationType extends js.Any
+  object EvaluationType extends js.Object {
+    val SUMMARY  = "SUMMARY".asInstanceOf[EvaluationType]
+    val COMPUTED = "COMPUTED".asInstanceOf[EvaluationType]
 
     val values = js.Object.freeze(js.Array(SUMMARY, COMPUTED))
   }
@@ -1315,9 +1312,10 @@ package forecast {
       __obj.asInstanceOf[FeaturizationMethod]
     }
   }
-
-  object FeaturizationMethodNameEnum {
-    val filling = "filling"
+  @js.native
+  sealed trait FeaturizationMethodName extends js.Any
+  object FeaturizationMethodName extends js.Object {
+    val filling = "filling".asInstanceOf[FeaturizationMethodName]
 
     val values = js.Object.freeze(js.Array(filling))
   }
@@ -1348,10 +1346,11 @@ package forecast {
       __obj.asInstanceOf[Filter]
     }
   }
-
-  object FilterConditionStringEnum {
-    val IS     = "IS"
-    val IS_NOT = "IS_NOT"
+  @js.native
+  sealed trait FilterConditionString extends js.Any
+  object FilterConditionString extends js.Object {
+    val IS     = "IS".asInstanceOf[FilterConditionString]
+    val IS_NOT = "IS_NOT".asInstanceOf[FilterConditionString]
 
     val values = js.Object.freeze(js.Array(IS, IS_NOT))
   }
@@ -1939,12 +1938,13 @@ package forecast {
       __obj.asInstanceOf[S3Config]
     }
   }
-
-  object ScalingTypeEnum {
-    val Auto               = "Auto"
-    val Linear             = "Linear"
-    val Logarithmic        = "Logarithmic"
-    val ReverseLogarithmic = "ReverseLogarithmic"
+  @js.native
+  sealed trait ScalingType extends js.Any
+  object ScalingType extends js.Object {
+    val Auto               = "Auto".asInstanceOf[ScalingType]
+    val Linear             = "Linear".asInstanceOf[ScalingType]
+    val Logarithmic        = "Logarithmic".asInstanceOf[ScalingType]
+    val ReverseLogarithmic = "ReverseLogarithmic".asInstanceOf[ScalingType]
 
     val values = js.Object.freeze(js.Array(Auto, Linear, Logarithmic, ReverseLogarithmic))
   }

--- a/services/frauddetector/src/main/scala/facade/amazonaws/services/FraudDetector.scala
+++ b/services/frauddetector/src/main/scala/facade/amazonaws/services/FraudDetector.scala
@@ -10,11 +10,8 @@ package object frauddetector {
   type BatchCreateVariableErrorList     = js.Array[BatchCreateVariableError]
   type BatchGetVariableErrorList        = js.Array[BatchGetVariableError]
   type CsvIndexToVariableMap            = js.Dictionary[String]
-  type DataSource                       = String
-  type DataType                         = String
   type DetectorList                     = js.Array[Detector]
   type DetectorVersionMaxResults        = Int
-  type DetectorVersionStatus            = String
   type DetectorVersionSummaryList       = js.Array[DetectorVersionSummary]
   type DetectorsMaxResults              = Int
   type EventAttributeMap                = js.Dictionary[attributeValue]
@@ -24,23 +21,16 @@ package object frauddetector {
   type IsOpaque                         = Boolean
   type JsonKeyToVariableMap             = js.Dictionary[String]
   type LabelMapper                      = js.Dictionary[ListOfStrings]
-  type Language                         = String
   type ListOfModelScores                = js.Array[ModelScores]
   type ListOfModelVersions              = js.Array[ModelVersion]
   type ListOfStrings                    = js.Array[String]
   type MaxResults                       = Int
   type MetricsMap                       = js.Dictionary[String]
-  type ModelEndpointStatus              = String
-  type ModelInputDataFormat             = String
   type ModelList                        = js.Array[Model]
-  type ModelOutputDataFormat            = String
   type ModelPredictionMap               = js.Dictionary[Float]
-  type ModelSource                      = String
-  type ModelTypeEnum                    = String
   type ModelVariableIndex               = Int
   type ModelVariablesList               = js.Array[ModelVariable]
   type ModelVersionDetailList           = js.Array[ModelVersionDetail]
-  type ModelVersionStatus               = String
   type NameList                         = js.Array[String]
   type NonEmptyListOfStrings            = js.Array[String]
   type OutcomeList                      = js.Array[Outcome]
@@ -488,20 +478,22 @@ package frauddetector {
       __obj.asInstanceOf[CreateVariableResult]
     }
   }
-
-  object DataSourceEnum {
-    val EVENT                = "EVENT"
-    val MODEL_SCORE          = "MODEL_SCORE"
-    val EXTERNAL_MODEL_SCORE = "EXTERNAL_MODEL_SCORE"
+  @js.native
+  sealed trait DataSource extends js.Any
+  object DataSource extends js.Object {
+    val EVENT                = "EVENT".asInstanceOf[DataSource]
+    val MODEL_SCORE          = "MODEL_SCORE".asInstanceOf[DataSource]
+    val EXTERNAL_MODEL_SCORE = "EXTERNAL_MODEL_SCORE".asInstanceOf[DataSource]
 
     val values = js.Object.freeze(js.Array(EVENT, MODEL_SCORE, EXTERNAL_MODEL_SCORE))
   }
-
-  object DataTypeEnum {
-    val STRING  = "STRING"
-    val INTEGER = "INTEGER"
-    val FLOAT   = "FLOAT"
-    val BOOLEAN = "BOOLEAN"
+  @js.native
+  sealed trait DataType extends js.Any
+  object DataType extends js.Object {
+    val STRING  = "STRING".asInstanceOf[DataType]
+    val INTEGER = "INTEGER".asInstanceOf[DataType]
+    val FLOAT   = "FLOAT".asInstanceOf[DataType]
+    val BOOLEAN = "BOOLEAN".asInstanceOf[DataType]
 
     val values = js.Object.freeze(js.Array(STRING, INTEGER, FLOAT, BOOLEAN))
   }
@@ -691,11 +683,12 @@ package frauddetector {
       __obj.asInstanceOf[Detector]
     }
   }
-
-  object DetectorVersionStatusEnum {
-    val DRAFT    = "DRAFT"
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait DetectorVersionStatus extends js.Any
+  object DetectorVersionStatus extends js.Object {
+    val DRAFT    = "DRAFT".asInstanceOf[DetectorVersionStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[DetectorVersionStatus]
+    val INACTIVE = "INACTIVE".asInstanceOf[DetectorVersionStatus]
 
     val values = js.Object.freeze(js.Array(DRAFT, ACTIVE, INACTIVE))
   }
@@ -1212,9 +1205,10 @@ package frauddetector {
       __obj.asInstanceOf[LabelSchema]
     }
   }
-
-  object LanguageEnum {
-    val DETECTORPL = "DETECTORPL"
+  @js.native
+  sealed trait Language extends js.Any
+  object Language extends js.Object {
+    val DETECTORPL = "DETECTORPL".asInstanceOf[Language]
 
     val values = js.Object.freeze(js.Array(DETECTORPL))
   }
@@ -1280,10 +1274,11 @@ package frauddetector {
       __obj.asInstanceOf[ModelEndpointDataBlob]
     }
   }
-
-  object ModelEndpointStatusEnum {
-    val ASSOCIATED  = "ASSOCIATED"
-    val DISSOCIATED = "DISSOCIATED"
+  @js.native
+  sealed trait ModelEndpointStatus extends js.Any
+  object ModelEndpointStatus extends js.Object {
+    val ASSOCIATED  = "ASSOCIATED".asInstanceOf[ModelEndpointStatus]
+    val DISSOCIATED = "DISSOCIATED".asInstanceOf[ModelEndpointStatus]
 
     val values = js.Object.freeze(js.Array(ASSOCIATED, DISSOCIATED))
   }
@@ -1317,10 +1312,11 @@ package frauddetector {
       __obj.asInstanceOf[ModelInputConfiguration]
     }
   }
-
-  object ModelInputDataFormatEnum {
-    val TEXT_CSV         = "TEXT_CSV"
-    val APPLICATION_JSON = "APPLICATION_JSON"
+  @js.native
+  sealed trait ModelInputDataFormat extends js.Any
+  object ModelInputDataFormat extends js.Object {
+    val TEXT_CSV         = "TEXT_CSV".asInstanceOf[ModelInputDataFormat]
+    val APPLICATION_JSON = "APPLICATION_JSON".asInstanceOf[ModelInputDataFormat]
 
     val values = js.Object.freeze(js.Array(TEXT_CSV, APPLICATION_JSON))
   }
@@ -1351,10 +1347,11 @@ package frauddetector {
       __obj.asInstanceOf[ModelOutputConfiguration]
     }
   }
-
-  object ModelOutputDataFormatEnum {
-    val TEXT_CSV              = "TEXT_CSV"
-    val APPLICATION_JSONLINES = "APPLICATION_JSONLINES"
+  @js.native
+  sealed trait ModelOutputDataFormat extends js.Any
+  object ModelOutputDataFormat extends js.Object {
+    val TEXT_CSV              = "TEXT_CSV".asInstanceOf[ModelOutputDataFormat]
+    val APPLICATION_JSONLINES = "APPLICATION_JSONLINES".asInstanceOf[ModelOutputDataFormat]
 
     val values = js.Object.freeze(js.Array(TEXT_CSV, APPLICATION_JSONLINES))
   }
@@ -1380,15 +1377,17 @@ package frauddetector {
       __obj.asInstanceOf[ModelScores]
     }
   }
-
-  object ModelSourceEnum {
-    val SAGEMAKER = "SAGEMAKER"
+  @js.native
+  sealed trait ModelSource extends js.Any
+  object ModelSource extends js.Object {
+    val SAGEMAKER = "SAGEMAKER".asInstanceOf[ModelSource]
 
     val values = js.Object.freeze(js.Array(SAGEMAKER))
   }
-
-  object ModelTypeEnumEnum {
-    val ONLINE_FRAUD_INSIGHTS = "ONLINE_FRAUD_INSIGHTS"
+  @js.native
+  sealed trait ModelTypeEnum extends js.Any
+  object ModelTypeEnum extends js.Object {
+    val ONLINE_FRAUD_INSIGHTS = "ONLINE_FRAUD_INSIGHTS".asInstanceOf[ModelTypeEnum]
 
     val values = js.Object.freeze(js.Array(ONLINE_FRAUD_INSIGHTS))
   }
@@ -1495,16 +1494,17 @@ package frauddetector {
       __obj.asInstanceOf[ModelVersionDetail]
     }
   }
-
-  object ModelVersionStatusEnum {
-    val TRAINING_IN_PROGRESS   = "TRAINING_IN_PROGRESS"
-    val TRAINING_COMPLETE      = "TRAINING_COMPLETE"
-    val ACTIVATE_REQUESTED     = "ACTIVATE_REQUESTED"
-    val ACTIVATE_IN_PROGRESS   = "ACTIVATE_IN_PROGRESS"
-    val ACTIVE                 = "ACTIVE"
-    val INACTIVATE_IN_PROGRESS = "INACTIVATE_IN_PROGRESS"
-    val INACTIVE               = "INACTIVE"
-    val ERROR                  = "ERROR"
+  @js.native
+  sealed trait ModelVersionStatus extends js.Any
+  object ModelVersionStatus extends js.Object {
+    val TRAINING_IN_PROGRESS   = "TRAINING_IN_PROGRESS".asInstanceOf[ModelVersionStatus]
+    val TRAINING_COMPLETE      = "TRAINING_COMPLETE".asInstanceOf[ModelVersionStatus]
+    val ACTIVATE_REQUESTED     = "ACTIVATE_REQUESTED".asInstanceOf[ModelVersionStatus]
+    val ACTIVATE_IN_PROGRESS   = "ACTIVATE_IN_PROGRESS".asInstanceOf[ModelVersionStatus]
+    val ACTIVE                 = "ACTIVE".asInstanceOf[ModelVersionStatus]
+    val INACTIVATE_IN_PROGRESS = "INACTIVATE_IN_PROGRESS".asInstanceOf[ModelVersionStatus]
+    val INACTIVE               = "INACTIVE".asInstanceOf[ModelVersionStatus]
+    val ERROR                  = "ERROR".asInstanceOf[ModelVersionStatus]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/fsx/src/main/scala/facade/amazonaws/services/FSx.scala
+++ b/services/fsx/src/main/scala/facade/amazonaws/services/FSx.scala
@@ -13,21 +13,16 @@ package object fsx {
   type AutomaticBackupRetentionDays        = Int
   type BackupId                            = String
   type BackupIds                           = js.Array[BackupId]
-  type BackupLifecycle                     = String
-  type BackupType                          = String
   type Backups                             = js.Array[Backup]
   type ClientRequestToken                  = String
   type CreationTime                        = js.Date
   type DNSName                             = String
   type DailyTime                           = String
-  type DataRepositoryTaskFilterName        = String
   type DataRepositoryTaskFilterValue       = String
   type DataRepositoryTaskFilterValues      = js.Array[DataRepositoryTaskFilterValue]
   type DataRepositoryTaskFilters           = js.Array[DataRepositoryTaskFilter]
-  type DataRepositoryTaskLifecycle         = String
   type DataRepositoryTaskPath              = String
   type DataRepositoryTaskPaths             = js.Array[DataRepositoryTaskPath]
-  type DataRepositoryTaskType              = String
   type DataRepositoryTasks                 = js.Array[DataRepositoryTask]
   type DirectoryId                         = String
   type DirectoryPassword                   = String
@@ -39,12 +34,8 @@ package object fsx {
   type FileSystemAdministratorsGroupName   = String
   type FileSystemId                        = String
   type FileSystemIds                       = js.Array[FileSystemId]
-  type FileSystemLifecycle                 = String
-  type FileSystemMaintenanceOperation      = String
   type FileSystemMaintenanceOperations     = js.Array[FileSystemMaintenanceOperation]
-  type FileSystemType                      = String
   type FileSystems                         = js.Array[FileSystem]
-  type FilterName                          = String
   type FilterValue                         = String
   type FilterValues                        = js.Array[FilterValue]
   type Filters                             = js.Array[Filter]
@@ -60,8 +51,6 @@ package object fsx {
   type NextToken                           = String
   type OrganizationalUnitDistinguishedName = String
   type ProgressPercent                     = Int
-  type ReportFormat                        = String
-  type ReportScope                         = String
   type ResourceARN                         = String
   type SecurityGroupId                     = String
   type SecurityGroupIds                    = js.Array[SecurityGroupId]
@@ -79,7 +68,6 @@ package object fsx {
   type TotalCount                          = Double
   type VpcId                               = String
   type WeeklyTime                          = String
-  type WindowsDeploymentType               = String
 
   implicit final class FSxOps(private val service: FSx) extends AnyVal {
 
@@ -241,11 +229,13 @@ package fsx {
   /**
     * The lifecycle status of the backup.
     */
-  object BackupLifecycleEnum {
-    val AVAILABLE = "AVAILABLE"
-    val CREATING  = "CREATING"
-    val DELETED   = "DELETED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait BackupLifecycle extends js.Any
+  object BackupLifecycle extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[BackupLifecycle]
+    val CREATING  = "CREATING".asInstanceOf[BackupLifecycle]
+    val DELETED   = "DELETED".asInstanceOf[BackupLifecycle]
+    val FAILED    = "FAILED".asInstanceOf[BackupLifecycle]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, CREATING, DELETED, FAILED))
   }
@@ -253,9 +243,11 @@ package fsx {
   /**
     * The type of the backup.
     */
-  object BackupTypeEnum {
-    val AUTOMATIC      = "AUTOMATIC"
-    val USER_INITIATED = "USER_INITIATED"
+  @js.native
+  sealed trait BackupType extends js.Any
+  object BackupType extends js.Object {
+    val AUTOMATIC      = "AUTOMATIC".asInstanceOf[BackupType]
+    val USER_INITIATED = "USER_INITIATED".asInstanceOf[BackupType]
 
     val values = js.Object.freeze(js.Array(AUTOMATIC, USER_INITIATED))
   }
@@ -749,21 +741,23 @@ package fsx {
       __obj.asInstanceOf[DataRepositoryTaskFilter]
     }
   }
-
-  object DataRepositoryTaskFilterNameEnum {
-    val `file-system-id` = "file-system-id"
-    val `task-lifecycle` = "task-lifecycle"
+  @js.native
+  sealed trait DataRepositoryTaskFilterName extends js.Any
+  object DataRepositoryTaskFilterName extends js.Object {
+    val `file-system-id` = "file-system-id".asInstanceOf[DataRepositoryTaskFilterName]
+    val `task-lifecycle` = "task-lifecycle".asInstanceOf[DataRepositoryTaskFilterName]
 
     val values = js.Object.freeze(js.Array(`file-system-id`, `task-lifecycle`))
   }
-
-  object DataRepositoryTaskLifecycleEnum {
-    val PENDING   = "PENDING"
-    val EXECUTING = "EXECUTING"
-    val FAILED    = "FAILED"
-    val SUCCEEDED = "SUCCEEDED"
-    val CANCELED  = "CANCELED"
-    val CANCELING = "CANCELING"
+  @js.native
+  sealed trait DataRepositoryTaskLifecycle extends js.Any
+  object DataRepositoryTaskLifecycle extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[DataRepositoryTaskLifecycle]
+    val EXECUTING = "EXECUTING".asInstanceOf[DataRepositoryTaskLifecycle]
+    val FAILED    = "FAILED".asInstanceOf[DataRepositoryTaskLifecycle]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[DataRepositoryTaskLifecycle]
+    val CANCELED  = "CANCELED".asInstanceOf[DataRepositoryTaskLifecycle]
+    val CANCELING = "CANCELING".asInstanceOf[DataRepositoryTaskLifecycle]
 
     val values = js.Object.freeze(js.Array(PENDING, EXECUTING, FAILED, SUCCEEDED, CANCELED, CANCELING))
   }
@@ -795,9 +789,10 @@ package fsx {
       __obj.asInstanceOf[DataRepositoryTaskStatus]
     }
   }
-
-  object DataRepositoryTaskTypeEnum {
-    val EXPORT_TO_REPOSITORY = "EXPORT_TO_REPOSITORY"
+  @js.native
+  sealed trait DataRepositoryTaskType extends js.Any
+  object DataRepositoryTaskType extends js.Object {
+    val EXPORT_TO_REPOSITORY = "EXPORT_TO_REPOSITORY".asInstanceOf[DataRepositoryTaskType]
 
     val values = js.Object.freeze(js.Array(EXPORT_TO_REPOSITORY))
   }
@@ -1171,13 +1166,15 @@ package fsx {
   /**
     * The lifecycle status of the file system.
     */
-  object FileSystemLifecycleEnum {
-    val AVAILABLE     = "AVAILABLE"
-    val CREATING      = "CREATING"
-    val FAILED        = "FAILED"
-    val DELETING      = "DELETING"
-    val MISCONFIGURED = "MISCONFIGURED"
-    val UPDATING      = "UPDATING"
+  @js.native
+  sealed trait FileSystemLifecycle extends js.Any
+  object FileSystemLifecycle extends js.Object {
+    val AVAILABLE     = "AVAILABLE".asInstanceOf[FileSystemLifecycle]
+    val CREATING      = "CREATING".asInstanceOf[FileSystemLifecycle]
+    val FAILED        = "FAILED".asInstanceOf[FileSystemLifecycle]
+    val DELETING      = "DELETING".asInstanceOf[FileSystemLifecycle]
+    val MISCONFIGURED = "MISCONFIGURED".asInstanceOf[FileSystemLifecycle]
+    val UPDATING      = "UPDATING".asInstanceOf[FileSystemLifecycle]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, CREATING, FAILED, DELETING, MISCONFIGURED, UPDATING))
   }
@@ -1185,9 +1182,11 @@ package fsx {
   /**
     * An enumeration specifying the currently ongoing maintenance operation.
     */
-  object FileSystemMaintenanceOperationEnum {
-    val PATCHING   = "PATCHING"
-    val BACKING_UP = "BACKING_UP"
+  @js.native
+  sealed trait FileSystemMaintenanceOperation extends js.Any
+  object FileSystemMaintenanceOperation extends js.Object {
+    val PATCHING   = "PATCHING".asInstanceOf[FileSystemMaintenanceOperation]
+    val BACKING_UP = "BACKING_UP".asInstanceOf[FileSystemMaintenanceOperation]
 
     val values = js.Object.freeze(js.Array(PATCHING, BACKING_UP))
   }
@@ -1195,9 +1194,11 @@ package fsx {
   /**
     * The type of file system.
     */
-  object FileSystemTypeEnum {
-    val WINDOWS = "WINDOWS"
-    val LUSTRE  = "LUSTRE"
+  @js.native
+  sealed trait FileSystemType extends js.Any
+  object FileSystemType extends js.Object {
+    val WINDOWS = "WINDOWS".asInstanceOf[FileSystemType]
+    val LUSTRE  = "LUSTRE".asInstanceOf[FileSystemType]
 
     val values = js.Object.freeze(js.Array(WINDOWS, LUSTRE))
   }
@@ -1227,9 +1228,11 @@ package fsx {
   /**
     * The name for a filter.
     */
-  object FilterNameEnum {
-    val `file-system-id` = "file-system-id"
-    val `backup-type`    = "backup-type"
+  @js.native
+  sealed trait FilterName extends js.Any
+  object FilterName extends js.Object {
+    val `file-system-id` = "file-system-id".asInstanceOf[FilterName]
+    val `backup-type`    = "backup-type".asInstanceOf[FilterName]
 
     val values = js.Object.freeze(js.Array(`file-system-id`, `backup-type`))
   }
@@ -1308,15 +1311,17 @@ package fsx {
       __obj.asInstanceOf[LustreFileSystemConfiguration]
     }
   }
-
-  object ReportFormatEnum {
-    val REPORT_CSV_20191124 = "REPORT_CSV_20191124"
+  @js.native
+  sealed trait ReportFormat extends js.Any
+  object ReportFormat extends js.Object {
+    val REPORT_CSV_20191124 = "REPORT_CSV_20191124".asInstanceOf[ReportFormat]
 
     val values = js.Object.freeze(js.Array(REPORT_CSV_20191124))
   }
-
-  object ReportScopeEnum {
-    val FAILED_FILES_ONLY = "FAILED_FILES_ONLY"
+  @js.native
+  sealed trait ReportScope extends js.Any
+  object ReportScope extends js.Object {
+    val FAILED_FILES_ONLY = "FAILED_FILES_ONLY".asInstanceOf[ReportScope]
 
     val values = js.Object.freeze(js.Array(FAILED_FILES_ONLY))
   }
@@ -1629,10 +1634,11 @@ package fsx {
       __obj.asInstanceOf[UpdateFileSystemWindowsConfiguration]
     }
   }
-
-  object WindowsDeploymentTypeEnum {
-    val MULTI_AZ_1  = "MULTI_AZ_1"
-    val SINGLE_AZ_1 = "SINGLE_AZ_1"
+  @js.native
+  sealed trait WindowsDeploymentType extends js.Any
+  object WindowsDeploymentType extends js.Object {
+    val MULTI_AZ_1  = "MULTI_AZ_1".asInstanceOf[WindowsDeploymentType]
+    val SINGLE_AZ_1 = "SINGLE_AZ_1".asInstanceOf[WindowsDeploymentType]
 
     val values = js.Object.freeze(js.Array(MULTI_AZ_1, SINGLE_AZ_1))
   }

--- a/services/gamelift/src/main/scala/facade/amazonaws/services/GameLift.scala
+++ b/services/gamelift/src/main/scala/facade/amazonaws/services/GameLift.scala
@@ -7,35 +7,25 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object gamelift {
-  type AcceptanceType                      = String
   type AliasId                             = String
   type AliasList                           = js.Array[Alias]
   type AmazonResourceName                  = String
   type ArnStringModel                      = String
-  type BackfillMode                        = String
   type BooleanModel                        = Boolean
   type BuildArn                            = String
   type BuildId                             = String
   type BuildList                           = js.Array[Build]
-  type BuildStatus                         = String
-  type CertificateType                     = String
-  type ComparisonOperatorType              = String
   type CustomEventData                     = String
   type DesiredPlayerSessionList            = js.Array[DesiredPlayerSession]
   type DnsName                             = String
   type DoubleObject                        = Double
   type EC2InstanceLimitList                = js.Array[EC2InstanceLimit]
-  type EC2InstanceType                     = String
-  type EventCode                           = String
   type EventList                           = js.Array[Event]
-  type FleetAction                         = String
   type FleetActionList                     = js.Array[FleetAction]
   type FleetAttributesList                 = js.Array[FleetAttributes]
   type FleetCapacityList                   = js.Array[FleetCapacity]
   type FleetId                             = String
   type FleetIdList                         = js.Array[FleetId]
-  type FleetStatus                         = String
-  type FleetType                           = String
   type FleetUtilizationList                = js.Array[FleetUtilization]
   type FreeText                            = String
   type GamePropertyKey                     = String
@@ -45,20 +35,15 @@ package object gamelift {
   type GameSessionData                     = String
   type GameSessionDetailList               = js.Array[GameSessionDetail]
   type GameSessionList                     = js.Array[GameSession]
-  type GameSessionPlacementState           = String
   type GameSessionQueueDestinationList     = js.Array[GameSessionQueueDestination]
   type GameSessionQueueList                = js.Array[GameSessionQueue]
   type GameSessionQueueName                = String
   type GameSessionQueueNameList            = js.Array[GameSessionQueueName]
-  type GameSessionStatus                   = String
-  type GameSessionStatusReason             = String
   type IdStringModel                       = String
   type InstanceId                          = String
   type InstanceList                        = js.Array[Instance]
-  type InstanceStatus                      = String
   type IpAddress                           = String
   type IpPermissionsList                   = js.Array[IpPermission]
-  type IpProtocol                          = String
   type LatencyMap                          = js.Dictionary[PositiveInteger]
   type MatchedPlayerSessionList            = js.Array[MatchedPlayerSession]
   type MatchmakerData                      = String
@@ -67,7 +52,6 @@ package object gamelift {
   type MatchmakingConfigurationList        = js.Array[MatchmakingConfiguration]
   type MatchmakingConfigurationName        = String
   type MatchmakingConfigurationNameList    = js.Array[MatchmakingConfigurationName]
-  type MatchmakingConfigurationStatus      = String
   type MatchmakingIdList                   = js.Array[MatchmakingIdStringModel]
   type MatchmakingIdStringModel            = String
   type MatchmakingRequestTimeoutInteger    = Int
@@ -79,12 +63,10 @@ package object gamelift {
   type MaxConcurrentGameSessionActivations = Int
   type MetricGroup                         = String
   type MetricGroupList                     = js.Array[MetricGroup]
-  type MetricName                          = String
   type NonBlankAndLengthConstraintString   = String
   type NonBlankString                      = String
   type NonEmptyString                      = String
   type NonZeroAndMaxString                 = String
-  type OperatingSystem                     = String
   type PlacedPlayerSessionList             = js.Array[PlacedPlayerSession]
   type PlayerAttributeMap                  = js.Dictionary[AttributeValue]
   type PlayerData                          = String
@@ -93,22 +75,15 @@ package object gamelift {
   type PlayerLatencyList                   = js.Array[PlayerLatency]
   type PlayerLatencyPolicyList             = js.Array[PlayerLatencyPolicy]
   type PlayerList                          = js.Array[Player]
-  type PlayerSessionCreationPolicy         = String
   type PlayerSessionId                     = String
   type PlayerSessionList                   = js.Array[PlayerSession]
-  type PlayerSessionStatus                 = String
-  type PolicyType                          = String
   type PortNumber                          = Int
   type PositiveInteger                     = Int
   type PositiveLong                        = Double
-  type ProtectionPolicy                    = String
   type QueueArnsList                       = js.Array[ArnStringModel]
-  type RoutingStrategyType                 = String
   type RuleSetBody                         = String
   type RuleSetLimit                        = Int
-  type ScalingAdjustmentType               = String
   type ScalingPolicyList                   = js.Array[ScalingPolicy]
-  type ScalingStatusType                   = String
   type ScriptArn                           = String
   type ScriptId                            = String
   type ScriptList                          = js.Array[Script]
@@ -480,10 +455,11 @@ package gamelift {
       __obj.asInstanceOf[AcceptMatchOutput]
     }
   }
-
-  object AcceptanceTypeEnum {
-    val ACCEPT = "ACCEPT"
-    val REJECT = "REJECT"
+  @js.native
+  sealed trait AcceptanceType extends js.Any
+  object AcceptanceType extends js.Object {
+    val ACCEPT = "ACCEPT".asInstanceOf[AcceptanceType]
+    val REJECT = "REJECT".asInstanceOf[AcceptanceType]
 
     val values = js.Object.freeze(js.Array(ACCEPT, REJECT))
   }
@@ -583,10 +559,11 @@ package gamelift {
       __obj.asInstanceOf[AwsCredentials]
     }
   }
-
-  object BackfillModeEnum {
-    val AUTOMATIC = "AUTOMATIC"
-    val MANUAL    = "MANUAL"
+  @js.native
+  sealed trait BackfillMode extends js.Any
+  object BackfillMode extends js.Object {
+    val AUTOMATIC = "AUTOMATIC".asInstanceOf[BackfillMode]
+    val MANUAL    = "MANUAL".asInstanceOf[BackfillMode]
 
     val values = js.Object.freeze(js.Array(AUTOMATIC, MANUAL))
   }
@@ -636,11 +613,12 @@ package gamelift {
       __obj.asInstanceOf[Build]
     }
   }
-
-  object BuildStatusEnum {
-    val INITIALIZED = "INITIALIZED"
-    val READY       = "READY"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait BuildStatus extends js.Any
+  object BuildStatus extends js.Object {
+    val INITIALIZED = "INITIALIZED".asInstanceOf[BuildStatus]
+    val READY       = "READY".asInstanceOf[BuildStatus]
+    val FAILED      = "FAILED".asInstanceOf[BuildStatus]
 
     val values = js.Object.freeze(js.Array(INITIALIZED, READY, FAILED))
   }
@@ -665,19 +643,21 @@ package gamelift {
       __obj.asInstanceOf[CertificateConfiguration]
     }
   }
-
-  object CertificateTypeEnum {
-    val DISABLED  = "DISABLED"
-    val GENERATED = "GENERATED"
+  @js.native
+  sealed trait CertificateType extends js.Any
+  object CertificateType extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[CertificateType]
+    val GENERATED = "GENERATED".asInstanceOf[CertificateType]
 
     val values = js.Object.freeze(js.Array(DISABLED, GENERATED))
   }
-
-  object ComparisonOperatorTypeEnum {
-    val GreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold"
-    val GreaterThanThreshold          = "GreaterThanThreshold"
-    val LessThanThreshold             = "LessThanThreshold"
-    val LessThanOrEqualToThreshold    = "LessThanOrEqualToThreshold"
+  @js.native
+  sealed trait ComparisonOperatorType extends js.Any
+  object ComparisonOperatorType extends js.Object {
+    val GreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold".asInstanceOf[ComparisonOperatorType]
+    val GreaterThanThreshold          = "GreaterThanThreshold".asInstanceOf[ComparisonOperatorType]
+    val LessThanThreshold             = "LessThanThreshold".asInstanceOf[ComparisonOperatorType]
+    val LessThanOrEqualToThreshold    = "LessThanOrEqualToThreshold".asInstanceOf[ComparisonOperatorType]
 
     val values = js.Object.freeze(
       js.Array(GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold)
@@ -2720,66 +2700,67 @@ package gamelift {
       __obj.asInstanceOf[EC2InstanceLimit]
     }
   }
-
-  object EC2InstanceTypeEnum {
-    val `t2.micro`    = "t2.micro"
-    val `t2.small`    = "t2.small"
-    val `t2.medium`   = "t2.medium"
-    val `t2.large`    = "t2.large"
-    val `c3.large`    = "c3.large"
-    val `c3.xlarge`   = "c3.xlarge"
-    val `c3.2xlarge`  = "c3.2xlarge"
-    val `c3.4xlarge`  = "c3.4xlarge"
-    val `c3.8xlarge`  = "c3.8xlarge"
-    val `c4.large`    = "c4.large"
-    val `c4.xlarge`   = "c4.xlarge"
-    val `c4.2xlarge`  = "c4.2xlarge"
-    val `c4.4xlarge`  = "c4.4xlarge"
-    val `c4.8xlarge`  = "c4.8xlarge"
-    val `c5.large`    = "c5.large"
-    val `c5.xlarge`   = "c5.xlarge"
-    val `c5.2xlarge`  = "c5.2xlarge"
-    val `c5.4xlarge`  = "c5.4xlarge"
-    val `c5.9xlarge`  = "c5.9xlarge"
-    val `c5.12xlarge` = "c5.12xlarge"
-    val `c5.18xlarge` = "c5.18xlarge"
-    val `c5.24xlarge` = "c5.24xlarge"
-    val `r3.large`    = "r3.large"
-    val `r3.xlarge`   = "r3.xlarge"
-    val `r3.2xlarge`  = "r3.2xlarge"
-    val `r3.4xlarge`  = "r3.4xlarge"
-    val `r3.8xlarge`  = "r3.8xlarge"
-    val `r4.large`    = "r4.large"
-    val `r4.xlarge`   = "r4.xlarge"
-    val `r4.2xlarge`  = "r4.2xlarge"
-    val `r4.4xlarge`  = "r4.4xlarge"
-    val `r4.8xlarge`  = "r4.8xlarge"
-    val `r4.16xlarge` = "r4.16xlarge"
-    val `r5.large`    = "r5.large"
-    val `r5.xlarge`   = "r5.xlarge"
-    val `r5.2xlarge`  = "r5.2xlarge"
-    val `r5.4xlarge`  = "r5.4xlarge"
-    val `r5.8xlarge`  = "r5.8xlarge"
-    val `r5.12xlarge` = "r5.12xlarge"
-    val `r5.16xlarge` = "r5.16xlarge"
-    val `r5.24xlarge` = "r5.24xlarge"
-    val `m3.medium`   = "m3.medium"
-    val `m3.large`    = "m3.large"
-    val `m3.xlarge`   = "m3.xlarge"
-    val `m3.2xlarge`  = "m3.2xlarge"
-    val `m4.large`    = "m4.large"
-    val `m4.xlarge`   = "m4.xlarge"
-    val `m4.2xlarge`  = "m4.2xlarge"
-    val `m4.4xlarge`  = "m4.4xlarge"
-    val `m4.10xlarge` = "m4.10xlarge"
-    val `m5.large`    = "m5.large"
-    val `m5.xlarge`   = "m5.xlarge"
-    val `m5.2xlarge`  = "m5.2xlarge"
-    val `m5.4xlarge`  = "m5.4xlarge"
-    val `m5.8xlarge`  = "m5.8xlarge"
-    val `m5.12xlarge` = "m5.12xlarge"
-    val `m5.16xlarge` = "m5.16xlarge"
-    val `m5.24xlarge` = "m5.24xlarge"
+  @js.native
+  sealed trait EC2InstanceType extends js.Any
+  object EC2InstanceType extends js.Object {
+    val `t2.micro`    = "t2.micro".asInstanceOf[EC2InstanceType]
+    val `t2.small`    = "t2.small".asInstanceOf[EC2InstanceType]
+    val `t2.medium`   = "t2.medium".asInstanceOf[EC2InstanceType]
+    val `t2.large`    = "t2.large".asInstanceOf[EC2InstanceType]
+    val `c3.large`    = "c3.large".asInstanceOf[EC2InstanceType]
+    val `c3.xlarge`   = "c3.xlarge".asInstanceOf[EC2InstanceType]
+    val `c3.2xlarge`  = "c3.2xlarge".asInstanceOf[EC2InstanceType]
+    val `c3.4xlarge`  = "c3.4xlarge".asInstanceOf[EC2InstanceType]
+    val `c3.8xlarge`  = "c3.8xlarge".asInstanceOf[EC2InstanceType]
+    val `c4.large`    = "c4.large".asInstanceOf[EC2InstanceType]
+    val `c4.xlarge`   = "c4.xlarge".asInstanceOf[EC2InstanceType]
+    val `c4.2xlarge`  = "c4.2xlarge".asInstanceOf[EC2InstanceType]
+    val `c4.4xlarge`  = "c4.4xlarge".asInstanceOf[EC2InstanceType]
+    val `c4.8xlarge`  = "c4.8xlarge".asInstanceOf[EC2InstanceType]
+    val `c5.large`    = "c5.large".asInstanceOf[EC2InstanceType]
+    val `c5.xlarge`   = "c5.xlarge".asInstanceOf[EC2InstanceType]
+    val `c5.2xlarge`  = "c5.2xlarge".asInstanceOf[EC2InstanceType]
+    val `c5.4xlarge`  = "c5.4xlarge".asInstanceOf[EC2InstanceType]
+    val `c5.9xlarge`  = "c5.9xlarge".asInstanceOf[EC2InstanceType]
+    val `c5.12xlarge` = "c5.12xlarge".asInstanceOf[EC2InstanceType]
+    val `c5.18xlarge` = "c5.18xlarge".asInstanceOf[EC2InstanceType]
+    val `c5.24xlarge` = "c5.24xlarge".asInstanceOf[EC2InstanceType]
+    val `r3.large`    = "r3.large".asInstanceOf[EC2InstanceType]
+    val `r3.xlarge`   = "r3.xlarge".asInstanceOf[EC2InstanceType]
+    val `r3.2xlarge`  = "r3.2xlarge".asInstanceOf[EC2InstanceType]
+    val `r3.4xlarge`  = "r3.4xlarge".asInstanceOf[EC2InstanceType]
+    val `r3.8xlarge`  = "r3.8xlarge".asInstanceOf[EC2InstanceType]
+    val `r4.large`    = "r4.large".asInstanceOf[EC2InstanceType]
+    val `r4.xlarge`   = "r4.xlarge".asInstanceOf[EC2InstanceType]
+    val `r4.2xlarge`  = "r4.2xlarge".asInstanceOf[EC2InstanceType]
+    val `r4.4xlarge`  = "r4.4xlarge".asInstanceOf[EC2InstanceType]
+    val `r4.8xlarge`  = "r4.8xlarge".asInstanceOf[EC2InstanceType]
+    val `r4.16xlarge` = "r4.16xlarge".asInstanceOf[EC2InstanceType]
+    val `r5.large`    = "r5.large".asInstanceOf[EC2InstanceType]
+    val `r5.xlarge`   = "r5.xlarge".asInstanceOf[EC2InstanceType]
+    val `r5.2xlarge`  = "r5.2xlarge".asInstanceOf[EC2InstanceType]
+    val `r5.4xlarge`  = "r5.4xlarge".asInstanceOf[EC2InstanceType]
+    val `r5.8xlarge`  = "r5.8xlarge".asInstanceOf[EC2InstanceType]
+    val `r5.12xlarge` = "r5.12xlarge".asInstanceOf[EC2InstanceType]
+    val `r5.16xlarge` = "r5.16xlarge".asInstanceOf[EC2InstanceType]
+    val `r5.24xlarge` = "r5.24xlarge".asInstanceOf[EC2InstanceType]
+    val `m3.medium`   = "m3.medium".asInstanceOf[EC2InstanceType]
+    val `m3.large`    = "m3.large".asInstanceOf[EC2InstanceType]
+    val `m3.xlarge`   = "m3.xlarge".asInstanceOf[EC2InstanceType]
+    val `m3.2xlarge`  = "m3.2xlarge".asInstanceOf[EC2InstanceType]
+    val `m4.large`    = "m4.large".asInstanceOf[EC2InstanceType]
+    val `m4.xlarge`   = "m4.xlarge".asInstanceOf[EC2InstanceType]
+    val `m4.2xlarge`  = "m4.2xlarge".asInstanceOf[EC2InstanceType]
+    val `m4.4xlarge`  = "m4.4xlarge".asInstanceOf[EC2InstanceType]
+    val `m4.10xlarge` = "m4.10xlarge".asInstanceOf[EC2InstanceType]
+    val `m5.large`    = "m5.large".asInstanceOf[EC2InstanceType]
+    val `m5.xlarge`   = "m5.xlarge".asInstanceOf[EC2InstanceType]
+    val `m5.2xlarge`  = "m5.2xlarge".asInstanceOf[EC2InstanceType]
+    val `m5.4xlarge`  = "m5.4xlarge".asInstanceOf[EC2InstanceType]
+    val `m5.8xlarge`  = "m5.8xlarge".asInstanceOf[EC2InstanceType]
+    val `m5.12xlarge` = "m5.12xlarge".asInstanceOf[EC2InstanceType]
+    val `m5.16xlarge` = "m5.16xlarge".asInstanceOf[EC2InstanceType]
+    val `m5.24xlarge` = "m5.24xlarge".asInstanceOf[EC2InstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2878,41 +2859,44 @@ package gamelift {
       __obj.asInstanceOf[Event]
     }
   }
-
-  object EventCodeEnum {
-    val GENERIC_EVENT                                    = "GENERIC_EVENT"
-    val FLEET_CREATED                                    = "FLEET_CREATED"
-    val FLEET_DELETED                                    = "FLEET_DELETED"
-    val FLEET_SCALING_EVENT                              = "FLEET_SCALING_EVENT"
-    val FLEET_STATE_DOWNLOADING                          = "FLEET_STATE_DOWNLOADING"
-    val FLEET_STATE_VALIDATING                           = "FLEET_STATE_VALIDATING"
-    val FLEET_STATE_BUILDING                             = "FLEET_STATE_BUILDING"
-    val FLEET_STATE_ACTIVATING                           = "FLEET_STATE_ACTIVATING"
-    val FLEET_STATE_ACTIVE                               = "FLEET_STATE_ACTIVE"
-    val FLEET_STATE_ERROR                                = "FLEET_STATE_ERROR"
-    val FLEET_INITIALIZATION_FAILED                      = "FLEET_INITIALIZATION_FAILED"
-    val FLEET_BINARY_DOWNLOAD_FAILED                     = "FLEET_BINARY_DOWNLOAD_FAILED"
-    val FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND           = "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND"
-    val FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE      = "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE"
-    val FLEET_VALIDATION_TIMED_OUT                       = "FLEET_VALIDATION_TIMED_OUT"
-    val FLEET_ACTIVATION_FAILED                          = "FLEET_ACTIVATION_FAILED"
-    val FLEET_ACTIVATION_FAILED_NO_INSTANCES             = "FLEET_ACTIVATION_FAILED_NO_INSTANCES"
-    val FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED = "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED"
-    val SERVER_PROCESS_INVALID_PATH                      = "SERVER_PROCESS_INVALID_PATH"
-    val SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT        = "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT"
-    val SERVER_PROCESS_PROCESS_READY_TIMEOUT             = "SERVER_PROCESS_PROCESS_READY_TIMEOUT"
-    val SERVER_PROCESS_CRASHED                           = "SERVER_PROCESS_CRASHED"
-    val SERVER_PROCESS_TERMINATED_UNHEALTHY              = "SERVER_PROCESS_TERMINATED_UNHEALTHY"
-    val SERVER_PROCESS_FORCE_TERMINATED                  = "SERVER_PROCESS_FORCE_TERMINATED"
-    val SERVER_PROCESS_PROCESS_EXIT_TIMEOUT              = "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT"
-    val GAME_SESSION_ACTIVATION_TIMEOUT                  = "GAME_SESSION_ACTIVATION_TIMEOUT"
-    val FLEET_CREATION_EXTRACTING_BUILD                  = "FLEET_CREATION_EXTRACTING_BUILD"
-    val FLEET_CREATION_RUNNING_INSTALLER                 = "FLEET_CREATION_RUNNING_INSTALLER"
-    val FLEET_CREATION_VALIDATING_RUNTIME_CONFIG         = "FLEET_CREATION_VALIDATING_RUNTIME_CONFIG"
-    val FLEET_VPC_PEERING_SUCCEEDED                      = "FLEET_VPC_PEERING_SUCCEEDED"
-    val FLEET_VPC_PEERING_FAILED                         = "FLEET_VPC_PEERING_FAILED"
-    val FLEET_VPC_PEERING_DELETED                        = "FLEET_VPC_PEERING_DELETED"
-    val INSTANCE_INTERRUPTED                             = "INSTANCE_INTERRUPTED"
+  @js.native
+  sealed trait EventCode extends js.Any
+  object EventCode extends js.Object {
+    val GENERIC_EVENT                          = "GENERIC_EVENT".asInstanceOf[EventCode]
+    val FLEET_CREATED                          = "FLEET_CREATED".asInstanceOf[EventCode]
+    val FLEET_DELETED                          = "FLEET_DELETED".asInstanceOf[EventCode]
+    val FLEET_SCALING_EVENT                    = "FLEET_SCALING_EVENT".asInstanceOf[EventCode]
+    val FLEET_STATE_DOWNLOADING                = "FLEET_STATE_DOWNLOADING".asInstanceOf[EventCode]
+    val FLEET_STATE_VALIDATING                 = "FLEET_STATE_VALIDATING".asInstanceOf[EventCode]
+    val FLEET_STATE_BUILDING                   = "FLEET_STATE_BUILDING".asInstanceOf[EventCode]
+    val FLEET_STATE_ACTIVATING                 = "FLEET_STATE_ACTIVATING".asInstanceOf[EventCode]
+    val FLEET_STATE_ACTIVE                     = "FLEET_STATE_ACTIVE".asInstanceOf[EventCode]
+    val FLEET_STATE_ERROR                      = "FLEET_STATE_ERROR".asInstanceOf[EventCode]
+    val FLEET_INITIALIZATION_FAILED            = "FLEET_INITIALIZATION_FAILED".asInstanceOf[EventCode]
+    val FLEET_BINARY_DOWNLOAD_FAILED           = "FLEET_BINARY_DOWNLOAD_FAILED".asInstanceOf[EventCode]
+    val FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND = "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND".asInstanceOf[EventCode]
+    val FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE =
+      "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE".asInstanceOf[EventCode]
+    val FLEET_VALIDATION_TIMED_OUT           = "FLEET_VALIDATION_TIMED_OUT".asInstanceOf[EventCode]
+    val FLEET_ACTIVATION_FAILED              = "FLEET_ACTIVATION_FAILED".asInstanceOf[EventCode]
+    val FLEET_ACTIVATION_FAILED_NO_INSTANCES = "FLEET_ACTIVATION_FAILED_NO_INSTANCES".asInstanceOf[EventCode]
+    val FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED =
+      "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED".asInstanceOf[EventCode]
+    val SERVER_PROCESS_INVALID_PATH               = "SERVER_PROCESS_INVALID_PATH".asInstanceOf[EventCode]
+    val SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT = "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT".asInstanceOf[EventCode]
+    val SERVER_PROCESS_PROCESS_READY_TIMEOUT      = "SERVER_PROCESS_PROCESS_READY_TIMEOUT".asInstanceOf[EventCode]
+    val SERVER_PROCESS_CRASHED                    = "SERVER_PROCESS_CRASHED".asInstanceOf[EventCode]
+    val SERVER_PROCESS_TERMINATED_UNHEALTHY       = "SERVER_PROCESS_TERMINATED_UNHEALTHY".asInstanceOf[EventCode]
+    val SERVER_PROCESS_FORCE_TERMINATED           = "SERVER_PROCESS_FORCE_TERMINATED".asInstanceOf[EventCode]
+    val SERVER_PROCESS_PROCESS_EXIT_TIMEOUT       = "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT".asInstanceOf[EventCode]
+    val GAME_SESSION_ACTIVATION_TIMEOUT           = "GAME_SESSION_ACTIVATION_TIMEOUT".asInstanceOf[EventCode]
+    val FLEET_CREATION_EXTRACTING_BUILD           = "FLEET_CREATION_EXTRACTING_BUILD".asInstanceOf[EventCode]
+    val FLEET_CREATION_RUNNING_INSTALLER          = "FLEET_CREATION_RUNNING_INSTALLER".asInstanceOf[EventCode]
+    val FLEET_CREATION_VALIDATING_RUNTIME_CONFIG  = "FLEET_CREATION_VALIDATING_RUNTIME_CONFIG".asInstanceOf[EventCode]
+    val FLEET_VPC_PEERING_SUCCEEDED               = "FLEET_VPC_PEERING_SUCCEEDED".asInstanceOf[EventCode]
+    val FLEET_VPC_PEERING_FAILED                  = "FLEET_VPC_PEERING_FAILED".asInstanceOf[EventCode]
+    val FLEET_VPC_PEERING_DELETED                 = "FLEET_VPC_PEERING_DELETED".asInstanceOf[EventCode]
+    val INSTANCE_INTERRUPTED                      = "INSTANCE_INTERRUPTED".asInstanceOf[EventCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2952,9 +2936,10 @@ package gamelift {
       )
     )
   }
-
-  object FleetActionEnum {
-    val AUTO_SCALING = "AUTO_SCALING"
+  @js.native
+  sealed trait FleetAction extends js.Any
+  object FleetAction extends js.Object {
+    val AUTO_SCALING = "AUTO_SCALING".asInstanceOf[FleetAction]
 
     val values = js.Object.freeze(js.Array(AUTO_SCALING))
   }
@@ -3090,26 +3075,28 @@ package gamelift {
       __obj.asInstanceOf[FleetCapacity]
     }
   }
-
-  object FleetStatusEnum {
-    val NEW         = "NEW"
-    val DOWNLOADING = "DOWNLOADING"
-    val VALIDATING  = "VALIDATING"
-    val BUILDING    = "BUILDING"
-    val ACTIVATING  = "ACTIVATING"
-    val ACTIVE      = "ACTIVE"
-    val DELETING    = "DELETING"
-    val ERROR       = "ERROR"
-    val TERMINATED  = "TERMINATED"
+  @js.native
+  sealed trait FleetStatus extends js.Any
+  object FleetStatus extends js.Object {
+    val NEW         = "NEW".asInstanceOf[FleetStatus]
+    val DOWNLOADING = "DOWNLOADING".asInstanceOf[FleetStatus]
+    val VALIDATING  = "VALIDATING".asInstanceOf[FleetStatus]
+    val BUILDING    = "BUILDING".asInstanceOf[FleetStatus]
+    val ACTIVATING  = "ACTIVATING".asInstanceOf[FleetStatus]
+    val ACTIVE      = "ACTIVE".asInstanceOf[FleetStatus]
+    val DELETING    = "DELETING".asInstanceOf[FleetStatus]
+    val ERROR       = "ERROR".asInstanceOf[FleetStatus]
+    val TERMINATED  = "TERMINATED".asInstanceOf[FleetStatus]
 
     val values = js.Object.freeze(
       js.Array(NEW, DOWNLOADING, VALIDATING, BUILDING, ACTIVATING, ACTIVE, DELETING, ERROR, TERMINATED)
     )
   }
-
-  object FleetTypeEnum {
-    val ON_DEMAND = "ON_DEMAND"
-    val SPOT      = "SPOT"
+  @js.native
+  sealed trait FleetType extends js.Any
+  object FleetType extends js.Object {
+    val ON_DEMAND = "ON_DEMAND".asInstanceOf[FleetType]
+    val SPOT      = "SPOT".asInstanceOf[FleetType]
 
     val values = js.Object.freeze(js.Array(ON_DEMAND, SPOT))
   }
@@ -3399,13 +3386,14 @@ package gamelift {
       __obj.asInstanceOf[GameSessionPlacement]
     }
   }
-
-  object GameSessionPlacementStateEnum {
-    val PENDING   = "PENDING"
-    val FULFILLED = "FULFILLED"
-    val CANCELLED = "CANCELLED"
-    val TIMED_OUT = "TIMED_OUT"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait GameSessionPlacementState extends js.Any
+  object GameSessionPlacementState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[GameSessionPlacementState]
+    val FULFILLED = "FULFILLED".asInstanceOf[GameSessionPlacementState]
+    val CANCELLED = "CANCELLED".asInstanceOf[GameSessionPlacementState]
+    val TIMED_OUT = "TIMED_OUT".asInstanceOf[GameSessionPlacementState]
+    val FAILED    = "FAILED".asInstanceOf[GameSessionPlacementState]
 
     val values = js.Object.freeze(js.Array(PENDING, FULFILLED, CANCELLED, TIMED_OUT, FAILED))
   }
@@ -3470,19 +3458,21 @@ package gamelift {
       __obj.asInstanceOf[GameSessionQueueDestination]
     }
   }
-
-  object GameSessionStatusEnum {
-    val ACTIVE      = "ACTIVE"
-    val ACTIVATING  = "ACTIVATING"
-    val TERMINATED  = "TERMINATED"
-    val TERMINATING = "TERMINATING"
-    val ERROR       = "ERROR"
+  @js.native
+  sealed trait GameSessionStatus extends js.Any
+  object GameSessionStatus extends js.Object {
+    val ACTIVE      = "ACTIVE".asInstanceOf[GameSessionStatus]
+    val ACTIVATING  = "ACTIVATING".asInstanceOf[GameSessionStatus]
+    val TERMINATED  = "TERMINATED".asInstanceOf[GameSessionStatus]
+    val TERMINATING = "TERMINATING".asInstanceOf[GameSessionStatus]
+    val ERROR       = "ERROR".asInstanceOf[GameSessionStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, ACTIVATING, TERMINATED, TERMINATING, ERROR))
   }
-
-  object GameSessionStatusReasonEnum {
-    val INTERRUPTED = "INTERRUPTED"
+  @js.native
+  sealed trait GameSessionStatusReason extends js.Any
+  object GameSessionStatusReason extends js.Object {
+    val INTERRUPTED = "INTERRUPTED".asInstanceOf[GameSessionStatusReason]
 
     val values = js.Object.freeze(js.Array(INTERRUPTED))
   }
@@ -3662,11 +3652,12 @@ package gamelift {
       __obj.asInstanceOf[InstanceCredentials]
     }
   }
-
-  object InstanceStatusEnum {
-    val PENDING     = "PENDING"
-    val ACTIVE      = "ACTIVE"
-    val TERMINATING = "TERMINATING"
+  @js.native
+  sealed trait InstanceStatus extends js.Any
+  object InstanceStatus extends js.Object {
+    val PENDING     = "PENDING".asInstanceOf[InstanceStatus]
+    val ACTIVE      = "ACTIVE".asInstanceOf[InstanceStatus]
+    val TERMINATING = "TERMINATING".asInstanceOf[InstanceStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, ACTIVE, TERMINATING))
   }
@@ -3700,10 +3691,11 @@ package gamelift {
       __obj.asInstanceOf[IpPermission]
     }
   }
-
-  object IpProtocolEnum {
-    val TCP = "TCP"
-    val UDP = "UDP"
+  @js.native
+  sealed trait IpProtocol extends js.Any
+  object IpProtocol extends js.Object {
+    val TCP = "TCP".asInstanceOf[IpProtocol]
+    val UDP = "UDP".asInstanceOf[IpProtocol]
 
     val values = js.Object.freeze(js.Array(TCP, UDP))
   }
@@ -4013,16 +4005,17 @@ package gamelift {
       __obj.asInstanceOf[MatchmakingConfiguration]
     }
   }
-
-  object MatchmakingConfigurationStatusEnum {
-    val CANCELLED           = "CANCELLED"
-    val COMPLETED           = "COMPLETED"
-    val FAILED              = "FAILED"
-    val PLACING             = "PLACING"
-    val QUEUED              = "QUEUED"
-    val REQUIRES_ACCEPTANCE = "REQUIRES_ACCEPTANCE"
-    val SEARCHING           = "SEARCHING"
-    val TIMED_OUT           = "TIMED_OUT"
+  @js.native
+  sealed trait MatchmakingConfigurationStatus extends js.Any
+  object MatchmakingConfigurationStatus extends js.Object {
+    val CANCELLED           = "CANCELLED".asInstanceOf[MatchmakingConfigurationStatus]
+    val COMPLETED           = "COMPLETED".asInstanceOf[MatchmakingConfigurationStatus]
+    val FAILED              = "FAILED".asInstanceOf[MatchmakingConfigurationStatus]
+    val PLACING             = "PLACING".asInstanceOf[MatchmakingConfigurationStatus]
+    val QUEUED              = "QUEUED".asInstanceOf[MatchmakingConfigurationStatus]
+    val REQUIRES_ACCEPTANCE = "REQUIRES_ACCEPTANCE".asInstanceOf[MatchmakingConfigurationStatus]
+    val SEARCHING           = "SEARCHING".asInstanceOf[MatchmakingConfigurationStatus]
+    val TIMED_OUT           = "TIMED_OUT".asInstanceOf[MatchmakingConfigurationStatus]
 
     val values = js.Object.freeze(
       js.Array(CANCELLED, COMPLETED, FAILED, PLACING, QUEUED, REQUIRES_ACCEPTANCE, SEARCHING, TIMED_OUT)
@@ -4114,19 +4107,20 @@ package gamelift {
       __obj.asInstanceOf[MatchmakingTicket]
     }
   }
-
-  object MetricNameEnum {
-    val ActivatingGameSessions       = "ActivatingGameSessions"
-    val ActiveGameSessions           = "ActiveGameSessions"
-    val ActiveInstances              = "ActiveInstances"
-    val AvailableGameSessions        = "AvailableGameSessions"
-    val AvailablePlayerSessions      = "AvailablePlayerSessions"
-    val CurrentPlayerSessions        = "CurrentPlayerSessions"
-    val IdleInstances                = "IdleInstances"
-    val PercentAvailableGameSessions = "PercentAvailableGameSessions"
-    val PercentIdleInstances         = "PercentIdleInstances"
-    val QueueDepth                   = "QueueDepth"
-    val WaitTime                     = "WaitTime"
+  @js.native
+  sealed trait MetricName extends js.Any
+  object MetricName extends js.Object {
+    val ActivatingGameSessions       = "ActivatingGameSessions".asInstanceOf[MetricName]
+    val ActiveGameSessions           = "ActiveGameSessions".asInstanceOf[MetricName]
+    val ActiveInstances              = "ActiveInstances".asInstanceOf[MetricName]
+    val AvailableGameSessions        = "AvailableGameSessions".asInstanceOf[MetricName]
+    val AvailablePlayerSessions      = "AvailablePlayerSessions".asInstanceOf[MetricName]
+    val CurrentPlayerSessions        = "CurrentPlayerSessions".asInstanceOf[MetricName]
+    val IdleInstances                = "IdleInstances".asInstanceOf[MetricName]
+    val PercentAvailableGameSessions = "PercentAvailableGameSessions".asInstanceOf[MetricName]
+    val PercentIdleInstances         = "PercentIdleInstances".asInstanceOf[MetricName]
+    val QueueDepth                   = "QueueDepth".asInstanceOf[MetricName]
+    val WaitTime                     = "WaitTime".asInstanceOf[MetricName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4144,11 +4138,12 @@ package gamelift {
       )
     )
   }
-
-  object OperatingSystemEnum {
-    val WINDOWS_2012   = "WINDOWS_2012"
-    val AMAZON_LINUX   = "AMAZON_LINUX"
-    val AMAZON_LINUX_2 = "AMAZON_LINUX_2"
+  @js.native
+  sealed trait OperatingSystem extends js.Any
+  object OperatingSystem extends js.Object {
+    val WINDOWS_2012   = "WINDOWS_2012".asInstanceOf[OperatingSystem]
+    val AMAZON_LINUX   = "AMAZON_LINUX".asInstanceOf[OperatingSystem]
+    val AMAZON_LINUX_2 = "AMAZON_LINUX_2".asInstanceOf[OperatingSystem]
 
     val values = js.Object.freeze(js.Array(WINDOWS_2012, AMAZON_LINUX, AMAZON_LINUX_2))
   }
@@ -4324,33 +4319,37 @@ package gamelift {
       __obj.asInstanceOf[PlayerSession]
     }
   }
-
-  object PlayerSessionCreationPolicyEnum {
-    val ACCEPT_ALL = "ACCEPT_ALL"
-    val DENY_ALL   = "DENY_ALL"
+  @js.native
+  sealed trait PlayerSessionCreationPolicy extends js.Any
+  object PlayerSessionCreationPolicy extends js.Object {
+    val ACCEPT_ALL = "ACCEPT_ALL".asInstanceOf[PlayerSessionCreationPolicy]
+    val DENY_ALL   = "DENY_ALL".asInstanceOf[PlayerSessionCreationPolicy]
 
     val values = js.Object.freeze(js.Array(ACCEPT_ALL, DENY_ALL))
   }
-
-  object PlayerSessionStatusEnum {
-    val RESERVED  = "RESERVED"
-    val ACTIVE    = "ACTIVE"
-    val COMPLETED = "COMPLETED"
-    val TIMEDOUT  = "TIMEDOUT"
+  @js.native
+  sealed trait PlayerSessionStatus extends js.Any
+  object PlayerSessionStatus extends js.Object {
+    val RESERVED  = "RESERVED".asInstanceOf[PlayerSessionStatus]
+    val ACTIVE    = "ACTIVE".asInstanceOf[PlayerSessionStatus]
+    val COMPLETED = "COMPLETED".asInstanceOf[PlayerSessionStatus]
+    val TIMEDOUT  = "TIMEDOUT".asInstanceOf[PlayerSessionStatus]
 
     val values = js.Object.freeze(js.Array(RESERVED, ACTIVE, COMPLETED, TIMEDOUT))
   }
-
-  object PolicyTypeEnum {
-    val RuleBased   = "RuleBased"
-    val TargetBased = "TargetBased"
+  @js.native
+  sealed trait PolicyType extends js.Any
+  object PolicyType extends js.Object {
+    val RuleBased   = "RuleBased".asInstanceOf[PolicyType]
+    val TargetBased = "TargetBased".asInstanceOf[PolicyType]
 
     val values = js.Object.freeze(js.Array(RuleBased, TargetBased))
   }
-
-  object ProtectionPolicyEnum {
-    val NoProtection   = "NoProtection"
-    val FullProtection = "FullProtection"
+  @js.native
+  sealed trait ProtectionPolicy extends js.Any
+  object ProtectionPolicy extends js.Object {
+    val NoProtection   = "NoProtection".asInstanceOf[ProtectionPolicy]
+    val FullProtection = "FullProtection".asInstanceOf[ProtectionPolicy]
 
     val values = js.Object.freeze(js.Array(NoProtection, FullProtection))
   }
@@ -4563,10 +4562,11 @@ package gamelift {
       __obj.asInstanceOf[RoutingStrategy]
     }
   }
-
-  object RoutingStrategyTypeEnum {
-    val SIMPLE   = "SIMPLE"
-    val TERMINAL = "TERMINAL"
+  @js.native
+  sealed trait RoutingStrategyType extends js.Any
+  object RoutingStrategyType extends js.Object {
+    val SIMPLE   = "SIMPLE".asInstanceOf[RoutingStrategyType]
+    val TERMINAL = "TERMINAL".asInstanceOf[RoutingStrategyType]
 
     val values = js.Object.freeze(js.Array(SIMPLE, TERMINAL))
   }
@@ -4638,11 +4638,12 @@ package gamelift {
       __obj.asInstanceOf[S3Location]
     }
   }
-
-  object ScalingAdjustmentTypeEnum {
-    val ChangeInCapacity        = "ChangeInCapacity"
-    val ExactCapacity           = "ExactCapacity"
-    val PercentChangeInCapacity = "PercentChangeInCapacity"
+  @js.native
+  sealed trait ScalingAdjustmentType extends js.Any
+  object ScalingAdjustmentType extends js.Object {
+    val ChangeInCapacity        = "ChangeInCapacity".asInstanceOf[ScalingAdjustmentType]
+    val ExactCapacity           = "ExactCapacity".asInstanceOf[ScalingAdjustmentType]
+    val PercentChangeInCapacity = "PercentChangeInCapacity".asInstanceOf[ScalingAdjustmentType]
 
     val values = js.Object.freeze(js.Array(ChangeInCapacity, ExactCapacity, PercentChangeInCapacity))
   }
@@ -4706,15 +4707,16 @@ package gamelift {
       __obj.asInstanceOf[ScalingPolicy]
     }
   }
-
-  object ScalingStatusTypeEnum {
-    val ACTIVE           = "ACTIVE"
-    val UPDATE_REQUESTED = "UPDATE_REQUESTED"
-    val UPDATING         = "UPDATING"
-    val DELETE_REQUESTED = "DELETE_REQUESTED"
-    val DELETING         = "DELETING"
-    val DELETED          = "DELETED"
-    val ERROR            = "ERROR"
+  @js.native
+  sealed trait ScalingStatusType extends js.Any
+  object ScalingStatusType extends js.Object {
+    val ACTIVE           = "ACTIVE".asInstanceOf[ScalingStatusType]
+    val UPDATE_REQUESTED = "UPDATE_REQUESTED".asInstanceOf[ScalingStatusType]
+    val UPDATING         = "UPDATING".asInstanceOf[ScalingStatusType]
+    val DELETE_REQUESTED = "DELETE_REQUESTED".asInstanceOf[ScalingStatusType]
+    val DELETING         = "DELETING".asInstanceOf[ScalingStatusType]
+    val DELETED          = "DELETED".asInstanceOf[ScalingStatusType]
+    val ERROR            = "ERROR".asInstanceOf[ScalingStatusType]
 
     val values =
       js.Object.freeze(js.Array(ACTIVE, UPDATE_REQUESTED, UPDATING, DELETE_REQUESTED, DELETING, DELETED, ERROR))

--- a/services/glacier/src/main/scala/facade/amazonaws/services/Glacier.scala
+++ b/services/glacier/src/main/scala/facade/amazonaws/services/Glacier.scala
@@ -8,29 +8,19 @@ import facade.amazonaws._
 
 package object glacier {
   type AccessControlPolicyList = js.Array[Grant]
-  type ActionCode              = String
-  type CannedACL               = String
   type DataRetrievalRulesList  = js.Array[DataRetrievalRule]
   type DateTime                = String
-  type EncryptionType          = String
-  type ExpressionType          = String
-  type FileHeaderInfo          = String
   type JobList                 = js.Array[GlacierJobDescription]
   type NotificationEventList   = js.Array[String]
   type NullableLong            = Double
   type PartList                = js.Array[PartListElement]
-  type Permission              = String
   type ProvisionedCapacityList = js.Array[ProvisionedCapacityDescription]
-  type QuoteFields             = String
   type Size                    = Double
-  type StatusCode              = String
-  type StorageClass            = String
   type Stream                  = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type TagKey                  = String
   type TagKeyList              = js.Array[String]
   type TagMap                  = js.Dictionary[TagValue]
   type TagValue                = String
-  type Type                    = String
   type UploadsList             = js.Array[UploadListElement]
   type VaultList               = js.Array[DescribeVaultOutput]
   type hashmap                 = js.Dictionary[String]
@@ -207,11 +197,12 @@ package glacier {
       __obj.asInstanceOf[AbortVaultLockInput]
     }
   }
-
-  object ActionCodeEnum {
-    val ArchiveRetrieval   = "ArchiveRetrieval"
-    val InventoryRetrieval = "InventoryRetrieval"
-    val Select             = "Select"
+  @js.native
+  sealed trait ActionCode extends js.Any
+  object ActionCode extends js.Object {
+    val ArchiveRetrieval   = "ArchiveRetrieval".asInstanceOf[ActionCode]
+    val InventoryRetrieval = "InventoryRetrieval".asInstanceOf[ActionCode]
+    val Select             = "Select".asInstanceOf[ActionCode]
 
     val values = js.Object.freeze(js.Array(ArchiveRetrieval, InventoryRetrieval, Select))
   }
@@ -333,15 +324,16 @@ package glacier {
       __obj.asInstanceOf[CSVOutput]
     }
   }
-
-  object CannedACLEnum {
-    val `private`                   = "private"
-    val `public-read`               = "public-read"
-    val `public-read-write`         = "public-read-write"
-    val `aws-exec-read`             = "aws-exec-read"
-    val `authenticated-read`        = "authenticated-read"
-    val `bucket-owner-read`         = "bucket-owner-read"
-    val `bucket-owner-full-control` = "bucket-owner-full-control"
+  @js.native
+  sealed trait CannedACL extends js.Any
+  object CannedACL extends js.Object {
+    val `private`                   = "private".asInstanceOf[CannedACL]
+    val `public-read`               = "public-read".asInstanceOf[CannedACL]
+    val `public-read-write`         = "public-read-write".asInstanceOf[CannedACL]
+    val `aws-exec-read`             = "aws-exec-read".asInstanceOf[CannedACL]
+    val `authenticated-read`        = "authenticated-read".asInstanceOf[CannedACL]
+    val `bucket-owner-read`         = "bucket-owner-read".asInstanceOf[CannedACL]
+    val `bucket-owner-full-control` = "bucket-owner-full-control".asInstanceOf[CannedACL]
 
     val values = js.Object.freeze(
       js.Array(
@@ -708,24 +700,27 @@ package glacier {
       __obj.asInstanceOf[Encryption]
     }
   }
-
-  object EncryptionTypeEnum {
-    val `aws:kms` = "aws:kms"
-    val AES256    = "AES256"
+  @js.native
+  sealed trait EncryptionType extends js.Any
+  object EncryptionType extends js.Object {
+    val `aws:kms` = "aws:kms".asInstanceOf[EncryptionType]
+    val AES256    = "AES256".asInstanceOf[EncryptionType]
 
     val values = js.Object.freeze(js.Array(`aws:kms`, AES256))
   }
-
-  object ExpressionTypeEnum {
-    val SQL = "SQL"
+  @js.native
+  sealed trait ExpressionType extends js.Any
+  object ExpressionType extends js.Object {
+    val SQL = "SQL".asInstanceOf[ExpressionType]
 
     val values = js.Object.freeze(js.Array(SQL))
   }
-
-  object FileHeaderInfoEnum {
-    val USE    = "USE"
-    val IGNORE = "IGNORE"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait FileHeaderInfo extends js.Any
+  object FileHeaderInfo extends js.Object {
+    val USE    = "USE".asInstanceOf[FileHeaderInfo]
+    val IGNORE = "IGNORE".asInstanceOf[FileHeaderInfo]
+    val NONE   = "NONE".asInstanceOf[FileHeaderInfo]
 
     val values = js.Object.freeze(js.Array(USE, IGNORE, NONE))
   }
@@ -1752,13 +1747,14 @@ package glacier {
       __obj.asInstanceOf[PartListElement]
     }
   }
-
-  object PermissionEnum {
-    val FULL_CONTROL = "FULL_CONTROL"
-    val WRITE        = "WRITE"
-    val WRITE_ACP    = "WRITE_ACP"
-    val READ         = "READ"
-    val READ_ACP     = "READ_ACP"
+  @js.native
+  sealed trait Permission extends js.Any
+  object Permission extends js.Object {
+    val FULL_CONTROL = "FULL_CONTROL".asInstanceOf[Permission]
+    val WRITE        = "WRITE".asInstanceOf[Permission]
+    val WRITE_ACP    = "WRITE_ACP".asInstanceOf[Permission]
+    val READ         = "READ".asInstanceOf[Permission]
+    val READ_ACP     = "READ_ACP".asInstanceOf[Permission]
 
     val values = js.Object.freeze(js.Array(FULL_CONTROL, WRITE, WRITE_ACP, READ, READ_ACP))
   }
@@ -1821,10 +1817,11 @@ package glacier {
       __obj.asInstanceOf[PurchaseProvisionedCapacityOutput]
     }
   }
-
-  object QuoteFieldsEnum {
-    val ALWAYS   = "ALWAYS"
-    val ASNEEDED = "ASNEEDED"
+  @js.native
+  sealed trait QuoteFields extends js.Any
+  object QuoteFields extends js.Object {
+    val ALWAYS   = "ALWAYS".asInstanceOf[QuoteFields]
+    val ASNEEDED = "ASNEEDED".asInstanceOf[QuoteFields]
 
     val values = js.Object.freeze(js.Array(ALWAYS, ASNEEDED))
   }
@@ -2001,27 +1998,30 @@ package glacier {
       __obj.asInstanceOf[SetVaultNotificationsInput]
     }
   }
-
-  object StatusCodeEnum {
-    val InProgress = "InProgress"
-    val Succeeded  = "Succeeded"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait StatusCode extends js.Any
+  object StatusCode extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[StatusCode]
+    val Succeeded  = "Succeeded".asInstanceOf[StatusCode]
+    val Failed     = "Failed".asInstanceOf[StatusCode]
 
     val values = js.Object.freeze(js.Array(InProgress, Succeeded, Failed))
   }
-
-  object StorageClassEnum {
-    val STANDARD           = "STANDARD"
-    val REDUCED_REDUNDANCY = "REDUCED_REDUNDANCY"
-    val STANDARD_IA        = "STANDARD_IA"
+  @js.native
+  sealed trait StorageClass extends js.Any
+  object StorageClass extends js.Object {
+    val STANDARD           = "STANDARD".asInstanceOf[StorageClass]
+    val REDUCED_REDUNDANCY = "REDUCED_REDUNDANCY".asInstanceOf[StorageClass]
+    val STANDARD_IA        = "STANDARD_IA".asInstanceOf[StorageClass]
 
     val values = js.Object.freeze(js.Array(STANDARD, REDUCED_REDUNDANCY, STANDARD_IA))
   }
-
-  object TypeEnum {
-    val AmazonCustomerByEmail = "AmazonCustomerByEmail"
-    val CanonicalUser         = "CanonicalUser"
-    val Group                 = "Group"
+  @js.native
+  sealed trait Type extends js.Any
+  object Type extends js.Object {
+    val AmazonCustomerByEmail = "AmazonCustomerByEmail".asInstanceOf[Type]
+    val CanonicalUser         = "CanonicalUser".asInstanceOf[Type]
+    val Group                 = "Group".asInstanceOf[Type]
 
     val values = js.Object.freeze(js.Array(AmazonCustomerByEmail, CanonicalUser, Group))
   }

--- a/services/globalaccelerator/src/main/scala/facade/amazonaws/services/GlobalAccelerator.scala
+++ b/services/globalaccelerator/src/main/scala/facade/amazonaws/services/GlobalAccelerator.scala
@@ -7,9 +7,7 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object globalaccelerator {
-  type AcceleratorStatus          = String
   type Accelerators               = js.Array[Accelerator]
-  type ClientAffinity             = String
   type EndpointConfigurations     = js.Array[EndpointConfiguration]
   type EndpointDescriptions       = js.Array[EndpointDescription]
   type EndpointGroups             = js.Array[EndpointGroup]
@@ -18,18 +16,14 @@ package object globalaccelerator {
   type GenericString              = String
   type HealthCheckIntervalSeconds = Int
   type HealthCheckPort            = Int
-  type HealthCheckProtocol        = String
-  type HealthState                = String
   type IdempotencyToken           = String
   type IpAddress                  = String
-  type IpAddressType              = String
   type IpAddresses                = js.Array[IpAddress]
   type IpSets                     = js.Array[IpSet]
   type Listeners                  = js.Array[Listener]
   type MaxResults                 = Int
   type PortNumber                 = Int
   type PortRanges                 = js.Array[PortRange]
-  type Protocol                   = String
   type ThresholdCount             = Int
   type Timestamp                  = js.Date
   type TrafficDialPercentage      = Float
@@ -172,17 +166,19 @@ package globalaccelerator {
       __obj.asInstanceOf[AcceleratorAttributes]
     }
   }
-
-  object AcceleratorStatusEnum {
-    val DEPLOYED    = "DEPLOYED"
-    val IN_PROGRESS = "IN_PROGRESS"
+  @js.native
+  sealed trait AcceleratorStatus extends js.Any
+  object AcceleratorStatus extends js.Object {
+    val DEPLOYED    = "DEPLOYED".asInstanceOf[AcceleratorStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[AcceleratorStatus]
 
     val values = js.Object.freeze(js.Array(DEPLOYED, IN_PROGRESS))
   }
-
-  object ClientAffinityEnum {
-    val NONE      = "NONE"
-    val SOURCE_IP = "SOURCE_IP"
+  @js.native
+  sealed trait ClientAffinity extends js.Any
+  object ClientAffinity extends js.Object {
+    val NONE      = "NONE".asInstanceOf[ClientAffinity]
+    val SOURCE_IP = "SOURCE_IP".asInstanceOf[ClientAffinity]
 
     val values = js.Object.freeze(js.Array(NONE, SOURCE_IP))
   }
@@ -633,25 +629,28 @@ package globalaccelerator {
       __obj.asInstanceOf[EndpointGroup]
     }
   }
-
-  object HealthCheckProtocolEnum {
-    val TCP   = "TCP"
-    val HTTP  = "HTTP"
-    val HTTPS = "HTTPS"
+  @js.native
+  sealed trait HealthCheckProtocol extends js.Any
+  object HealthCheckProtocol extends js.Object {
+    val TCP   = "TCP".asInstanceOf[HealthCheckProtocol]
+    val HTTP  = "HTTP".asInstanceOf[HealthCheckProtocol]
+    val HTTPS = "HTTPS".asInstanceOf[HealthCheckProtocol]
 
     val values = js.Object.freeze(js.Array(TCP, HTTP, HTTPS))
   }
-
-  object HealthStateEnum {
-    val INITIAL   = "INITIAL"
-    val HEALTHY   = "HEALTHY"
-    val UNHEALTHY = "UNHEALTHY"
+  @js.native
+  sealed trait HealthState extends js.Any
+  object HealthState extends js.Object {
+    val INITIAL   = "INITIAL".asInstanceOf[HealthState]
+    val HEALTHY   = "HEALTHY".asInstanceOf[HealthState]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[HealthState]
 
     val values = js.Object.freeze(js.Array(INITIAL, HEALTHY, UNHEALTHY))
   }
-
-  object IpAddressTypeEnum {
-    val IPV4 = "IPV4"
+  @js.native
+  sealed trait IpAddressType extends js.Any
+  object IpAddressType extends js.Object {
+    val IPV4 = "IPV4".asInstanceOf[IpAddressType]
 
     val values = js.Object.freeze(js.Array(IPV4))
   }
@@ -851,10 +850,11 @@ package globalaccelerator {
       __obj.asInstanceOf[PortRange]
     }
   }
-
-  object ProtocolEnum {
-    val TCP = "TCP"
-    val UDP = "UDP"
+  @js.native
+  sealed trait Protocol extends js.Any
+  object Protocol extends js.Object {
+    val TCP = "TCP".asInstanceOf[Protocol]
+    val UDP = "UDP".asInstanceOf[Protocol]
 
     val values = js.Object.freeze(js.Array(TCP, UDP))
   }

--- a/services/glue/src/main/scala/facade/amazonaws/services/Glue.scala
+++ b/services/glue/src/main/scala/facade/amazonaws/services/Glue.scala
@@ -19,7 +19,6 @@ package object glue {
   type BooleanNullable                         = Boolean
   type BooleanValue                            = Boolean
   type BoundedPartitionValueList               = js.Array[ValueString]
-  type CatalogEncryptionMode                   = String
   type CatalogEntries                          = js.Array[CatalogEntry]
   type CatalogIdString                         = String
   type CatalogTablesList                       = js.Array[NameString]
@@ -27,7 +26,6 @@ package object glue {
   type Classification                          = String
   type ClassifierList                          = js.Array[Classifier]
   type ClassifierNameList                      = js.Array[NameString]
-  type CloudWatchEncryptionMode                = String
   type CodeGenArgName                          = String
   type CodeGenArgValue                         = String
   type CodeGenIdentifier                       = String
@@ -39,25 +37,19 @@ package object glue {
   type ColumnValueStringList                   = js.Array[ColumnValuesString]
   type ColumnValuesString                      = String
   type CommentString                           = String
-  type Comparator                              = String
   type ConditionList                           = js.Array[Condition]
   type ConnectionList                          = js.Array[Connection]
   type ConnectionName                          = String
   type ConnectionProperties                    = js.Dictionary[ValueString]
-  type ConnectionPropertyKey                   = String
-  type ConnectionType                          = String
   type CrawlList                               = js.Array[Crawl]
-  type CrawlState                              = String
   type CrawlerConfiguration                    = String
   type CrawlerList                             = js.Array[Crawler]
   type CrawlerMetricsList                      = js.Array[CrawlerMetrics]
   type CrawlerNameList                         = js.Array[NameString]
   type CrawlerSecurityConfiguration            = String
-  type CrawlerState                            = String
   type CronExpression                          = String
   type CsvColumnDelimiter                      = String
   type CsvHeader                               = js.Array[NameString]
-  type CsvHeaderOption                         = String
   type CsvQuoteSymbol                          = String
   type CustomPatterns                          = String
   type DagEdges                                = js.Array[CodeGenEdge]
@@ -65,7 +57,6 @@ package object glue {
   type DataLakePrincipalString                 = String
   type DatabaseList                            = js.Array[Database]
   type DatabaseName                            = String
-  type DeleteBehavior                          = String
   type DeleteConnectionNameList                = js.Array[NameString]
   type DescriptionString                       = String
   type DescriptionStringRemovable              = String
@@ -77,7 +68,6 @@ package object glue {
   type ErrorByName                             = js.Dictionary[ErrorDetail]
   type ErrorString                             = String
   type ExecutionTime                           = Int
-  type ExistCondition                          = String
   type FieldType                               = String
   type FilterString                            = String
   type FormatString                            = String
@@ -94,25 +84,19 @@ package object glue {
   type IntegerFlag                             = Int
   type IntegerValue                            = Int
   type JdbcTargetList                          = js.Array[JdbcTarget]
-  type JobBookmarksEncryptionMode              = String
   type JobList                                 = js.Array[Job]
   type JobName                                 = String
   type JobNameList                             = js.Array[NameString]
   type JobRunList                              = js.Array[JobRun]
-  type JobRunState                             = String
   type JsonPath                                = String
   type JsonValue                               = String
   type KeyString                               = String
   type KmsKeyArn                               = String
   type LabelCount                              = Int
-  type Language                                = String
-  type LastCrawlStatus                         = String
   type LocationMap                             = js.Dictionary[ColumnValuesString]
   type LocationString                          = String
   type LogGroup                                = String
   type LogStream                               = String
-  type Logical                                 = String
-  type LogicalOperator                         = String
   type MapValue                                = js.Dictionary[GenericString]
   type MappingList                             = js.Array[MappingEntry]
   type MatchCriteria                           = js.Array[NameString]
@@ -123,7 +107,6 @@ package object glue {
   type NameString                              = String
   type NameStringList                          = js.Array[NameString]
   type NodeList                                = js.Array[Node]
-  type NodeType                                = String
   type NonNegativeDouble                       = Double
   type NonNegativeInteger                      = Int
   type NotifyDelayAfter                        = Int
@@ -141,19 +124,16 @@ package object glue {
   type PartitionList                           = js.Array[Partition]
   type Path                                    = String
   type PathList                                = js.Array[Path]
-  type Permission                              = String
   type PermissionList                          = js.Array[Permission]
   type PolicyJsonString                        = String
   type PredecessorList                         = js.Array[Predecessor]
   type PredicateString                         = String
   type PrincipalPermissionsList                = js.Array[PrincipalPermissions]
-  type PrincipalType                           = String
   type PublicKeysList                          = js.Array[GenericString]
   type PythonScript                            = String
   type PythonVersionString                     = String
   type RecordsCount                            = Double
   type ReplaceBoolean                          = Boolean
-  type ResourceType                            = String
   type ResourceUriList                         = js.Array[ResourceUri]
   type Role                                    = String
   type RoleArn                                 = String
@@ -161,18 +141,14 @@ package object glue {
   type RowTag                                  = String
   type RunId                                   = String
   type S3EncryptionList                        = js.Array[S3Encryption]
-  type S3EncryptionMode                        = String
   type S3TargetList                            = js.Array[S3Target]
   type ScalaCode                               = String
-  type ScheduleState                           = String
   type SchemaPathString                        = String
   type ScriptLocationString                    = String
   type SearchPropertyPredicates                = js.Array[PropertyPredicate]
   type SecurityConfigurationList               = js.Array[SecurityConfiguration]
   type SecurityGroupIdList                     = js.Array[NameString]
-  type Sort                                    = String
   type SortCriteria                            = js.Array[SortCriterion]
-  type SortDirectionType                       = String
   type StringList                              = js.Array[GenericString]
   type TableErrors                             = js.Array[TableError]
   type TableList                               = js.Array[Table]
@@ -185,9 +161,6 @@ package object glue {
   type TagValue                                = String
   type TagsMap                                 = js.Dictionary[TagValue]
   type TaskRunList                             = js.Array[TaskRun]
-  type TaskRunSortColumnType                   = String
-  type TaskStatusType                          = String
-  type TaskType                                = String
   type Timeout                                 = Int
   type Timestamp                               = js.Date
   type TimestampValue                          = js.Date
@@ -195,15 +168,9 @@ package object glue {
   type TotalSegmentsInteger                    = Int
   type TransformList                           = js.Array[MLTransform]
   type TransformSchema                         = js.Array[SchemaColumn]
-  type TransformSortColumnType                 = String
-  type TransformStatusType                     = String
-  type TransformType                           = String
   type TriggerList                             = js.Array[Trigger]
   type TriggerNameList                         = js.Array[NameString]
-  type TriggerState                            = String
-  type TriggerType                             = String
   type URI                                     = String
-  type UpdateBehavior                          = String
   type UriString                               = String
   type UserDefinedFunctionList                 = js.Array[UserDefinedFunction]
   type ValueString                             = String
@@ -211,10 +178,8 @@ package object glue {
   type VersionId                               = Double
   type VersionString                           = String
   type ViewTextString                          = String
-  type WorkerType                              = String
   type WorkflowNames                           = js.Array[NameString]
   type WorkflowRunProperties                   = js.Dictionary[GenericString]
-  type WorkflowRunStatus                       = String
   type WorkflowRuns                            = js.Array[WorkflowRun]
   type Workflows                               = js.Array[Workflow]
 
@@ -1257,10 +1222,11 @@ package glue {
       __obj.asInstanceOf[CancelMLTaskRunResponse]
     }
   }
-
-  object CatalogEncryptionModeEnum {
-    val DISABLED  = "DISABLED"
-    val `SSE-KMS` = "SSE-KMS"
+  @js.native
+  sealed trait CatalogEncryptionMode extends js.Any
+  object CatalogEncryptionMode extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[CatalogEncryptionMode]
+    val `SSE-KMS` = "SSE-KMS".asInstanceOf[CatalogEncryptionMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, `SSE-KMS`))
   }
@@ -1388,10 +1354,11 @@ package glue {
       __obj.asInstanceOf[CloudWatchEncryption]
     }
   }
-
-  object CloudWatchEncryptionModeEnum {
-    val DISABLED  = "DISABLED"
-    val `SSE-KMS` = "SSE-KMS"
+  @js.native
+  sealed trait CloudWatchEncryptionMode extends js.Any
+  object CloudWatchEncryptionMode extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[CloudWatchEncryptionMode]
+    val `SSE-KMS` = "SSE-KMS".asInstanceOf[CloudWatchEncryptionMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, `SSE-KMS`))
   }
@@ -1509,13 +1476,14 @@ package glue {
       __obj.asInstanceOf[Column]
     }
   }
-
-  object ComparatorEnum {
-    val EQUALS              = "EQUALS"
-    val GREATER_THAN        = "GREATER_THAN"
-    val LESS_THAN           = "LESS_THAN"
-    val GREATER_THAN_EQUALS = "GREATER_THAN_EQUALS"
-    val LESS_THAN_EQUALS    = "LESS_THAN_EQUALS"
+  @js.native
+  sealed trait Comparator extends js.Any
+  object Comparator extends js.Object {
+    val EQUALS              = "EQUALS".asInstanceOf[Comparator]
+    val GREATER_THAN        = "GREATER_THAN".asInstanceOf[Comparator]
+    val LESS_THAN           = "LESS_THAN".asInstanceOf[Comparator]
+    val GREATER_THAN_EQUALS = "GREATER_THAN_EQUALS".asInstanceOf[Comparator]
+    val LESS_THAN_EQUALS    = "LESS_THAN_EQUALS".asInstanceOf[Comparator]
 
     val values = js.Object.freeze(js.Array(EQUALS, GREATER_THAN, LESS_THAN, GREATER_THAN_EQUALS, LESS_THAN_EQUALS))
   }
@@ -1688,24 +1656,25 @@ package glue {
       __obj.asInstanceOf[ConnectionPasswordEncryption]
     }
   }
-
-  object ConnectionPropertyKeyEnum {
-    val HOST                             = "HOST"
-    val PORT                             = "PORT"
-    val USERNAME                         = "USERNAME"
-    val PASSWORD                         = "PASSWORD"
-    val ENCRYPTED_PASSWORD               = "ENCRYPTED_PASSWORD"
-    val JDBC_DRIVER_JAR_URI              = "JDBC_DRIVER_JAR_URI"
-    val JDBC_DRIVER_CLASS_NAME           = "JDBC_DRIVER_CLASS_NAME"
-    val JDBC_ENGINE                      = "JDBC_ENGINE"
-    val JDBC_ENGINE_VERSION              = "JDBC_ENGINE_VERSION"
-    val CONFIG_FILES                     = "CONFIG_FILES"
-    val INSTANCE_ID                      = "INSTANCE_ID"
-    val JDBC_CONNECTION_URL              = "JDBC_CONNECTION_URL"
-    val JDBC_ENFORCE_SSL                 = "JDBC_ENFORCE_SSL"
-    val CUSTOM_JDBC_CERT                 = "CUSTOM_JDBC_CERT"
-    val SKIP_CUSTOM_JDBC_CERT_VALIDATION = "SKIP_CUSTOM_JDBC_CERT_VALIDATION"
-    val CUSTOM_JDBC_CERT_STRING          = "CUSTOM_JDBC_CERT_STRING"
+  @js.native
+  sealed trait ConnectionPropertyKey extends js.Any
+  object ConnectionPropertyKey extends js.Object {
+    val HOST                             = "HOST".asInstanceOf[ConnectionPropertyKey]
+    val PORT                             = "PORT".asInstanceOf[ConnectionPropertyKey]
+    val USERNAME                         = "USERNAME".asInstanceOf[ConnectionPropertyKey]
+    val PASSWORD                         = "PASSWORD".asInstanceOf[ConnectionPropertyKey]
+    val ENCRYPTED_PASSWORD               = "ENCRYPTED_PASSWORD".asInstanceOf[ConnectionPropertyKey]
+    val JDBC_DRIVER_JAR_URI              = "JDBC_DRIVER_JAR_URI".asInstanceOf[ConnectionPropertyKey]
+    val JDBC_DRIVER_CLASS_NAME           = "JDBC_DRIVER_CLASS_NAME".asInstanceOf[ConnectionPropertyKey]
+    val JDBC_ENGINE                      = "JDBC_ENGINE".asInstanceOf[ConnectionPropertyKey]
+    val JDBC_ENGINE_VERSION              = "JDBC_ENGINE_VERSION".asInstanceOf[ConnectionPropertyKey]
+    val CONFIG_FILES                     = "CONFIG_FILES".asInstanceOf[ConnectionPropertyKey]
+    val INSTANCE_ID                      = "INSTANCE_ID".asInstanceOf[ConnectionPropertyKey]
+    val JDBC_CONNECTION_URL              = "JDBC_CONNECTION_URL".asInstanceOf[ConnectionPropertyKey]
+    val JDBC_ENFORCE_SSL                 = "JDBC_ENFORCE_SSL".asInstanceOf[ConnectionPropertyKey]
+    val CUSTOM_JDBC_CERT                 = "CUSTOM_JDBC_CERT".asInstanceOf[ConnectionPropertyKey]
+    val SKIP_CUSTOM_JDBC_CERT_VALIDATION = "SKIP_CUSTOM_JDBC_CERT_VALIDATION".asInstanceOf[ConnectionPropertyKey]
+    val CUSTOM_JDBC_CERT_STRING          = "CUSTOM_JDBC_CERT_STRING".asInstanceOf[ConnectionPropertyKey]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1728,10 +1697,11 @@ package glue {
       )
     )
   }
-
-  object ConnectionTypeEnum {
-    val JDBC = "JDBC"
-    val SFTP = "SFTP"
+  @js.native
+  sealed trait ConnectionType extends js.Any
+  object ConnectionType extends js.Object {
+    val JDBC = "JDBC".asInstanceOf[ConnectionType]
+    val SFTP = "SFTP".asInstanceOf[ConnectionType]
 
     val values = js.Object.freeze(js.Array(JDBC, SFTP))
   }
@@ -1788,12 +1758,13 @@ package glue {
       __obj.asInstanceOf[Crawl]
     }
   }
-
-  object CrawlStateEnum {
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val CANCELLED = "CANCELLED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait CrawlState extends js.Any
+  object CrawlState extends js.Object {
+    val RUNNING   = "RUNNING".asInstanceOf[CrawlState]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[CrawlState]
+    val CANCELLED = "CANCELLED".asInstanceOf[CrawlState]
+    val FAILED    = "FAILED".asInstanceOf[CrawlState]
 
     val values = js.Object.freeze(js.Array(RUNNING, SUCCEEDED, CANCELLED, FAILED))
   }
@@ -1925,11 +1896,12 @@ package glue {
       __obj.asInstanceOf[CrawlerNodeDetails]
     }
   }
-
-  object CrawlerStateEnum {
-    val READY    = "READY"
-    val RUNNING  = "RUNNING"
-    val STOPPING = "STOPPING"
+  @js.native
+  sealed trait CrawlerState extends js.Any
+  object CrawlerState extends js.Object {
+    val READY    = "READY".asInstanceOf[CrawlerState]
+    val RUNNING  = "RUNNING".asInstanceOf[CrawlerState]
+    val STOPPING = "STOPPING".asInstanceOf[CrawlerState]
 
     val values = js.Object.freeze(js.Array(READY, RUNNING, STOPPING))
   }
@@ -2881,11 +2853,12 @@ package glue {
       __obj.asInstanceOf[CsvClassifier]
     }
   }
-
-  object CsvHeaderOptionEnum {
-    val UNKNOWN = "UNKNOWN"
-    val PRESENT = "PRESENT"
-    val ABSENT  = "ABSENT"
+  @js.native
+  sealed trait CsvHeaderOption extends js.Any
+  object CsvHeaderOption extends js.Object {
+    val UNKNOWN = "UNKNOWN".asInstanceOf[CsvHeaderOption]
+    val PRESENT = "PRESENT".asInstanceOf[CsvHeaderOption]
+    val ABSENT  = "ABSENT".asInstanceOf[CsvHeaderOption]
 
     val values = js.Object.freeze(js.Array(UNKNOWN, PRESENT, ABSENT))
   }
@@ -3007,11 +2980,12 @@ package glue {
       __obj.asInstanceOf[DatabaseInput]
     }
   }
-
-  object DeleteBehaviorEnum {
-    val LOG                   = "LOG"
-    val DELETE_FROM_DATABASE  = "DELETE_FROM_DATABASE"
-    val DEPRECATE_IN_DATABASE = "DEPRECATE_IN_DATABASE"
+  @js.native
+  sealed trait DeleteBehavior extends js.Any
+  object DeleteBehavior extends js.Object {
+    val LOG                   = "LOG".asInstanceOf[DeleteBehavior]
+    val DELETE_FROM_DATABASE  = "DELETE_FROM_DATABASE".asInstanceOf[DeleteBehavior]
+    val DEPRECATE_IN_DATABASE = "DEPRECATE_IN_DATABASE".asInstanceOf[DeleteBehavior]
 
     val values = js.Object.freeze(js.Array(LOG, DELETE_FROM_DATABASE, DEPRECATE_IN_DATABASE))
   }
@@ -3796,11 +3770,12 @@ package glue {
       __obj.asInstanceOf[ExecutionProperty]
     }
   }
-
-  object ExistConditionEnum {
-    val MUST_EXIST = "MUST_EXIST"
-    val NOT_EXIST  = "NOT_EXIST"
-    val NONE       = "NONE"
+  @js.native
+  sealed trait ExistCondition extends js.Any
+  object ExistCondition extends js.Object {
+    val MUST_EXIST = "MUST_EXIST".asInstanceOf[ExistCondition]
+    val NOT_EXIST  = "NOT_EXIST".asInstanceOf[ExistCondition]
+    val NONE       = "NONE".asInstanceOf[ExistCondition]
 
     val values = js.Object.freeze(js.Array(MUST_EXIST, NOT_EXIST, NONE))
   }
@@ -6010,10 +5985,11 @@ package glue {
       __obj.asInstanceOf[JobBookmarksEncryption]
     }
   }
-
-  object JobBookmarksEncryptionModeEnum {
-    val DISABLED  = "DISABLED"
-    val `CSE-KMS` = "CSE-KMS"
+  @js.native
+  sealed trait JobBookmarksEncryptionMode extends js.Any
+  object JobBookmarksEncryptionMode extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[JobBookmarksEncryptionMode]
+    val `CSE-KMS` = "CSE-KMS".asInstanceOf[JobBookmarksEncryptionMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, `CSE-KMS`))
   }
@@ -6143,15 +6119,16 @@ package glue {
       __obj.asInstanceOf[JobRun]
     }
   }
-
-  object JobRunStateEnum {
-    val STARTING  = "STARTING"
-    val RUNNING   = "RUNNING"
-    val STOPPING  = "STOPPING"
-    val STOPPED   = "STOPPED"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
-    val TIMEOUT   = "TIMEOUT"
+  @js.native
+  sealed trait JobRunState extends js.Any
+  object JobRunState extends js.Object {
+    val STARTING  = "STARTING".asInstanceOf[JobRunState]
+    val RUNNING   = "RUNNING".asInstanceOf[JobRunState]
+    val STOPPING  = "STOPPING".asInstanceOf[JobRunState]
+    val STOPPED   = "STOPPED".asInstanceOf[JobRunState]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[JobRunState]
+    val FAILED    = "FAILED".asInstanceOf[JobRunState]
+    val TIMEOUT   = "TIMEOUT".asInstanceOf[JobRunState]
 
     val values = js.Object.freeze(js.Array(STARTING, RUNNING, STOPPING, STOPPED, SUCCEEDED, FAILED, TIMEOUT))
   }
@@ -6274,10 +6251,11 @@ package glue {
       __obj.asInstanceOf[LabelingSetGenerationTaskRunProperties]
     }
   }
-
-  object LanguageEnum {
-    val PYTHON = "PYTHON"
-    val SCALA  = "SCALA"
+  @js.native
+  sealed trait Language extends js.Any
+  object Language extends js.Object {
+    val PYTHON = "PYTHON".asInstanceOf[Language]
+    val SCALA  = "SCALA".asInstanceOf[Language]
 
     val values = js.Object.freeze(js.Array(PYTHON, SCALA))
   }
@@ -6315,11 +6293,12 @@ package glue {
       __obj.asInstanceOf[LastCrawlInfo]
     }
   }
-
-  object LastCrawlStatusEnum {
-    val SUCCEEDED = "SUCCEEDED"
-    val CANCELLED = "CANCELLED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait LastCrawlStatus extends js.Any
+  object LastCrawlStatus extends js.Object {
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[LastCrawlStatus]
+    val CANCELLED = "CANCELLED".asInstanceOf[LastCrawlStatus]
+    val FAILED    = "FAILED".asInstanceOf[LastCrawlStatus]
 
     val values = js.Object.freeze(js.Array(SUCCEEDED, CANCELLED, FAILED))
   }
@@ -6553,16 +6532,18 @@ package glue {
       __obj.asInstanceOf[Location]
     }
   }
-
-  object LogicalEnum {
-    val AND = "AND"
-    val ANY = "ANY"
+  @js.native
+  sealed trait Logical extends js.Any
+  object Logical extends js.Object {
+    val AND = "AND".asInstanceOf[Logical]
+    val ANY = "ANY".asInstanceOf[Logical]
 
     val values = js.Object.freeze(js.Array(AND, ANY))
   }
-
-  object LogicalOperatorEnum {
-    val EQUALS = "EQUALS"
+  @js.native
+  sealed trait LogicalOperator extends js.Any
+  object LogicalOperator extends js.Object {
+    val EQUALS = "EQUALS".asInstanceOf[LogicalOperator]
 
     val values = js.Object.freeze(js.Array(EQUALS))
   }
@@ -6704,11 +6685,12 @@ package glue {
       __obj.asInstanceOf[Node]
     }
   }
-
-  object NodeTypeEnum {
-    val CRAWLER = "CRAWLER"
-    val JOB     = "JOB"
-    val TRIGGER = "TRIGGER"
+  @js.native
+  sealed trait NodeType extends js.Any
+  object NodeType extends js.Object {
+    val CRAWLER = "CRAWLER".asInstanceOf[NodeType]
+    val JOB     = "JOB".asInstanceOf[NodeType]
+    val TRIGGER = "TRIGGER".asInstanceOf[NodeType]
 
     val values = js.Object.freeze(js.Array(CRAWLER, JOB, TRIGGER))
   }
@@ -6869,17 +6851,18 @@ package glue {
       __obj.asInstanceOf[PartitionValueList]
     }
   }
-
-  object PermissionEnum {
-    val ALL                  = "ALL"
-    val SELECT               = "SELECT"
-    val ALTER                = "ALTER"
-    val DROP                 = "DROP"
-    val DELETE               = "DELETE"
-    val INSERT               = "INSERT"
-    val CREATE_DATABASE      = "CREATE_DATABASE"
-    val CREATE_TABLE         = "CREATE_TABLE"
-    val DATA_LOCATION_ACCESS = "DATA_LOCATION_ACCESS"
+  @js.native
+  sealed trait Permission extends js.Any
+  object Permission extends js.Object {
+    val ALL                  = "ALL".asInstanceOf[Permission]
+    val SELECT               = "SELECT".asInstanceOf[Permission]
+    val ALTER                = "ALTER".asInstanceOf[Permission]
+    val DROP                 = "DROP".asInstanceOf[Permission]
+    val DELETE               = "DELETE".asInstanceOf[Permission]
+    val INSERT               = "INSERT".asInstanceOf[Permission]
+    val CREATE_DATABASE      = "CREATE_DATABASE".asInstanceOf[Permission]
+    val CREATE_TABLE         = "CREATE_TABLE".asInstanceOf[Permission]
+    val DATA_LOCATION_ACCESS = "DATA_LOCATION_ACCESS".asInstanceOf[Permission]
 
     val values = js.Object.freeze(
       js.Array(ALL, SELECT, ALTER, DROP, DELETE, INSERT, CREATE_DATABASE, CREATE_TABLE, DATA_LOCATION_ACCESS)
@@ -6976,11 +6959,12 @@ package glue {
       __obj.asInstanceOf[PrincipalPermissions]
     }
   }
-
-  object PrincipalTypeEnum {
-    val USER  = "USER"
-    val ROLE  = "ROLE"
-    val GROUP = "GROUP"
+  @js.native
+  sealed trait PrincipalType extends js.Any
+  object PrincipalType extends js.Object {
+    val USER  = "USER".asInstanceOf[PrincipalType]
+    val ROLE  = "ROLE".asInstanceOf[PrincipalType]
+    val GROUP = "GROUP".asInstanceOf[PrincipalType]
 
     val values = js.Object.freeze(js.Array(USER, ROLE, GROUP))
   }
@@ -7157,11 +7141,12 @@ package glue {
       __obj.asInstanceOf[ResetJobBookmarkResponse]
     }
   }
-
-  object ResourceTypeEnum {
-    val JAR     = "JAR"
-    val FILE    = "FILE"
-    val ARCHIVE = "ARCHIVE"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val JAR     = "JAR".asInstanceOf[ResourceType]
+    val FILE    = "FILE".asInstanceOf[ResourceType]
+    val ARCHIVE = "ARCHIVE".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(JAR, FILE, ARCHIVE))
   }
@@ -7209,11 +7194,12 @@ package glue {
       __obj.asInstanceOf[S3Encryption]
     }
   }
-
-  object S3EncryptionModeEnum {
-    val DISABLED  = "DISABLED"
-    val `SSE-KMS` = "SSE-KMS"
-    val `SSE-S3`  = "SSE-S3"
+  @js.native
+  sealed trait S3EncryptionMode extends js.Any
+  object S3EncryptionMode extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[S3EncryptionMode]
+    val `SSE-KMS` = "SSE-KMS".asInstanceOf[S3EncryptionMode]
+    val `SSE-S3`  = "SSE-S3".asInstanceOf[S3EncryptionMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, `SSE-KMS`, `SSE-S3`))
   }
@@ -7261,11 +7247,12 @@ package glue {
       __obj.asInstanceOf[Schedule]
     }
   }
-
-  object ScheduleStateEnum {
-    val SCHEDULED     = "SCHEDULED"
-    val NOT_SCHEDULED = "NOT_SCHEDULED"
-    val TRANSITIONING = "TRANSITIONING"
+  @js.native
+  sealed trait ScheduleState extends js.Any
+  object ScheduleState extends js.Object {
+    val SCHEDULED     = "SCHEDULED".asInstanceOf[ScheduleState]
+    val NOT_SCHEDULED = "NOT_SCHEDULED".asInstanceOf[ScheduleState]
+    val TRANSITIONING = "TRANSITIONING".asInstanceOf[ScheduleState]
 
     val values = js.Object.freeze(js.Array(SCHEDULED, NOT_SCHEDULED, TRANSITIONING))
   }
@@ -7464,10 +7451,11 @@ package glue {
       __obj.asInstanceOf[SkewedInfo]
     }
   }
-
-  object SortEnum {
-    val ASC  = "ASC"
-    val DESC = "DESC"
+  @js.native
+  sealed trait Sort extends js.Any
+  object Sort extends js.Object {
+    val ASC  = "ASC".asInstanceOf[Sort]
+    val DESC = "DESC".asInstanceOf[Sort]
 
     val values = js.Object.freeze(js.Array(ASC, DESC))
   }
@@ -7493,10 +7481,11 @@ package glue {
       __obj.asInstanceOf[SortCriterion]
     }
   }
-
-  object SortDirectionTypeEnum {
-    val DESCENDING = "DESCENDING"
-    val ASCENDING  = "ASCENDING"
+  @js.native
+  sealed trait SortDirectionType extends js.Any
+  object SortDirectionType extends js.Object {
+    val DESCENDING = "DESCENDING".asInstanceOf[SortDirectionType]
+    val ASCENDING  = "ASCENDING".asInstanceOf[SortDirectionType]
 
     val values = js.Object.freeze(js.Array(DESCENDING, ASCENDING))
   }
@@ -8328,11 +8317,12 @@ package glue {
       __obj.asInstanceOf[TaskRunProperties]
     }
   }
-
-  object TaskRunSortColumnTypeEnum {
-    val TASK_RUN_TYPE = "TASK_RUN_TYPE"
-    val STATUS        = "STATUS"
-    val STARTED       = "STARTED"
+  @js.native
+  sealed trait TaskRunSortColumnType extends js.Any
+  object TaskRunSortColumnType extends js.Object {
+    val TASK_RUN_TYPE = "TASK_RUN_TYPE".asInstanceOf[TaskRunSortColumnType]
+    val STATUS        = "STATUS".asInstanceOf[TaskRunSortColumnType]
+    val STARTED       = "STARTED".asInstanceOf[TaskRunSortColumnType]
 
     val values = js.Object.freeze(js.Array(TASK_RUN_TYPE, STATUS, STARTED))
   }
@@ -8360,25 +8350,27 @@ package glue {
       __obj.asInstanceOf[TaskRunSortCriteria]
     }
   }
-
-  object TaskStatusTypeEnum {
-    val STARTING  = "STARTING"
-    val RUNNING   = "RUNNING"
-    val STOPPING  = "STOPPING"
-    val STOPPED   = "STOPPED"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
-    val TIMEOUT   = "TIMEOUT"
+  @js.native
+  sealed trait TaskStatusType extends js.Any
+  object TaskStatusType extends js.Object {
+    val STARTING  = "STARTING".asInstanceOf[TaskStatusType]
+    val RUNNING   = "RUNNING".asInstanceOf[TaskStatusType]
+    val STOPPING  = "STOPPING".asInstanceOf[TaskStatusType]
+    val STOPPED   = "STOPPED".asInstanceOf[TaskStatusType]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[TaskStatusType]
+    val FAILED    = "FAILED".asInstanceOf[TaskStatusType]
+    val TIMEOUT   = "TIMEOUT".asInstanceOf[TaskStatusType]
 
     val values = js.Object.freeze(js.Array(STARTING, RUNNING, STOPPING, STOPPED, SUCCEEDED, FAILED, TIMEOUT))
   }
-
-  object TaskTypeEnum {
-    val EVALUATION              = "EVALUATION"
-    val LABELING_SET_GENERATION = "LABELING_SET_GENERATION"
-    val IMPORT_LABELS           = "IMPORT_LABELS"
-    val EXPORT_LABELS           = "EXPORT_LABELS"
-    val FIND_MATCHES            = "FIND_MATCHES"
+  @js.native
+  sealed trait TaskType extends js.Any
+  object TaskType extends js.Object {
+    val EVALUATION              = "EVALUATION".asInstanceOf[TaskType]
+    val LABELING_SET_GENERATION = "LABELING_SET_GENERATION".asInstanceOf[TaskType]
+    val IMPORT_LABELS           = "IMPORT_LABELS".asInstanceOf[TaskType]
+    val EXPORT_LABELS           = "EXPORT_LABELS".asInstanceOf[TaskType]
+    val FIND_MATCHES            = "FIND_MATCHES".asInstanceOf[TaskType]
 
     val values =
       js.Object.freeze(js.Array(EVALUATION, LABELING_SET_GENERATION, IMPORT_LABELS, EXPORT_LABELS, FIND_MATCHES))
@@ -8450,13 +8442,14 @@ package glue {
       __obj.asInstanceOf[TransformParameters]
     }
   }
-
-  object TransformSortColumnTypeEnum {
-    val NAME           = "NAME"
-    val TRANSFORM_TYPE = "TRANSFORM_TYPE"
-    val STATUS         = "STATUS"
-    val CREATED        = "CREATED"
-    val LAST_MODIFIED  = "LAST_MODIFIED"
+  @js.native
+  sealed trait TransformSortColumnType extends js.Any
+  object TransformSortColumnType extends js.Object {
+    val NAME           = "NAME".asInstanceOf[TransformSortColumnType]
+    val TRANSFORM_TYPE = "TRANSFORM_TYPE".asInstanceOf[TransformSortColumnType]
+    val STATUS         = "STATUS".asInstanceOf[TransformSortColumnType]
+    val CREATED        = "CREATED".asInstanceOf[TransformSortColumnType]
+    val LAST_MODIFIED  = "LAST_MODIFIED".asInstanceOf[TransformSortColumnType]
 
     val values = js.Object.freeze(js.Array(NAME, TRANSFORM_TYPE, STATUS, CREATED, LAST_MODIFIED))
   }
@@ -8484,17 +8477,19 @@ package glue {
       __obj.asInstanceOf[TransformSortCriteria]
     }
   }
-
-  object TransformStatusTypeEnum {
-    val NOT_READY = "NOT_READY"
-    val READY     = "READY"
-    val DELETING  = "DELETING"
+  @js.native
+  sealed trait TransformStatusType extends js.Any
+  object TransformStatusType extends js.Object {
+    val NOT_READY = "NOT_READY".asInstanceOf[TransformStatusType]
+    val READY     = "READY".asInstanceOf[TransformStatusType]
+    val DELETING  = "DELETING".asInstanceOf[TransformStatusType]
 
     val values = js.Object.freeze(js.Array(NOT_READY, READY, DELETING))
   }
-
-  object TransformTypeEnum {
-    val FIND_MATCHES = "FIND_MATCHES"
+  @js.native
+  sealed trait TransformType extends js.Any
+  object TransformType extends js.Object {
+    val FIND_MATCHES = "FIND_MATCHES".asInstanceOf[TransformType]
 
     val values = js.Object.freeze(js.Array(FIND_MATCHES))
   }
@@ -8560,26 +8555,28 @@ package glue {
       __obj.asInstanceOf[TriggerNodeDetails]
     }
   }
-
-  object TriggerStateEnum {
-    val CREATING     = "CREATING"
-    val CREATED      = "CREATED"
-    val ACTIVATING   = "ACTIVATING"
-    val ACTIVATED    = "ACTIVATED"
-    val DEACTIVATING = "DEACTIVATING"
-    val DEACTIVATED  = "DEACTIVATED"
-    val DELETING     = "DELETING"
-    val UPDATING     = "UPDATING"
+  @js.native
+  sealed trait TriggerState extends js.Any
+  object TriggerState extends js.Object {
+    val CREATING     = "CREATING".asInstanceOf[TriggerState]
+    val CREATED      = "CREATED".asInstanceOf[TriggerState]
+    val ACTIVATING   = "ACTIVATING".asInstanceOf[TriggerState]
+    val ACTIVATED    = "ACTIVATED".asInstanceOf[TriggerState]
+    val DEACTIVATING = "DEACTIVATING".asInstanceOf[TriggerState]
+    val DEACTIVATED  = "DEACTIVATED".asInstanceOf[TriggerState]
+    val DELETING     = "DELETING".asInstanceOf[TriggerState]
+    val UPDATING     = "UPDATING".asInstanceOf[TriggerState]
 
     val values = js.Object.freeze(
       js.Array(CREATING, CREATED, ACTIVATING, ACTIVATED, DEACTIVATING, DEACTIVATED, DELETING, UPDATING)
     )
   }
-
-  object TriggerTypeEnum {
-    val SCHEDULED   = "SCHEDULED"
-    val CONDITIONAL = "CONDITIONAL"
-    val ON_DEMAND   = "ON_DEMAND"
+  @js.native
+  sealed trait TriggerType extends js.Any
+  object TriggerType extends js.Object {
+    val SCHEDULED   = "SCHEDULED".asInstanceOf[TriggerType]
+    val CONDITIONAL = "CONDITIONAL".asInstanceOf[TriggerType]
+    val ON_DEMAND   = "ON_DEMAND".asInstanceOf[TriggerType]
 
     val values = js.Object.freeze(js.Array(SCHEDULED, CONDITIONAL, ON_DEMAND))
   }
@@ -8648,10 +8645,11 @@ package glue {
       __obj.asInstanceOf[UntagResourceResponse]
     }
   }
-
-  object UpdateBehaviorEnum {
-    val LOG                = "LOG"
-    val UPDATE_IN_DATABASE = "UPDATE_IN_DATABASE"
+  @js.native
+  sealed trait UpdateBehavior extends js.Any
+  object UpdateBehavior extends js.Object {
+    val LOG                = "LOG".asInstanceOf[UpdateBehavior]
+    val UPDATE_IN_DATABASE = "UPDATE_IN_DATABASE".asInstanceOf[UpdateBehavior]
 
     val values = js.Object.freeze(js.Array(LOG, UPDATE_IN_DATABASE))
   }
@@ -9402,11 +9400,12 @@ package glue {
       __obj.asInstanceOf[UserDefinedFunctionInput]
     }
   }
-
-  object WorkerTypeEnum {
-    val Standard = "Standard"
-    val `G.1X`   = "G.1X"
-    val `G.2X`   = "G.2X"
+  @js.native
+  sealed trait WorkerType extends js.Any
+  object WorkerType extends js.Object {
+    val Standard = "Standard".asInstanceOf[WorkerType]
+    val `G.1X`   = "G.1X".asInstanceOf[WorkerType]
+    val `G.2X`   = "G.2X".asInstanceOf[WorkerType]
 
     val values = js.Object.freeze(js.Array(Standard, `G.1X`, `G.2X`))
   }
@@ -9543,10 +9542,11 @@ package glue {
       __obj.asInstanceOf[WorkflowRunStatistics]
     }
   }
-
-  object WorkflowRunStatusEnum {
-    val RUNNING   = "RUNNING"
-    val COMPLETED = "COMPLETED"
+  @js.native
+  sealed trait WorkflowRunStatus extends js.Any
+  object WorkflowRunStatus extends js.Object {
+    val RUNNING   = "RUNNING".asInstanceOf[WorkflowRunStatus]
+    val COMPLETED = "COMPLETED".asInstanceOf[WorkflowRunStatus]
 
     val values = js.Object.freeze(js.Array(RUNNING, COMPLETED))
   }

--- a/services/greengrass/src/main/scala/facade/amazonaws/services/Greengrass.scala
+++ b/services/greengrass/src/main/scala/facade/amazonaws/services/Greengrass.scala
@@ -8,24 +8,12 @@ import facade.amazonaws._
 
 package object greengrass {
   type BulkDeploymentResults                       = js.Array[BulkDeploymentResult]
-  type BulkDeploymentStatus                        = String
   type BulkDeployments                             = js.Array[BulkDeployment]
-  type DeploymentType                              = String
   type Deployments                                 = js.Array[Deployment]
-  type EncodingType                                = String
   type ErrorDetails                                = js.Array[ErrorDetail]
-  type FunctionIsolationMode                       = String
-  type LoggerComponent                             = String
-  type LoggerLevel                                 = String
-  type LoggerType                                  = String
-  type Permission                                  = String
   type S3UrlSignerRole                             = String
-  type SoftwareToUpdate                            = String
   type Tags                                        = js.Dictionary[__string]
-  type UpdateAgentLogLevel                         = String
   type UpdateTargets                               = js.Array[__string]
-  type UpdateTargetsArchitecture                   = String
-  type UpdateTargetsOperatingSystem                = String
   type __boolean                                   = Boolean
   type __integer                                   = Int
   type __listOfConnectivityInfo                    = js.Array[ConnectivityInfo]
@@ -662,13 +650,15 @@ package greengrass {
   /**
     * The current status of the bulk deployment.
     */
-  object BulkDeploymentStatusEnum {
-    val Initializing = "Initializing"
-    val Running      = "Running"
-    val Completed    = "Completed"
-    val Stopping     = "Stopping"
-    val Stopped      = "Stopped"
-    val Failed       = "Failed"
+  @js.native
+  sealed trait BulkDeploymentStatus extends js.Any
+  object BulkDeploymentStatus extends js.Object {
+    val Initializing = "Initializing".asInstanceOf[BulkDeploymentStatus]
+    val Running      = "Running".asInstanceOf[BulkDeploymentStatus]
+    val Completed    = "Completed".asInstanceOf[BulkDeploymentStatus]
+    val Stopping     = "Stopping".asInstanceOf[BulkDeploymentStatus]
+    val Stopped      = "Stopped".asInstanceOf[BulkDeploymentStatus]
+    val Failed       = "Failed".asInstanceOf[BulkDeploymentStatus]
 
     val values = js.Object.freeze(js.Array(Initializing, Running, Completed, Stopping, Stopped, Failed))
   }
@@ -2167,11 +2157,13 @@ package greengrass {
   /**
     * The type of deployment. When used for ''CreateDeployment'', only ''NewDeployment'' and ''Redeployment'' are valid.
     */
-  object DeploymentTypeEnum {
-    val NewDeployment        = "NewDeployment"
-    val Redeployment         = "Redeployment"
-    val ResetDeployment      = "ResetDeployment"
-    val ForceResetDeployment = "ForceResetDeployment"
+  @js.native
+  sealed trait DeploymentType extends js.Any
+  object DeploymentType extends js.Object {
+    val NewDeployment        = "NewDeployment".asInstanceOf[DeploymentType]
+    val Redeployment         = "Redeployment".asInstanceOf[DeploymentType]
+    val ResetDeployment      = "ResetDeployment".asInstanceOf[DeploymentType]
+    val ForceResetDeployment = "ForceResetDeployment".asInstanceOf[DeploymentType]
 
     val values = js.Object.freeze(js.Array(NewDeployment, Redeployment, ResetDeployment, ForceResetDeployment))
   }
@@ -2287,10 +2279,11 @@ package greengrass {
       __obj.asInstanceOf[DisassociateServiceRoleFromAccountResponse]
     }
   }
-
-  object EncodingTypeEnum {
-    val binary = "binary"
-    val json   = "json"
+  @js.native
+  sealed trait EncodingType extends js.Any
+  object EncodingType extends js.Object {
+    val binary = "binary".asInstanceOf[EncodingType]
+    val json   = "json".asInstanceOf[EncodingType]
 
     val values = js.Object.freeze(js.Array(binary, json))
   }
@@ -2497,9 +2490,11 @@ package greengrass {
   /**
     * Specifies whether the Lambda function runs in a Greengrass container (default) or without containerization. Unless your scenario requires that you run without containerization, we recommend that you run in a Greengrass container. Omit this value to run the Lambda function with the default containerization for the group.
     */
-  object FunctionIsolationModeEnum {
-    val GreengrassContainer = "GreengrassContainer"
-    val NoContainer         = "NoContainer"
+  @js.native
+  sealed trait FunctionIsolationMode extends js.Any
+  object FunctionIsolationMode extends js.Object {
+    val GreengrassContainer = "GreengrassContainer".asInstanceOf[FunctionIsolationMode]
+    val NoContainer         = "NoContainer".asInstanceOf[FunctionIsolationMode]
 
     val values = js.Object.freeze(js.Array(GreengrassContainer, NoContainer))
   }
@@ -4738,10 +4733,11 @@ package greengrass {
       __obj.asInstanceOf[Logger]
     }
   }
-
-  object LoggerComponentEnum {
-    val GreengrassSystem = "GreengrassSystem"
-    val Lambda           = "Lambda"
+  @js.native
+  sealed trait LoggerComponent extends js.Any
+  object LoggerComponent extends js.Object {
+    val GreengrassSystem = "GreengrassSystem".asInstanceOf[LoggerComponent]
+    val Lambda           = "Lambda".asInstanceOf[LoggerComponent]
 
     val values = js.Object.freeze(js.Array(GreengrassSystem, Lambda))
   }
@@ -4764,20 +4760,22 @@ package greengrass {
       __obj.asInstanceOf[LoggerDefinitionVersion]
     }
   }
-
-  object LoggerLevelEnum {
-    val DEBUG = "DEBUG"
-    val INFO  = "INFO"
-    val WARN  = "WARN"
-    val ERROR = "ERROR"
-    val FATAL = "FATAL"
+  @js.native
+  sealed trait LoggerLevel extends js.Any
+  object LoggerLevel extends js.Object {
+    val DEBUG = "DEBUG".asInstanceOf[LoggerLevel]
+    val INFO  = "INFO".asInstanceOf[LoggerLevel]
+    val WARN  = "WARN".asInstanceOf[LoggerLevel]
+    val ERROR = "ERROR".asInstanceOf[LoggerLevel]
+    val FATAL = "FATAL".asInstanceOf[LoggerLevel]
 
     val values = js.Object.freeze(js.Array(DEBUG, INFO, WARN, ERROR, FATAL))
   }
-
-  object LoggerTypeEnum {
-    val FileSystem    = "FileSystem"
-    val AWSCloudWatch = "AWSCloudWatch"
+  @js.native
+  sealed trait LoggerType extends js.Any
+  object LoggerType extends js.Object {
+    val FileSystem    = "FileSystem".asInstanceOf[LoggerType]
+    val AWSCloudWatch = "AWSCloudWatch".asInstanceOf[LoggerType]
 
     val values = js.Object.freeze(js.Array(FileSystem, AWSCloudWatch))
   }
@@ -4785,9 +4783,11 @@ package greengrass {
   /**
     * The type of permission a function has to access a resource.
     */
-  object PermissionEnum {
-    val ro = "ro"
-    val rw = "rw"
+  @js.native
+  sealed trait Permission extends js.Any
+  object Permission extends js.Object {
+    val ro = "ro".asInstanceOf[Permission]
+    val rw = "rw".asInstanceOf[Permission]
 
     val values = js.Object.freeze(js.Array(ro, rw))
   }
@@ -5046,9 +5046,11 @@ package greengrass {
   /**
     * The piece of software on the Greengrass core that will be updated.
     */
-  object SoftwareToUpdateEnum {
-    val core      = "core"
-    val ota_agent = "ota_agent"
+  @js.native
+  sealed trait SoftwareToUpdate extends js.Any
+  object SoftwareToUpdate extends js.Object {
+    val core      = "core".asInstanceOf[SoftwareToUpdate]
+    val ota_agent = "ota_agent".asInstanceOf[SoftwareToUpdate]
 
     val values = js.Object.freeze(js.Array(core, ota_agent))
   }
@@ -5227,15 +5229,17 @@ package greengrass {
   /**
     * The minimum level of log statements that should be logged by the OTA Agent during an update.
     */
-  object UpdateAgentLogLevelEnum {
-    val NONE    = "NONE"
-    val TRACE   = "TRACE"
-    val DEBUG   = "DEBUG"
-    val VERBOSE = "VERBOSE"
-    val INFO    = "INFO"
-    val WARN    = "WARN"
-    val ERROR   = "ERROR"
-    val FATAL   = "FATAL"
+  @js.native
+  sealed trait UpdateAgentLogLevel extends js.Any
+  object UpdateAgentLogLevel extends js.Object {
+    val NONE    = "NONE".asInstanceOf[UpdateAgentLogLevel]
+    val TRACE   = "TRACE".asInstanceOf[UpdateAgentLogLevel]
+    val DEBUG   = "DEBUG".asInstanceOf[UpdateAgentLogLevel]
+    val VERBOSE = "VERBOSE".asInstanceOf[UpdateAgentLogLevel]
+    val INFO    = "INFO".asInstanceOf[UpdateAgentLogLevel]
+    val WARN    = "WARN".asInstanceOf[UpdateAgentLogLevel]
+    val ERROR   = "ERROR".asInstanceOf[UpdateAgentLogLevel]
+    val FATAL   = "FATAL".asInstanceOf[UpdateAgentLogLevel]
 
     val values = js.Object.freeze(js.Array(NONE, TRACE, DEBUG, VERBOSE, INFO, WARN, ERROR, FATAL))
   }
@@ -5607,11 +5611,13 @@ package greengrass {
   /**
     * The architecture of the cores which are the targets of an update.
     */
-  object UpdateTargetsArchitectureEnum {
-    val armv6l  = "armv6l"
-    val armv7l  = "armv7l"
-    val x86_64  = "x86_64"
-    val aarch64 = "aarch64"
+  @js.native
+  sealed trait UpdateTargetsArchitecture extends js.Any
+  object UpdateTargetsArchitecture extends js.Object {
+    val armv6l  = "armv6l".asInstanceOf[UpdateTargetsArchitecture]
+    val armv7l  = "armv7l".asInstanceOf[UpdateTargetsArchitecture]
+    val x86_64  = "x86_64".asInstanceOf[UpdateTargetsArchitecture]
+    val aarch64 = "aarch64".asInstanceOf[UpdateTargetsArchitecture]
 
     val values = js.Object.freeze(js.Array(armv6l, armv7l, x86_64, aarch64))
   }
@@ -5619,11 +5625,13 @@ package greengrass {
   /**
     * The operating system of the cores which are the targets of an update.
     */
-  object UpdateTargetsOperatingSystemEnum {
-    val ubuntu       = "ubuntu"
-    val raspbian     = "raspbian"
-    val amazon_linux = "amazon_linux"
-    val openwrt      = "openwrt"
+  @js.native
+  sealed trait UpdateTargetsOperatingSystem extends js.Any
+  object UpdateTargetsOperatingSystem extends js.Object {
+    val ubuntu       = "ubuntu".asInstanceOf[UpdateTargetsOperatingSystem]
+    val raspbian     = "raspbian".asInstanceOf[UpdateTargetsOperatingSystem]
+    val amazon_linux = "amazon_linux".asInstanceOf[UpdateTargetsOperatingSystem]
+    val openwrt      = "openwrt".asInstanceOf[UpdateTargetsOperatingSystem]
 
     val values = js.Object.freeze(js.Array(ubuntu, raspbian, amazon_linux, openwrt))
   }

--- a/services/groundstation/src/main/scala/facade/amazonaws/services/GroundStation.scala
+++ b/services/groundstation/src/main/scala/facade/amazonaws/services/GroundStation.scala
@@ -7,29 +7,20 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object groundstation {
-  type AngleUnits                = String
-  type BandwidthUnits            = String
   type ConfigArn                 = String
-  type ConfigCapabilityType      = String
   type ConfigList                = js.Array[ConfigListItem]
   type ContactList               = js.Array[ContactData]
-  type ContactStatus             = String
-  type Criticality               = String
   type DataflowEdge              = js.Array[ConfigArn]
   type DataflowEdgeList          = js.Array[DataflowEdge]
   type DataflowEndpointGroupArn  = String
   type DataflowEndpointGroupList = js.Array[DataflowEndpointListItem]
   type DurationInSeconds         = Int
-  type EirpUnits                 = String
   type EndpointDetailsList       = js.Array[EndpointDetails]
-  type EndpointStatus            = String
-  type FrequencyUnits            = String
   type GroundStationIdList       = js.Array[String]
   type GroundStationList         = js.Array[GroundStationData]
   type JsonString                = String
   type MissionProfileArn         = String
   type MissionProfileList        = js.Array[MissionProfileListItem]
-  type Polarization              = String
   type RoleArn                   = String
   type SafeName                  = String
   type SatelliteList             = js.Array[SatelliteListItem]
@@ -141,10 +132,11 @@ package groundstation {
     def updateConfig(params: UpdateConfigRequest): Request[ConfigIdResponse]                          = js.native
     def updateMissionProfile(params: UpdateMissionProfileRequest): Request[MissionProfileIdResponse]  = js.native
   }
-
-  object AngleUnitsEnum {
-    val DEGREE_ANGLE = "DEGREE_ANGLE"
-    val RADIAN       = "RADIAN"
+  @js.native
+  sealed trait AngleUnits extends js.Any
+  object AngleUnits extends js.Object {
+    val DEGREE_ANGLE = "DEGREE_ANGLE".asInstanceOf[AngleUnits]
+    val RADIAN       = "RADIAN".asInstanceOf[AngleUnits]
 
     val values = js.Object.freeze(js.Array(DEGREE_ANGLE, RADIAN))
   }
@@ -220,11 +212,12 @@ package groundstation {
       __obj.asInstanceOf[AntennaUplinkConfig]
     }
   }
-
-  object BandwidthUnitsEnum {
-    val GHz = "GHz"
-    val MHz = "MHz"
-    val kHz = "kHz"
+  @js.native
+  sealed trait BandwidthUnits extends js.Any
+  object BandwidthUnits extends js.Object {
+    val GHz = "GHz".asInstanceOf[BandwidthUnits]
+    val MHz = "MHz".asInstanceOf[BandwidthUnits]
+    val kHz = "kHz".asInstanceOf[BandwidthUnits]
 
     val values = js.Object.freeze(js.Array(GHz, MHz, kHz))
   }
@@ -249,14 +242,15 @@ package groundstation {
       __obj.asInstanceOf[CancelContactRequest]
     }
   }
-
-  object ConfigCapabilityTypeEnum {
-    val `antenna-downlink`              = "antenna-downlink"
-    val `antenna-downlink-demod-decode` = "antenna-downlink-demod-decode"
-    val `antenna-uplink`                = "antenna-uplink"
-    val `dataflow-endpoint`             = "dataflow-endpoint"
-    val tracking                        = "tracking"
-    val `uplink-echo`                   = "uplink-echo"
+  @js.native
+  sealed trait ConfigCapabilityType extends js.Any
+  object ConfigCapabilityType extends js.Object {
+    val `antenna-downlink`              = "antenna-downlink".asInstanceOf[ConfigCapabilityType]
+    val `antenna-downlink-demod-decode` = "antenna-downlink-demod-decode".asInstanceOf[ConfigCapabilityType]
+    val `antenna-uplink`                = "antenna-uplink".asInstanceOf[ConfigCapabilityType]
+    val `dataflow-endpoint`             = "dataflow-endpoint".asInstanceOf[ConfigCapabilityType]
+    val tracking                        = "tracking".asInstanceOf[ConfigCapabilityType]
+    val `uplink-echo`                   = "uplink-echo".asInstanceOf[ConfigCapabilityType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -433,20 +427,21 @@ package groundstation {
       __obj.asInstanceOf[ContactIdResponse]
     }
   }
-
-  object ContactStatusEnum {
-    val AVAILABLE          = "AVAILABLE"
-    val AWS_CANCELLED      = "AWS_CANCELLED"
-    val CANCELLED          = "CANCELLED"
-    val CANCELLING         = "CANCELLING"
-    val COMPLETED          = "COMPLETED"
-    val FAILED             = "FAILED"
-    val FAILED_TO_SCHEDULE = "FAILED_TO_SCHEDULE"
-    val PASS               = "PASS"
-    val POSTPASS           = "POSTPASS"
-    val PREPASS            = "PREPASS"
-    val SCHEDULED          = "SCHEDULED"
-    val SCHEDULING         = "SCHEDULING"
+  @js.native
+  sealed trait ContactStatus extends js.Any
+  object ContactStatus extends js.Object {
+    val AVAILABLE          = "AVAILABLE".asInstanceOf[ContactStatus]
+    val AWS_CANCELLED      = "AWS_CANCELLED".asInstanceOf[ContactStatus]
+    val CANCELLED          = "CANCELLED".asInstanceOf[ContactStatus]
+    val CANCELLING         = "CANCELLING".asInstanceOf[ContactStatus]
+    val COMPLETED          = "COMPLETED".asInstanceOf[ContactStatus]
+    val FAILED             = "FAILED".asInstanceOf[ContactStatus]
+    val FAILED_TO_SCHEDULE = "FAILED_TO_SCHEDULE".asInstanceOf[ContactStatus]
+    val PASS               = "PASS".asInstanceOf[ContactStatus]
+    val POSTPASS           = "POSTPASS".asInstanceOf[ContactStatus]
+    val PREPASS            = "PREPASS".asInstanceOf[ContactStatus]
+    val SCHEDULED          = "SCHEDULED".asInstanceOf[ContactStatus]
+    val SCHEDULING         = "SCHEDULING".asInstanceOf[ContactStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -559,11 +554,12 @@ package groundstation {
       __obj.asInstanceOf[CreateMissionProfileRequest]
     }
   }
-
-  object CriticalityEnum {
-    val PREFERRED = "PREFERRED"
-    val REMOVED   = "REMOVED"
-    val REQUIRED  = "REQUIRED"
+  @js.native
+  sealed trait Criticality extends js.Any
+  object Criticality extends js.Object {
+    val PREFERRED = "PREFERRED".asInstanceOf[Criticality]
+    val REMOVED   = "REMOVED".asInstanceOf[Criticality]
+    val REQUIRED  = "REQUIRED".asInstanceOf[Criticality]
 
     val values = js.Object.freeze(js.Array(PREFERRED, REMOVED, REQUIRED))
   }
@@ -865,9 +861,10 @@ package groundstation {
       __obj.asInstanceOf[Eirp]
     }
   }
-
-  object EirpUnitsEnum {
-    val dBW = "dBW"
+  @js.native
+  sealed trait EirpUnits extends js.Any
+  object EirpUnits extends js.Object {
+    val dBW = "dBW".asInstanceOf[EirpUnits]
 
     val values = js.Object.freeze(js.Array(dBW))
   }
@@ -917,13 +914,14 @@ package groundstation {
       __obj.asInstanceOf[EndpointDetails]
     }
   }
-
-  object EndpointStatusEnum {
-    val created  = "created"
-    val creating = "creating"
-    val deleted  = "deleted"
-    val deleting = "deleting"
-    val failed   = "failed"
+  @js.native
+  sealed trait EndpointStatus extends js.Any
+  object EndpointStatus extends js.Object {
+    val created  = "created".asInstanceOf[EndpointStatus]
+    val creating = "creating".asInstanceOf[EndpointStatus]
+    val deleted  = "deleted".asInstanceOf[EndpointStatus]
+    val deleting = "deleting".asInstanceOf[EndpointStatus]
+    val failed   = "failed".asInstanceOf[EndpointStatus]
 
     val values = js.Object.freeze(js.Array(created, creating, deleted, deleting, failed))
   }
@@ -975,11 +973,12 @@ package groundstation {
       __obj.asInstanceOf[FrequencyBandwidth]
     }
   }
-
-  object FrequencyUnitsEnum {
-    val GHz = "GHz"
-    val MHz = "MHz"
-    val kHz = "kHz"
+  @js.native
+  sealed trait FrequencyUnits extends js.Any
+  object FrequencyUnits extends js.Object {
+    val GHz = "GHz".asInstanceOf[FrequencyUnits]
+    val MHz = "MHz".asInstanceOf[FrequencyUnits]
+    val kHz = "kHz".asInstanceOf[FrequencyUnits]
 
     val values = js.Object.freeze(js.Array(GHz, MHz, kHz))
   }
@@ -1676,11 +1675,12 @@ package groundstation {
       __obj.asInstanceOf[MissionProfileListItem]
     }
   }
-
-  object PolarizationEnum {
-    val LEFT_HAND  = "LEFT_HAND"
-    val NONE       = "NONE"
-    val RIGHT_HAND = "RIGHT_HAND"
+  @js.native
+  sealed trait Polarization extends js.Any
+  object Polarization extends js.Object {
+    val LEFT_HAND  = "LEFT_HAND".asInstanceOf[Polarization]
+    val NONE       = "NONE".asInstanceOf[Polarization]
+    val RIGHT_HAND = "RIGHT_HAND".asInstanceOf[Polarization]
 
     val values = js.Object.freeze(js.Array(LEFT_HAND, NONE, RIGHT_HAND))
   }

--- a/services/guardduty/src/main/scala/facade/amazonaws/services/GuardDuty.scala
+++ b/services/guardduty/src/main/scala/facade/amazonaws/services/GuardDuty.scala
@@ -7,64 +7,52 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object guardduty {
-  type AccountDetails             = js.Array[AccountDetail]
-  type AccountId                  = String
-  type AccountIds                 = js.Array[AccountId]
-  type ClientToken                = String
-  type CountBySeverity            = js.Dictionary[Int]
-  type Criterion                  = js.Dictionary[Condition]
-  type DestinationType            = String
-  type Destinations               = js.Array[Destination]
-  type DetectorId                 = String
-  type DetectorIds                = js.Array[DetectorId]
-  type DetectorStatus             = String
-  type Email                      = String
-  type Eq                         = js.Array[String]
-  type Equals                     = js.Array[String]
-  type Feedback                   = String
-  type FilterAction               = String
-  type FilterDescription          = String
-  type FilterName                 = String
-  type FilterNames                = js.Array[FilterName]
-  type FilterRank                 = Int
-  type FindingId                  = String
-  type FindingIds                 = js.Array[FindingId]
-  type FindingPublishingFrequency = String
-  type FindingStatisticType       = String
-  type FindingStatisticTypes      = js.Array[FindingStatisticType]
-  type FindingType                = String
-  type FindingTypes               = js.Array[FindingType]
-  type Findings                   = js.Array[Finding]
-  type GuardDutyArn               = String
-  type Invitations                = js.Array[Invitation]
-  type IpSetFormat                = String
-  type IpSetIds                   = js.Array[String]
-  type IpSetStatus                = String
-  type Ipv6Addresses              = js.Array[String]
-  type Location                   = String
-  type MaxResults                 = Int
-  type Members                    = js.Array[Member]
-  type Name                       = String
-  type Neq                        = js.Array[String]
-  type NetworkInterfaces          = js.Array[NetworkInterface]
-  type NotEquals                  = js.Array[String]
-  type OrderBy                    = String
-  type PortProbeDetails           = js.Array[PortProbeDetail]
-  type PrivateIpAddresses         = js.Array[PrivateIpAddressDetails]
-  type ProductCodes               = js.Array[ProductCode]
-  type PublishingStatus           = String
-  type SecurityGroups             = js.Array[SecurityGroup]
-  type TagKey                     = String
-  type TagKeyList                 = js.Array[TagKey]
-  type TagMap                     = js.Dictionary[TagValue]
-  type TagValue                   = String
-  type Tags                       = js.Array[Tag]
-  type ThreatIntelSetFormat       = String
-  type ThreatIntelSetIds          = js.Array[String]
-  type ThreatIntelSetStatus       = String
-  type ThreatIntelligenceDetails  = js.Array[ThreatIntelligenceDetail]
-  type ThreatNames                = js.Array[String]
-  type UnprocessedAccounts        = js.Array[UnprocessedAccount]
+  type AccountDetails            = js.Array[AccountDetail]
+  type AccountId                 = String
+  type AccountIds                = js.Array[AccountId]
+  type ClientToken               = String
+  type CountBySeverity           = js.Dictionary[Int]
+  type Criterion                 = js.Dictionary[Condition]
+  type Destinations              = js.Array[Destination]
+  type DetectorId                = String
+  type DetectorIds               = js.Array[DetectorId]
+  type Email                     = String
+  type Eq                        = js.Array[String]
+  type Equals                    = js.Array[String]
+  type FilterDescription         = String
+  type FilterName                = String
+  type FilterNames               = js.Array[FilterName]
+  type FilterRank                = Int
+  type FindingId                 = String
+  type FindingIds                = js.Array[FindingId]
+  type FindingStatisticTypes     = js.Array[FindingStatisticType]
+  type FindingType               = String
+  type FindingTypes              = js.Array[FindingType]
+  type Findings                  = js.Array[Finding]
+  type GuardDutyArn              = String
+  type Invitations               = js.Array[Invitation]
+  type IpSetIds                  = js.Array[String]
+  type Ipv6Addresses             = js.Array[String]
+  type Location                  = String
+  type MaxResults                = Int
+  type Members                   = js.Array[Member]
+  type Name                      = String
+  type Neq                       = js.Array[String]
+  type NetworkInterfaces         = js.Array[NetworkInterface]
+  type NotEquals                 = js.Array[String]
+  type PortProbeDetails          = js.Array[PortProbeDetail]
+  type PrivateIpAddresses        = js.Array[PrivateIpAddressDetails]
+  type ProductCodes              = js.Array[ProductCode]
+  type SecurityGroups            = js.Array[SecurityGroup]
+  type TagKey                    = String
+  type TagKeyList                = js.Array[TagKey]
+  type TagMap                    = js.Dictionary[TagValue]
+  type TagValue                  = String
+  type Tags                      = js.Array[Tag]
+  type ThreatIntelSetIds         = js.Array[String]
+  type ThreatIntelligenceDetails = js.Array[ThreatIntelligenceDetail]
+  type ThreatNames               = js.Array[String]
+  type UnprocessedAccounts       = js.Array[UnprocessedAccount]
 
   implicit final class GuardDutyOps(private val service: GuardDuty) extends AnyVal {
 
@@ -1236,16 +1224,18 @@ package guardduty {
       __obj.asInstanceOf[DestinationProperties]
     }
   }
-
-  object DestinationTypeEnum {
-    val S3 = "S3"
+  @js.native
+  sealed trait DestinationType extends js.Any
+  object DestinationType extends js.Object {
+    val S3 = "S3".asInstanceOf[DestinationType]
 
     val values = js.Object.freeze(js.Array(S3))
   }
-
-  object DetectorStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait DetectorStatus extends js.Any
+  object DetectorStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[DetectorStatus]
+    val DISABLED = "DISABLED".asInstanceOf[DetectorStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -1378,17 +1368,19 @@ package guardduty {
       __obj.asInstanceOf[Evidence]
     }
   }
-
-  object FeedbackEnum {
-    val USEFUL     = "USEFUL"
-    val NOT_USEFUL = "NOT_USEFUL"
+  @js.native
+  sealed trait Feedback extends js.Any
+  object Feedback extends js.Object {
+    val USEFUL     = "USEFUL".asInstanceOf[Feedback]
+    val NOT_USEFUL = "NOT_USEFUL".asInstanceOf[Feedback]
 
     val values = js.Object.freeze(js.Array(USEFUL, NOT_USEFUL))
   }
-
-  object FilterActionEnum {
-    val NOOP    = "NOOP"
-    val ARCHIVE = "ARCHIVE"
+  @js.native
+  sealed trait FilterAction extends js.Any
+  object FilterAction extends js.Object {
+    val NOOP    = "NOOP".asInstanceOf[FilterAction]
+    val ARCHIVE = "ARCHIVE".asInstanceOf[FilterAction]
 
     val values = js.Object.freeze(js.Array(NOOP, ARCHIVE))
   }
@@ -1474,17 +1466,19 @@ package guardduty {
       __obj.asInstanceOf[FindingCriteria]
     }
   }
-
-  object FindingPublishingFrequencyEnum {
-    val FIFTEEN_MINUTES = "FIFTEEN_MINUTES"
-    val ONE_HOUR        = "ONE_HOUR"
-    val SIX_HOURS       = "SIX_HOURS"
+  @js.native
+  sealed trait FindingPublishingFrequency extends js.Any
+  object FindingPublishingFrequency extends js.Object {
+    val FIFTEEN_MINUTES = "FIFTEEN_MINUTES".asInstanceOf[FindingPublishingFrequency]
+    val ONE_HOUR        = "ONE_HOUR".asInstanceOf[FindingPublishingFrequency]
+    val SIX_HOURS       = "SIX_HOURS".asInstanceOf[FindingPublishingFrequency]
 
     val values = js.Object.freeze(js.Array(FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS))
   }
-
-  object FindingStatisticTypeEnum {
-    val COUNT_BY_SEVERITY = "COUNT_BY_SEVERITY"
+  @js.native
+  sealed trait FindingStatisticType extends js.Any
+  object FindingStatisticType extends js.Object {
+    val COUNT_BY_SEVERITY = "COUNT_BY_SEVERITY".asInstanceOf[FindingStatisticType]
 
     val values = js.Object.freeze(js.Array(COUNT_BY_SEVERITY))
   }
@@ -2076,26 +2070,28 @@ package guardduty {
       __obj.asInstanceOf[InviteMembersResponse]
     }
   }
-
-  object IpSetFormatEnum {
-    val TXT         = "TXT"
-    val STIX        = "STIX"
-    val OTX_CSV     = "OTX_CSV"
-    val ALIEN_VAULT = "ALIEN_VAULT"
-    val PROOF_POINT = "PROOF_POINT"
-    val FIRE_EYE    = "FIRE_EYE"
+  @js.native
+  sealed trait IpSetFormat extends js.Any
+  object IpSetFormat extends js.Object {
+    val TXT         = "TXT".asInstanceOf[IpSetFormat]
+    val STIX        = "STIX".asInstanceOf[IpSetFormat]
+    val OTX_CSV     = "OTX_CSV".asInstanceOf[IpSetFormat]
+    val ALIEN_VAULT = "ALIEN_VAULT".asInstanceOf[IpSetFormat]
+    val PROOF_POINT = "PROOF_POINT".asInstanceOf[IpSetFormat]
+    val FIRE_EYE    = "FIRE_EYE".asInstanceOf[IpSetFormat]
 
     val values = js.Object.freeze(js.Array(TXT, STIX, OTX_CSV, ALIEN_VAULT, PROOF_POINT, FIRE_EYE))
   }
-
-  object IpSetStatusEnum {
-    val INACTIVE       = "INACTIVE"
-    val ACTIVATING     = "ACTIVATING"
-    val ACTIVE         = "ACTIVE"
-    val DEACTIVATING   = "DEACTIVATING"
-    val ERROR          = "ERROR"
-    val DELETE_PENDING = "DELETE_PENDING"
-    val DELETED        = "DELETED"
+  @js.native
+  sealed trait IpSetStatus extends js.Any
+  object IpSetStatus extends js.Object {
+    val INACTIVE       = "INACTIVE".asInstanceOf[IpSetStatus]
+    val ACTIVATING     = "ACTIVATING".asInstanceOf[IpSetStatus]
+    val ACTIVE         = "ACTIVE".asInstanceOf[IpSetStatus]
+    val DEACTIVATING   = "DEACTIVATING".asInstanceOf[IpSetStatus]
+    val ERROR          = "ERROR".asInstanceOf[IpSetStatus]
+    val DELETE_PENDING = "DELETE_PENDING".asInstanceOf[IpSetStatus]
+    val DELETED        = "DELETED".asInstanceOf[IpSetStatus]
 
     val values = js.Object.freeze(js.Array(INACTIVE, ACTIVATING, ACTIVE, DEACTIVATING, ERROR, DELETE_PENDING, DELETED))
   }
@@ -2657,10 +2653,11 @@ package guardduty {
       __obj.asInstanceOf[NetworkInterface]
     }
   }
-
-  object OrderByEnum {
-    val ASC  = "ASC"
-    val DESC = "DESC"
+  @js.native
+  sealed trait OrderBy extends js.Any
+  object OrderBy extends js.Object {
+    val ASC  = "ASC".asInstanceOf[OrderBy]
+    val DESC = "DESC".asInstanceOf[OrderBy]
 
     val values = js.Object.freeze(js.Array(ASC, DESC))
   }
@@ -2780,12 +2777,14 @@ package guardduty {
       __obj.asInstanceOf[ProductCode]
     }
   }
-
-  object PublishingStatusEnum {
-    val PENDING_VERIFICATION                       = "PENDING_VERIFICATION"
-    val PUBLISHING                                 = "PUBLISHING"
-    val UNABLE_TO_PUBLISH_FIX_DESTINATION_PROPERTY = "UNABLE_TO_PUBLISH_FIX_DESTINATION_PROPERTY"
-    val STOPPED                                    = "STOPPED"
+  @js.native
+  sealed trait PublishingStatus extends js.Any
+  object PublishingStatus extends js.Object {
+    val PENDING_VERIFICATION = "PENDING_VERIFICATION".asInstanceOf[PublishingStatus]
+    val PUBLISHING           = "PUBLISHING".asInstanceOf[PublishingStatus]
+    val UNABLE_TO_PUBLISH_FIX_DESTINATION_PROPERTY =
+      "UNABLE_TO_PUBLISH_FIX_DESTINATION_PROPERTY".asInstanceOf[PublishingStatus]
+    val STOPPED = "STOPPED".asInstanceOf[PublishingStatus]
 
     val values =
       js.Object.freeze(js.Array(PENDING_VERIFICATION, PUBLISHING, UNABLE_TO_PUBLISH_FIX_DESTINATION_PROPERTY, STOPPED))
@@ -3092,26 +3091,28 @@ package guardduty {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object ThreatIntelSetFormatEnum {
-    val TXT         = "TXT"
-    val STIX        = "STIX"
-    val OTX_CSV     = "OTX_CSV"
-    val ALIEN_VAULT = "ALIEN_VAULT"
-    val PROOF_POINT = "PROOF_POINT"
-    val FIRE_EYE    = "FIRE_EYE"
+  @js.native
+  sealed trait ThreatIntelSetFormat extends js.Any
+  object ThreatIntelSetFormat extends js.Object {
+    val TXT         = "TXT".asInstanceOf[ThreatIntelSetFormat]
+    val STIX        = "STIX".asInstanceOf[ThreatIntelSetFormat]
+    val OTX_CSV     = "OTX_CSV".asInstanceOf[ThreatIntelSetFormat]
+    val ALIEN_VAULT = "ALIEN_VAULT".asInstanceOf[ThreatIntelSetFormat]
+    val PROOF_POINT = "PROOF_POINT".asInstanceOf[ThreatIntelSetFormat]
+    val FIRE_EYE    = "FIRE_EYE".asInstanceOf[ThreatIntelSetFormat]
 
     val values = js.Object.freeze(js.Array(TXT, STIX, OTX_CSV, ALIEN_VAULT, PROOF_POINT, FIRE_EYE))
   }
-
-  object ThreatIntelSetStatusEnum {
-    val INACTIVE       = "INACTIVE"
-    val ACTIVATING     = "ACTIVATING"
-    val ACTIVE         = "ACTIVE"
-    val DEACTIVATING   = "DEACTIVATING"
-    val ERROR          = "ERROR"
-    val DELETE_PENDING = "DELETE_PENDING"
-    val DELETED        = "DELETED"
+  @js.native
+  sealed trait ThreatIntelSetStatus extends js.Any
+  object ThreatIntelSetStatus extends js.Object {
+    val INACTIVE       = "INACTIVE".asInstanceOf[ThreatIntelSetStatus]
+    val ACTIVATING     = "ACTIVATING".asInstanceOf[ThreatIntelSetStatus]
+    val ACTIVE         = "ACTIVE".asInstanceOf[ThreatIntelSetStatus]
+    val DEACTIVATING   = "DEACTIVATING".asInstanceOf[ThreatIntelSetStatus]
+    val ERROR          = "ERROR".asInstanceOf[ThreatIntelSetStatus]
+    val DELETE_PENDING = "DELETE_PENDING".asInstanceOf[ThreatIntelSetStatus]
+    val DELETED        = "DELETED".asInstanceOf[ThreatIntelSetStatus]
 
     val values = js.Object.freeze(js.Array(INACTIVE, ACTIVATING, ACTIVE, DEACTIVATING, ERROR, DELETE_PENDING, DELETED))
   }

--- a/services/health/src/main/scala/facade/amazonaws/services/Health.scala
+++ b/services/health/src/main/scala/facade/amazonaws/services/Health.scala
@@ -33,20 +33,16 @@ package object health {
   type dateTimeRangeList                                = js.Array[DateTimeRange]
   type entityArn                                        = String
   type entityArnList                                    = js.Array[entityArn]
-  type entityStatusCode                                 = String
   type entityStatusCodeList                             = js.Array[entityStatusCode]
   type entityUrl                                        = String
   type entityValue                                      = String
   type entityValueList                                  = js.Array[entityValue]
-  type eventAggregateField                              = String
   type eventArn                                         = String
   type eventArnList                                     = js.Array[eventArn]
   type eventDescription                                 = String
   type eventMetadata                                    = js.Dictionary[metadataValue]
-  type eventStatusCode                                  = String
   type eventStatusCodeList                              = js.Array[eventStatusCode]
   type eventType                                        = String
-  type eventTypeCategory                                = String
   type eventTypeCategoryList                            = js.Array[eventTypeCategory]
   type eventTypeCode                                    = String
   type eventTypeList                                    = js.Array[eventType]
@@ -1148,34 +1144,38 @@ package health {
       __obj.asInstanceOf[OrganizationEventFilter]
     }
   }
-
-  object entityStatusCodeEnum {
-    val IMPAIRED   = "IMPAIRED"
-    val UNIMPAIRED = "UNIMPAIRED"
-    val UNKNOWN    = "UNKNOWN"
+  @js.native
+  sealed trait entityStatusCode extends js.Any
+  object entityStatusCode extends js.Object {
+    val IMPAIRED   = "IMPAIRED".asInstanceOf[entityStatusCode]
+    val UNIMPAIRED = "UNIMPAIRED".asInstanceOf[entityStatusCode]
+    val UNKNOWN    = "UNKNOWN".asInstanceOf[entityStatusCode]
 
     val values = js.Object.freeze(js.Array(IMPAIRED, UNIMPAIRED, UNKNOWN))
   }
-
-  object eventAggregateFieldEnum {
-    val eventTypeCategory = "eventTypeCategory"
+  @js.native
+  sealed trait eventAggregateField extends js.Any
+  object eventAggregateField extends js.Object {
+    val eventTypeCategory = "eventTypeCategory".asInstanceOf[eventAggregateField]
 
     val values = js.Object.freeze(js.Array(eventTypeCategory))
   }
-
-  object eventStatusCodeEnum {
-    val open     = "open"
-    val closed   = "closed"
-    val upcoming = "upcoming"
+  @js.native
+  sealed trait eventStatusCode extends js.Any
+  object eventStatusCode extends js.Object {
+    val open     = "open".asInstanceOf[eventStatusCode]
+    val closed   = "closed".asInstanceOf[eventStatusCode]
+    val upcoming = "upcoming".asInstanceOf[eventStatusCode]
 
     val values = js.Object.freeze(js.Array(open, closed, upcoming))
   }
-
-  object eventTypeCategoryEnum {
-    val issue               = "issue"
-    val accountNotification = "accountNotification"
-    val scheduledChange     = "scheduledChange"
-    val investigation       = "investigation"
+  @js.native
+  sealed trait eventTypeCategory extends js.Any
+  object eventTypeCategory extends js.Object {
+    val issue               = "issue".asInstanceOf[eventTypeCategory]
+    val accountNotification = "accountNotification".asInstanceOf[eventTypeCategory]
+    val scheduledChange     = "scheduledChange".asInstanceOf[eventTypeCategory]
+    val investigation       = "investigation".asInstanceOf[eventTypeCategory]
 
     val values = js.Object.freeze(js.Array(issue, accountNotification, scheduledChange, investigation))
   }

--- a/services/iam/src/main/scala/facade/amazonaws/services/IAM.scala
+++ b/services/iam/src/main/scala/facade/amazonaws/services/IAM.scala
@@ -16,12 +16,9 @@ package object iam {
   type ContextEntryListType                            = js.Array[ContextEntry]
   type ContextKeyNameType                              = String
   type ContextKeyNamesResultListType                   = js.Array[ContextKeyNameType]
-  type ContextKeyTypeEnum                              = String
   type ContextKeyValueListType                         = js.Array[ContextKeyValueType]
   type ContextKeyValueType                             = String
   type DeletionTaskIdType                              = String
-  type DeletionTaskStatusType                          = String
-  type EntityType                                      = String
   type EvalDecisionDetailsType                         = js.Dictionary[PolicyEvaluationDecisionType]
   type EvalDecisionSourceType                          = String
   type EvaluationResultsListType                       = js.Array[EvaluationResult]
@@ -29,20 +26,14 @@ package object iam {
   type ManagedPolicyDetailListType                     = js.Array[ManagedPolicyDetail]
   type OpenIDConnectProviderListType                   = js.Array[OpenIDConnectProviderListEntry]
   type OpenIDConnectProviderUrlType                    = String
-  type PermissionsBoundaryAttachmentType               = String
-  type PolicyEvaluationDecisionType                    = String
   type PolicyGroupListType                             = js.Array[PolicyGroup]
   type PolicyIdentifierType                            = String
   type PolicyRoleListType                              = js.Array[PolicyRole]
-  type PolicySourceType                                = String
-  type PolicyUsageType                                 = String
   type PolicyUserListType                              = js.Array[PolicyUser]
   type ReasonType                                      = String
   type RegionNameType                                  = String
   type ReportContentType                               = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type ReportFormatType                                = String
   type ReportStateDescriptionType                      = String
-  type ReportStateType                                 = String
   type ResourceHandlingOptionType                      = String
   type ResourceNameListType                            = js.Array[ResourceNameType]
   type ResourceNameType                                = String
@@ -62,7 +53,6 @@ package object iam {
   type accountAliasListType                            = js.Array[accountAliasType]
   type accountAliasType                                = String
   type arnType                                         = String
-  type assignmentStatusType                            = String
   type attachedPoliciesListType                        = js.Array[AttachedPolicy]
   type attachmentCountType                             = Int
   type authenticationCodeType                          = String
@@ -76,12 +66,10 @@ package object iam {
   type clientIDType                                    = String
   type customSuffixType                                = String
   type dateType                                        = js.Date
-  type encodingType                                    = String
   type entityDetailsListType                           = js.Array[EntityDetails]
   type entityListType                                  = js.Array[EntityType]
   type entityNameType                                  = String
   type existingUserNameType                            = String
-  type globalEndpointTokenVersion                      = String
   type groupDetailListType                             = js.Array[GroupDetail]
   type groupListType                                   = js.Array[Group]
   type groupNameListType                               = js.Array[groupNameType]
@@ -91,7 +79,6 @@ package object iam {
   type instanceProfileNameType                         = String
   type integerType                                     = Int
   type jobIDType                                       = String
-  type jobStatusType                                   = String
   type listPolicyGrantingServiceAccessResponseListType = js.Array[ListPoliciesGrantingServiceAccessEntry]
   type markerType                                      = String
   type maxItemsType                                    = Int
@@ -112,10 +99,7 @@ package object iam {
   type policyListType                                  = js.Array[Policy]
   type policyNameListType                              = js.Array[policyNameType]
   type policyNameType                                  = String
-  type policyOwnerEntityType                           = String
   type policyPathType                                  = String
-  type policyScopeType                                 = String
-  type policyType                                      = String
   type policyVersionIdType                             = String
   type privateKeyType                                  = String
   type publicKeyFingerprintType                        = String
@@ -137,10 +121,7 @@ package object iam {
   type servicePassword                                 = String
   type serviceSpecificCredentialId                     = String
   type serviceUserName                                 = String
-  type sortKeyType                                     = String
-  type statusType                                      = String
   type stringType                                      = String
-  type summaryKeyType                                  = String
   type summaryMapType                                  = js.Dictionary[summaryValueType]
   type summaryValueType                                = Int
   type tagKeyListType                                  = js.Array[tagKeyType]
@@ -1031,20 +1012,21 @@ package iam {
       __obj.asInstanceOf[ContextEntry]
     }
   }
-
-  object ContextKeyTypeEnumEnum {
-    val string      = "string"
-    val stringList  = "stringList"
-    val numeric     = "numeric"
-    val numericList = "numericList"
-    val boolean     = "boolean"
-    val booleanList = "booleanList"
-    val ip          = "ip"
-    val ipList      = "ipList"
-    val binary      = "binary"
-    val binaryList  = "binaryList"
-    val date        = "date"
-    val dateList    = "dateList"
+  @js.native
+  sealed trait ContextKeyTypeEnum extends js.Any
+  object ContextKeyTypeEnum extends js.Object {
+    val string      = "string".asInstanceOf[ContextKeyTypeEnum]
+    val stringList  = "stringList".asInstanceOf[ContextKeyTypeEnum]
+    val numeric     = "numeric".asInstanceOf[ContextKeyTypeEnum]
+    val numericList = "numericList".asInstanceOf[ContextKeyTypeEnum]
+    val boolean     = "boolean".asInstanceOf[ContextKeyTypeEnum]
+    val booleanList = "booleanList".asInstanceOf[ContextKeyTypeEnum]
+    val ip          = "ip".asInstanceOf[ContextKeyTypeEnum]
+    val ipList      = "ipList".asInstanceOf[ContextKeyTypeEnum]
+    val binary      = "binary".asInstanceOf[ContextKeyTypeEnum]
+    val binaryList  = "binaryList".asInstanceOf[ContextKeyTypeEnum]
+    val date        = "date".asInstanceOf[ContextKeyTypeEnum]
+    val dateList    = "dateList".asInstanceOf[ContextKeyTypeEnum]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2125,12 +2107,13 @@ package iam {
       __obj.asInstanceOf[DeletionTaskFailureReasonType]
     }
   }
-
-  object DeletionTaskStatusTypeEnum {
-    val SUCCEEDED   = "SUCCEEDED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val FAILED      = "FAILED"
-    val NOT_STARTED = "NOT_STARTED"
+  @js.native
+  sealed trait DeletionTaskStatusType extends js.Any
+  object DeletionTaskStatusType extends js.Object {
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[DeletionTaskStatusType]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[DeletionTaskStatusType]
+    val FAILED      = "FAILED".asInstanceOf[DeletionTaskStatusType]
+    val NOT_STARTED = "NOT_STARTED".asInstanceOf[DeletionTaskStatusType]
 
     val values = js.Object.freeze(js.Array(SUCCEEDED, IN_PROGRESS, FAILED, NOT_STARTED))
   }
@@ -2283,13 +2266,14 @@ package iam {
       __obj.asInstanceOf[EntityInfo]
     }
   }
-
-  object EntityTypeEnum {
-    val User               = "User"
-    val Role               = "Role"
-    val Group              = "Group"
-    val LocalManagedPolicy = "LocalManagedPolicy"
-    val AWSManagedPolicy   = "AWSManagedPolicy"
+  @js.native
+  sealed trait EntityType extends js.Any
+  object EntityType extends js.Object {
+    val User               = "User".asInstanceOf[EntityType]
+    val Role               = "Role".asInstanceOf[EntityType]
+    val Group              = "Group".asInstanceOf[EntityType]
+    val LocalManagedPolicy = "LocalManagedPolicy".asInstanceOf[EntityType]
+    val AWSManagedPolicy   = "AWSManagedPolicy".asInstanceOf[EntityType]
 
     val values = js.Object.freeze(js.Array(User, Role, Group, LocalManagedPolicy, AWSManagedPolicy))
   }
@@ -5218,9 +5202,10 @@ package iam {
       __obj.asInstanceOf[PasswordPolicy]
     }
   }
-
-  object PermissionsBoundaryAttachmentTypeEnum {
-    val PermissionsBoundaryPolicy = "PermissionsBoundaryPolicy"
+  @js.native
+  sealed trait PermissionsBoundaryAttachmentType extends js.Any
+  object PermissionsBoundaryAttachmentType extends js.Object {
+    val PermissionsBoundaryPolicy = "PermissionsBoundaryPolicy".asInstanceOf[PermissionsBoundaryAttachmentType]
 
     val values = js.Object.freeze(js.Array(PermissionsBoundaryPolicy))
   }
@@ -5321,11 +5306,12 @@ package iam {
       __obj.asInstanceOf[PolicyDetail]
     }
   }
-
-  object PolicyEvaluationDecisionTypeEnum {
-    val allowed      = "allowed"
-    val explicitDeny = "explicitDeny"
-    val implicitDeny = "implicitDeny"
+  @js.native
+  sealed trait PolicyEvaluationDecisionType extends js.Any
+  object PolicyEvaluationDecisionType extends js.Object {
+    val allowed      = "allowed".asInstanceOf[PolicyEvaluationDecisionType]
+    val explicitDeny = "explicitDeny".asInstanceOf[PolicyEvaluationDecisionType]
+    val implicitDeny = "implicitDeny".asInstanceOf[PolicyEvaluationDecisionType]
 
     val values = js.Object.freeze(js.Array(allowed, explicitDeny, implicitDeny))
   }
@@ -5411,15 +5397,16 @@ package iam {
       __obj.asInstanceOf[PolicyRole]
     }
   }
-
-  object PolicySourceTypeEnum {
-    val user           = "user"
-    val group          = "group"
-    val role           = "role"
-    val `aws-managed`  = "aws-managed"
-    val `user-managed` = "user-managed"
-    val resource       = "resource"
-    val none           = "none"
+  @js.native
+  sealed trait PolicySourceType extends js.Any
+  object PolicySourceType extends js.Object {
+    val user           = "user".asInstanceOf[PolicySourceType]
+    val group          = "group".asInstanceOf[PolicySourceType]
+    val role           = "role".asInstanceOf[PolicySourceType]
+    val `aws-managed`  = "aws-managed".asInstanceOf[PolicySourceType]
+    val `user-managed` = "user-managed".asInstanceOf[PolicySourceType]
+    val resource       = "resource".asInstanceOf[PolicySourceType]
+    val none           = "none".asInstanceOf[PolicySourceType]
 
     val values = js.Object.freeze(js.Array(user, group, role, `aws-managed`, `user-managed`, resource, none))
   }
@@ -5428,9 +5415,11 @@ package iam {
     * The policy usage type that indicates whether the policy is used as a permissions policy or as the permissions boundary for an entity.
     *  For more information about permissions boundaries, see [[https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html|Permissions Boundaries for IAM Identities ]] in the <i>IAM User Guide</i>.
     */
-  object PolicyUsageTypeEnum {
-    val PermissionsPolicy   = "PermissionsPolicy"
-    val PermissionsBoundary = "PermissionsBoundary"
+  @js.native
+  sealed trait PolicyUsageType extends js.Any
+  object PolicyUsageType extends js.Object {
+    val PermissionsPolicy   = "PermissionsPolicy".asInstanceOf[PolicyUsageType]
+    val PermissionsBoundary = "PermissionsBoundary".asInstanceOf[PolicyUsageType]
 
     val values = js.Object.freeze(js.Array(PermissionsPolicy, PermissionsBoundary))
   }
@@ -5688,17 +5677,19 @@ package iam {
       __obj.asInstanceOf[RemoveUserFromGroupRequest]
     }
   }
-
-  object ReportFormatTypeEnum {
-    val `text/csv` = "text/csv"
+  @js.native
+  sealed trait ReportFormatType extends js.Any
+  object ReportFormatType extends js.Object {
+    val `text/csv` = "text/csv".asInstanceOf[ReportFormatType]
 
     val values = js.Object.freeze(js.Array(`text/csv`))
   }
-
-  object ReportStateTypeEnum {
-    val STARTED    = "STARTED"
-    val INPROGRESS = "INPROGRESS"
-    val COMPLETE   = "COMPLETE"
+  @js.native
+  sealed trait ReportStateType extends js.Any
+  object ReportStateType extends js.Object {
+    val STARTED    = "STARTED".asInstanceOf[ReportStateType]
+    val INPROGRESS = "INPROGRESS".asInstanceOf[ReportStateType]
+    val COMPLETE   = "COMPLETE".asInstanceOf[ReportStateType]
 
     val values = js.Object.freeze(js.Array(STARTED, INPROGRESS, COMPLETE))
   }
@@ -7217,65 +7208,73 @@ package iam {
       __obj.asInstanceOf[VirtualMFADevice]
     }
   }
-
-  object assignmentStatusTypeEnum {
-    val Assigned   = "Assigned"
-    val Unassigned = "Unassigned"
-    val Any        = "Any"
+  @js.native
+  sealed trait assignmentStatusType extends js.Any
+  object assignmentStatusType extends js.Object {
+    val Assigned   = "Assigned".asInstanceOf[assignmentStatusType]
+    val Unassigned = "Unassigned".asInstanceOf[assignmentStatusType]
+    val Any        = "Any".asInstanceOf[assignmentStatusType]
 
     val values = js.Object.freeze(js.Array(Assigned, Unassigned, Any))
   }
-
-  object encodingTypeEnum {
-    val SSH = "SSH"
-    val PEM = "PEM"
+  @js.native
+  sealed trait encodingType extends js.Any
+  object encodingType extends js.Object {
+    val SSH = "SSH".asInstanceOf[encodingType]
+    val PEM = "PEM".asInstanceOf[encodingType]
 
     val values = js.Object.freeze(js.Array(SSH, PEM))
   }
-
-  object globalEndpointTokenVersionEnum {
-    val v1Token = "v1Token"
-    val v2Token = "v2Token"
+  @js.native
+  sealed trait globalEndpointTokenVersion extends js.Any
+  object globalEndpointTokenVersion extends js.Object {
+    val v1Token = "v1Token".asInstanceOf[globalEndpointTokenVersion]
+    val v2Token = "v2Token".asInstanceOf[globalEndpointTokenVersion]
 
     val values = js.Object.freeze(js.Array(v1Token, v2Token))
   }
-
-  object jobStatusTypeEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait jobStatusType extends js.Any
+  object jobStatusType extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[jobStatusType]
+    val COMPLETED   = "COMPLETED".asInstanceOf[jobStatusType]
+    val FAILED      = "FAILED".asInstanceOf[jobStatusType]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETED, FAILED))
   }
-
-  object policyOwnerEntityTypeEnum {
-    val USER  = "USER"
-    val ROLE  = "ROLE"
-    val GROUP = "GROUP"
+  @js.native
+  sealed trait policyOwnerEntityType extends js.Any
+  object policyOwnerEntityType extends js.Object {
+    val USER  = "USER".asInstanceOf[policyOwnerEntityType]
+    val ROLE  = "ROLE".asInstanceOf[policyOwnerEntityType]
+    val GROUP = "GROUP".asInstanceOf[policyOwnerEntityType]
 
     val values = js.Object.freeze(js.Array(USER, ROLE, GROUP))
   }
-
-  object policyScopeTypeEnum {
-    val All   = "All"
-    val AWS   = "AWS"
-    val Local = "Local"
+  @js.native
+  sealed trait policyScopeType extends js.Any
+  object policyScopeType extends js.Object {
+    val All   = "All".asInstanceOf[policyScopeType]
+    val AWS   = "AWS".asInstanceOf[policyScopeType]
+    val Local = "Local".asInstanceOf[policyScopeType]
 
     val values = js.Object.freeze(js.Array(All, AWS, Local))
   }
-
-  object policyTypeEnum {
-    val INLINE  = "INLINE"
-    val MANAGED = "MANAGED"
+  @js.native
+  sealed trait policyType extends js.Any
+  object policyType extends js.Object {
+    val INLINE  = "INLINE".asInstanceOf[policyType]
+    val MANAGED = "MANAGED".asInstanceOf[policyType]
 
     val values = js.Object.freeze(js.Array(INLINE, MANAGED))
   }
-
-  object sortKeyTypeEnum {
-    val SERVICE_NAMESPACE_ASCENDING        = "SERVICE_NAMESPACE_ASCENDING"
-    val SERVICE_NAMESPACE_DESCENDING       = "SERVICE_NAMESPACE_DESCENDING"
-    val LAST_AUTHENTICATED_TIME_ASCENDING  = "LAST_AUTHENTICATED_TIME_ASCENDING"
-    val LAST_AUTHENTICATED_TIME_DESCENDING = "LAST_AUTHENTICATED_TIME_DESCENDING"
+  @js.native
+  sealed trait sortKeyType extends js.Any
+  object sortKeyType extends js.Object {
+    val SERVICE_NAMESPACE_ASCENDING        = "SERVICE_NAMESPACE_ASCENDING".asInstanceOf[sortKeyType]
+    val SERVICE_NAMESPACE_DESCENDING       = "SERVICE_NAMESPACE_DESCENDING".asInstanceOf[sortKeyType]
+    val LAST_AUTHENTICATED_TIME_ASCENDING  = "LAST_AUTHENTICATED_TIME_ASCENDING".asInstanceOf[sortKeyType]
+    val LAST_AUTHENTICATED_TIME_DESCENDING = "LAST_AUTHENTICATED_TIME_DESCENDING".asInstanceOf[sortKeyType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -7286,41 +7285,43 @@ package iam {
       )
     )
   }
-
-  object statusTypeEnum {
-    val Active   = "Active"
-    val Inactive = "Inactive"
+  @js.native
+  sealed trait statusType extends js.Any
+  object statusType extends js.Object {
+    val Active   = "Active".asInstanceOf[statusType]
+    val Inactive = "Inactive".asInstanceOf[statusType]
 
     val values = js.Object.freeze(js.Array(Active, Inactive))
   }
-
-  object summaryKeyTypeEnum {
-    val Users                             = "Users"
-    val UsersQuota                        = "UsersQuota"
-    val Groups                            = "Groups"
-    val GroupsQuota                       = "GroupsQuota"
-    val ServerCertificates                = "ServerCertificates"
-    val ServerCertificatesQuota           = "ServerCertificatesQuota"
-    val UserPolicySizeQuota               = "UserPolicySizeQuota"
-    val GroupPolicySizeQuota              = "GroupPolicySizeQuota"
-    val GroupsPerUserQuota                = "GroupsPerUserQuota"
-    val SigningCertificatesPerUserQuota   = "SigningCertificatesPerUserQuota"
-    val AccessKeysPerUserQuota            = "AccessKeysPerUserQuota"
-    val MFADevices                        = "MFADevices"
-    val MFADevicesInUse                   = "MFADevicesInUse"
-    val AccountMFAEnabled                 = "AccountMFAEnabled"
-    val AccountAccessKeysPresent          = "AccountAccessKeysPresent"
-    val AccountSigningCertificatesPresent = "AccountSigningCertificatesPresent"
-    val AttachedPoliciesPerGroupQuota     = "AttachedPoliciesPerGroupQuota"
-    val AttachedPoliciesPerRoleQuota      = "AttachedPoliciesPerRoleQuota"
-    val AttachedPoliciesPerUserQuota      = "AttachedPoliciesPerUserQuota"
-    val Policies                          = "Policies"
-    val PoliciesQuota                     = "PoliciesQuota"
-    val PolicySizeQuota                   = "PolicySizeQuota"
-    val PolicyVersionsInUse               = "PolicyVersionsInUse"
-    val PolicyVersionsInUseQuota          = "PolicyVersionsInUseQuota"
-    val VersionsPerPolicyQuota            = "VersionsPerPolicyQuota"
-    val GlobalEndpointTokenVersion        = "GlobalEndpointTokenVersion"
+  @js.native
+  sealed trait summaryKeyType extends js.Any
+  object summaryKeyType extends js.Object {
+    val Users                             = "Users".asInstanceOf[summaryKeyType]
+    val UsersQuota                        = "UsersQuota".asInstanceOf[summaryKeyType]
+    val Groups                            = "Groups".asInstanceOf[summaryKeyType]
+    val GroupsQuota                       = "GroupsQuota".asInstanceOf[summaryKeyType]
+    val ServerCertificates                = "ServerCertificates".asInstanceOf[summaryKeyType]
+    val ServerCertificatesQuota           = "ServerCertificatesQuota".asInstanceOf[summaryKeyType]
+    val UserPolicySizeQuota               = "UserPolicySizeQuota".asInstanceOf[summaryKeyType]
+    val GroupPolicySizeQuota              = "GroupPolicySizeQuota".asInstanceOf[summaryKeyType]
+    val GroupsPerUserQuota                = "GroupsPerUserQuota".asInstanceOf[summaryKeyType]
+    val SigningCertificatesPerUserQuota   = "SigningCertificatesPerUserQuota".asInstanceOf[summaryKeyType]
+    val AccessKeysPerUserQuota            = "AccessKeysPerUserQuota".asInstanceOf[summaryKeyType]
+    val MFADevices                        = "MFADevices".asInstanceOf[summaryKeyType]
+    val MFADevicesInUse                   = "MFADevicesInUse".asInstanceOf[summaryKeyType]
+    val AccountMFAEnabled                 = "AccountMFAEnabled".asInstanceOf[summaryKeyType]
+    val AccountAccessKeysPresent          = "AccountAccessKeysPresent".asInstanceOf[summaryKeyType]
+    val AccountSigningCertificatesPresent = "AccountSigningCertificatesPresent".asInstanceOf[summaryKeyType]
+    val AttachedPoliciesPerGroupQuota     = "AttachedPoliciesPerGroupQuota".asInstanceOf[summaryKeyType]
+    val AttachedPoliciesPerRoleQuota      = "AttachedPoliciesPerRoleQuota".asInstanceOf[summaryKeyType]
+    val AttachedPoliciesPerUserQuota      = "AttachedPoliciesPerUserQuota".asInstanceOf[summaryKeyType]
+    val Policies                          = "Policies".asInstanceOf[summaryKeyType]
+    val PoliciesQuota                     = "PoliciesQuota".asInstanceOf[summaryKeyType]
+    val PolicySizeQuota                   = "PolicySizeQuota".asInstanceOf[summaryKeyType]
+    val PolicyVersionsInUse               = "PolicyVersionsInUse".asInstanceOf[summaryKeyType]
+    val PolicyVersionsInUseQuota          = "PolicyVersionsInUseQuota".asInstanceOf[summaryKeyType]
+    val VersionsPerPolicyQuota            = "VersionsPerPolicyQuota".asInstanceOf[summaryKeyType]
+    val GlobalEndpointTokenVersion        = "GlobalEndpointTokenVersion".asInstanceOf[summaryKeyType]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/imagebuilder/src/main/scala/facade/amazonaws/services/Imagebuilder.scala
+++ b/services/imagebuilder/src/main/scala/facade/amazonaws/services/Imagebuilder.scala
@@ -16,9 +16,7 @@ package object imagebuilder {
   type ComponentBuildVersionArn               = String
   type ComponentConfigurationList             = js.Array[ComponentConfiguration]
   type ComponentData                          = String
-  type ComponentFormat                        = String
   type ComponentSummaryList                   = js.Array[ComponentSummary]
-  type ComponentType                          = String
   type ComponentVersionArn                    = String
   type ComponentVersionArnOrBuildVersionArn   = String
   type ComponentVersionList                   = js.Array[ComponentVersion]
@@ -29,7 +27,6 @@ package object imagebuilder {
   type DistributionTimeoutMinutes             = Int
   type EbsIopsInteger                         = Int
   type EbsVolumeSizeInteger                   = Int
-  type EbsVolumeType                          = String
   type EmptyString                            = String
   type FilterList                             = js.Array[Filter]
   type FilterName                             = String
@@ -41,7 +38,6 @@ package object imagebuilder {
   type ImagePipelineList                      = js.Array[ImagePipeline]
   type ImageRecipeArn                         = String
   type ImageRecipeSummaryList                 = js.Array[ImageRecipeSummary]
-  type ImageStatus                            = String
   type ImageSummaryList                       = js.Array[ImageSummary]
   type ImageTestsTimeoutMinutes               = Int
   type ImageVersionArn                        = String
@@ -54,10 +50,6 @@ package object imagebuilder {
   type InstanceTypeList                       = js.Array[InstanceType]
   type NonEmptyString                         = String
   type NullableBoolean                        = Boolean
-  type Ownership                              = String
-  type PipelineExecutionStartCondition        = String
-  type PipelineStatus                         = String
-  type Platform                               = String
   type ResourceName                           = String
   type ResourcePolicyDocument                 = String
   type RestrictedInteger                      = Int
@@ -434,9 +426,10 @@ package imagebuilder {
       __obj.asInstanceOf[ComponentConfiguration]
     }
   }
-
-  object ComponentFormatEnum {
-    val SHELL = "SHELL"
+  @js.native
+  sealed trait ComponentFormat extends js.Any
+  object ComponentFormat extends js.Object {
+    val SHELL = "SHELL".asInstanceOf[ComponentFormat]
 
     val values = js.Object.freeze(js.Array(SHELL))
   }
@@ -486,10 +479,11 @@ package imagebuilder {
       __obj.asInstanceOf[ComponentSummary]
     }
   }
-
-  object ComponentTypeEnum {
-    val BUILD = "BUILD"
-    val TEST  = "TEST"
+  @js.native
+  sealed trait ComponentType extends js.Any
+  object ComponentType extends js.Object {
+    val BUILD = "BUILD".asInstanceOf[ComponentType]
+    val TEST  = "TEST".asInstanceOf[ComponentType]
 
     val values = js.Object.freeze(js.Array(BUILD, TEST))
   }
@@ -1286,13 +1280,14 @@ package imagebuilder {
       __obj.asInstanceOf[EbsInstanceBlockDeviceSpecification]
     }
   }
-
-  object EbsVolumeTypeEnum {
-    val standard = "standard"
-    val io1      = "io1"
-    val gp2      = "gp2"
-    val sc1      = "sc1"
-    val st1      = "st1"
+  @js.native
+  sealed trait EbsVolumeType extends js.Any
+  object EbsVolumeType extends js.Object {
+    val standard = "standard".asInstanceOf[EbsVolumeType]
+    val io1      = "io1".asInstanceOf[EbsVolumeType]
+    val gp2      = "gp2".asInstanceOf[EbsVolumeType]
+    val sc1      = "sc1".asInstanceOf[EbsVolumeType]
+    val st1      = "st1".asInstanceOf[EbsVolumeType]
 
     val values = js.Object.freeze(js.Array(standard, io1, gp2, sc1, st1))
   }
@@ -1896,19 +1891,20 @@ package imagebuilder {
       __obj.asInstanceOf[ImageState]
     }
   }
-
-  object ImageStatusEnum {
-    val PENDING      = "PENDING"
-    val CREATING     = "CREATING"
-    val BUILDING     = "BUILDING"
-    val TESTING      = "TESTING"
-    val DISTRIBUTING = "DISTRIBUTING"
-    val INTEGRATING  = "INTEGRATING"
-    val AVAILABLE    = "AVAILABLE"
-    val CANCELLED    = "CANCELLED"
-    val FAILED       = "FAILED"
-    val DEPRECATED   = "DEPRECATED"
-    val DELETED      = "DELETED"
+  @js.native
+  sealed trait ImageStatus extends js.Any
+  object ImageStatus extends js.Object {
+    val PENDING      = "PENDING".asInstanceOf[ImageStatus]
+    val CREATING     = "CREATING".asInstanceOf[ImageStatus]
+    val BUILDING     = "BUILDING".asInstanceOf[ImageStatus]
+    val TESTING      = "TESTING".asInstanceOf[ImageStatus]
+    val DISTRIBUTING = "DISTRIBUTING".asInstanceOf[ImageStatus]
+    val INTEGRATING  = "INTEGRATING".asInstanceOf[ImageStatus]
+    val AVAILABLE    = "AVAILABLE".asInstanceOf[ImageStatus]
+    val CANCELLED    = "CANCELLED".asInstanceOf[ImageStatus]
+    val FAILED       = "FAILED".asInstanceOf[ImageStatus]
+    val DEPRECATED   = "DEPRECATED".asInstanceOf[ImageStatus]
+    val DELETED      = "DELETED".asInstanceOf[ImageStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2735,32 +2731,37 @@ package imagebuilder {
       __obj.asInstanceOf[OutputResources]
     }
   }
-
-  object OwnershipEnum {
-    val Self   = "Self"
-    val Shared = "Shared"
-    val Amazon = "Amazon"
+  @js.native
+  sealed trait Ownership extends js.Any
+  object Ownership extends js.Object {
+    val Self   = "Self".asInstanceOf[Ownership]
+    val Shared = "Shared".asInstanceOf[Ownership]
+    val Amazon = "Amazon".asInstanceOf[Ownership]
 
     val values = js.Object.freeze(js.Array(Self, Shared, Amazon))
   }
-
-  object PipelineExecutionStartConditionEnum {
-    val EXPRESSION_MATCH_ONLY                             = "EXPRESSION_MATCH_ONLY"
-    val EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE = "EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE"
+  @js.native
+  sealed trait PipelineExecutionStartCondition extends js.Any
+  object PipelineExecutionStartCondition extends js.Object {
+    val EXPRESSION_MATCH_ONLY = "EXPRESSION_MATCH_ONLY".asInstanceOf[PipelineExecutionStartCondition]
+    val EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE =
+      "EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE".asInstanceOf[PipelineExecutionStartCondition]
 
     val values = js.Object.freeze(js.Array(EXPRESSION_MATCH_ONLY, EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE))
   }
-
-  object PipelineStatusEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait PipelineStatus extends js.Any
+  object PipelineStatus extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[PipelineStatus]
+    val ENABLED  = "ENABLED".asInstanceOf[PipelineStatus]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
-
-  object PlatformEnum {
-    val Windows = "Windows"
-    val Linux   = "Linux"
+  @js.native
+  sealed trait Platform extends js.Any
+  object Platform extends js.Object {
+    val Windows = "Windows".asInstanceOf[Platform]
+    val Linux   = "Linux".asInstanceOf[Platform]
 
     val values = js.Object.freeze(js.Array(Windows, Linux))
   }

--- a/services/importexport/src/main/scala/facade/amazonaws/services/ImportExport.scala
+++ b/services/importexport/src/main/scala/facade/amazonaws/services/ImportExport.scala
@@ -20,7 +20,6 @@ package object importexport {
   type IsTruncated           = Boolean
   type JobId                 = String
   type JobIdList             = js.Array[GenericString]
-  type JobType               = String
   type JobsList              = js.Array[Job]
   type LocationCode          = String
   type LocationMessage       = String
@@ -498,9 +497,11 @@ package importexport {
   /**
     * Specifies whether the job to initiate is an import or export job.
     */
-  object JobTypeEnum {
-    val Import = "Import"
-    val Export = "Export"
+  @js.native
+  sealed trait JobType extends js.Any
+  object JobType extends js.Object {
+    val Import = "Import".asInstanceOf[JobType]
+    val Export = "Export".asInstanceOf[JobType]
 
     val values = js.Object.freeze(js.Array(Import, Export))
   }

--- a/services/inspector/src/main/scala/facade/amazonaws/services/Inspector.scala
+++ b/services/inspector/src/main/scala/facade/amazonaws/services/Inspector.scala
@@ -7,105 +7,90 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object inspector {
-  type AddRemoveAttributesFindingArnList      = js.Array[Arn]
-  type AgentHealth                            = String
-  type AgentHealthCode                        = String
-  type AgentHealthCodeList                    = js.Array[AgentHealthCode]
-  type AgentHealthList                        = js.Array[AgentHealth]
-  type AgentId                                = String
-  type AgentIdList                            = js.Array[AgentId]
-  type AgentPreviewList                       = js.Array[AgentPreview]
-  type AgentVersion                           = String
-  type AmiId                                  = String
-  type Arn                                    = String
-  type ArnCount                               = Int
-  type AssessmentRulesPackageArnList          = js.Array[Arn]
-  type AssessmentRunAgentList                 = js.Array[AssessmentRunAgent]
-  type AssessmentRunDuration                  = Int
-  type AssessmentRunFindingCounts             = js.Dictionary[FindingCount]
-  type AssessmentRunList                      = js.Array[AssessmentRun]
-  type AssessmentRunName                      = String
-  type AssessmentRunNotificationList          = js.Array[AssessmentRunNotification]
-  type AssessmentRunNotificationSnsStatusCode = String
-  type AssessmentRunState                     = String
-  type AssessmentRunStateChangeList           = js.Array[AssessmentRunStateChange]
-  type AssessmentRunStateList                 = js.Array[AssessmentRunState]
-  type AssessmentTargetList                   = js.Array[AssessmentTarget]
-  type AssessmentTargetName                   = String
-  type AssessmentTemplateList                 = js.Array[AssessmentTemplate]
-  type AssessmentTemplateName                 = String
-  type AssessmentTemplateRulesPackageArnList  = js.Array[Arn]
-  type AssetType                              = String
-  type AttributeKey                           = String
-  type AttributeList                          = js.Array[Attribute]
-  type AttributeValue                         = String
-  type AutoScalingGroup                       = String
-  type AutoScalingGroupList                   = js.Array[AutoScalingGroup]
-  type BatchDescribeArnList                   = js.Array[Arn]
-  type BatchDescribeExclusionsArnList         = js.Array[Arn]
-  type EventSubscriptionList                  = js.Array[EventSubscription]
-  type ExclusionMap                           = js.Dictionary[Exclusion]
-  type ExclusionPreviewList                   = js.Array[ExclusionPreview]
-  type FailedItemErrorCode                    = String
-  type FailedItems                            = js.Dictionary[FailedItemDetails]
-  type FilterRulesPackageArnList              = js.Array[Arn]
-  type FindingCount                           = Int
-  type FindingId                              = String
-  type FindingList                            = js.Array[Finding]
-  type Hostname                               = String
-  type InspectorEvent                         = String
-  type IocConfidence                          = Int
-  type Ipv4Address                            = String
-  type Ipv4AddressList                        = js.Array[Ipv4Address]
-  type Ipv6Addresses                          = js.Array[Text]
-  type KernelVersion                          = String
-  type ListEventSubscriptionsMaxResults       = Int
-  type ListMaxResults                         = Int
-  type ListParentArnList                      = js.Array[Arn]
-  type ListReturnedArnList                    = js.Array[Arn]
-  type Locale                                 = String
-  type Message                                = String
-  type MessageType                            = String
-  type NamePattern                            = String
-  type NetworkInterfaces                      = js.Array[NetworkInterface]
-  type NumericSeverity                        = Double
-  type NumericVersion                         = Int
-  type OperatingSystem                        = String
-  type PaginationToken                        = String
-  type PreviewAgentsMaxResults                = Int
-  type PreviewStatus                          = String
-  type PrivateIpAddresses                     = js.Array[PrivateIp]
-  type ProviderName                           = String
-  type ReportFileFormat                       = String
-  type ReportStatus                           = String
-  type ReportType                             = String
-  type ResourceGroupList                      = js.Array[ResourceGroup]
-  type ResourceGroupTags                      = js.Array[ResourceGroupTag]
-  type RuleName                               = String
-  type RuleNameList                           = js.Array[RuleName]
-  type RulesPackageList                       = js.Array[RulesPackage]
-  type RulesPackageName                       = String
-  type ScopeList                              = js.Array[Scope]
-  type ScopeType                              = String
-  type ScopeValue                             = String
-  type SecurityGroups                         = js.Array[SecurityGroup]
-  type ServiceName                            = String
-  type Severity                               = String
-  type SeverityList                           = js.Array[Severity]
-  type StopAction                             = String
-  type SubscriptionList                       = js.Array[Subscription]
-  type TagKey                                 = String
-  type TagList                                = js.Array[Tag]
-  type TagValue                               = String
-  type Tags                                   = js.Array[Tag]
-  type TelemetryMetadataList                  = js.Array[TelemetryMetadata]
-  type Text                                   = String
-  type Timestamp                              = js.Date
-  type UUID                                   = String
-  type Url                                    = String
-  type UserAttributeKeyList                   = js.Array[AttributeKey]
-  type UserAttributeList                      = js.Array[Attribute]
-  type Version                                = String
+  type AddRemoveAttributesFindingArnList     = js.Array[Arn]
+  type AgentHealthCodeList                   = js.Array[AgentHealthCode]
+  type AgentHealthList                       = js.Array[AgentHealth]
+  type AgentId                               = String
+  type AgentIdList                           = js.Array[AgentId]
+  type AgentPreviewList                      = js.Array[AgentPreview]
+  type AgentVersion                          = String
+  type AmiId                                 = String
+  type Arn                                   = String
+  type ArnCount                              = Int
+  type AssessmentRulesPackageArnList         = js.Array[Arn]
+  type AssessmentRunAgentList                = js.Array[AssessmentRunAgent]
+  type AssessmentRunDuration                 = Int
+  type AssessmentRunFindingCounts            = js.Dictionary[FindingCount]
+  type AssessmentRunList                     = js.Array[AssessmentRun]
+  type AssessmentRunName                     = String
+  type AssessmentRunNotificationList         = js.Array[AssessmentRunNotification]
+  type AssessmentRunStateChangeList          = js.Array[AssessmentRunStateChange]
+  type AssessmentRunStateList                = js.Array[AssessmentRunState]
+  type AssessmentTargetList                  = js.Array[AssessmentTarget]
+  type AssessmentTargetName                  = String
+  type AssessmentTemplateList                = js.Array[AssessmentTemplate]
+  type AssessmentTemplateName                = String
+  type AssessmentTemplateRulesPackageArnList = js.Array[Arn]
+  type AttributeKey                          = String
+  type AttributeList                         = js.Array[Attribute]
+  type AttributeValue                        = String
+  type AutoScalingGroup                      = String
+  type AutoScalingGroupList                  = js.Array[AutoScalingGroup]
+  type BatchDescribeArnList                  = js.Array[Arn]
+  type BatchDescribeExclusionsArnList        = js.Array[Arn]
+  type EventSubscriptionList                 = js.Array[EventSubscription]
+  type ExclusionMap                          = js.Dictionary[Exclusion]
+  type ExclusionPreviewList                  = js.Array[ExclusionPreview]
+  type FailedItems                           = js.Dictionary[FailedItemDetails]
+  type FilterRulesPackageArnList             = js.Array[Arn]
+  type FindingCount                          = Int
+  type FindingId                             = String
+  type FindingList                           = js.Array[Finding]
+  type Hostname                              = String
+  type IocConfidence                         = Int
+  type Ipv4Address                           = String
+  type Ipv4AddressList                       = js.Array[Ipv4Address]
+  type Ipv6Addresses                         = js.Array[Text]
+  type KernelVersion                         = String
+  type ListEventSubscriptionsMaxResults      = Int
+  type ListMaxResults                        = Int
+  type ListParentArnList                     = js.Array[Arn]
+  type ListReturnedArnList                   = js.Array[Arn]
+  type Message                               = String
+  type MessageType                           = String
+  type NamePattern                           = String
+  type NetworkInterfaces                     = js.Array[NetworkInterface]
+  type NumericSeverity                       = Double
+  type NumericVersion                        = Int
+  type OperatingSystem                       = String
+  type PaginationToken                       = String
+  type PreviewAgentsMaxResults               = Int
+  type PrivateIpAddresses                    = js.Array[PrivateIp]
+  type ProviderName                          = String
+  type ResourceGroupList                     = js.Array[ResourceGroup]
+  type ResourceGroupTags                     = js.Array[ResourceGroupTag]
+  type RuleName                              = String
+  type RuleNameList                          = js.Array[RuleName]
+  type RulesPackageList                      = js.Array[RulesPackage]
+  type RulesPackageName                      = String
+  type ScopeList                             = js.Array[Scope]
+  type ScopeValue                            = String
+  type SecurityGroups                        = js.Array[SecurityGroup]
+  type ServiceName                           = String
+  type SeverityList                          = js.Array[Severity]
+  type SubscriptionList                      = js.Array[Subscription]
+  type TagKey                                = String
+  type TagList                               = js.Array[Tag]
+  type TagValue                              = String
+  type Tags                                  = js.Array[Tag]
+  type TelemetryMetadataList                 = js.Array[TelemetryMetadata]
+  type Text                                  = String
+  type Timestamp                             = js.Date
+  type UUID                                  = String
+  type Url                                   = String
+  type UserAttributeKeyList                  = js.Array[AttributeKey]
+  type UserAttributeList                     = js.Array[Attribute]
+  type Version                               = String
 
   implicit final class InspectorOps(private val service: Inspector) extends AnyVal {
 
@@ -322,22 +307,24 @@ package inspector {
       __obj.asInstanceOf[AgentFilter]
     }
   }
-
-  object AgentHealthEnum {
-    val HEALTHY   = "HEALTHY"
-    val UNHEALTHY = "UNHEALTHY"
-    val UNKNOWN   = "UNKNOWN"
+  @js.native
+  sealed trait AgentHealth extends js.Any
+  object AgentHealth extends js.Object {
+    val HEALTHY   = "HEALTHY".asInstanceOf[AgentHealth]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[AgentHealth]
+    val UNKNOWN   = "UNKNOWN".asInstanceOf[AgentHealth]
 
     val values = js.Object.freeze(js.Array(HEALTHY, UNHEALTHY, UNKNOWN))
   }
-
-  object AgentHealthCodeEnum {
-    val IDLE      = "IDLE"
-    val RUNNING   = "RUNNING"
-    val SHUTDOWN  = "SHUTDOWN"
-    val UNHEALTHY = "UNHEALTHY"
-    val THROTTLED = "THROTTLED"
-    val UNKNOWN   = "UNKNOWN"
+  @js.native
+  sealed trait AgentHealthCode extends js.Any
+  object AgentHealthCode extends js.Object {
+    val IDLE      = "IDLE".asInstanceOf[AgentHealthCode]
+    val RUNNING   = "RUNNING".asInstanceOf[AgentHealthCode]
+    val SHUTDOWN  = "SHUTDOWN".asInstanceOf[AgentHealthCode]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[AgentHealthCode]
+    val THROTTLED = "THROTTLED".asInstanceOf[AgentHealthCode]
+    val UNKNOWN   = "UNKNOWN".asInstanceOf[AgentHealthCode]
 
     val values = js.Object.freeze(js.Array(IDLE, RUNNING, SHUTDOWN, UNHEALTHY, THROTTLED, UNKNOWN))
   }
@@ -559,30 +546,32 @@ package inspector {
       __obj.asInstanceOf[AssessmentRunNotification]
     }
   }
-
-  object AssessmentRunNotificationSnsStatusCodeEnum {
-    val SUCCESS              = "SUCCESS"
-    val TOPIC_DOES_NOT_EXIST = "TOPIC_DOES_NOT_EXIST"
-    val ACCESS_DENIED        = "ACCESS_DENIED"
-    val INTERNAL_ERROR       = "INTERNAL_ERROR"
+  @js.native
+  sealed trait AssessmentRunNotificationSnsStatusCode extends js.Any
+  object AssessmentRunNotificationSnsStatusCode extends js.Object {
+    val SUCCESS              = "SUCCESS".asInstanceOf[AssessmentRunNotificationSnsStatusCode]
+    val TOPIC_DOES_NOT_EXIST = "TOPIC_DOES_NOT_EXIST".asInstanceOf[AssessmentRunNotificationSnsStatusCode]
+    val ACCESS_DENIED        = "ACCESS_DENIED".asInstanceOf[AssessmentRunNotificationSnsStatusCode]
+    val INTERNAL_ERROR       = "INTERNAL_ERROR".asInstanceOf[AssessmentRunNotificationSnsStatusCode]
 
     val values = js.Object.freeze(js.Array(SUCCESS, TOPIC_DOES_NOT_EXIST, ACCESS_DENIED, INTERNAL_ERROR))
   }
-
-  object AssessmentRunStateEnum {
-    val CREATED                           = "CREATED"
-    val START_DATA_COLLECTION_PENDING     = "START_DATA_COLLECTION_PENDING"
-    val START_DATA_COLLECTION_IN_PROGRESS = "START_DATA_COLLECTION_IN_PROGRESS"
-    val COLLECTING_DATA                   = "COLLECTING_DATA"
-    val STOP_DATA_COLLECTION_PENDING      = "STOP_DATA_COLLECTION_PENDING"
-    val DATA_COLLECTED                    = "DATA_COLLECTED"
-    val START_EVALUATING_RULES_PENDING    = "START_EVALUATING_RULES_PENDING"
-    val EVALUATING_RULES                  = "EVALUATING_RULES"
-    val FAILED                            = "FAILED"
-    val ERROR                             = "ERROR"
-    val COMPLETED                         = "COMPLETED"
-    val COMPLETED_WITH_ERRORS             = "COMPLETED_WITH_ERRORS"
-    val CANCELED                          = "CANCELED"
+  @js.native
+  sealed trait AssessmentRunState extends js.Any
+  object AssessmentRunState extends js.Object {
+    val CREATED                           = "CREATED".asInstanceOf[AssessmentRunState]
+    val START_DATA_COLLECTION_PENDING     = "START_DATA_COLLECTION_PENDING".asInstanceOf[AssessmentRunState]
+    val START_DATA_COLLECTION_IN_PROGRESS = "START_DATA_COLLECTION_IN_PROGRESS".asInstanceOf[AssessmentRunState]
+    val COLLECTING_DATA                   = "COLLECTING_DATA".asInstanceOf[AssessmentRunState]
+    val STOP_DATA_COLLECTION_PENDING      = "STOP_DATA_COLLECTION_PENDING".asInstanceOf[AssessmentRunState]
+    val DATA_COLLECTED                    = "DATA_COLLECTED".asInstanceOf[AssessmentRunState]
+    val START_EVALUATING_RULES_PENDING    = "START_EVALUATING_RULES_PENDING".asInstanceOf[AssessmentRunState]
+    val EVALUATING_RULES                  = "EVALUATING_RULES".asInstanceOf[AssessmentRunState]
+    val FAILED                            = "FAILED".asInstanceOf[AssessmentRunState]
+    val ERROR                             = "ERROR".asInstanceOf[AssessmentRunState]
+    val COMPLETED                         = "COMPLETED".asInstanceOf[AssessmentRunState]
+    val COMPLETED_WITH_ERRORS             = "COMPLETED_WITH_ERRORS".asInstanceOf[AssessmentRunState]
+    val CANCELED                          = "CANCELED".asInstanceOf[AssessmentRunState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -792,9 +781,10 @@ package inspector {
       __obj.asInstanceOf[AssetAttributes]
     }
   }
-
-  object AssetTypeEnum {
-    val `ec2-instance` = "ec2-instance"
+  @js.native
+  sealed trait AssetType extends js.Any
+  object AssetType extends js.Object {
+    val `ec2-instance` = "ec2-instance".asInstanceOf[AssetType]
 
     val values = js.Object.freeze(js.Array(`ec2-instance`))
   }
@@ -1482,14 +1472,15 @@ package inspector {
       __obj.asInstanceOf[FailedItemDetails]
     }
   }
-
-  object FailedItemErrorCodeEnum {
-    val INVALID_ARN         = "INVALID_ARN"
-    val DUPLICATE_ARN       = "DUPLICATE_ARN"
-    val ITEM_DOES_NOT_EXIST = "ITEM_DOES_NOT_EXIST"
-    val ACCESS_DENIED       = "ACCESS_DENIED"
-    val LIMIT_EXCEEDED      = "LIMIT_EXCEEDED"
-    val INTERNAL_ERROR      = "INTERNAL_ERROR"
+  @js.native
+  sealed trait FailedItemErrorCode extends js.Any
+  object FailedItemErrorCode extends js.Object {
+    val INVALID_ARN         = "INVALID_ARN".asInstanceOf[FailedItemErrorCode]
+    val DUPLICATE_ARN       = "DUPLICATE_ARN".asInstanceOf[FailedItemErrorCode]
+    val ITEM_DOES_NOT_EXIST = "ITEM_DOES_NOT_EXIST".asInstanceOf[FailedItemErrorCode]
+    val ACCESS_DENIED       = "ACCESS_DENIED".asInstanceOf[FailedItemErrorCode]
+    val LIMIT_EXCEEDED      = "LIMIT_EXCEEDED".asInstanceOf[FailedItemErrorCode]
+    val INTERNAL_ERROR      = "INTERNAL_ERROR".asInstanceOf[FailedItemErrorCode]
 
     val values = js.Object.freeze(
       js.Array(INVALID_ARN, DUPLICATE_ARN, ITEM_DOES_NOT_EXIST, ACCESS_DENIED, LIMIT_EXCEEDED, INTERNAL_ERROR)
@@ -1742,13 +1733,14 @@ package inspector {
       __obj.asInstanceOf[GetTelemetryMetadataResponse]
     }
   }
-
-  object InspectorEventEnum {
-    val ASSESSMENT_RUN_STARTED       = "ASSESSMENT_RUN_STARTED"
-    val ASSESSMENT_RUN_COMPLETED     = "ASSESSMENT_RUN_COMPLETED"
-    val ASSESSMENT_RUN_STATE_CHANGED = "ASSESSMENT_RUN_STATE_CHANGED"
-    val FINDING_REPORTED             = "FINDING_REPORTED"
-    val OTHER                        = "OTHER"
+  @js.native
+  sealed trait InspectorEvent extends js.Any
+  object InspectorEvent extends js.Object {
+    val ASSESSMENT_RUN_STARTED       = "ASSESSMENT_RUN_STARTED".asInstanceOf[InspectorEvent]
+    val ASSESSMENT_RUN_COMPLETED     = "ASSESSMENT_RUN_COMPLETED".asInstanceOf[InspectorEvent]
+    val ASSESSMENT_RUN_STATE_CHANGED = "ASSESSMENT_RUN_STATE_CHANGED".asInstanceOf[InspectorEvent]
+    val FINDING_REPORTED             = "FINDING_REPORTED".asInstanceOf[InspectorEvent]
+    val OTHER                        = "OTHER".asInstanceOf[InspectorEvent]
 
     val values = js.Object.freeze(
       js.Array(ASSESSMENT_RUN_STARTED, ASSESSMENT_RUN_COMPLETED, ASSESSMENT_RUN_STATE_CHANGED, FINDING_REPORTED, OTHER)
@@ -2174,9 +2166,10 @@ package inspector {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object LocaleEnum {
-    val EN_US = "EN_US"
+  @js.native
+  sealed trait Locale extends js.Any
+  object Locale extends js.Object {
+    val EN_US = "EN_US".asInstanceOf[Locale]
 
     val values = js.Object.freeze(js.Array(EN_US))
   }
@@ -2271,10 +2264,11 @@ package inspector {
       __obj.asInstanceOf[PreviewAgentsResponse]
     }
   }
-
-  object PreviewStatusEnum {
-    val WORK_IN_PROGRESS = "WORK_IN_PROGRESS"
-    val COMPLETED        = "COMPLETED"
+  @js.native
+  sealed trait PreviewStatus extends js.Any
+  object PreviewStatus extends js.Object {
+    val WORK_IN_PROGRESS = "WORK_IN_PROGRESS".asInstanceOf[PreviewStatus]
+    val COMPLETED        = "COMPLETED".asInstanceOf[PreviewStatus]
 
     val values = js.Object.freeze(js.Array(WORK_IN_PROGRESS, COMPLETED))
   }
@@ -2357,25 +2351,28 @@ package inspector {
       __obj.asInstanceOf[RemoveAttributesFromFindingsResponse]
     }
   }
-
-  object ReportFileFormatEnum {
-    val HTML = "HTML"
-    val PDF  = "PDF"
+  @js.native
+  sealed trait ReportFileFormat extends js.Any
+  object ReportFileFormat extends js.Object {
+    val HTML = "HTML".asInstanceOf[ReportFileFormat]
+    val PDF  = "PDF".asInstanceOf[ReportFileFormat]
 
     val values = js.Object.freeze(js.Array(HTML, PDF))
   }
-
-  object ReportStatusEnum {
-    val WORK_IN_PROGRESS = "WORK_IN_PROGRESS"
-    val FAILED           = "FAILED"
-    val COMPLETED        = "COMPLETED"
+  @js.native
+  sealed trait ReportStatus extends js.Any
+  object ReportStatus extends js.Object {
+    val WORK_IN_PROGRESS = "WORK_IN_PROGRESS".asInstanceOf[ReportStatus]
+    val FAILED           = "FAILED".asInstanceOf[ReportStatus]
+    val COMPLETED        = "COMPLETED".asInstanceOf[ReportStatus]
 
     val values = js.Object.freeze(js.Array(WORK_IN_PROGRESS, FAILED, COMPLETED))
   }
-
-  object ReportTypeEnum {
-    val FINDING = "FINDING"
-    val FULL    = "FULL"
+  @js.native
+  sealed trait ReportType extends js.Any
+  object ReportType extends js.Object {
+    val FINDING = "FINDING".asInstanceOf[ReportType]
+    val FULL    = "FULL".asInstanceOf[ReportType]
 
     val values = js.Object.freeze(js.Array(FINDING, FULL))
   }
@@ -2485,10 +2482,11 @@ package inspector {
       __obj.asInstanceOf[Scope]
     }
   }
-
-  object ScopeTypeEnum {
-    val INSTANCE_ID       = "INSTANCE_ID"
-    val RULES_PACKAGE_ARN = "RULES_PACKAGE_ARN"
+  @js.native
+  sealed trait ScopeType extends js.Any
+  object ScopeType extends js.Object {
+    val INSTANCE_ID       = "INSTANCE_ID".asInstanceOf[ScopeType]
+    val RULES_PACKAGE_ARN = "RULES_PACKAGE_ARN".asInstanceOf[ScopeType]
 
     val values = js.Object.freeze(js.Array(INSTANCE_ID, RULES_PACKAGE_ARN))
   }
@@ -2535,13 +2533,14 @@ package inspector {
       __obj.asInstanceOf[SetTagsForResourceRequest]
     }
   }
-
-  object SeverityEnum {
-    val Low           = "Low"
-    val Medium        = "Medium"
-    val High          = "High"
-    val Informational = "Informational"
-    val Undefined     = "Undefined"
+  @js.native
+  sealed trait Severity extends js.Any
+  object Severity extends js.Object {
+    val Low           = "Low".asInstanceOf[Severity]
+    val Medium        = "Medium".asInstanceOf[Severity]
+    val High          = "High".asInstanceOf[Severity]
+    val Informational = "Informational".asInstanceOf[Severity]
+    val Undefined     = "Undefined".asInstanceOf[Severity]
 
     val values = js.Object.freeze(js.Array(Low, Medium, High, Informational, Undefined))
   }
@@ -2584,10 +2583,11 @@ package inspector {
       __obj.asInstanceOf[StartAssessmentRunResponse]
     }
   }
-
-  object StopActionEnum {
-    val START_EVALUATION = "START_EVALUATION"
-    val SKIP_EVALUATION  = "SKIP_EVALUATION"
+  @js.native
+  sealed trait StopAction extends js.Any
+  object StopAction extends js.Object {
+    val START_EVALUATION = "START_EVALUATION".asInstanceOf[StopAction]
+    val SKIP_EVALUATION  = "SKIP_EVALUATION".asInstanceOf[StopAction]
 
     val values = js.Object.freeze(js.Array(START_EVALUATION, SKIP_EVALUATION))
   }

--- a/services/iot/src/main/scala/facade/amazonaws/services/Iot.scala
+++ b/services/iot/src/main/scala/facade/amazonaws/services/Iot.scala
@@ -7,19 +7,16 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object iot {
-  type AbortAction                                = String
   type AbortCriteriaList                          = js.Array[AbortCriteria]
   type AbortThresholdPercentage                   = Double
   type AcmCertificateArn                          = String
   type ActionList                                 = js.Array[Action]
-  type ActionType                                 = String
   type ActiveViolations                           = js.Array[ActiveViolation]
   type AdditionalMetricsToRetainList              = js.Array[BehaviorMetric]
   type AdditionalParameterMap                     = js.Dictionary[Value]
   type AggregationField                           = String
   type AlarmName                                  = String
   type AlertTargetArn                             = String
-  type AlertTargetType                            = String
   type AlertTargets                               = js.Dictionary[AlertTarget]
   type AllowAuthorizerOverride                    = Boolean
   type AllowAutoRegistration                      = Boolean
@@ -44,34 +41,23 @@ package object iot {
   type AttributesMap                              = js.Dictionary[Value]
   type AuditCheckConfigurations                   = js.Dictionary[AuditCheckConfiguration]
   type AuditCheckName                             = String
-  type AuditCheckRunStatus                        = String
   type AuditCheckToActionsMapping                 = js.Dictionary[MitigationActionNameList]
   type AuditCheckToReasonCodeFilter               = js.Dictionary[ReasonForNonComplianceCodes]
   type AuditDetails                               = js.Dictionary[AuditCheckDetails]
-  type AuditFindingSeverity                       = String
   type AuditFindings                              = js.Array[AuditFinding]
-  type AuditFrequency                             = String
   type AuditMitigationActionExecutionMetadataList = js.Array[AuditMitigationActionExecutionMetadata]
-  type AuditMitigationActionsExecutionStatus      = String
   type AuditMitigationActionsTaskId               = String
   type AuditMitigationActionsTaskMetadataList     = js.Array[AuditMitigationActionsTaskMetadata]
   type AuditMitigationActionsTaskStatistics       = js.Dictionary[TaskStatisticsForAuditCheck]
-  type AuditMitigationActionsTaskStatus           = String
   type AuditNotificationTargetConfigurations      = js.Dictionary[AuditNotificationTarget]
-  type AuditNotificationType                      = String
   type AuditTaskId                                = String
   type AuditTaskMetadataList                      = js.Array[AuditTaskMetadata]
-  type AuditTaskStatus                            = String
-  type AuditTaskType                              = String
-  type AuthDecision                               = String
   type AuthInfos                                  = js.Array[AuthInfo]
   type AuthResults                                = js.Array[AuthResult]
   type AuthorizerArn                              = String
   type AuthorizerFunctionArn                      = String
   type AuthorizerName                             = String
-  type AuthorizerStatus                           = String
   type Authorizers                                = js.Array[AuthorizerSummary]
-  type AutoRegistrationStatus                     = String
   type Average                                    = Double
   type AwsAccountId                               = String
   type AwsArn                                     = String
@@ -88,20 +74,16 @@ package object iot {
   type BillingGroupNameAndArnList                 = js.Array[GroupNameAndArn]
   type BooleanKey                                 = Boolean
   type BucketName                                 = String
-  type CACertificateStatus                        = String
-  type CACertificateUpdateAction                  = String
   type CACertificates                             = js.Array[CACertificate]
   type CanceledChecksCount                        = Int
   type CanceledFindingsCount                      = Double
   type CanceledThings                             = Int
-  type CannedAccessControlList                    = String
   type CertificateArn                             = String
   type CertificateId                              = String
   type CertificateName                            = String
   type CertificatePathOnDevice                    = String
   type CertificatePem                             = String
   type CertificateSigningRequest                  = String
-  type CertificateStatus                          = String
   type Certificates                               = js.Array[Certificate]
   type ChannelName                                = String
   type CheckCompliant                             = Boolean
@@ -112,7 +94,6 @@ package object iot {
   type Code                                       = String
   type CognitoIdentityPoolId                      = String
   type Comment                                    = String
-  type ComparisonOperator                         = String
   type CompliantChecksCount                       = Int
   type ConfirmationToken                          = String
   type ConnectivityTimestamp                      = Double
@@ -125,7 +106,6 @@ package object iot {
   type CustomerVersion                            = Int
   type DateType                                   = js.Date
   type DayOfMonth                                 = String
-  type DayOfWeek                                  = String
   type DeleteAdditionalMetricsToRetain            = Boolean
   type DeleteAlertTargets                         = Boolean
   type DeleteBehaviors                            = Boolean
@@ -137,18 +117,13 @@ package object iot {
   type DetailsKey                                 = String
   type DetailsMap                                 = js.Dictionary[DetailsValue]
   type DetailsValue                               = String
-  type DeviceCertificateUpdateAction              = String
   type DeviceDefenderThingName                    = String
   type DisableAllLogs                             = Boolean
   type DomainConfigurationArn                     = String
   type DomainConfigurationName                    = String
-  type DomainConfigurationStatus                  = String
   type DomainConfigurations                       = js.Array[DomainConfigurationSummary]
   type DomainName                                 = String
-  type DomainType                                 = String
   type DurationSeconds                            = Int
-  type DynamicGroupStatus                         = String
-  type DynamoKeyType                              = String
   type DynamoOperation                            = String
   type EffectivePolicies                          = js.Array[EffectivePolicy]
   type ElasticsearchEndpoint                      = String
@@ -162,7 +137,6 @@ package object iot {
   type ErrorMessage                               = String
   type EvaluationStatistic                        = String
   type EventConfigurations                        = js.Dictionary[Configuration]
-  type EventType                                  = String
   type ExecutionNamePrefix                        = String
   type ExecutionNumber                            = Double
   type ExpectedVersion                            = Double
@@ -172,7 +146,6 @@ package object iot {
   type FailedFindingsCount                        = Double
   type FailedThings                               = Int
   type FieldName                                  = String
-  type FieldType                                  = String
   type Fields                                     = js.Array[Field]
   type FileId                                     = Int
   type FileName                                   = String
@@ -203,7 +176,6 @@ package object iot {
   type IndexName                                  = String
   type IndexNamesList                             = js.Array[IndexName]
   type IndexSchema                                = String
-  type IndexStatus                                = String
   type InlineDocument                             = String
   type InputName                                  = String
   type IsAuthenticated                            = Boolean
@@ -213,12 +185,9 @@ package object iot {
   type JobDescription                             = String
   type JobDocument                                = String
   type JobDocumentSource                          = String
-  type JobExecutionFailureType                    = String
-  type JobExecutionStatus                         = String
   type JobExecutionSummaryForJobList              = js.Array[JobExecutionSummaryForJob]
   type JobExecutionSummaryForThingList            = js.Array[JobExecutionSummaryForThing]
   type JobId                                      = String
-  type JobStatus                                  = String
   type JobSummaryList                             = js.Array[JobSummary]
   type JobTargets                                 = js.Array[TargetArn]
   type JsonDocument                               = String
@@ -227,17 +196,14 @@ package object iot {
   type KeyValue                                   = String
   type LaserMaxResults                            = Int
   type LastModifiedDate                           = js.Date
-  type LogLevel                                   = String
   type LogTargetConfigurations                    = js.Array[LogTargetConfiguration]
   type LogTargetName                              = String
-  type LogTargetType                              = String
   type Marker                                     = String
   type MaxJobExecutionsPerMin                     = Int
   type MaxResults                                 = Int
   type Maximum                                    = Double
   type MaximumPerMinute                           = Int
   type Message                                    = String
-  type MessageFormat                              = String
   type MessageId                                  = String
   type Minimum                                    = Double
   type MinimumNumberOfExecutedThings              = Int
@@ -249,7 +215,6 @@ package object iot {
   type MitigationActionList                       = js.Array[MitigationAction]
   type MitigationActionName                       = String
   type MitigationActionNameList                   = js.Array[MitigationActionName]
-  type MitigationActionType                       = String
   type MqttClientId                               = String
   type MqttPassword                               = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type MqttUsername                               = String
@@ -263,7 +228,6 @@ package object iot {
   type OTAUpdateFileVersion                       = String
   type OTAUpdateFiles                             = js.Array[OTAUpdateFile]
   type OTAUpdateId                                = String
-  type OTAUpdateStatus                            = String
   type OTAUpdatesSummary                          = js.Array[OTAUpdateSummary]
   type OptionalVersion                            = Double
   type OutgoingCertificates                       = js.Array[OutgoingCertificate]
@@ -287,7 +251,6 @@ package object iot {
   type PolicyNames                                = js.Array[PolicyName]
   type PolicyTarget                               = String
   type PolicyTargets                              = js.Array[PolicyTarget]
-  type PolicyTemplateName                         = String
   type PolicyVersionId                            = String
   type PolicyVersions                             = js.Array[PolicyVersion]
   type Port                                       = Int
@@ -300,7 +263,6 @@ package object iot {
   type PrivateKey                                 = String
   type ProcessingTargetName                       = String
   type ProcessingTargetNameList                   = js.Array[ProcessingTargetName]
-  type Protocol                                   = String
   type Protocols                                  = js.Array[Protocol]
   type ProvisioningTemplateListing                = js.Array[ProvisioningTemplateSummary]
   type ProvisioningTemplateVersionListing         = js.Array[ProvisioningTemplateVersionSummary]
@@ -331,13 +293,11 @@ package object iot {
   type RemoveAutoRegistration                     = Boolean
   type RemoveThingType                            = Boolean
   type RemovedThings                              = Int
-  type ReportType                                 = String
   type ReservedDomainConfigurationName            = String
   type Resource                                   = String
   type ResourceArn                                = String
   type ResourceArns                               = js.Dictionary[ResourceArn]
   type ResourceLogicalId                          = String
-  type ResourceType                               = String
   type Resources                                  = js.Array[Resource]
   type RoleAlias                                  = String
   type RoleAliasArn                               = String
@@ -367,12 +327,10 @@ package object iot {
   type SecurityProfileTargetMappings              = js.Array[SecurityProfileTargetMapping]
   type SecurityProfileTargets                     = js.Array[SecurityProfileTarget]
   type ServerCertificateArns                      = js.Array[AcmCertificateArn]
-  type ServerCertificateStatus                    = String
   type ServerCertificateStatusDetail              = String
   type ServerCertificates                         = js.Array[ServerCertificateSummary]
   type ServerName                                 = String
   type ServiceName                                = String
-  type ServiceType                                = String
   type SetAsActive                                = Boolean
   type SetAsActiveFlag                            = Boolean
   type SetAsDefault                               = Boolean
@@ -387,7 +345,6 @@ package object iot {
   type StateMachineName                           = String
   type StateReason                                = String
   type StateValue                                 = String
-  type Status                                     = String
   type StdDeviation                               = Double
   type StreamArn                                  = String
   type StreamDescription                          = String
@@ -409,7 +366,6 @@ package object iot {
   type Target                                     = String
   type TargetArn                                  = String
   type TargetAuditCheckNames                      = js.Array[AuditCheckName]
-  type TargetSelection                            = String
   type Targets                                    = js.Array[Target]
   type TaskId                                     = String
   type TaskIdList                                 = js.Array[TaskId]
@@ -420,20 +376,17 @@ package object iot {
   type TemplateVersionId                          = Int
   type ThingArn                                   = String
   type ThingAttributeList                         = js.Array[ThingAttribute]
-  type ThingConnectivityIndexingMode              = String
   type ThingDocumentList                          = js.Array[ThingDocument]
   type ThingGroupArn                              = String
   type ThingGroupDescription                      = String
   type ThingGroupDocumentList                     = js.Array[ThingGroupDocument]
   type ThingGroupId                               = String
-  type ThingGroupIndexingMode                     = String
   type ThingGroupList                             = js.Array[ThingGroupName]
   type ThingGroupName                             = String
   type ThingGroupNameAndArnList                   = js.Array[GroupNameAndArn]
   type ThingGroupNameList                         = js.Array[ThingGroupName]
   type ThingGroupNames                            = js.Array[ThingGroupName]
   type ThingId                                    = String
-  type ThingIndexingMode                          = String
   type ThingName                                  = String
   type ThingNameList                              = js.Array[ThingName]
   type ThingTypeArn                               = String
@@ -449,7 +402,6 @@ package object iot {
   type Topic                                      = String
   type TopicPattern                               = String
   type TopicRuleDestinationMaxResults             = Int
-  type TopicRuleDestinationStatus                 = String
   type TopicRuleDestinationSummaries              = js.Array[TopicRuleDestinationSummary]
   type TopicRuleList                              = js.Array[TopicRuleListItem]
   type TopicRuleMaxResults                        = Int
@@ -466,7 +418,6 @@ package object iot {
   type Variance                                   = Double
   type Version                                    = Double
   type VersionNumber                              = Double
-  type ViolationEventType                         = String
   type ViolationEvents                            = js.Array[ViolationEvent]
   type ViolationId                                = String
   type WaitingForDataCollectionChecksCount        = Int
@@ -1284,9 +1235,10 @@ package iot {
         params: ListPrincipalPoliciesRequest
     ): Request[ListPrincipalPoliciesResponse] = js.native
   }
-
-  object AbortActionEnum {
-    val CANCEL = "CANCEL"
+  @js.native
+  sealed trait AbortAction extends js.Any
+  object AbortAction extends js.Object {
+    val CANCEL = "CANCEL".asInstanceOf[AbortAction]
 
     val values = js.Object.freeze(js.Array(CANCEL))
   }
@@ -1435,12 +1387,13 @@ package iot {
       __obj.asInstanceOf[Action]
     }
   }
-
-  object ActionTypeEnum {
-    val PUBLISH   = "PUBLISH"
-    val SUBSCRIBE = "SUBSCRIBE"
-    val RECEIVE   = "RECEIVE"
-    val CONNECT   = "CONNECT"
+  @js.native
+  sealed trait ActionType extends js.Any
+  object ActionType extends js.Object {
+    val PUBLISH   = "PUBLISH".asInstanceOf[ActionType]
+    val SUBSCRIBE = "SUBSCRIBE".asInstanceOf[ActionType]
+    val RECEIVE   = "RECEIVE".asInstanceOf[ActionType]
+    val CONNECT   = "CONNECT".asInstanceOf[ActionType]
 
     val values = js.Object.freeze(js.Array(PUBLISH, SUBSCRIBE, RECEIVE, CONNECT))
   }
@@ -1612,8 +1565,10 @@ package iot {
   /**
     * The type of alert target: one of "SNS".
     */
-  object AlertTargetTypeEnum {
-    val SNS = "SNS"
+  @js.native
+  sealed trait AlertTargetType extends js.Any
+  object AlertTargetType extends js.Object {
+    val SNS = "SNS".asInstanceOf[AlertTargetType]
 
     val values = js.Object.freeze(js.Array(SNS))
   }
@@ -1957,14 +1912,15 @@ package iot {
       __obj.asInstanceOf[AuditCheckDetails]
     }
   }
-
-  object AuditCheckRunStatusEnum {
-    val IN_PROGRESS                 = "IN_PROGRESS"
-    val WAITING_FOR_DATA_COLLECTION = "WAITING_FOR_DATA_COLLECTION"
-    val CANCELED                    = "CANCELED"
-    val COMPLETED_COMPLIANT         = "COMPLETED_COMPLIANT"
-    val COMPLETED_NON_COMPLIANT     = "COMPLETED_NON_COMPLIANT"
-    val FAILED                      = "FAILED"
+  @js.native
+  sealed trait AuditCheckRunStatus extends js.Any
+  object AuditCheckRunStatus extends js.Object {
+    val IN_PROGRESS                 = "IN_PROGRESS".asInstanceOf[AuditCheckRunStatus]
+    val WAITING_FOR_DATA_COLLECTION = "WAITING_FOR_DATA_COLLECTION".asInstanceOf[AuditCheckRunStatus]
+    val CANCELED                    = "CANCELED".asInstanceOf[AuditCheckRunStatus]
+    val COMPLETED_COMPLIANT         = "COMPLETED_COMPLIANT".asInstanceOf[AuditCheckRunStatus]
+    val COMPLETED_NON_COMPLIANT     = "COMPLETED_NON_COMPLIANT".asInstanceOf[AuditCheckRunStatus]
+    val FAILED                      = "FAILED".asInstanceOf[AuditCheckRunStatus]
 
     val values = js.Object.freeze(
       js.Array(IN_PROGRESS, WAITING_FOR_DATA_COLLECTION, CANCELED, COMPLETED_COMPLIANT, COMPLETED_NON_COMPLIANT, FAILED)
@@ -2018,21 +1974,23 @@ package iot {
       __obj.asInstanceOf[AuditFinding]
     }
   }
-
-  object AuditFindingSeverityEnum {
-    val CRITICAL = "CRITICAL"
-    val HIGH     = "HIGH"
-    val MEDIUM   = "MEDIUM"
-    val LOW      = "LOW"
+  @js.native
+  sealed trait AuditFindingSeverity extends js.Any
+  object AuditFindingSeverity extends js.Object {
+    val CRITICAL = "CRITICAL".asInstanceOf[AuditFindingSeverity]
+    val HIGH     = "HIGH".asInstanceOf[AuditFindingSeverity]
+    val MEDIUM   = "MEDIUM".asInstanceOf[AuditFindingSeverity]
+    val LOW      = "LOW".asInstanceOf[AuditFindingSeverity]
 
     val values = js.Object.freeze(js.Array(CRITICAL, HIGH, MEDIUM, LOW))
   }
-
-  object AuditFrequencyEnum {
-    val DAILY    = "DAILY"
-    val WEEKLY   = "WEEKLY"
-    val BIWEEKLY = "BIWEEKLY"
-    val MONTHLY  = "MONTHLY"
+  @js.native
+  sealed trait AuditFrequency extends js.Any
+  object AuditFrequency extends js.Object {
+    val DAILY    = "DAILY".asInstanceOf[AuditFrequency]
+    val WEEKLY   = "WEEKLY".asInstanceOf[AuditFrequency]
+    val BIWEEKLY = "BIWEEKLY".asInstanceOf[AuditFrequency]
+    val MONTHLY  = "MONTHLY".asInstanceOf[AuditFrequency]
 
     val values = js.Object.freeze(js.Array(DAILY, WEEKLY, BIWEEKLY, MONTHLY))
   }
@@ -2079,14 +2037,15 @@ package iot {
       __obj.asInstanceOf[AuditMitigationActionExecutionMetadata]
     }
   }
-
-  object AuditMitigationActionsExecutionStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
-    val FAILED      = "FAILED"
-    val CANCELED    = "CANCELED"
-    val SKIPPED     = "SKIPPED"
-    val PENDING     = "PENDING"
+  @js.native
+  sealed trait AuditMitigationActionsExecutionStatus extends js.Any
+  object AuditMitigationActionsExecutionStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[AuditMitigationActionsExecutionStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[AuditMitigationActionsExecutionStatus]
+    val FAILED      = "FAILED".asInstanceOf[AuditMitigationActionsExecutionStatus]
+    val CANCELED    = "CANCELED".asInstanceOf[AuditMitigationActionsExecutionStatus]
+    val SKIPPED     = "SKIPPED".asInstanceOf[AuditMitigationActionsExecutionStatus]
+    val PENDING     = "PENDING".asInstanceOf[AuditMitigationActionsExecutionStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETED, FAILED, CANCELED, SKIPPED, PENDING))
   }
@@ -2115,12 +2074,13 @@ package iot {
       __obj.asInstanceOf[AuditMitigationActionsTaskMetadata]
     }
   }
-
-  object AuditMitigationActionsTaskStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
-    val FAILED      = "FAILED"
-    val CANCELED    = "CANCELED"
+  @js.native
+  sealed trait AuditMitigationActionsTaskStatus extends js.Any
+  object AuditMitigationActionsTaskStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[AuditMitigationActionsTaskStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[AuditMitigationActionsTaskStatus]
+    val FAILED      = "FAILED".asInstanceOf[AuditMitigationActionsTaskStatus]
+    val CANCELED    = "CANCELED".asInstanceOf[AuditMitigationActionsTaskStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETED, FAILED, CANCELED))
   }
@@ -2176,9 +2136,10 @@ package iot {
       __obj.asInstanceOf[AuditNotificationTarget]
     }
   }
-
-  object AuditNotificationTypeEnum {
-    val SNS = "SNS"
+  @js.native
+  sealed trait AuditNotificationType extends js.Any
+  object AuditNotificationType extends js.Object {
+    val SNS = "SNS".asInstanceOf[AuditNotificationType]
 
     val values = js.Object.freeze(js.Array(SNS))
   }
@@ -2207,27 +2168,30 @@ package iot {
       __obj.asInstanceOf[AuditTaskMetadata]
     }
   }
-
-  object AuditTaskStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
-    val FAILED      = "FAILED"
-    val CANCELED    = "CANCELED"
+  @js.native
+  sealed trait AuditTaskStatus extends js.Any
+  object AuditTaskStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[AuditTaskStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[AuditTaskStatus]
+    val FAILED      = "FAILED".asInstanceOf[AuditTaskStatus]
+    val CANCELED    = "CANCELED".asInstanceOf[AuditTaskStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETED, FAILED, CANCELED))
   }
-
-  object AuditTaskTypeEnum {
-    val ON_DEMAND_AUDIT_TASK = "ON_DEMAND_AUDIT_TASK"
-    val SCHEDULED_AUDIT_TASK = "SCHEDULED_AUDIT_TASK"
+  @js.native
+  sealed trait AuditTaskType extends js.Any
+  object AuditTaskType extends js.Object {
+    val ON_DEMAND_AUDIT_TASK = "ON_DEMAND_AUDIT_TASK".asInstanceOf[AuditTaskType]
+    val SCHEDULED_AUDIT_TASK = "SCHEDULED_AUDIT_TASK".asInstanceOf[AuditTaskType]
 
     val values = js.Object.freeze(js.Array(ON_DEMAND_AUDIT_TASK, SCHEDULED_AUDIT_TASK))
   }
-
-  object AuthDecisionEnum {
-    val ALLOWED       = "ALLOWED"
-    val EXPLICIT_DENY = "EXPLICIT_DENY"
-    val IMPLICIT_DENY = "IMPLICIT_DENY"
+  @js.native
+  sealed trait AuthDecision extends js.Any
+  object AuthDecision extends js.Object {
+    val ALLOWED       = "ALLOWED".asInstanceOf[AuthDecision]
+    val EXPLICIT_DENY = "EXPLICIT_DENY".asInstanceOf[AuthDecision]
+    val IMPLICIT_DENY = "IMPLICIT_DENY".asInstanceOf[AuthDecision]
 
     val values = js.Object.freeze(js.Array(ALLOWED, EXPLICIT_DENY, IMPLICIT_DENY))
   }
@@ -2349,10 +2313,11 @@ package iot {
       __obj.asInstanceOf[AuthorizerDescription]
     }
   }
-
-  object AuthorizerStatusEnum {
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait AuthorizerStatus extends js.Any
+  object AuthorizerStatus extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[AuthorizerStatus]
+    val INACTIVE = "INACTIVE".asInstanceOf[AuthorizerStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, INACTIVE))
   }
@@ -2378,10 +2343,11 @@ package iot {
       __obj.asInstanceOf[AuthorizerSummary]
     }
   }
-
-  object AutoRegistrationStatusEnum {
-    val ENABLE  = "ENABLE"
-    val DISABLE = "DISABLE"
+  @js.native
+  sealed trait AutoRegistrationStatus extends js.Any
+  object AutoRegistrationStatus extends js.Object {
+    val ENABLE  = "ENABLE".asInstanceOf[AutoRegistrationStatus]
+    val DISABLE = "DISABLE".asInstanceOf[AutoRegistrationStatus]
 
     val values = js.Object.freeze(js.Array(ENABLE, DISABLE))
   }
@@ -2603,16 +2569,18 @@ package iot {
       __obj.asInstanceOf[CACertificateDescription]
     }
   }
-
-  object CACertificateStatusEnum {
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait CACertificateStatus extends js.Any
+  object CACertificateStatus extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[CACertificateStatus]
+    val INACTIVE = "INACTIVE".asInstanceOf[CACertificateStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, INACTIVE))
   }
-
-  object CACertificateUpdateActionEnum {
-    val DEACTIVATE = "DEACTIVATE"
+  @js.native
+  sealed trait CACertificateUpdateAction extends js.Any
+  object CACertificateUpdateAction extends js.Object {
+    val DEACTIVATE = "DEACTIVATE".asInstanceOf[CACertificateUpdateAction]
 
     val values = js.Object.freeze(js.Array(DEACTIVATE))
   }
@@ -2778,16 +2746,17 @@ package iot {
       __obj.asInstanceOf[CancelJobResponse]
     }
   }
-
-  object CannedAccessControlListEnum {
-    val `private`                   = "private"
-    val `public-read`               = "public-read"
-    val `public-read-write`         = "public-read-write"
-    val `aws-exec-read`             = "aws-exec-read"
-    val `authenticated-read`        = "authenticated-read"
-    val `bucket-owner-read`         = "bucket-owner-read"
-    val `bucket-owner-full-control` = "bucket-owner-full-control"
-    val `log-delivery-write`        = "log-delivery-write"
+  @js.native
+  sealed trait CannedAccessControlList extends js.Any
+  object CannedAccessControlList extends js.Object {
+    val `private`                   = "private".asInstanceOf[CannedAccessControlList]
+    val `public-read`               = "public-read".asInstanceOf[CannedAccessControlList]
+    val `public-read-write`         = "public-read-write".asInstanceOf[CannedAccessControlList]
+    val `aws-exec-read`             = "aws-exec-read".asInstanceOf[CannedAccessControlList]
+    val `authenticated-read`        = "authenticated-read".asInstanceOf[CannedAccessControlList]
+    val `bucket-owner-read`         = "bucket-owner-read".asInstanceOf[CannedAccessControlList]
+    val `bucket-owner-full-control` = "bucket-owner-full-control".asInstanceOf[CannedAccessControlList]
+    val `log-delivery-write`        = "log-delivery-write".asInstanceOf[CannedAccessControlList]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2885,14 +2854,15 @@ package iot {
       __obj.asInstanceOf[CertificateDescription]
     }
   }
-
-  object CertificateStatusEnum {
-    val ACTIVE             = "ACTIVE"
-    val INACTIVE           = "INACTIVE"
-    val REVOKED            = "REVOKED"
-    val PENDING_TRANSFER   = "PENDING_TRANSFER"
-    val REGISTER_INACTIVE  = "REGISTER_INACTIVE"
-    val PENDING_ACTIVATION = "PENDING_ACTIVATION"
+  @js.native
+  sealed trait CertificateStatus extends js.Any
+  object CertificateStatus extends js.Object {
+    val ACTIVE             = "ACTIVE".asInstanceOf[CertificateStatus]
+    val INACTIVE           = "INACTIVE".asInstanceOf[CertificateStatus]
+    val REVOKED            = "REVOKED".asInstanceOf[CertificateStatus]
+    val PENDING_TRANSFER   = "PENDING_TRANSFER".asInstanceOf[CertificateStatus]
+    val REGISTER_INACTIVE  = "REGISTER_INACTIVE".asInstanceOf[CertificateStatus]
+    val PENDING_ACTIVATION = "PENDING_ACTIVATION".asInstanceOf[CertificateStatus]
 
     val values =
       js.Object.freeze(js.Array(ACTIVE, INACTIVE, REVOKED, PENDING_TRANSFER, REGISTER_INACTIVE, PENDING_ACTIVATION))
@@ -3077,16 +3047,17 @@ package iot {
       __obj.asInstanceOf[CodeSigningSignature]
     }
   }
-
-  object ComparisonOperatorEnum {
-    val `less-than`           = "less-than"
-    val `less-than-equals`    = "less-than-equals"
-    val `greater-than`        = "greater-than"
-    val `greater-than-equals` = "greater-than-equals"
-    val `in-cidr-set`         = "in-cidr-set"
-    val `not-in-cidr-set`     = "not-in-cidr-set"
-    val `in-port-set`         = "in-port-set"
-    val `not-in-port-set`     = "not-in-port-set"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val `less-than`           = "less-than".asInstanceOf[ComparisonOperator]
+    val `less-than-equals`    = "less-than-equals".asInstanceOf[ComparisonOperator]
+    val `greater-than`        = "greater-than".asInstanceOf[ComparisonOperator]
+    val `greater-than-equals` = "greater-than-equals".asInstanceOf[ComparisonOperator]
+    val `in-cidr-set`         = "in-cidr-set".asInstanceOf[ComparisonOperator]
+    val `not-in-cidr-set`     = "not-in-cidr-set".asInstanceOf[ComparisonOperator]
+    val `in-port-set`         = "in-port-set".asInstanceOf[ComparisonOperator]
+    val `not-in-port-set`     = "not-in-port-set".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4361,15 +4332,16 @@ package iot {
       __obj.asInstanceOf[CustomCodeSigning]
     }
   }
-
-  object DayOfWeekEnum {
-    val SUN = "SUN"
-    val MON = "MON"
-    val TUE = "TUE"
-    val WED = "WED"
-    val THU = "THU"
-    val FRI = "FRI"
-    val SAT = "SAT"
+  @js.native
+  sealed trait DayOfWeek extends js.Any
+  object DayOfWeek extends js.Object {
+    val SUN = "SUN".asInstanceOf[DayOfWeek]
+    val MON = "MON".asInstanceOf[DayOfWeek]
+    val TUE = "TUE".asInstanceOf[DayOfWeek]
+    val WED = "WED".asInstanceOf[DayOfWeek]
+    val THU = "THU".asInstanceOf[DayOfWeek]
+    val FRI = "FRI".asInstanceOf[DayOfWeek]
+    val SAT = "SAT".asInstanceOf[DayOfWeek]
 
     val values = js.Object.freeze(js.Array(SUN, MON, TUE, WED, THU, FRI, SAT))
   }
@@ -6557,9 +6529,10 @@ package iot {
       __obj.asInstanceOf[DetachThingPrincipalResponse]
     }
   }
-
-  object DeviceCertificateUpdateActionEnum {
-    val DEACTIVATE = "DEACTIVATE"
+  @js.native
+  sealed trait DeviceCertificateUpdateAction extends js.Any
+  object DeviceCertificateUpdateAction extends js.Object {
+    val DEACTIVATE = "DEACTIVATE".asInstanceOf[DeviceCertificateUpdateAction]
 
     val values = js.Object.freeze(js.Array(DEACTIVATE))
   }
@@ -6584,10 +6557,11 @@ package iot {
       __obj.asInstanceOf[DisableTopicRuleRequest]
     }
   }
-
-  object DomainConfigurationStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait DomainConfigurationStatus extends js.Any
+  object DomainConfigurationStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[DomainConfigurationStatus]
+    val DISABLED = "DISABLED".asInstanceOf[DomainConfigurationStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -6620,19 +6594,21 @@ package iot {
       __obj.asInstanceOf[DomainConfigurationSummary]
     }
   }
-
-  object DomainTypeEnum {
-    val ENDPOINT         = "ENDPOINT"
-    val AWS_MANAGED      = "AWS_MANAGED"
-    val CUSTOMER_MANAGED = "CUSTOMER_MANAGED"
+  @js.native
+  sealed trait DomainType extends js.Any
+  object DomainType extends js.Object {
+    val ENDPOINT         = "ENDPOINT".asInstanceOf[DomainType]
+    val AWS_MANAGED      = "AWS_MANAGED".asInstanceOf[DomainType]
+    val CUSTOMER_MANAGED = "CUSTOMER_MANAGED".asInstanceOf[DomainType]
 
     val values = js.Object.freeze(js.Array(ENDPOINT, AWS_MANAGED, CUSTOMER_MANAGED))
   }
-
-  object DynamicGroupStatusEnum {
-    val ACTIVE     = "ACTIVE"
-    val BUILDING   = "BUILDING"
-    val REBUILDING = "REBUILDING"
+  @js.native
+  sealed trait DynamicGroupStatus extends js.Any
+  object DynamicGroupStatus extends js.Object {
+    val ACTIVE     = "ACTIVE".asInstanceOf[DynamicGroupStatus]
+    val BUILDING   = "BUILDING".asInstanceOf[DynamicGroupStatus]
+    val REBUILDING = "REBUILDING".asInstanceOf[DynamicGroupStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, BUILDING, REBUILDING))
   }
@@ -6715,10 +6691,11 @@ package iot {
       __obj.asInstanceOf[DynamoDBv2Action]
     }
   }
-
-  object DynamoKeyTypeEnum {
-    val STRING = "STRING"
-    val NUMBER = "NUMBER"
+  @js.native
+  sealed trait DynamoKeyType extends js.Any
+  object DynamoKeyType extends js.Object {
+    val STRING = "STRING".asInstanceOf[DynamoKeyType]
+    val NUMBER = "NUMBER".asInstanceOf[DynamoKeyType]
 
     val values = js.Object.freeze(js.Array(STRING, NUMBER))
   }
@@ -6847,19 +6824,20 @@ package iot {
       __obj.asInstanceOf[ErrorInfo]
     }
   }
-
-  object EventTypeEnum {
-    val THING                  = "THING"
-    val THING_GROUP            = "THING_GROUP"
-    val THING_TYPE             = "THING_TYPE"
-    val THING_GROUP_MEMBERSHIP = "THING_GROUP_MEMBERSHIP"
-    val THING_GROUP_HIERARCHY  = "THING_GROUP_HIERARCHY"
-    val THING_TYPE_ASSOCIATION = "THING_TYPE_ASSOCIATION"
-    val JOB                    = "JOB"
-    val JOB_EXECUTION          = "JOB_EXECUTION"
-    val POLICY                 = "POLICY"
-    val CERTIFICATE            = "CERTIFICATE"
-    val CA_CERTIFICATE         = "CA_CERTIFICATE"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val THING                  = "THING".asInstanceOf[EventType]
+    val THING_GROUP            = "THING_GROUP".asInstanceOf[EventType]
+    val THING_TYPE             = "THING_TYPE".asInstanceOf[EventType]
+    val THING_GROUP_MEMBERSHIP = "THING_GROUP_MEMBERSHIP".asInstanceOf[EventType]
+    val THING_GROUP_HIERARCHY  = "THING_GROUP_HIERARCHY".asInstanceOf[EventType]
+    val THING_TYPE_ASSOCIATION = "THING_TYPE_ASSOCIATION".asInstanceOf[EventType]
+    val JOB                    = "JOB".asInstanceOf[EventType]
+    val JOB_EXECUTION          = "JOB_EXECUTION".asInstanceOf[EventType]
+    val POLICY                 = "POLICY".asInstanceOf[EventType]
+    val CERTIFICATE            = "CERTIFICATE".asInstanceOf[EventType]
+    val CA_CERTIFICATE         = "CA_CERTIFICATE".asInstanceOf[EventType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -6945,11 +6923,12 @@ package iot {
       __obj.asInstanceOf[Field]
     }
   }
-
-  object FieldTypeEnum {
-    val Number  = "Number"
-    val String  = "String"
-    val Boolean = "Boolean"
+  @js.native
+  sealed trait FieldType extends js.Any
+  object FieldType extends js.Object {
+    val Number  = "Number".asInstanceOf[FieldType]
+    val String  = "String".asInstanceOf[FieldType]
+    val Boolean = "Boolean".asInstanceOf[FieldType]
 
     val values = js.Object.freeze(js.Array(Number, String, Boolean))
   }
@@ -7778,11 +7757,12 @@ package iot {
       __obj.asInstanceOf[ImplicitDeny]
     }
   }
-
-  object IndexStatusEnum {
-    val ACTIVE     = "ACTIVE"
-    val BUILDING   = "BUILDING"
-    val REBUILDING = "REBUILDING"
+  @js.native
+  sealed trait IndexStatus extends js.Any
+  object IndexStatus extends js.Object {
+    val ACTIVE     = "ACTIVE".asInstanceOf[IndexStatus]
+    val BUILDING   = "BUILDING".asInstanceOf[IndexStatus]
+    val REBUILDING = "REBUILDING".asInstanceOf[IndexStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, BUILDING, REBUILDING))
   }
@@ -7982,25 +7962,27 @@ package iot {
       __obj.asInstanceOf[JobExecution]
     }
   }
-
-  object JobExecutionFailureTypeEnum {
-    val FAILED    = "FAILED"
-    val REJECTED  = "REJECTED"
-    val TIMED_OUT = "TIMED_OUT"
-    val ALL       = "ALL"
+  @js.native
+  sealed trait JobExecutionFailureType extends js.Any
+  object JobExecutionFailureType extends js.Object {
+    val FAILED    = "FAILED".asInstanceOf[JobExecutionFailureType]
+    val REJECTED  = "REJECTED".asInstanceOf[JobExecutionFailureType]
+    val TIMED_OUT = "TIMED_OUT".asInstanceOf[JobExecutionFailureType]
+    val ALL       = "ALL".asInstanceOf[JobExecutionFailureType]
 
     val values = js.Object.freeze(js.Array(FAILED, REJECTED, TIMED_OUT, ALL))
   }
-
-  object JobExecutionStatusEnum {
-    val QUEUED      = "QUEUED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
-    val TIMED_OUT   = "TIMED_OUT"
-    val REJECTED    = "REJECTED"
-    val REMOVED     = "REMOVED"
-    val CANCELED    = "CANCELED"
+  @js.native
+  sealed trait JobExecutionStatus extends js.Any
+  object JobExecutionStatus extends js.Object {
+    val QUEUED      = "QUEUED".asInstanceOf[JobExecutionStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[JobExecutionStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[JobExecutionStatus]
+    val FAILED      = "FAILED".asInstanceOf[JobExecutionStatus]
+    val TIMED_OUT   = "TIMED_OUT".asInstanceOf[JobExecutionStatus]
+    val REJECTED    = "REJECTED".asInstanceOf[JobExecutionStatus]
+    val REMOVED     = "REMOVED".asInstanceOf[JobExecutionStatus]
+    val CANCELED    = "CANCELED".asInstanceOf[JobExecutionStatus]
 
     val values =
       js.Object.freeze(js.Array(QUEUED, IN_PROGRESS, SUCCEEDED, FAILED, TIMED_OUT, REJECTED, REMOVED, CANCELED))
@@ -8164,12 +8146,13 @@ package iot {
       __obj.asInstanceOf[JobProcessDetails]
     }
   }
-
-  object JobStatusEnum {
-    val IN_PROGRESS          = "IN_PROGRESS"
-    val CANCELED             = "CANCELED"
-    val COMPLETED            = "COMPLETED"
-    val DELETION_IN_PROGRESS = "DELETION_IN_PROGRESS"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val IN_PROGRESS          = "IN_PROGRESS".asInstanceOf[JobStatus]
+    val CANCELED             = "CANCELED".asInstanceOf[JobStatus]
+    val COMPLETED            = "COMPLETED".asInstanceOf[JobStatus]
+    val DELETION_IN_PROGRESS = "DELETION_IN_PROGRESS".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, CANCELED, COMPLETED, DELETION_IN_PROGRESS))
   }
@@ -10408,13 +10391,14 @@ package iot {
       __obj.asInstanceOf[ListViolationEventsResponse]
     }
   }
-
-  object LogLevelEnum {
-    val DEBUG    = "DEBUG"
-    val INFO     = "INFO"
-    val ERROR    = "ERROR"
-    val WARN     = "WARN"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait LogLevel extends js.Any
+  object LogLevel extends js.Object {
+    val DEBUG    = "DEBUG".asInstanceOf[LogLevel]
+    val INFO     = "INFO".asInstanceOf[LogLevel]
+    val ERROR    = "ERROR".asInstanceOf[LogLevel]
+    val WARN     = "WARN".asInstanceOf[LogLevel]
+    val DISABLED = "DISABLED".asInstanceOf[LogLevel]
 
     val values = js.Object.freeze(js.Array(DEBUG, INFO, ERROR, WARN, DISABLED))
   }
@@ -10464,10 +10448,11 @@ package iot {
       __obj.asInstanceOf[LogTargetConfiguration]
     }
   }
-
-  object LogTargetTypeEnum {
-    val DEFAULT     = "DEFAULT"
-    val THING_GROUP = "THING_GROUP"
+  @js.native
+  sealed trait LogTargetType extends js.Any
+  object LogTargetType extends js.Object {
+    val DEFAULT     = "DEFAULT".asInstanceOf[LogTargetType]
+    val THING_GROUP = "THING_GROUP".asInstanceOf[LogTargetType]
 
     val values = js.Object.freeze(js.Array(DEFAULT, THING_GROUP))
   }
@@ -10495,10 +10480,11 @@ package iot {
       __obj.asInstanceOf[LoggingOptionsPayload]
     }
   }
-
-  object MessageFormatEnum {
-    val RAW  = "RAW"
-    val JSON = "JSON"
+  @js.native
+  sealed trait MessageFormat extends js.Any
+  object MessageFormat extends js.Object {
+    val RAW  = "RAW".asInstanceOf[MessageFormat]
+    val JSON = "JSON".asInstanceOf[MessageFormat]
 
     val values = js.Object.freeze(js.Array(RAW, JSON))
   }
@@ -10624,14 +10610,15 @@ package iot {
       __obj.asInstanceOf[MitigationActionParams]
     }
   }
-
-  object MitigationActionTypeEnum {
-    val UPDATE_DEVICE_CERTIFICATE      = "UPDATE_DEVICE_CERTIFICATE"
-    val UPDATE_CA_CERTIFICATE          = "UPDATE_CA_CERTIFICATE"
-    val ADD_THINGS_TO_THING_GROUP      = "ADD_THINGS_TO_THING_GROUP"
-    val REPLACE_DEFAULT_POLICY_VERSION = "REPLACE_DEFAULT_POLICY_VERSION"
-    val ENABLE_IOT_LOGGING             = "ENABLE_IOT_LOGGING"
-    val PUBLISH_FINDING_TO_SNS         = "PUBLISH_FINDING_TO_SNS"
+  @js.native
+  sealed trait MitigationActionType extends js.Any
+  object MitigationActionType extends js.Object {
+    val UPDATE_DEVICE_CERTIFICATE      = "UPDATE_DEVICE_CERTIFICATE".asInstanceOf[MitigationActionType]
+    val UPDATE_CA_CERTIFICATE          = "UPDATE_CA_CERTIFICATE".asInstanceOf[MitigationActionType]
+    val ADD_THINGS_TO_THING_GROUP      = "ADD_THINGS_TO_THING_GROUP".asInstanceOf[MitigationActionType]
+    val REPLACE_DEFAULT_POLICY_VERSION = "REPLACE_DEFAULT_POLICY_VERSION".asInstanceOf[MitigationActionType]
+    val ENABLE_IOT_LOGGING             = "ENABLE_IOT_LOGGING".asInstanceOf[MitigationActionType]
+    val PUBLISH_FINDING_TO_SNS         = "PUBLISH_FINDING_TO_SNS".asInstanceOf[MitigationActionType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -10791,12 +10778,13 @@ package iot {
       __obj.asInstanceOf[OTAUpdateInfo]
     }
   }
-
-  object OTAUpdateStatusEnum {
-    val CREATE_PENDING     = "CREATE_PENDING"
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_COMPLETE    = "CREATE_COMPLETE"
-    val CREATE_FAILED      = "CREATE_FAILED"
+  @js.native
+  sealed trait OTAUpdateStatus extends js.Any
+  object OTAUpdateStatus extends js.Object {
+    val CREATE_PENDING     = "CREATE_PENDING".asInstanceOf[OTAUpdateStatus]
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[OTAUpdateStatus]
+    val CREATE_COMPLETE    = "CREATE_COMPLETE".asInstanceOf[OTAUpdateStatus]
+    val CREATE_FAILED      = "CREATE_FAILED".asInstanceOf[OTAUpdateStatus]
 
     val values = js.Object.freeze(js.Array(CREATE_PENDING, CREATE_IN_PROGRESS, CREATE_COMPLETE, CREATE_FAILED))
   }
@@ -10903,9 +10891,10 @@ package iot {
       __obj.asInstanceOf[Policy]
     }
   }
-
-  object PolicyTemplateNameEnum {
-    val BLANK_POLICY = "BLANK_POLICY"
+  @js.native
+  sealed trait PolicyTemplateName extends js.Any
+  object PolicyTemplateName extends js.Object {
+    val BLANK_POLICY = "BLANK_POLICY".asInstanceOf[PolicyTemplateName]
 
     val values = js.Object.freeze(js.Array(BLANK_POLICY))
   }
@@ -10978,10 +10967,11 @@ package iot {
       __obj.asInstanceOf[PresignedUrlConfig]
     }
   }
-
-  object ProtocolEnum {
-    val MQTT = "MQTT"
-    val HTTP = "HTTP"
+  @js.native
+  sealed trait Protocol extends js.Any
+  object Protocol extends js.Object {
+    val MQTT = "MQTT".asInstanceOf[Protocol]
+    val HTTP = "HTTP".asInstanceOf[Protocol]
 
     val values = js.Object.freeze(js.Array(MQTT, HTTP))
   }
@@ -11480,10 +11470,11 @@ package iot {
       __obj.asInstanceOf[ReplaceTopicRuleRequest]
     }
   }
-
-  object ReportTypeEnum {
-    val ERRORS  = "ERRORS"
-    val RESULTS = "RESULTS"
+  @js.native
+  sealed trait ReportType extends js.Any
+  object ReportType extends js.Object {
+    val ERRORS  = "ERRORS".asInstanceOf[ReportType]
+    val RESULTS = "RESULTS".asInstanceOf[ReportType]
 
     val values = js.Object.freeze(js.Array(ERRORS, RESULTS))
   }
@@ -11554,16 +11545,17 @@ package iot {
       __obj.asInstanceOf[ResourceIdentifier]
     }
   }
-
-  object ResourceTypeEnum {
-    val DEVICE_CERTIFICATE    = "DEVICE_CERTIFICATE"
-    val CA_CERTIFICATE        = "CA_CERTIFICATE"
-    val IOT_POLICY            = "IOT_POLICY"
-    val COGNITO_IDENTITY_POOL = "COGNITO_IDENTITY_POOL"
-    val CLIENT_ID             = "CLIENT_ID"
-    val ACCOUNT_SETTINGS      = "ACCOUNT_SETTINGS"
-    val ROLE_ALIAS            = "ROLE_ALIAS"
-    val IAM_ROLE              = "IAM_ROLE"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val DEVICE_CERTIFICATE    = "DEVICE_CERTIFICATE".asInstanceOf[ResourceType]
+    val CA_CERTIFICATE        = "CA_CERTIFICATE".asInstanceOf[ResourceType]
+    val IOT_POLICY            = "IOT_POLICY".asInstanceOf[ResourceType]
+    val COGNITO_IDENTITY_POOL = "COGNITO_IDENTITY_POOL".asInstanceOf[ResourceType]
+    val CLIENT_ID             = "CLIENT_ID".asInstanceOf[ResourceType]
+    val ACCOUNT_SETTINGS      = "ACCOUNT_SETTINGS".asInstanceOf[ResourceType]
+    val ROLE_ALIAS            = "ROLE_ALIAS".asInstanceOf[ResourceType]
+    val IAM_ROLE              = "IAM_ROLE".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -11870,10 +11862,11 @@ package iot {
       __obj.asInstanceOf[SecurityProfileTargetMapping]
     }
   }
-
-  object ServerCertificateStatusEnum {
-    val INVALID = "INVALID"
-    val VALID   = "VALID"
+  @js.native
+  sealed trait ServerCertificateStatus extends js.Any
+  object ServerCertificateStatus extends js.Object {
+    val INVALID = "INVALID".asInstanceOf[ServerCertificateStatus]
+    val VALID   = "VALID".asInstanceOf[ServerCertificateStatus]
 
     val values = js.Object.freeze(js.Array(INVALID, VALID))
   }
@@ -11904,11 +11897,12 @@ package iot {
       __obj.asInstanceOf[ServerCertificateSummary]
     }
   }
-
-  object ServiceTypeEnum {
-    val DATA                = "DATA"
-    val CREDENTIAL_PROVIDER = "CREDENTIAL_PROVIDER"
-    val JOBS                = "JOBS"
+  @js.native
+  sealed trait ServiceType extends js.Any
+  object ServiceType extends js.Object {
+    val DATA                = "DATA".asInstanceOf[ServiceType]
+    val CREDENTIAL_PROVIDER = "CREDENTIAL_PROVIDER".asInstanceOf[ServiceType]
+    val JOBS                = "JOBS".asInstanceOf[ServiceType]
 
     val values = js.Object.freeze(js.Array(DATA, CREDENTIAL_PROVIDER, JOBS))
   }
@@ -12347,13 +12341,14 @@ package iot {
       __obj.asInstanceOf[Statistics]
     }
   }
-
-  object StatusEnum {
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-    val Cancelled  = "Cancelled"
-    val Cancelling = "Cancelling"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[Status]
+    val Completed  = "Completed".asInstanceOf[Status]
+    val Failed     = "Failed".asInstanceOf[Status]
+    val Cancelled  = "Cancelled".asInstanceOf[Status]
+    val Cancelling = "Cancelling".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(InProgress, Completed, Failed, Cancelled, Cancelling))
   }
@@ -12583,10 +12578,11 @@ package iot {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TargetSelectionEnum {
-    val CONTINUOUS = "CONTINUOUS"
-    val SNAPSHOT   = "SNAPSHOT"
+  @js.native
+  sealed trait TargetSelection extends js.Any
+  object TargetSelection extends js.Object {
+    val CONTINUOUS = "CONTINUOUS".asInstanceOf[TargetSelection]
+    val SNAPSHOT   = "SNAPSHOT".asInstanceOf[TargetSelection]
 
     val values = js.Object.freeze(js.Array(CONTINUOUS, SNAPSHOT))
   }
@@ -12823,10 +12819,11 @@ package iot {
       __obj.asInstanceOf[ThingConnectivity]
     }
   }
-
-  object ThingConnectivityIndexingModeEnum {
-    val OFF    = "OFF"
-    val STATUS = "STATUS"
+  @js.native
+  sealed trait ThingConnectivityIndexingMode extends js.Any
+  object ThingConnectivityIndexingMode extends js.Object {
+    val OFF    = "OFF".asInstanceOf[ThingConnectivityIndexingMode]
+    val STATUS = "STATUS".asInstanceOf[ThingConnectivityIndexingMode]
 
     val values = js.Object.freeze(js.Array(OFF, STATUS))
   }
@@ -12925,10 +12922,11 @@ package iot {
       __obj.asInstanceOf[ThingGroupIndexingConfiguration]
     }
   }
-
-  object ThingGroupIndexingModeEnum {
-    val OFF = "OFF"
-    val ON  = "ON"
+  @js.native
+  sealed trait ThingGroupIndexingMode extends js.Any
+  object ThingGroupIndexingMode extends js.Object {
+    val OFF = "OFF".asInstanceOf[ThingGroupIndexingMode]
+    val ON  = "ON".asInstanceOf[ThingGroupIndexingMode]
 
     val values = js.Object.freeze(js.Array(OFF, ON))
   }
@@ -13011,11 +13009,12 @@ package iot {
       __obj.asInstanceOf[ThingIndexingConfiguration]
     }
   }
-
-  object ThingIndexingModeEnum {
-    val OFF                 = "OFF"
-    val REGISTRY            = "REGISTRY"
-    val REGISTRY_AND_SHADOW = "REGISTRY_AND_SHADOW"
+  @js.native
+  sealed trait ThingIndexingMode extends js.Any
+  object ThingIndexingMode extends js.Object {
+    val OFF                 = "OFF".asInstanceOf[ThingIndexingMode]
+    val REGISTRY            = "REGISTRY".asInstanceOf[ThingIndexingMode]
+    val REGISTRY_AND_SHADOW = "REGISTRY_AND_SHADOW".asInstanceOf[ThingIndexingMode]
 
     val values = js.Object.freeze(js.Array(OFF, REGISTRY, REGISTRY_AND_SHADOW))
   }
@@ -13221,12 +13220,13 @@ package iot {
       __obj.asInstanceOf[TopicRuleDestinationConfiguration]
     }
   }
-
-  object TopicRuleDestinationStatusEnum {
-    val ENABLED     = "ENABLED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val DISABLED    = "DISABLED"
-    val ERROR       = "ERROR"
+  @js.native
+  sealed trait TopicRuleDestinationStatus extends js.Any
+  object TopicRuleDestinationStatus extends js.Object {
+    val ENABLED     = "ENABLED".asInstanceOf[TopicRuleDestinationStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[TopicRuleDestinationStatus]
+    val DISABLED    = "DISABLED".asInstanceOf[TopicRuleDestinationStatus]
+    val ERROR       = "ERROR".asInstanceOf[TopicRuleDestinationStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, IN_PROGRESS, DISABLED, ERROR))
   }
@@ -14437,11 +14437,12 @@ package iot {
       __obj.asInstanceOf[ViolationEvent]
     }
   }
-
-  object ViolationEventTypeEnum {
-    val `in-alarm`          = "in-alarm"
-    val `alarm-cleared`     = "alarm-cleared"
-    val `alarm-invalidated` = "alarm-invalidated"
+  @js.native
+  sealed trait ViolationEventType extends js.Any
+  object ViolationEventType extends js.Object {
+    val `in-alarm`          = "in-alarm".asInstanceOf[ViolationEventType]
+    val `alarm-cleared`     = "alarm-cleared".asInstanceOf[ViolationEventType]
+    val `alarm-invalidated` = "alarm-invalidated".asInstanceOf[ViolationEventType]
 
     val values = js.Object.freeze(js.Array(`in-alarm`, `alarm-cleared`, `alarm-invalidated`))
   }

--- a/services/iotanalytics/src/main/scala/facade/amazonaws/services/IoTAnalytics.scala
+++ b/services/iotanalytics/src/main/scala/facade/amazonaws/services/IoTAnalytics.scala
@@ -17,26 +17,20 @@ package object iotanalytics {
   type BucketName                  = String
   type ChannelArn                  = String
   type ChannelName                 = String
-  type ChannelStatus               = String
   type ChannelSummaries            = js.Array[ChannelSummary]
-  type ComputeType                 = String
   type DatasetActionName           = String
   type DatasetActionSummaries      = js.Array[DatasetActionSummary]
-  type DatasetActionType           = String
   type DatasetActions              = js.Array[DatasetAction]
   type DatasetArn                  = String
   type DatasetContentDeliveryRules = js.Array[DatasetContentDeliveryRule]
-  type DatasetContentState         = String
   type DatasetContentSummaries     = js.Array[DatasetContentSummary]
   type DatasetContentVersion       = String
   type DatasetEntries              = js.Array[DatasetEntry]
   type DatasetName                 = String
-  type DatasetStatus               = String
   type DatasetSummaries            = js.Array[DatasetSummary]
   type DatasetTriggers             = js.Array[DatasetTrigger]
   type DatastoreArn                = String
   type DatastoreName               = String
-  type DatastoreStatus             = String
   type DatastoreSummaries          = js.Array[DatastoreSummary]
   type DoubleValue                 = Double
   type EndTime                     = js.Date
@@ -52,7 +46,6 @@ package object iotanalytics {
   type LambdaName                  = String
   type LogResult                   = String
   type LoggingEnabled              = Boolean
-  type LoggingLevel                = String
   type MathExpression              = String
   type MaxMessages                 = Int
   type MaxResults                  = Int
@@ -72,7 +65,6 @@ package object iotanalytics {
   type QueryFilters                = js.Array[QueryFilter]
   type Reason                      = String
   type ReprocessingId              = String
-  type ReprocessingStatus          = String
   type ReprocessingSummaries       = js.Array[ReprocessingSummary]
   type ResourceArn                 = String
   type RetentionPeriodInDays       = Int
@@ -425,11 +417,12 @@ package iotanalytics {
       __obj.asInstanceOf[ChannelStatistics]
     }
   }
-
-  object ChannelStatusEnum {
-    val CREATING = "CREATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait ChannelStatus extends js.Any
+  object ChannelStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[ChannelStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[ChannelStatus]
+    val DELETING = "DELETING".asInstanceOf[ChannelStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING))
   }
@@ -508,10 +501,11 @@ package iotanalytics {
       __obj.asInstanceOf[ChannelSummary]
     }
   }
-
-  object ComputeTypeEnum {
-    val ACU_1 = "ACU_1"
-    val ACU_2 = "ACU_2"
+  @js.native
+  sealed trait ComputeType extends js.Any
+  object ComputeType extends js.Object {
+    val ACU_1 = "ACU_1".asInstanceOf[ComputeType]
+    val ACU_2 = "ACU_2".asInstanceOf[ComputeType]
 
     val values = js.Object.freeze(js.Array(ACU_1, ACU_2))
   }
@@ -975,10 +969,11 @@ package iotanalytics {
       __obj.asInstanceOf[DatasetActionSummary]
     }
   }
-
-  object DatasetActionTypeEnum {
-    val QUERY     = "QUERY"
-    val CONTAINER = "CONTAINER"
+  @js.native
+  sealed trait DatasetActionType extends js.Any
+  object DatasetActionType extends js.Object {
+    val QUERY     = "QUERY".asInstanceOf[DatasetActionType]
+    val CONTAINER = "CONTAINER".asInstanceOf[DatasetActionType]
 
     val values = js.Object.freeze(js.Array(QUERY, CONTAINER))
   }
@@ -1032,11 +1027,12 @@ package iotanalytics {
       __obj.asInstanceOf[DatasetContentDeliveryRule]
     }
   }
-
-  object DatasetContentStateEnum {
-    val CREATING  = "CREATING"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait DatasetContentState extends js.Any
+  object DatasetContentState extends js.Object {
+    val CREATING  = "CREATING".asInstanceOf[DatasetContentState]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[DatasetContentState]
+    val FAILED    = "FAILED".asInstanceOf[DatasetContentState]
 
     val values = js.Object.freeze(js.Array(CREATING, SUCCEEDED, FAILED))
   }
@@ -1136,11 +1132,12 @@ package iotanalytics {
       __obj.asInstanceOf[DatasetEntry]
     }
   }
-
-  object DatasetStatusEnum {
-    val CREATING = "CREATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait DatasetStatus extends js.Any
+  object DatasetStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[DatasetStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[DatasetStatus]
+    val DELETING = "DELETING".asInstanceOf[DatasetStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING))
   }
@@ -1280,11 +1277,12 @@ package iotanalytics {
       __obj.asInstanceOf[DatastoreStatistics]
     }
   }
-
-  object DatastoreStatusEnum {
-    val CREATING = "CREATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait DatastoreStatus extends js.Any
+  object DatastoreStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[DatastoreStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[DatastoreStatus]
+    val DELETING = "DELETING".asInstanceOf[DatastoreStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING))
   }
@@ -2128,9 +2126,10 @@ package iotanalytics {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object LoggingLevelEnum {
-    val ERROR = "ERROR"
+  @js.native
+  sealed trait LoggingLevel extends js.Any
+  object LoggingLevel extends js.Object {
+    val ERROR = "ERROR".asInstanceOf[LoggingLevel]
 
     val values = js.Object.freeze(js.Array(ERROR))
   }
@@ -2408,12 +2407,13 @@ package iotanalytics {
       __obj.asInstanceOf[RemoveAttributesActivity]
     }
   }
-
-  object ReprocessingStatusEnum {
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val CANCELLED = "CANCELLED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait ReprocessingStatus extends js.Any
+  object ReprocessingStatus extends js.Object {
+    val RUNNING   = "RUNNING".asInstanceOf[ReprocessingStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[ReprocessingStatus]
+    val CANCELLED = "CANCELLED".asInstanceOf[ReprocessingStatus]
+    val FAILED    = "FAILED".asInstanceOf[ReprocessingStatus]
 
     val values = js.Object.freeze(js.Array(RUNNING, SUCCEEDED, CANCELLED, FAILED))
   }

--- a/services/iotevents/src/main/scala/facade/amazonaws/services/IoTEvents.scala
+++ b/services/iotevents/src/main/scala/facade/amazonaws/services/IoTEvents.scala
@@ -19,20 +19,16 @@ package object iotevents {
   type DetectorModelName             = String
   type DetectorModelSummaries        = js.Array[DetectorModelSummary]
   type DetectorModelVersion          = String
-  type DetectorModelVersionStatus    = String
   type DetectorModelVersionSummaries = js.Array[DetectorModelVersionSummary]
-  type EvaluationMethod              = String
   type EventName                     = String
   type Events                        = js.Array[Event]
   type FirehoseSeparator             = String
   type InputArn                      = String
   type InputDescription              = String
   type InputName                     = String
-  type InputStatus                   = String
   type InputSummaries                = js.Array[InputSummary]
   type KeyValue                      = String
   type LoggingEnabled                = Boolean
-  type LoggingLevel                  = String
   type MQTTTopic                     = String
   type MaxResults                    = Int
   type NextToken                     = String
@@ -607,15 +603,16 @@ package iotevents {
       __obj.asInstanceOf[DetectorModelSummary]
     }
   }
-
-  object DetectorModelVersionStatusEnum {
-    val ACTIVE     = "ACTIVE"
-    val ACTIVATING = "ACTIVATING"
-    val INACTIVE   = "INACTIVE"
-    val DEPRECATED = "DEPRECATED"
-    val DRAFT      = "DRAFT"
-    val PAUSED     = "PAUSED"
-    val FAILED     = "FAILED"
+  @js.native
+  sealed trait DetectorModelVersionStatus extends js.Any
+  object DetectorModelVersionStatus extends js.Object {
+    val ACTIVE     = "ACTIVE".asInstanceOf[DetectorModelVersionStatus]
+    val ACTIVATING = "ACTIVATING".asInstanceOf[DetectorModelVersionStatus]
+    val INACTIVE   = "INACTIVE".asInstanceOf[DetectorModelVersionStatus]
+    val DEPRECATED = "DEPRECATED".asInstanceOf[DetectorModelVersionStatus]
+    val DRAFT      = "DRAFT".asInstanceOf[DetectorModelVersionStatus]
+    val PAUSED     = "PAUSED".asInstanceOf[DetectorModelVersionStatus]
+    val FAILED     = "FAILED".asInstanceOf[DetectorModelVersionStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, ACTIVATING, INACTIVE, DEPRECATED, DRAFT, PAUSED, FAILED))
   }
@@ -659,10 +656,11 @@ package iotevents {
       __obj.asInstanceOf[DetectorModelVersionSummary]
     }
   }
-
-  object EvaluationMethodEnum {
-    val BATCH  = "BATCH"
-    val SERIAL = "SERIAL"
+  @js.native
+  sealed trait EvaluationMethod extends js.Any
+  object EvaluationMethod extends js.Object {
+    val BATCH  = "BATCH".asInstanceOf[EvaluationMethod]
+    val SERIAL = "SERIAL".asInstanceOf[EvaluationMethod]
 
     val values = js.Object.freeze(js.Array(BATCH, SERIAL))
   }
@@ -796,12 +794,13 @@ package iotevents {
       __obj.asInstanceOf[InputDefinition]
     }
   }
-
-  object InputStatusEnum {
-    val CREATING = "CREATING"
-    val UPDATING = "UPDATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait InputStatus extends js.Any
+  object InputStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[InputStatus]
+    val UPDATING = "UPDATING".asInstanceOf[InputStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[InputStatus]
+    val DELETING = "DELETING".asInstanceOf[InputStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, UPDATING, ACTIVE, DELETING))
   }
@@ -1057,11 +1056,12 @@ package iotevents {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object LoggingLevelEnum {
-    val ERROR = "ERROR"
-    val INFO  = "INFO"
-    val DEBUG = "DEBUG"
+  @js.native
+  sealed trait LoggingLevel extends js.Any
+  object LoggingLevel extends js.Object {
+    val ERROR = "ERROR".asInstanceOf[LoggingLevel]
+    val INFO  = "INFO".asInstanceOf[LoggingLevel]
+    val DEBUG = "DEBUG".asInstanceOf[LoggingLevel]
 
     val values = js.Object.freeze(js.Array(ERROR, INFO, DEBUG))
   }

--- a/services/ioteventsdata/src/main/scala/facade/amazonaws/services/IoTEventsData.scala
+++ b/services/ioteventsdata/src/main/scala/facade/amazonaws/services/IoTEventsData.scala
@@ -12,7 +12,6 @@ package object ioteventsdata {
   type DetectorModelName               = String
   type DetectorModelVersion            = String
   type DetectorSummaries               = js.Array[DetectorSummary]
-  type ErrorCode                       = String
   type ErrorMessage                    = String
   type InputName                       = String
   type KeyValue                        = String
@@ -357,13 +356,14 @@ package ioteventsdata {
       __obj.asInstanceOf[DetectorSummary]
     }
   }
-
-  object ErrorCodeEnum {
-    val ResourceNotFoundException   = "ResourceNotFoundException"
-    val InvalidRequestException     = "InvalidRequestException"
-    val InternalFailureException    = "InternalFailureException"
-    val ServiceUnavailableException = "ServiceUnavailableException"
-    val ThrottlingException         = "ThrottlingException"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val ResourceNotFoundException   = "ResourceNotFoundException".asInstanceOf[ErrorCode]
+    val InvalidRequestException     = "InvalidRequestException".asInstanceOf[ErrorCode]
+    val InternalFailureException    = "InternalFailureException".asInstanceOf[ErrorCode]
+    val ServiceUnavailableException = "ServiceUnavailableException".asInstanceOf[ErrorCode]
+    val ThrottlingException         = "ThrottlingException".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/iotjobsdataplane/src/main/scala/facade/amazonaws/services/IoTJobsDataPlane.scala
+++ b/services/iotjobsdataplane/src/main/scala/facade/amazonaws/services/IoTJobsDataPlane.scala
@@ -17,7 +17,6 @@ package object iotjobsdataplane {
   type IncludeExecutionState            = Boolean
   type IncludeJobDocument               = Boolean
   type JobDocument                      = String
-  type JobExecutionStatus               = String
   type JobExecutionSummaryList          = js.Array[JobExecutionSummary]
   type JobId                            = String
   type LastUpdatedAt                    = Double
@@ -212,16 +211,17 @@ package iotjobsdataplane {
       __obj.asInstanceOf[JobExecutionState]
     }
   }
-
-  object JobExecutionStatusEnum {
-    val QUEUED      = "QUEUED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
-    val TIMED_OUT   = "TIMED_OUT"
-    val REJECTED    = "REJECTED"
-    val REMOVED     = "REMOVED"
-    val CANCELED    = "CANCELED"
+  @js.native
+  sealed trait JobExecutionStatus extends js.Any
+  object JobExecutionStatus extends js.Object {
+    val QUEUED      = "QUEUED".asInstanceOf[JobExecutionStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[JobExecutionStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[JobExecutionStatus]
+    val FAILED      = "FAILED".asInstanceOf[JobExecutionStatus]
+    val TIMED_OUT   = "TIMED_OUT".asInstanceOf[JobExecutionStatus]
+    val REJECTED    = "REJECTED".asInstanceOf[JobExecutionStatus]
+    val REMOVED     = "REMOVED".asInstanceOf[JobExecutionStatus]
+    val CANCELED    = "CANCELED".asInstanceOf[JobExecutionStatus]
 
     val values =
       js.Object.freeze(js.Array(QUEUED, IN_PROGRESS, SUCCEEDED, FAILED, TIMED_OUT, REJECTED, REMOVED, CANCELED))

--- a/services/iotsecuretunneling/src/main/scala/facade/amazonaws/services/IoTSecureTunneling.scala
+++ b/services/iotsecuretunneling/src/main/scala/facade/amazonaws/services/IoTSecureTunneling.scala
@@ -9,7 +9,6 @@ import facade.amazonaws._
 package object iotsecuretunneling {
   type AmazonResourceName = String
   type ClientAccessToken  = String
-  type ConnectionStatus   = String
   type DateType           = js.Date
   type DeleteFlag         = Boolean
   type Description        = String
@@ -25,7 +24,6 @@ package object iotsecuretunneling {
   type TimeoutInMin       = Int
   type TunnelArn          = String
   type TunnelId           = String
-  type TunnelStatus       = String
   type TunnelSummaryList  = js.Array[TunnelSummary]
 
   implicit final class IoTSecureTunnelingOps(private val service: IoTSecureTunneling) extends AnyVal {
@@ -117,10 +115,11 @@ package iotsecuretunneling {
       __obj.asInstanceOf[ConnectionState]
     }
   }
-
-  object ConnectionStatusEnum {
-    val CONNECTED    = "CONNECTED"
-    val DISCONNECTED = "DISCONNECTED"
+  @js.native
+  sealed trait ConnectionStatus extends js.Any
+  object ConnectionStatus extends js.Object {
+    val CONNECTED    = "CONNECTED".asInstanceOf[ConnectionStatus]
+    val DISCONNECTED = "DISCONNECTED".asInstanceOf[ConnectionStatus]
 
     val values = js.Object.freeze(js.Array(CONNECTED, DISCONNECTED))
   }
@@ -437,10 +436,11 @@ package iotsecuretunneling {
       __obj.asInstanceOf[Tunnel]
     }
   }
-
-  object TunnelStatusEnum {
-    val OPEN   = "OPEN"
-    val CLOSED = "CLOSED"
+  @js.native
+  sealed trait TunnelStatus extends js.Any
+  object TunnelStatus extends js.Object {
+    val OPEN   = "OPEN".asInstanceOf[TunnelStatus]
+    val CLOSED = "CLOSED".asInstanceOf[TunnelStatus]
 
     val values = js.Object.freeze(js.Array(OPEN, CLOSED))
   }

--- a/services/iotthingsgraph/src/main/scala/facade/amazonaws/services/IoTThingsGraph.scala
+++ b/services/iotthingsgraph/src/main/scala/facade/amazonaws/services/IoTThingsGraph.scala
@@ -7,70 +7,57 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object iotthingsgraph {
-  type Arn                               = String
-  type DefinitionLanguage                = String
-  type DefinitionText                    = String
-  type DependencyRevisions               = js.Array[DependencyRevision]
-  type DeploymentTarget                  = String
-  type DeprecateExistingEntities         = Boolean
-  type Enabled                           = Boolean
-  type EntityDescriptions                = js.Array[EntityDescription]
-  type EntityFilterName                  = String
-  type EntityFilterValue                 = String
-  type EntityFilterValues                = js.Array[EntityFilterValue]
-  type EntityFilters                     = js.Array[EntityFilter]
-  type EntityType                        = String
-  type EntityTypes                       = js.Array[EntityType]
-  type FlowExecutionEventType            = String
-  type FlowExecutionId                   = String
-  type FlowExecutionMessageId            = String
-  type FlowExecutionMessagePayload       = String
-  type FlowExecutionMessages             = js.Array[FlowExecutionMessage]
-  type FlowExecutionStatus               = String
-  type FlowExecutionSummaries            = js.Array[FlowExecutionSummary]
-  type FlowTemplateFilterName            = String
-  type FlowTemplateFilterValue           = String
-  type FlowTemplateFilterValues          = js.Array[FlowTemplateFilterValue]
-  type FlowTemplateFilters               = js.Array[FlowTemplateFilter]
-  type FlowTemplateSummaries             = js.Array[FlowTemplateSummary]
-  type GreengrassDeploymentId            = String
-  type GreengrassGroupId                 = String
-  type GreengrassGroupVersionId          = String
-  type GroupName                         = String
-  type MaxResults                        = Int
-  type NamespaceDeletionStatus           = String
-  type NamespaceDeletionStatusErrorCodes = String
-  type NamespaceName                     = String
-  type NextToken                         = String
-  type ResourceArn                       = String
-  type RoleArn                           = String
-  type S3BucketName                      = String
-  type StringList                        = js.Array[String]
-  type SyncWithPublicNamespace           = Boolean
-  type SystemInstanceDeploymentStatus    = String
-  type SystemInstanceFilterName          = String
-  type SystemInstanceFilterValue         = String
-  type SystemInstanceFilterValues        = js.Array[SystemInstanceFilterValue]
-  type SystemInstanceFilters             = js.Array[SystemInstanceFilter]
-  type SystemInstanceSummaries           = js.Array[SystemInstanceSummary]
-  type SystemTemplateFilterName          = String
-  type SystemTemplateFilterValue         = String
-  type SystemTemplateFilterValues        = js.Array[SystemTemplateFilterValue]
-  type SystemTemplateFilters             = js.Array[SystemTemplateFilter]
-  type SystemTemplateSummaries           = js.Array[SystemTemplateSummary]
-  type TagKey                            = String
-  type TagKeyList                        = js.Array[TagKey]
-  type TagList                           = js.Array[Tag]
-  type TagValue                          = String
-  type ThingArn                          = String
-  type ThingName                         = String
-  type Things                            = js.Array[Thing]
-  type Timestamp                         = js.Date
-  type UploadId                          = String
-  type UploadStatus                      = String
-  type Urn                               = String
-  type Urns                              = js.Array[Urn]
-  type Version                           = Double
+  type Arn                         = String
+  type DefinitionText              = String
+  type DependencyRevisions         = js.Array[DependencyRevision]
+  type DeprecateExistingEntities   = Boolean
+  type Enabled                     = Boolean
+  type EntityDescriptions          = js.Array[EntityDescription]
+  type EntityFilterValue           = String
+  type EntityFilterValues          = js.Array[EntityFilterValue]
+  type EntityFilters               = js.Array[EntityFilter]
+  type EntityTypes                 = js.Array[EntityType]
+  type FlowExecutionId             = String
+  type FlowExecutionMessageId      = String
+  type FlowExecutionMessagePayload = String
+  type FlowExecutionMessages       = js.Array[FlowExecutionMessage]
+  type FlowExecutionSummaries      = js.Array[FlowExecutionSummary]
+  type FlowTemplateFilterValue     = String
+  type FlowTemplateFilterValues    = js.Array[FlowTemplateFilterValue]
+  type FlowTemplateFilters         = js.Array[FlowTemplateFilter]
+  type FlowTemplateSummaries       = js.Array[FlowTemplateSummary]
+  type GreengrassDeploymentId      = String
+  type GreengrassGroupId           = String
+  type GreengrassGroupVersionId    = String
+  type GroupName                   = String
+  type MaxResults                  = Int
+  type NamespaceName               = String
+  type NextToken                   = String
+  type ResourceArn                 = String
+  type RoleArn                     = String
+  type S3BucketName                = String
+  type StringList                  = js.Array[String]
+  type SyncWithPublicNamespace     = Boolean
+  type SystemInstanceFilterValue   = String
+  type SystemInstanceFilterValues  = js.Array[SystemInstanceFilterValue]
+  type SystemInstanceFilters       = js.Array[SystemInstanceFilter]
+  type SystemInstanceSummaries     = js.Array[SystemInstanceSummary]
+  type SystemTemplateFilterValue   = String
+  type SystemTemplateFilterValues  = js.Array[SystemTemplateFilterValue]
+  type SystemTemplateFilters       = js.Array[SystemTemplateFilter]
+  type SystemTemplateSummaries     = js.Array[SystemTemplateSummary]
+  type TagKey                      = String
+  type TagKeyList                  = js.Array[TagKey]
+  type TagList                     = js.Array[Tag]
+  type TagValue                    = String
+  type ThingArn                    = String
+  type ThingName                   = String
+  type Things                      = js.Array[Thing]
+  type Timestamp                   = js.Date
+  type UploadId                    = String
+  type Urn                         = String
+  type Urns                        = js.Array[Urn]
+  type Version                     = Double
 
   implicit final class IoTThingsGraphOps(private val service: IoTThingsGraph) extends AnyVal {
 
@@ -405,9 +392,10 @@ package iotthingsgraph {
       __obj.asInstanceOf[DefinitionDocument]
     }
   }
-
-  object DefinitionLanguageEnum {
-    val GRAPHQL = "GRAPHQL"
+  @js.native
+  sealed trait DefinitionLanguage extends js.Any
+  object DefinitionLanguage extends js.Object {
+    val GRAPHQL = "GRAPHQL".asInstanceOf[DefinitionLanguage]
 
     val values = js.Object.freeze(js.Array(GRAPHQL))
   }
@@ -593,10 +581,11 @@ package iotthingsgraph {
       __obj.asInstanceOf[DeploySystemInstanceResponse]
     }
   }
-
-  object DeploymentTargetEnum {
-    val GREENGRASS = "GREENGRASS"
-    val CLOUD      = "CLOUD"
+  @js.native
+  sealed trait DeploymentTarget extends js.Any
+  object DeploymentTarget extends js.Object {
+    val GREENGRASS = "GREENGRASS".asInstanceOf[DeploymentTarget]
+    val CLOUD      = "CLOUD".asInstanceOf[DeploymentTarget]
 
     val values = js.Object.freeze(js.Array(GREENGRASS, CLOUD))
   }
@@ -793,51 +782,54 @@ package iotthingsgraph {
       __obj.asInstanceOf[EntityFilter]
     }
   }
-
-  object EntityFilterNameEnum {
-    val NAME                 = "NAME"
-    val NAMESPACE            = "NAMESPACE"
-    val SEMANTIC_TYPE_PATH   = "SEMANTIC_TYPE_PATH"
-    val REFERENCED_ENTITY_ID = "REFERENCED_ENTITY_ID"
+  @js.native
+  sealed trait EntityFilterName extends js.Any
+  object EntityFilterName extends js.Object {
+    val NAME                 = "NAME".asInstanceOf[EntityFilterName]
+    val NAMESPACE            = "NAMESPACE".asInstanceOf[EntityFilterName]
+    val SEMANTIC_TYPE_PATH   = "SEMANTIC_TYPE_PATH".asInstanceOf[EntityFilterName]
+    val REFERENCED_ENTITY_ID = "REFERENCED_ENTITY_ID".asInstanceOf[EntityFilterName]
 
     val values = js.Object.freeze(js.Array(NAME, NAMESPACE, SEMANTIC_TYPE_PATH, REFERENCED_ENTITY_ID))
   }
-
-  object EntityTypeEnum {
-    val DEVICE       = "DEVICE"
-    val SERVICE      = "SERVICE"
-    val DEVICE_MODEL = "DEVICE_MODEL"
-    val CAPABILITY   = "CAPABILITY"
-    val STATE        = "STATE"
-    val ACTION       = "ACTION"
-    val EVENT        = "EVENT"
-    val PROPERTY     = "PROPERTY"
-    val MAPPING      = "MAPPING"
-    val ENUM         = "ENUM"
+  @js.native
+  sealed trait EntityType extends js.Any
+  object EntityType extends js.Object {
+    val DEVICE       = "DEVICE".asInstanceOf[EntityType]
+    val SERVICE      = "SERVICE".asInstanceOf[EntityType]
+    val DEVICE_MODEL = "DEVICE_MODEL".asInstanceOf[EntityType]
+    val CAPABILITY   = "CAPABILITY".asInstanceOf[EntityType]
+    val STATE        = "STATE".asInstanceOf[EntityType]
+    val ACTION       = "ACTION".asInstanceOf[EntityType]
+    val EVENT        = "EVENT".asInstanceOf[EntityType]
+    val PROPERTY     = "PROPERTY".asInstanceOf[EntityType]
+    val MAPPING      = "MAPPING".asInstanceOf[EntityType]
+    val ENUM         = "ENUM".asInstanceOf[EntityType]
 
     val values = js.Object.freeze(
       js.Array(DEVICE, SERVICE, DEVICE_MODEL, CAPABILITY, STATE, ACTION, EVENT, PROPERTY, MAPPING, ENUM)
     )
   }
-
-  object FlowExecutionEventTypeEnum {
-    val EXECUTION_STARTED              = "EXECUTION_STARTED"
-    val EXECUTION_FAILED               = "EXECUTION_FAILED"
-    val EXECUTION_ABORTED              = "EXECUTION_ABORTED"
-    val EXECUTION_SUCCEEDED            = "EXECUTION_SUCCEEDED"
-    val STEP_STARTED                   = "STEP_STARTED"
-    val STEP_FAILED                    = "STEP_FAILED"
-    val STEP_SUCCEEDED                 = "STEP_SUCCEEDED"
-    val ACTIVITY_SCHEDULED             = "ACTIVITY_SCHEDULED"
-    val ACTIVITY_STARTED               = "ACTIVITY_STARTED"
-    val ACTIVITY_FAILED                = "ACTIVITY_FAILED"
-    val ACTIVITY_SUCCEEDED             = "ACTIVITY_SUCCEEDED"
-    val START_FLOW_EXECUTION_TASK      = "START_FLOW_EXECUTION_TASK"
-    val SCHEDULE_NEXT_READY_STEPS_TASK = "SCHEDULE_NEXT_READY_STEPS_TASK"
-    val THING_ACTION_TASK              = "THING_ACTION_TASK"
-    val THING_ACTION_TASK_FAILED       = "THING_ACTION_TASK_FAILED"
-    val THING_ACTION_TASK_SUCCEEDED    = "THING_ACTION_TASK_SUCCEEDED"
-    val ACKNOWLEDGE_TASK_MESSAGE       = "ACKNOWLEDGE_TASK_MESSAGE"
+  @js.native
+  sealed trait FlowExecutionEventType extends js.Any
+  object FlowExecutionEventType extends js.Object {
+    val EXECUTION_STARTED              = "EXECUTION_STARTED".asInstanceOf[FlowExecutionEventType]
+    val EXECUTION_FAILED               = "EXECUTION_FAILED".asInstanceOf[FlowExecutionEventType]
+    val EXECUTION_ABORTED              = "EXECUTION_ABORTED".asInstanceOf[FlowExecutionEventType]
+    val EXECUTION_SUCCEEDED            = "EXECUTION_SUCCEEDED".asInstanceOf[FlowExecutionEventType]
+    val STEP_STARTED                   = "STEP_STARTED".asInstanceOf[FlowExecutionEventType]
+    val STEP_FAILED                    = "STEP_FAILED".asInstanceOf[FlowExecutionEventType]
+    val STEP_SUCCEEDED                 = "STEP_SUCCEEDED".asInstanceOf[FlowExecutionEventType]
+    val ACTIVITY_SCHEDULED             = "ACTIVITY_SCHEDULED".asInstanceOf[FlowExecutionEventType]
+    val ACTIVITY_STARTED               = "ACTIVITY_STARTED".asInstanceOf[FlowExecutionEventType]
+    val ACTIVITY_FAILED                = "ACTIVITY_FAILED".asInstanceOf[FlowExecutionEventType]
+    val ACTIVITY_SUCCEEDED             = "ACTIVITY_SUCCEEDED".asInstanceOf[FlowExecutionEventType]
+    val START_FLOW_EXECUTION_TASK      = "START_FLOW_EXECUTION_TASK".asInstanceOf[FlowExecutionEventType]
+    val SCHEDULE_NEXT_READY_STEPS_TASK = "SCHEDULE_NEXT_READY_STEPS_TASK".asInstanceOf[FlowExecutionEventType]
+    val THING_ACTION_TASK              = "THING_ACTION_TASK".asInstanceOf[FlowExecutionEventType]
+    val THING_ACTION_TASK_FAILED       = "THING_ACTION_TASK_FAILED".asInstanceOf[FlowExecutionEventType]
+    val THING_ACTION_TASK_SUCCEEDED    = "THING_ACTION_TASK_SUCCEEDED".asInstanceOf[FlowExecutionEventType]
+    val ACKNOWLEDGE_TASK_MESSAGE       = "ACKNOWLEDGE_TASK_MESSAGE".asInstanceOf[FlowExecutionEventType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -889,12 +881,13 @@ package iotthingsgraph {
       __obj.asInstanceOf[FlowExecutionMessage]
     }
   }
-
-  object FlowExecutionStatusEnum {
-    val RUNNING   = "RUNNING"
-    val ABORTED   = "ABORTED"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait FlowExecutionStatus extends js.Any
+  object FlowExecutionStatus extends js.Object {
+    val RUNNING   = "RUNNING".asInstanceOf[FlowExecutionStatus]
+    val ABORTED   = "ABORTED".asInstanceOf[FlowExecutionStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[FlowExecutionStatus]
+    val FAILED    = "FAILED".asInstanceOf[FlowExecutionStatus]
 
     val values = js.Object.freeze(js.Array(RUNNING, ABORTED, SUCCEEDED, FAILED))
   }
@@ -983,9 +976,10 @@ package iotthingsgraph {
       __obj.asInstanceOf[FlowTemplateFilter]
     }
   }
-
-  object FlowTemplateFilterNameEnum {
-    val DEVICE_MODEL_ID = "DEVICE_MODEL_ID"
+  @js.native
+  sealed trait FlowTemplateFilterName extends js.Any
+  object FlowTemplateFilterName extends js.Object {
+    val DEVICE_MODEL_ID = "DEVICE_MODEL_ID".asInstanceOf[FlowTemplateFilterName]
 
     val values = js.Object.freeze(js.Array(DEVICE_MODEL_ID))
   }
@@ -1451,17 +1445,19 @@ package iotthingsgraph {
       __obj.asInstanceOf[MetricsConfiguration]
     }
   }
-
-  object NamespaceDeletionStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait NamespaceDeletionStatus extends js.Any
+  object NamespaceDeletionStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[NamespaceDeletionStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[NamespaceDeletionStatus]
+    val FAILED      = "FAILED".asInstanceOf[NamespaceDeletionStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, SUCCEEDED, FAILED))
   }
-
-  object NamespaceDeletionStatusErrorCodesEnum {
-    val VALIDATION_FAILED = "VALIDATION_FAILED"
+  @js.native
+  sealed trait NamespaceDeletionStatusErrorCodes extends js.Any
+  object NamespaceDeletionStatusErrorCodes extends js.Object {
+    val VALIDATION_FAILED = "VALIDATION_FAILED".asInstanceOf[NamespaceDeletionStatusErrorCodes]
 
     val values = js.Object.freeze(js.Array(VALIDATION_FAILED))
   }
@@ -1735,16 +1731,17 @@ package iotthingsgraph {
       __obj.asInstanceOf[SearchThingsResponse]
     }
   }
-
-  object SystemInstanceDeploymentStatusEnum {
-    val NOT_DEPLOYED         = "NOT_DEPLOYED"
-    val BOOTSTRAP            = "BOOTSTRAP"
-    val DEPLOY_IN_PROGRESS   = "DEPLOY_IN_PROGRESS"
-    val DEPLOYED_IN_TARGET   = "DEPLOYED_IN_TARGET"
-    val UNDEPLOY_IN_PROGRESS = "UNDEPLOY_IN_PROGRESS"
-    val FAILED               = "FAILED"
-    val PENDING_DELETE       = "PENDING_DELETE"
-    val DELETED_IN_TARGET    = "DELETED_IN_TARGET"
+  @js.native
+  sealed trait SystemInstanceDeploymentStatus extends js.Any
+  object SystemInstanceDeploymentStatus extends js.Object {
+    val NOT_DEPLOYED         = "NOT_DEPLOYED".asInstanceOf[SystemInstanceDeploymentStatus]
+    val BOOTSTRAP            = "BOOTSTRAP".asInstanceOf[SystemInstanceDeploymentStatus]
+    val DEPLOY_IN_PROGRESS   = "DEPLOY_IN_PROGRESS".asInstanceOf[SystemInstanceDeploymentStatus]
+    val DEPLOYED_IN_TARGET   = "DEPLOYED_IN_TARGET".asInstanceOf[SystemInstanceDeploymentStatus]
+    val UNDEPLOY_IN_PROGRESS = "UNDEPLOY_IN_PROGRESS".asInstanceOf[SystemInstanceDeploymentStatus]
+    val FAILED               = "FAILED".asInstanceOf[SystemInstanceDeploymentStatus]
+    val PENDING_DELETE       = "PENDING_DELETE".asInstanceOf[SystemInstanceDeploymentStatus]
+    val DELETED_IN_TARGET    = "DELETED_IN_TARGET".asInstanceOf[SystemInstanceDeploymentStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1822,11 +1819,12 @@ package iotthingsgraph {
       __obj.asInstanceOf[SystemInstanceFilter]
     }
   }
-
-  object SystemInstanceFilterNameEnum {
-    val SYSTEM_TEMPLATE_ID    = "SYSTEM_TEMPLATE_ID"
-    val STATUS                = "STATUS"
-    val GREENGRASS_GROUP_NAME = "GREENGRASS_GROUP_NAME"
+  @js.native
+  sealed trait SystemInstanceFilterName extends js.Any
+  object SystemInstanceFilterName extends js.Object {
+    val SYSTEM_TEMPLATE_ID    = "SYSTEM_TEMPLATE_ID".asInstanceOf[SystemInstanceFilterName]
+    val STATUS                = "STATUS".asInstanceOf[SystemInstanceFilterName]
+    val GREENGRASS_GROUP_NAME = "GREENGRASS_GROUP_NAME".asInstanceOf[SystemInstanceFilterName]
 
     val values = js.Object.freeze(js.Array(SYSTEM_TEMPLATE_ID, STATUS, GREENGRASS_GROUP_NAME))
   }
@@ -1924,9 +1922,10 @@ package iotthingsgraph {
       __obj.asInstanceOf[SystemTemplateFilter]
     }
   }
-
-  object SystemTemplateFilterNameEnum {
-    val FLOW_TEMPLATE_ID = "FLOW_TEMPLATE_ID"
+  @js.native
+  sealed trait SystemTemplateFilterName extends js.Any
+  object SystemTemplateFilterName extends js.Object {
+    val FLOW_TEMPLATE_ID = "FLOW_TEMPLATE_ID".asInstanceOf[SystemTemplateFilterName]
 
     val values = js.Object.freeze(js.Array(FLOW_TEMPLATE_ID))
   }
@@ -2230,11 +2229,12 @@ package iotthingsgraph {
       __obj.asInstanceOf[UploadEntityDefinitionsResponse]
     }
   }
-
-  object UploadStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait UploadStatus extends js.Any
+  object UploadStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[UploadStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[UploadStatus]
+    val FAILED      = "FAILED".asInstanceOf[UploadStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, SUCCEEDED, FAILED))
   }

--- a/services/kafka/src/main/scala/facade/amazonaws/services/Kafka.scala
+++ b/services/kafka/src/main/scala/facade/amazonaws/services/Kafka.scala
@@ -7,13 +7,7 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object kafka {
-  type BrokerAZDistribution          = String
-  type ClientBroker                  = String
-  type ClusterState                  = String
-  type EnhancedMonitoring            = String
-  type KafkaVersionStatus            = String
   type MaxResults                    = Int
-  type NodeType                      = String
   type __blob                        = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type __boolean                     = Boolean
   type __double                      = Double
@@ -130,8 +124,10 @@ package kafka {
     *          Amazon MSK distributes the broker nodes evenly across the Availability Zones that correspond to the subnets you provide when you create the cluster.
     *
     */
-  object BrokerAZDistributionEnum {
-    val DEFAULT = "DEFAULT"
+  @js.native
+  sealed trait BrokerAZDistribution extends js.Any
+  object BrokerAZDistribution extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[BrokerAZDistribution]
 
     val values = js.Object.freeze(js.Array(DEFAULT))
   }
@@ -282,10 +278,12 @@ package kafka {
     *             Client-broker encryption in transit setting.
     *
     */
-  object ClientBrokerEnum {
-    val TLS           = "TLS"
-    val TLS_PLAINTEXT = "TLS_PLAINTEXT"
-    val PLAINTEXT     = "PLAINTEXT"
+  @js.native
+  sealed trait ClientBroker extends js.Any
+  object ClientBroker extends js.Object {
+    val TLS           = "TLS".asInstanceOf[ClientBroker]
+    val TLS_PLAINTEXT = "TLS_PLAINTEXT".asInstanceOf[ClientBroker]
+    val PLAINTEXT     = "PLAINTEXT".asInstanceOf[ClientBroker]
 
     val values = js.Object.freeze(js.Array(TLS, TLS_PLAINTEXT, PLAINTEXT))
   }
@@ -408,12 +406,14 @@ package kafka {
     *             The state of a Kafka cluster.
     *
     */
-  object ClusterStateEnum {
-    val ACTIVE   = "ACTIVE"
-    val CREATING = "CREATING"
-    val UPDATING = "UPDATING"
-    val DELETING = "DELETING"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait ClusterState extends js.Any
+  object ClusterState extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[ClusterState]
+    val CREATING = "CREATING".asInstanceOf[ClusterState]
+    val UPDATING = "UPDATING".asInstanceOf[ClusterState]
+    val DELETING = "DELETING".asInstanceOf[ClusterState]
+    val FAILED   = "FAILED".asInstanceOf[ClusterState]
 
     val values = js.Object.freeze(js.Array(ACTIVE, CREATING, UPDATING, DELETING, FAILED))
   }
@@ -925,10 +925,12 @@ package kafka {
     *             Specifies which metrics are gathered for the MSK cluster. This property has three possible values: DEFAULT, PER_BROKER, and PER_TOPIC_PER_BROKER. For a list of the metrics associated with each of these three levels of monitoring, see [[https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html|Monitoring]].
     *
     */
-  object EnhancedMonitoringEnum {
-    val DEFAULT              = "DEFAULT"
-    val PER_BROKER           = "PER_BROKER"
-    val PER_TOPIC_PER_BROKER = "PER_TOPIC_PER_BROKER"
+  @js.native
+  sealed trait EnhancedMonitoring extends js.Any
+  object EnhancedMonitoring extends js.Object {
+    val DEFAULT              = "DEFAULT".asInstanceOf[EnhancedMonitoring]
+    val PER_BROKER           = "PER_BROKER".asInstanceOf[EnhancedMonitoring]
+    val PER_TOPIC_PER_BROKER = "PER_TOPIC_PER_BROKER".asInstanceOf[EnhancedMonitoring]
 
     val values = js.Object.freeze(js.Array(DEFAULT, PER_BROKER, PER_TOPIC_PER_BROKER))
   }
@@ -1055,10 +1057,11 @@ package kafka {
       __obj.asInstanceOf[KafkaVersion]
     }
   }
-
-  object KafkaVersionStatusEnum {
-    val ACTIVE     = "ACTIVE"
-    val DEPRECATED = "DEPRECATED"
+  @js.native
+  sealed trait KafkaVersionStatus extends js.Any
+  object KafkaVersionStatus extends js.Object {
+    val ACTIVE     = "ACTIVE".asInstanceOf[KafkaVersionStatus]
+    val DEPRECATED = "DEPRECATED".asInstanceOf[KafkaVersionStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DEPRECATED))
   }
@@ -1458,8 +1461,10 @@ package kafka {
     *             The broker or Zookeeper node.
     *
     */
-  object NodeTypeEnum {
-    val BROKER = "BROKER"
+  @js.native
+  sealed trait NodeType extends js.Any
+  object NodeType extends js.Object {
+    val BROKER = "BROKER".asInstanceOf[NodeType]
 
     val values = js.Object.freeze(js.Array(BROKER))
   }

--- a/services/kendra/src/main/scala/facade/amazonaws/services/Kendra.scala
+++ b/services/kendra/src/main/scala/facade/amazonaws/services/Kendra.scala
@@ -8,7 +8,6 @@ import facade.amazonaws._
 
 package object kendra {
   type AdditionalResultAttributeList                     = js.Array[AdditionalResultAttribute]
-  type AdditionalResultAttributeValueType                = String
   type AttributeFilterList                               = js.Array[AttributeFilter]
   type BatchDeleteDocumentResponseFailedDocuments        = js.Array[BatchDeleteDocumentResponseFailedDocument]
   type BatchPutDocumentResponseFailedDocuments           = js.Array[BatchPutDocumentResponseFailedDocument]
@@ -16,20 +15,15 @@ package object kendra {
   type ChangeDetectingColumns                            = js.Array[ColumnName]
   type ClickFeedbackList                                 = js.Array[ClickFeedback]
   type ColumnName                                        = String
-  type ContentType                                       = String
   type DataSourceDateFieldFormat                         = String
   type DataSourceFieldName                               = String
   type DataSourceId                                      = String
   type DataSourceInclusionsExclusionsStrings             = js.Array[DataSourceInclusionsExclusionsStringsMember]
   type DataSourceInclusionsExclusionsStringsMember       = String
   type DataSourceName                                    = String
-  type DataSourceStatus                                  = String
   type DataSourceSummaryList                             = js.Array[DataSourceSummary]
   type DataSourceSyncJobHistoryList                      = js.Array[DataSourceSyncJob]
-  type DataSourceSyncJobStatus                           = String
   type DataSourceToIndexFieldMappingList                 = js.Array[DataSourceToIndexFieldMapping]
-  type DataSourceType                                    = String
-  type DatabaseEngineType                                = String
   type DatabaseHost                                      = String
   type DatabaseName                                      = String
   type DatabasePort                                      = Int
@@ -40,7 +34,6 @@ package object kendra {
   type DocumentAttributeStringListValue                  = js.Array[String]
   type DocumentAttributeStringValue                      = String
   type DocumentAttributeValueCountPairList               = js.Array[DocumentAttributeValueCountPair]
-  type DocumentAttributeValueType                        = String
   type DocumentId                                        = String
   type DocumentIdList                                    = js.Array[DocumentId]
   type DocumentList                                      = js.Array[Document]
@@ -48,13 +41,11 @@ package object kendra {
   type DocumentMetadataConfigurationList                 = js.Array[DocumentMetadataConfiguration]
   type DocumentMetadataConfigurationName                 = String
   type Duration                                          = String
-  type ErrorCode                                         = String
   type ErrorMessage                                      = String
   type FacetList                                         = js.Array[Facet]
   type FacetResultList                                   = js.Array[FacetResult]
   type FaqId                                             = String
   type FaqName                                           = String
-  type FaqStatus                                         = String
   type FaqSummaryItems                                   = js.Array[FaqSummary]
   type HighlightList                                     = js.Array[Highlight]
   type Importance                                        = Int
@@ -62,7 +53,6 @@ package object kendra {
   type IndexFieldName                                    = String
   type IndexId                                           = String
   type IndexName                                         = String
-  type IndexStatus                                       = String
   type IndexedQuestionAnswersCount                       = Int
   type IndexedTextDocumentsCount                         = Int
   type KmsKeyId                                          = String
@@ -71,17 +61,12 @@ package object kendra {
   type MaxResultsIntegerForListFaqsRequest               = Int
   type MaxResultsIntegerForListIndicesRequest            = Int
   type NextToken                                         = String
-  type Order                                             = String
   type PrincipalList                                     = js.Array[Principal]
   type PrincipalName                                     = String
-  type PrincipalType                                     = String
   type QueryId                                           = String
   type QueryResultItemList                               = js.Array[QueryResultItem]
-  type QueryResultType                                   = String
   type QueryText                                         = String
-  type ReadAccessType                                    = String
   type RelevanceFeedbackList                             = js.Array[RelevanceFeedback]
-  type RelevanceType                                     = String
   type ResultId                                          = String
   type RoleArn                                           = String
   type S3BucketName                                      = String
@@ -90,7 +75,6 @@ package object kendra {
   type SecretArn                                         = String
   type SecurityGroupIdList                               = js.Array[VpcSecurityGroupId]
   type SharePointUrlList                                 = js.Array[Url]
-  type SharePointVersion                                 = String
   type SubnetId                                          = String
   type SubnetIdList                                      = js.Array[SubnetId]
   type TableName                                         = String
@@ -262,9 +246,10 @@ package kendra {
       __obj.asInstanceOf[AdditionalResultAttributeValue]
     }
   }
-
-  object AdditionalResultAttributeValueTypeEnum {
-    val TEXT_WITH_HIGHLIGHTS_VALUE = "TEXT_WITH_HIGHLIGHTS_VALUE"
+  @js.native
+  sealed trait AdditionalResultAttributeValueType extends js.Any
+  object AdditionalResultAttributeValueType extends js.Object {
+    val TEXT_WITH_HIGHLIGHTS_VALUE = "TEXT_WITH_HIGHLIGHTS_VALUE".asInstanceOf[AdditionalResultAttributeValueType]
 
     val values = js.Object.freeze(js.Array(TEXT_WITH_HIGHLIGHTS_VALUE))
   }
@@ -531,13 +516,14 @@ package kendra {
       __obj.asInstanceOf[ConnectionConfiguration]
     }
   }
-
-  object ContentTypeEnum {
-    val PDF        = "PDF"
-    val HTML       = "HTML"
-    val MS_WORD    = "MS_WORD"
-    val PLAIN_TEXT = "PLAIN_TEXT"
-    val PPT        = "PPT"
+  @js.native
+  sealed trait ContentType extends js.Any
+  object ContentType extends js.Object {
+    val PDF        = "PDF".asInstanceOf[ContentType]
+    val HTML       = "HTML".asInstanceOf[ContentType]
+    val MS_WORD    = "MS_WORD".asInstanceOf[ContentType]
+    val PLAIN_TEXT = "PLAIN_TEXT".asInstanceOf[ContentType]
+    val PPT        = "PPT".asInstanceOf[ContentType]
 
     val values = js.Object.freeze(js.Array(PDF, HTML, MS_WORD, PLAIN_TEXT, PPT))
   }
@@ -711,13 +697,14 @@ package kendra {
       __obj.asInstanceOf[DataSourceConfiguration]
     }
   }
-
-  object DataSourceStatusEnum {
-    val CREATING = "CREATING"
-    val DELETING = "DELETING"
-    val FAILED   = "FAILED"
-    val UPDATING = "UPDATING"
-    val ACTIVE   = "ACTIVE"
+  @js.native
+  sealed trait DataSourceStatus extends js.Any
+  object DataSourceStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[DataSourceStatus]
+    val DELETING = "DELETING".asInstanceOf[DataSourceStatus]
+    val FAILED   = "FAILED".asInstanceOf[DataSourceStatus]
+    val UPDATING = "UPDATING".asInstanceOf[DataSourceStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[DataSourceStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, DELETING, FAILED, UPDATING, ACTIVE))
   }
@@ -792,14 +779,15 @@ package kendra {
       __obj.asInstanceOf[DataSourceSyncJob]
     }
   }
-
-  object DataSourceSyncJobStatusEnum {
-    val FAILED     = "FAILED"
-    val SUCCEEDED  = "SUCCEEDED"
-    val SYNCING    = "SYNCING"
-    val INCOMPLETE = "INCOMPLETE"
-    val STOPPING   = "STOPPING"
-    val ABORTED    = "ABORTED"
+  @js.native
+  sealed trait DataSourceSyncJobStatus extends js.Any
+  object DataSourceSyncJobStatus extends js.Object {
+    val FAILED     = "FAILED".asInstanceOf[DataSourceSyncJobStatus]
+    val SUCCEEDED  = "SUCCEEDED".asInstanceOf[DataSourceSyncJobStatus]
+    val SYNCING    = "SYNCING".asInstanceOf[DataSourceSyncJobStatus]
+    val INCOMPLETE = "INCOMPLETE".asInstanceOf[DataSourceSyncJobStatus]
+    val STOPPING   = "STOPPING".asInstanceOf[DataSourceSyncJobStatus]
+    val ABORTED    = "ABORTED".asInstanceOf[DataSourceSyncJobStatus]
 
     val values = js.Object.freeze(js.Array(FAILED, SUCCEEDED, SYNCING, INCOMPLETE, STOPPING, ABORTED))
   }
@@ -830,11 +818,12 @@ package kendra {
       __obj.asInstanceOf[DataSourceToIndexFieldMapping]
     }
   }
-
-  object DataSourceTypeEnum {
-    val S3         = "S3"
-    val SHAREPOINT = "SHAREPOINT"
-    val DATABASE   = "DATABASE"
+  @js.native
+  sealed trait DataSourceType extends js.Any
+  object DataSourceType extends js.Object {
+    val S3         = "S3".asInstanceOf[DataSourceType]
+    val SHAREPOINT = "SHAREPOINT".asInstanceOf[DataSourceType]
+    val DATABASE   = "DATABASE".asInstanceOf[DataSourceType]
 
     val values = js.Object.freeze(js.Array(S3, SHAREPOINT, DATABASE))
   }
@@ -895,12 +884,13 @@ package kendra {
       __obj.asInstanceOf[DatabaseConfiguration]
     }
   }
-
-  object DatabaseEngineTypeEnum {
-    val RDS_AURORA_MYSQL      = "RDS_AURORA_MYSQL"
-    val RDS_AURORA_POSTGRESQL = "RDS_AURORA_POSTGRESQL"
-    val RDS_MYSQL             = "RDS_MYSQL"
-    val RDS_POSTGRESQL        = "RDS_POSTGRESQL"
+  @js.native
+  sealed trait DatabaseEngineType extends js.Any
+  object DatabaseEngineType extends js.Object {
+    val RDS_AURORA_MYSQL      = "RDS_AURORA_MYSQL".asInstanceOf[DatabaseEngineType]
+    val RDS_AURORA_POSTGRESQL = "RDS_AURORA_POSTGRESQL".asInstanceOf[DatabaseEngineType]
+    val RDS_MYSQL             = "RDS_MYSQL".asInstanceOf[DatabaseEngineType]
+    val RDS_POSTGRESQL        = "RDS_POSTGRESQL".asInstanceOf[DatabaseEngineType]
 
     val values = js.Object.freeze(js.Array(RDS_AURORA_MYSQL, RDS_AURORA_POSTGRESQL, RDS_MYSQL, RDS_POSTGRESQL))
   }
@@ -1258,12 +1248,13 @@ package kendra {
       __obj.asInstanceOf[DocumentAttributeValueCountPair]
     }
   }
-
-  object DocumentAttributeValueTypeEnum {
-    val STRING_VALUE      = "STRING_VALUE"
-    val STRING_LIST_VALUE = "STRING_LIST_VALUE"
-    val LONG_VALUE        = "LONG_VALUE"
-    val DATE_VALUE        = "DATE_VALUE"
+  @js.native
+  sealed trait DocumentAttributeValueType extends js.Any
+  object DocumentAttributeValueType extends js.Object {
+    val STRING_VALUE      = "STRING_VALUE".asInstanceOf[DocumentAttributeValueType]
+    val STRING_LIST_VALUE = "STRING_LIST_VALUE".asInstanceOf[DocumentAttributeValueType]
+    val LONG_VALUE        = "LONG_VALUE".asInstanceOf[DocumentAttributeValueType]
+    val DATE_VALUE        = "DATE_VALUE".asInstanceOf[DocumentAttributeValueType]
 
     val values = js.Object.freeze(js.Array(STRING_VALUE, STRING_LIST_VALUE, LONG_VALUE, DATE_VALUE))
   }
@@ -1316,10 +1307,11 @@ package kendra {
       __obj.asInstanceOf[DocumentsMetadataConfiguration]
     }
   }
-
-  object ErrorCodeEnum {
-    val InternalError  = "InternalError"
-    val InvalidRequest = "InvalidRequest"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val InternalError  = "InternalError".asInstanceOf[ErrorCode]
+    val InvalidRequest = "InvalidRequest".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(js.Array(InternalError, InvalidRequest))
   }
@@ -1387,13 +1379,14 @@ package kendra {
       __obj.asInstanceOf[FaqStatistics]
     }
   }
-
-  object FaqStatusEnum {
-    val CREATING = "CREATING"
-    val UPDATING = "UPDATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait FaqStatus extends js.Any
+  object FaqStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[FaqStatus]
+    val UPDATING = "UPDATING".asInstanceOf[FaqStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[FaqStatus]
+    val DELETING = "DELETING".asInstanceOf[FaqStatus]
+    val FAILED   = "FAILED".asInstanceOf[FaqStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, UPDATING, ACTIVE, DELETING, FAILED))
   }
@@ -1512,13 +1505,14 @@ package kendra {
       __obj.asInstanceOf[IndexStatistics]
     }
   }
-
-  object IndexStatusEnum {
-    val CREATING        = "CREATING"
-    val ACTIVE          = "ACTIVE"
-    val DELETING        = "DELETING"
-    val FAILED          = "FAILED"
-    val SYSTEM_UPDATING = "SYSTEM_UPDATING"
+  @js.native
+  sealed trait IndexStatus extends js.Any
+  object IndexStatus extends js.Object {
+    val CREATING        = "CREATING".asInstanceOf[IndexStatus]
+    val ACTIVE          = "ACTIVE".asInstanceOf[IndexStatus]
+    val DELETING        = "DELETING".asInstanceOf[IndexStatus]
+    val FAILED          = "FAILED".asInstanceOf[IndexStatus]
+    val SYSTEM_UPDATING = "SYSTEM_UPDATING".asInstanceOf[IndexStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING, FAILED, SYSTEM_UPDATING))
   }
@@ -1700,10 +1694,11 @@ package kendra {
       __obj.asInstanceOf[ListIndicesResponse]
     }
   }
-
-  object OrderEnum {
-    val ASCENDING  = "ASCENDING"
-    val DESCENDING = "DESCENDING"
+  @js.native
+  sealed trait Order extends js.Any
+  object Order extends js.Object {
+    val ASCENDING  = "ASCENDING".asInstanceOf[Order]
+    val DESCENDING = "DESCENDING".asInstanceOf[Order]
 
     val values = js.Object.freeze(js.Array(ASCENDING, DESCENDING))
   }
@@ -1734,10 +1729,11 @@ package kendra {
       __obj.asInstanceOf[Principal]
     }
   }
-
-  object PrincipalTypeEnum {
-    val USER  = "USER"
-    val GROUP = "GROUP"
+  @js.native
+  sealed trait PrincipalType extends js.Any
+  object PrincipalType extends js.Object {
+    val USER  = "USER".asInstanceOf[PrincipalType]
+    val GROUP = "GROUP".asInstanceOf[PrincipalType]
 
     val values = js.Object.freeze(js.Array(USER, GROUP))
   }
@@ -1848,18 +1844,20 @@ package kendra {
       __obj.asInstanceOf[QueryResultItem]
     }
   }
-
-  object QueryResultTypeEnum {
-    val DOCUMENT        = "DOCUMENT"
-    val QUESTION_ANSWER = "QUESTION_ANSWER"
-    val ANSWER          = "ANSWER"
+  @js.native
+  sealed trait QueryResultType extends js.Any
+  object QueryResultType extends js.Object {
+    val DOCUMENT        = "DOCUMENT".asInstanceOf[QueryResultType]
+    val QUESTION_ANSWER = "QUESTION_ANSWER".asInstanceOf[QueryResultType]
+    val ANSWER          = "ANSWER".asInstanceOf[QueryResultType]
 
     val values = js.Object.freeze(js.Array(DOCUMENT, QUESTION_ANSWER, ANSWER))
   }
-
-  object ReadAccessTypeEnum {
-    val ALLOW = "ALLOW"
-    val DENY  = "DENY"
+  @js.native
+  sealed trait ReadAccessType extends js.Any
+  object ReadAccessType extends js.Object {
+    val ALLOW = "ALLOW".asInstanceOf[ReadAccessType]
+    val DENY  = "DENY".asInstanceOf[ReadAccessType]
 
     val values = js.Object.freeze(js.Array(ALLOW, DENY))
   }
@@ -1918,10 +1916,11 @@ package kendra {
       __obj.asInstanceOf[RelevanceFeedback]
     }
   }
-
-  object RelevanceTypeEnum {
-    val RELEVANT     = "RELEVANT"
-    val NOT_RELEVANT = "NOT_RELEVANT"
+  @js.native
+  sealed trait RelevanceType extends js.Any
+  object RelevanceType extends js.Object {
+    val RELEVANT     = "RELEVANT".asInstanceOf[RelevanceType]
+    val NOT_RELEVANT = "NOT_RELEVANT".asInstanceOf[RelevanceType]
 
     val values = js.Object.freeze(js.Array(RELEVANT, NOT_RELEVANT))
   }
@@ -2069,9 +2068,10 @@ package kendra {
       __obj.asInstanceOf[SharePointConfiguration]
     }
   }
-
-  object SharePointVersionEnum {
-    val SHAREPOINT_ONLINE = "SHAREPOINT_ONLINE"
+  @js.native
+  sealed trait SharePointVersion extends js.Any
+  object SharePointVersion extends js.Object {
+    val SHAREPOINT_ONLINE = "SHAREPOINT_ONLINE".asInstanceOf[SharePointVersion]
 
     val values = js.Object.freeze(js.Array(SHAREPOINT_ONLINE))
   }

--- a/services/kinesis/src/main/scala/facade/amazonaws/services/Kinesis.scala
+++ b/services/kinesis/src/main/scala/facade/amazonaws/services/Kinesis.scala
@@ -12,10 +12,8 @@ package object kinesis {
   type ConsumerCountObject           = Int
   type ConsumerList                  = js.Array[Consumer]
   type ConsumerName                  = String
-  type ConsumerStatus                = String
   type Data                          = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type DescribeStreamInputLimit      = Int
-  type EncryptionType                = String
   type EnhancedMonitoringList        = js.Array[EnhancedMetrics]
   type ErrorCode                     = String
   type ErrorMessage                  = String
@@ -26,7 +24,6 @@ package object kinesis {
   type ListStreamConsumersInputLimit = Int
   type ListStreamsInputLimit         = Int
   type ListTagsForStreamInputLimit   = Int
-  type MetricsName                   = String
   type MetricsNameList               = js.Array[MetricsName]
   type MillisBehindLatest            = Double
   type NextToken                     = String
@@ -36,17 +33,14 @@ package object kinesis {
   type PutRecordsResultEntryList     = js.Array[PutRecordsResultEntry]
   type RecordList                    = js.Array[Record]
   type RetentionPeriodHours          = Int
-  type ScalingType                   = String
   type SequenceNumber                = String
   type ShardCountObject              = Int
   type ShardId                       = String
   type ShardIterator                 = String
-  type ShardIteratorType             = String
   type ShardList                     = js.Array[Shard]
   type StreamARN                     = String
   type StreamName                    = String
   type StreamNameList                = js.Array[StreamName]
-  type StreamStatus                  = String
   type TagKey                        = String
   type TagKeyList                    = js.Array[TagKey]
   type TagList                       = js.Array[Tag]
@@ -238,11 +232,12 @@ package kinesis {
       __obj.asInstanceOf[ConsumerDescription]
     }
   }
-
-  object ConsumerStatusEnum {
-    val CREATING = "CREATING"
-    val DELETING = "DELETING"
-    val ACTIVE   = "ACTIVE"
+  @js.native
+  sealed trait ConsumerStatus extends js.Any
+  object ConsumerStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[ConsumerStatus]
+    val DELETING = "DELETING".asInstanceOf[ConsumerStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[ConsumerStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, DELETING, ACTIVE))
   }
@@ -546,10 +541,11 @@ package kinesis {
       __obj.asInstanceOf[EnableEnhancedMonitoringInput]
     }
   }
-
-  object EncryptionTypeEnum {
-    val NONE = "NONE"
-    val KMS  = "KMS"
+  @js.native
+  sealed trait EncryptionType extends js.Any
+  object EncryptionType extends js.Object {
+    val NONE = "NONE".asInstanceOf[EncryptionType]
+    val KMS  = "KMS".asInstanceOf[EncryptionType]
 
     val values = js.Object.freeze(js.Array(NONE, KMS))
   }
@@ -1050,16 +1046,17 @@ package kinesis {
       __obj.asInstanceOf[MergeShardsInput]
     }
   }
-
-  object MetricsNameEnum {
-    val IncomingBytes                      = "IncomingBytes"
-    val IncomingRecords                    = "IncomingRecords"
-    val OutgoingBytes                      = "OutgoingBytes"
-    val OutgoingRecords                    = "OutgoingRecords"
-    val WriteProvisionedThroughputExceeded = "WriteProvisionedThroughputExceeded"
-    val ReadProvisionedThroughputExceeded  = "ReadProvisionedThroughputExceeded"
-    val IteratorAgeMilliseconds            = "IteratorAgeMilliseconds"
-    val ALL                                = "ALL"
+  @js.native
+  sealed trait MetricsName extends js.Any
+  object MetricsName extends js.Object {
+    val IncomingBytes                      = "IncomingBytes".asInstanceOf[MetricsName]
+    val IncomingRecords                    = "IncomingRecords".asInstanceOf[MetricsName]
+    val OutgoingBytes                      = "OutgoingBytes".asInstanceOf[MetricsName]
+    val OutgoingRecords                    = "OutgoingRecords".asInstanceOf[MetricsName]
+    val WriteProvisionedThroughputExceeded = "WriteProvisionedThroughputExceeded".asInstanceOf[MetricsName]
+    val ReadProvisionedThroughputExceeded  = "ReadProvisionedThroughputExceeded".asInstanceOf[MetricsName]
+    val IteratorAgeMilliseconds            = "IteratorAgeMilliseconds".asInstanceOf[MetricsName]
+    val ALL                                = "ALL".asInstanceOf[MetricsName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1364,9 +1361,10 @@ package kinesis {
   trait ResourceNotFoundExceptionException extends js.Object {
     val message: ErrorMessage
   }
-
-  object ScalingTypeEnum {
-    val UNIFORM_SCALING = "UNIFORM_SCALING"
+  @js.native
+  sealed trait ScalingType extends js.Any
+  object ScalingType extends js.Object {
+    val UNIFORM_SCALING = "UNIFORM_SCALING".asInstanceOf[ScalingType]
 
     val values = js.Object.freeze(js.Array(UNIFORM_SCALING))
   }
@@ -1427,13 +1425,14 @@ package kinesis {
       __obj.asInstanceOf[Shard]
     }
   }
-
-  object ShardIteratorTypeEnum {
-    val AT_SEQUENCE_NUMBER    = "AT_SEQUENCE_NUMBER"
-    val AFTER_SEQUENCE_NUMBER = "AFTER_SEQUENCE_NUMBER"
-    val TRIM_HORIZON          = "TRIM_HORIZON"
-    val LATEST                = "LATEST"
-    val AT_TIMESTAMP          = "AT_TIMESTAMP"
+  @js.native
+  sealed trait ShardIteratorType extends js.Any
+  object ShardIteratorType extends js.Object {
+    val AT_SEQUENCE_NUMBER    = "AT_SEQUENCE_NUMBER".asInstanceOf[ShardIteratorType]
+    val AFTER_SEQUENCE_NUMBER = "AFTER_SEQUENCE_NUMBER".asInstanceOf[ShardIteratorType]
+    val TRIM_HORIZON          = "TRIM_HORIZON".asInstanceOf[ShardIteratorType]
+    val LATEST                = "LATEST".asInstanceOf[ShardIteratorType]
+    val AT_TIMESTAMP          = "AT_TIMESTAMP".asInstanceOf[ShardIteratorType]
 
     val values =
       js.Object.freeze(js.Array(AT_SEQUENCE_NUMBER, AFTER_SEQUENCE_NUMBER, TRIM_HORIZON, LATEST, AT_TIMESTAMP))
@@ -1633,12 +1632,13 @@ package kinesis {
       __obj.asInstanceOf[StreamDescriptionSummary]
     }
   }
-
-  object StreamStatusEnum {
-    val CREATING = "CREATING"
-    val DELETING = "DELETING"
-    val ACTIVE   = "ACTIVE"
-    val UPDATING = "UPDATING"
+  @js.native
+  sealed trait StreamStatus extends js.Any
+  object StreamStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[StreamStatus]
+    val DELETING = "DELETING".asInstanceOf[StreamStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[StreamStatus]
+    val UPDATING = "UPDATING".asInstanceOf[StreamStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, DELETING, ACTIVE, UPDATING))
   }

--- a/services/kinesisanalytics/src/main/scala/facade/amazonaws/services/KinesisAnalytics.scala
+++ b/services/kinesisanalytics/src/main/scala/facade/amazonaws/services/KinesisAnalytics.scala
@@ -10,7 +10,6 @@ package object kinesisanalytics {
   type ApplicationCode                     = String
   type ApplicationDescription              = String
   type ApplicationName                     = String
-  type ApplicationStatus                   = String
   type ApplicationSummaries                = js.Array[ApplicationSummary]
   type ApplicationVersionId                = Double
   type BooleanObject                       = Boolean
@@ -26,7 +25,6 @@ package object kinesisanalytics {
   type InputConfigurations                 = js.Array[InputConfiguration]
   type InputDescriptions                   = js.Array[InputDescription]
   type InputParallelismCount               = Int
-  type InputStartingPosition               = String
   type InputUpdates                        = js.Array[InputUpdate]
   type Inputs                              = js.Array[Input]
   type KinesisAnalyticsARN                 = String
@@ -48,7 +46,6 @@ package object kinesisanalytics {
   type RecordColumnSqlType                 = String
   type RecordColumns                       = js.Array[RecordColumn]
   type RecordEncoding                      = String
-  type RecordFormatType                    = String
   type RecordRowDelimiter                  = String
   type RecordRowPath                       = String
   type ReferenceDataSourceDescriptions     = js.Array[ReferenceDataSourceDescription]
@@ -424,14 +421,15 @@ package kinesisanalytics {
       __obj.asInstanceOf[ApplicationDetail]
     }
   }
-
-  object ApplicationStatusEnum {
-    val DELETING = "DELETING"
-    val STARTING = "STARTING"
-    val STOPPING = "STOPPING"
-    val READY    = "READY"
-    val RUNNING  = "RUNNING"
-    val UPDATING = "UPDATING"
+  @js.native
+  sealed trait ApplicationStatus extends js.Any
+  object ApplicationStatus extends js.Object {
+    val DELETING = "DELETING".asInstanceOf[ApplicationStatus]
+    val STARTING = "STARTING".asInstanceOf[ApplicationStatus]
+    val STOPPING = "STOPPING".asInstanceOf[ApplicationStatus]
+    val READY    = "READY".asInstanceOf[ApplicationStatus]
+    val RUNNING  = "RUNNING".asInstanceOf[ApplicationStatus]
+    val UPDATING = "UPDATING".asInstanceOf[ApplicationStatus]
 
     val values = js.Object.freeze(js.Array(DELETING, STARTING, STOPPING, READY, RUNNING, UPDATING))
   }
@@ -1288,11 +1286,12 @@ package kinesisanalytics {
       __obj.asInstanceOf[InputSchemaUpdate]
     }
   }
-
-  object InputStartingPositionEnum {
-    val NOW                = "NOW"
-    val TRIM_HORIZON       = "TRIM_HORIZON"
-    val LAST_STOPPED_POINT = "LAST_STOPPED_POINT"
+  @js.native
+  sealed trait InputStartingPosition extends js.Any
+  object InputStartingPosition extends js.Object {
+    val NOW                = "NOW".asInstanceOf[InputStartingPosition]
+    val TRIM_HORIZON       = "TRIM_HORIZON".asInstanceOf[InputStartingPosition]
+    val LAST_STOPPED_POINT = "LAST_STOPPED_POINT".asInstanceOf[InputStartingPosition]
 
     val values = js.Object.freeze(js.Array(NOW, TRIM_HORIZON, LAST_STOPPED_POINT))
   }
@@ -1989,10 +1988,11 @@ package kinesisanalytics {
       __obj.asInstanceOf[RecordFormat]
     }
   }
-
-  object RecordFormatTypeEnum {
-    val JSON = "JSON"
-    val CSV  = "CSV"
+  @js.native
+  sealed trait RecordFormatType extends js.Any
+  object RecordFormatType extends js.Object {
+    val JSON = "JSON".asInstanceOf[RecordFormatType]
+    val CSV  = "CSV".asInstanceOf[RecordFormatType]
 
     val values = js.Object.freeze(js.Array(JSON, CSV))
   }

--- a/services/kinesisanalyticsv2/src/main/scala/facade/amazonaws/services/KinesisAnalyticsV2.scala
+++ b/services/kinesisanalyticsv2/src/main/scala/facade/amazonaws/services/KinesisAnalyticsV2.scala
@@ -9,8 +9,6 @@ import facade.amazonaws._
 package object kinesisanalyticsv2 {
   type ApplicationDescription              = String
   type ApplicationName                     = String
-  type ApplicationRestoreType              = String
-  type ApplicationStatus                   = String
   type ApplicationSummaries                = js.Array[ApplicationSummary]
   type ApplicationVersionId                = Double
   type BooleanObject                       = Boolean
@@ -19,10 +17,8 @@ package object kinesisanalyticsv2 {
   type CloudWatchLoggingOptionDescriptions = js.Array[CloudWatchLoggingOptionDescription]
   type CloudWatchLoggingOptionUpdates      = js.Array[CloudWatchLoggingOptionUpdate]
   type CloudWatchLoggingOptions            = js.Array[CloudWatchLoggingOption]
-  type CodeContentType                     = String
   type CodeMD5                             = String
   type CodeSize                            = Double
-  type ConfigurationType                   = String
   type FileKey                             = String
   type Id                                  = String
   type InAppStreamName                     = String
@@ -30,16 +26,13 @@ package object kinesisanalyticsv2 {
   type InAppTableName                      = String
   type InputDescriptions                   = js.Array[InputDescription]
   type InputParallelismCount               = Int
-  type InputStartingPosition               = String
   type InputUpdates                        = js.Array[InputUpdate]
   type Inputs                              = js.Array[Input]
   type JobPlanDescription                  = String
   type KinesisAnalyticsARN                 = String
   type ListApplicationsInputLimit          = Int
   type ListSnapshotsInputLimit             = Int
-  type LogLevel                            = String
   type LogStreamARN                        = String
-  type MetricsLevel                        = String
   type MinPauseBetweenCheckpoints          = Double
   type NextToken                           = String
   type ObjectVersion                       = String
@@ -65,7 +58,6 @@ package object kinesisanalyticsv2 {
   type RecordColumnSqlType                 = String
   type RecordColumns                       = js.Array[RecordColumn]
   type RecordEncoding                      = String
-  type RecordFormatType                    = String
   type RecordRowDelimiter                  = String
   type RecordRowPath                       = String
   type ReferenceDataSourceDescriptions     = js.Array[ReferenceDataSourceDescription]
@@ -73,11 +65,9 @@ package object kinesisanalyticsv2 {
   type ReferenceDataSources                = js.Array[ReferenceDataSource]
   type ResourceARN                         = String
   type RoleARN                             = String
-  type RuntimeEnvironment                  = String
   type SecurityGroupId                     = String
   type SecurityGroupIds                    = js.Array[SecurityGroupId]
   type SnapshotName                        = String
-  type SnapshotStatus                      = String
   type SnapshotSummaries                   = js.Array[SnapshotDetails]
   type SqlRunConfigurations                = js.Array[SqlRunConfiguration]
   type SubnetId                            = String
@@ -805,11 +795,12 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[ApplicationRestoreConfiguration]
     }
   }
-
-  object ApplicationRestoreTypeEnum {
-    val SKIP_RESTORE_FROM_SNAPSHOT   = "SKIP_RESTORE_FROM_SNAPSHOT"
-    val RESTORE_FROM_LATEST_SNAPSHOT = "RESTORE_FROM_LATEST_SNAPSHOT"
-    val RESTORE_FROM_CUSTOM_SNAPSHOT = "RESTORE_FROM_CUSTOM_SNAPSHOT"
+  @js.native
+  sealed trait ApplicationRestoreType extends js.Any
+  object ApplicationRestoreType extends js.Object {
+    val SKIP_RESTORE_FROM_SNAPSHOT   = "SKIP_RESTORE_FROM_SNAPSHOT".asInstanceOf[ApplicationRestoreType]
+    val RESTORE_FROM_LATEST_SNAPSHOT = "RESTORE_FROM_LATEST_SNAPSHOT".asInstanceOf[ApplicationRestoreType]
+    val RESTORE_FROM_CUSTOM_SNAPSHOT = "RESTORE_FROM_CUSTOM_SNAPSHOT".asInstanceOf[ApplicationRestoreType]
 
     val values =
       js.Object.freeze(js.Array(SKIP_RESTORE_FROM_SNAPSHOT, RESTORE_FROM_LATEST_SNAPSHOT, RESTORE_FROM_CUSTOM_SNAPSHOT))
@@ -877,14 +868,15 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[ApplicationSnapshotConfigurationUpdate]
     }
   }
-
-  object ApplicationStatusEnum {
-    val DELETING = "DELETING"
-    val STARTING = "STARTING"
-    val STOPPING = "STOPPING"
-    val READY    = "READY"
-    val RUNNING  = "RUNNING"
-    val UPDATING = "UPDATING"
+  @js.native
+  sealed trait ApplicationStatus extends js.Any
+  object ApplicationStatus extends js.Object {
+    val DELETING = "DELETING".asInstanceOf[ApplicationStatus]
+    val STARTING = "STARTING".asInstanceOf[ApplicationStatus]
+    val STOPPING = "STOPPING".asInstanceOf[ApplicationStatus]
+    val READY    = "READY".asInstanceOf[ApplicationStatus]
+    val RUNNING  = "RUNNING".asInstanceOf[ApplicationStatus]
+    val UPDATING = "UPDATING".asInstanceOf[ApplicationStatus]
 
     val values = js.Object.freeze(js.Array(DELETING, STARTING, STOPPING, READY, RUNNING, UPDATING))
   }
@@ -1170,10 +1162,11 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[CodeContentDescription]
     }
   }
-
-  object CodeContentTypeEnum {
-    val PLAINTEXT = "PLAINTEXT"
-    val ZIPFILE   = "ZIPFILE"
+  @js.native
+  sealed trait CodeContentType extends js.Any
+  object CodeContentType extends js.Object {
+    val PLAINTEXT = "PLAINTEXT".asInstanceOf[CodeContentType]
+    val ZIPFILE   = "ZIPFILE".asInstanceOf[CodeContentType]
 
     val values = js.Object.freeze(js.Array(PLAINTEXT, ZIPFILE))
   }
@@ -1202,10 +1195,11 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[CodeContentUpdate]
     }
   }
-
-  object ConfigurationTypeEnum {
-    val DEFAULT = "DEFAULT"
-    val CUSTOM  = "CUSTOM"
+  @js.native
+  sealed trait ConfigurationType extends js.Any
+  object ConfigurationType extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[ConfigurationType]
+    val CUSTOM  = "CUSTOM".asInstanceOf[ConfigurationType]
 
     val values = js.Object.freeze(js.Array(DEFAULT, CUSTOM))
   }
@@ -2201,11 +2195,12 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[InputSchemaUpdate]
     }
   }
-
-  object InputStartingPositionEnum {
-    val NOW                = "NOW"
-    val TRIM_HORIZON       = "TRIM_HORIZON"
-    val LAST_STOPPED_POINT = "LAST_STOPPED_POINT"
+  @js.native
+  sealed trait InputStartingPosition extends js.Any
+  object InputStartingPosition extends js.Object {
+    val NOW                = "NOW".asInstanceOf[InputStartingPosition]
+    val TRIM_HORIZON       = "TRIM_HORIZON".asInstanceOf[InputStartingPosition]
+    val LAST_STOPPED_POINT = "LAST_STOPPED_POINT".asInstanceOf[InputStartingPosition]
 
     val values = js.Object.freeze(js.Array(NOW, TRIM_HORIZON, LAST_STOPPED_POINT))
   }
@@ -2741,12 +2736,13 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object LogLevelEnum {
-    val INFO  = "INFO"
-    val WARN  = "WARN"
-    val ERROR = "ERROR"
-    val DEBUG = "DEBUG"
+  @js.native
+  sealed trait LogLevel extends js.Any
+  object LogLevel extends js.Object {
+    val INFO  = "INFO".asInstanceOf[LogLevel]
+    val WARN  = "WARN".asInstanceOf[LogLevel]
+    val ERROR = "ERROR".asInstanceOf[LogLevel]
+    val DEBUG = "DEBUG".asInstanceOf[LogLevel]
 
     val values = js.Object.freeze(js.Array(INFO, WARN, ERROR, DEBUG))
   }
@@ -2772,12 +2768,13 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[MappingParameters]
     }
   }
-
-  object MetricsLevelEnum {
-    val APPLICATION = "APPLICATION"
-    val TASK        = "TASK"
-    val OPERATOR    = "OPERATOR"
-    val PARALLELISM = "PARALLELISM"
+  @js.native
+  sealed trait MetricsLevel extends js.Any
+  object MetricsLevel extends js.Object {
+    val APPLICATION = "APPLICATION".asInstanceOf[MetricsLevel]
+    val TASK        = "TASK".asInstanceOf[MetricsLevel]
+    val OPERATOR    = "OPERATOR".asInstanceOf[MetricsLevel]
+    val PARALLELISM = "PARALLELISM".asInstanceOf[MetricsLevel]
 
     val values = js.Object.freeze(js.Array(APPLICATION, TASK, OPERATOR, PARALLELISM))
   }
@@ -3135,10 +3132,11 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[RecordFormat]
     }
   }
-
-  object RecordFormatTypeEnum {
-    val JSON = "JSON"
-    val CSV  = "CSV"
+  @js.native
+  sealed trait RecordFormatType extends js.Any
+  object RecordFormatType extends js.Object {
+    val JSON = "JSON".asInstanceOf[RecordFormatType]
+    val CSV  = "CSV".asInstanceOf[RecordFormatType]
 
     val values = js.Object.freeze(js.Array(JSON, CSV))
   }
@@ -3303,11 +3301,12 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[RunConfigurationUpdate]
     }
   }
-
-  object RuntimeEnvironmentEnum {
-    val `SQL-1_0`   = "SQL-1_0"
-    val `FLINK-1_6` = "FLINK-1_6"
-    val `FLINK-1_8` = "FLINK-1_8"
+  @js.native
+  sealed trait RuntimeEnvironment extends js.Any
+  object RuntimeEnvironment extends js.Object {
+    val `SQL-1_0`   = "SQL-1_0".asInstanceOf[RuntimeEnvironment]
+    val `FLINK-1_6` = "FLINK-1_6".asInstanceOf[RuntimeEnvironment]
+    val `FLINK-1_8` = "FLINK-1_8".asInstanceOf[RuntimeEnvironment]
 
     val values = js.Object.freeze(js.Array(`SQL-1_0`, `FLINK-1_6`, `FLINK-1_8`))
   }
@@ -3518,12 +3517,13 @@ package kinesisanalyticsv2 {
       __obj.asInstanceOf[SnapshotDetails]
     }
   }
-
-  object SnapshotStatusEnum {
-    val CREATING = "CREATING"
-    val READY    = "READY"
-    val DELETING = "DELETING"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait SnapshotStatus extends js.Any
+  object SnapshotStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[SnapshotStatus]
+    val READY    = "READY".asInstanceOf[SnapshotStatus]
+    val DELETING = "DELETING".asInstanceOf[SnapshotStatus]
+    val FAILED   = "FAILED".asInstanceOf[SnapshotStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, READY, DELETING, FAILED))
   }

--- a/services/kinesisvideo/src/main/scala/facade/amazonaws/services/KinesisVideo.scala
+++ b/services/kinesisvideo/src/main/scala/facade/amazonaws/services/KinesisVideo.scala
@@ -7,38 +7,31 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object kinesisvideo {
-  type APIName                      = String
-  type ChannelInfoList              = js.Array[ChannelInfo]
-  type ChannelName                  = String
-  type ChannelProtocol              = String
-  type ChannelRole                  = String
-  type ChannelType                  = String
-  type ComparisonOperator           = String
-  type DataEndpoint                 = String
-  type DataRetentionChangeInHours   = Int
-  type DataRetentionInHours         = Int
-  type DeviceName                   = String
-  type KmsKeyId                     = String
-  type ListOfProtocols              = js.Array[ChannelProtocol]
-  type ListStreamsInputLimit        = Int
-  type MediaType                    = String
-  type MessageTtlSeconds            = Int
-  type NextToken                    = String
-  type ResourceARN                  = String
-  type ResourceEndpoint             = String
-  type ResourceEndpointList         = js.Array[ResourceEndpointListItem]
-  type ResourceTags                 = js.Dictionary[TagValue]
-  type Status                       = String
-  type StreamInfoList               = js.Array[StreamInfo]
-  type StreamName                   = String
-  type TagKey                       = String
-  type TagKeyList                   = js.Array[TagKey]
-  type TagList                      = js.Array[Tag]
-  type TagOnCreateList              = js.Array[Tag]
-  type TagValue                     = String
-  type Timestamp                    = js.Date
-  type UpdateDataRetentionOperation = String
-  type Version                      = String
+  type ChannelInfoList            = js.Array[ChannelInfo]
+  type ChannelName                = String
+  type DataEndpoint               = String
+  type DataRetentionChangeInHours = Int
+  type DataRetentionInHours       = Int
+  type DeviceName                 = String
+  type KmsKeyId                   = String
+  type ListOfProtocols            = js.Array[ChannelProtocol]
+  type ListStreamsInputLimit      = Int
+  type MediaType                  = String
+  type MessageTtlSeconds          = Int
+  type NextToken                  = String
+  type ResourceARN                = String
+  type ResourceEndpoint           = String
+  type ResourceEndpointList       = js.Array[ResourceEndpointListItem]
+  type ResourceTags               = js.Dictionary[TagValue]
+  type StreamInfoList             = js.Array[StreamInfo]
+  type StreamName                 = String
+  type TagKey                     = String
+  type TagKeyList                 = js.Array[TagKey]
+  type TagList                    = js.Array[Tag]
+  type TagOnCreateList            = js.Array[Tag]
+  type TagValue                   = String
+  type Timestamp                  = js.Date
+  type Version                    = String
 
   implicit final class KinesisVideoOps(private val service: KinesisVideo) extends AnyVal {
 
@@ -117,14 +110,15 @@ package kinesisvideo {
     def updateSignalingChannel(params: UpdateSignalingChannelInput): Request[UpdateSignalingChannelOutput] = js.native
     def updateStream(params: UpdateStreamInput): Request[UpdateStreamOutput]                               = js.native
   }
-
-  object APINameEnum {
-    val PUT_MEDIA                      = "PUT_MEDIA"
-    val GET_MEDIA                      = "GET_MEDIA"
-    val LIST_FRAGMENTS                 = "LIST_FRAGMENTS"
-    val GET_MEDIA_FOR_FRAGMENT_LIST    = "GET_MEDIA_FOR_FRAGMENT_LIST"
-    val GET_HLS_STREAMING_SESSION_URL  = "GET_HLS_STREAMING_SESSION_URL"
-    val GET_DASH_STREAMING_SESSION_URL = "GET_DASH_STREAMING_SESSION_URL"
+  @js.native
+  sealed trait APIName extends js.Any
+  object APIName extends js.Object {
+    val PUT_MEDIA                      = "PUT_MEDIA".asInstanceOf[APIName]
+    val GET_MEDIA                      = "GET_MEDIA".asInstanceOf[APIName]
+    val LIST_FRAGMENTS                 = "LIST_FRAGMENTS".asInstanceOf[APIName]
+    val GET_MEDIA_FOR_FRAGMENT_LIST    = "GET_MEDIA_FOR_FRAGMENT_LIST".asInstanceOf[APIName]
+    val GET_HLS_STREAMING_SESSION_URL  = "GET_HLS_STREAMING_SESSION_URL".asInstanceOf[APIName]
+    val GET_DASH_STREAMING_SESSION_URL = "GET_DASH_STREAMING_SESSION_URL".asInstanceOf[APIName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -198,29 +192,33 @@ package kinesisvideo {
       __obj.asInstanceOf[ChannelNameCondition]
     }
   }
-
-  object ChannelProtocolEnum {
-    val WSS   = "WSS"
-    val HTTPS = "HTTPS"
+  @js.native
+  sealed trait ChannelProtocol extends js.Any
+  object ChannelProtocol extends js.Object {
+    val WSS   = "WSS".asInstanceOf[ChannelProtocol]
+    val HTTPS = "HTTPS".asInstanceOf[ChannelProtocol]
 
     val values = js.Object.freeze(js.Array(WSS, HTTPS))
   }
-
-  object ChannelRoleEnum {
-    val MASTER = "MASTER"
-    val VIEWER = "VIEWER"
+  @js.native
+  sealed trait ChannelRole extends js.Any
+  object ChannelRole extends js.Object {
+    val MASTER = "MASTER".asInstanceOf[ChannelRole]
+    val VIEWER = "VIEWER".asInstanceOf[ChannelRole]
 
     val values = js.Object.freeze(js.Array(MASTER, VIEWER))
   }
-
-  object ChannelTypeEnum {
-    val SINGLE_MASTER = "SINGLE_MASTER"
+  @js.native
+  sealed trait ChannelType extends js.Any
+  object ChannelType extends js.Object {
+    val SINGLE_MASTER = "SINGLE_MASTER".asInstanceOf[ChannelType]
 
     val values = js.Object.freeze(js.Array(SINGLE_MASTER))
   }
-
-  object ComparisonOperatorEnum {
-    val BEGINS_WITH = "BEGINS_WITH"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val BEGINS_WITH = "BEGINS_WITH".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(js.Array(BEGINS_WITH))
   }
@@ -761,12 +759,13 @@ package kinesisvideo {
       __obj.asInstanceOf[SingleMasterConfiguration]
     }
   }
-
-  object StatusEnum {
-    val CREATING = "CREATING"
-    val ACTIVE   = "ACTIVE"
-    val UPDATING = "UPDATING"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[Status]
+    val ACTIVE   = "ACTIVE".asInstanceOf[Status]
+    val UPDATING = "UPDATING".asInstanceOf[Status]
+    val DELETING = "DELETING".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, UPDATING, DELETING))
   }
@@ -1031,10 +1030,11 @@ package kinesisvideo {
       __obj.asInstanceOf[UpdateDataRetentionInput]
     }
   }
-
-  object UpdateDataRetentionOperationEnum {
-    val INCREASE_DATA_RETENTION = "INCREASE_DATA_RETENTION"
-    val DECREASE_DATA_RETENTION = "DECREASE_DATA_RETENTION"
+  @js.native
+  sealed trait UpdateDataRetentionOperation extends js.Any
+  object UpdateDataRetentionOperation extends js.Object {
+    val INCREASE_DATA_RETENTION = "INCREASE_DATA_RETENTION".asInstanceOf[UpdateDataRetentionOperation]
+    val DECREASE_DATA_RETENTION = "DECREASE_DATA_RETENTION".asInstanceOf[UpdateDataRetentionOperation]
 
     val values = js.Object.freeze(js.Array(INCREASE_DATA_RETENTION, DECREASE_DATA_RETENTION))
   }

--- a/services/kinesisvideoarchivedmedia/src/main/scala/facade/amazonaws/services/KinesisVideoArchivedMedia.scala
+++ b/services/kinesisvideoarchivedmedia/src/main/scala/facade/amazonaws/services/KinesisVideoArchivedMedia.scala
@@ -7,28 +7,18 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object kinesisvideoarchivedmedia {
-  type ContainerFormat              = String
-  type ContentType                  = String
-  type DASHDisplayFragmentNumber    = String
-  type DASHDisplayFragmentTimestamp = String
-  type DASHFragmentSelectorType     = String
-  type DASHPlaybackMode             = String
-  type DASHStreamingSessionURL      = String
-  type Expires                      = Int
-  type FragmentList                 = js.Array[Fragment]
-  type FragmentNumberList           = js.Array[FragmentNumberString]
-  type FragmentNumberString         = String
-  type FragmentSelectorType         = String
-  type HLSDiscontinuityMode         = String
-  type HLSDisplayFragmentTimestamp  = String
-  type HLSFragmentSelectorType      = String
-  type HLSPlaybackMode              = String
-  type HLSStreamingSessionURL       = String
-  type PageLimit                    = Double
-  type Payload                      = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type ResourceARN                  = String
-  type StreamName                   = String
-  type Timestamp                    = js.Date
+  type ContentType             = String
+  type DASHStreamingSessionURL = String
+  type Expires                 = Int
+  type FragmentList            = js.Array[Fragment]
+  type FragmentNumberList      = js.Array[FragmentNumberString]
+  type FragmentNumberString    = String
+  type HLSStreamingSessionURL  = String
+  type PageLimit               = Double
+  type Payload                 = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type ResourceARN             = String
+  type StreamName              = String
+  type Timestamp               = js.Date
 
   implicit final class KinesisVideoArchivedMediaOps(private val service: KinesisVideoArchivedMedia) extends AnyVal {
 
@@ -60,24 +50,27 @@ package kinesisvideoarchivedmedia {
       js.native
     def listFragments(params: ListFragmentsInput): Request[ListFragmentsOutput] = js.native
   }
-
-  object ContainerFormatEnum {
-    val FRAGMENTED_MP4 = "FRAGMENTED_MP4"
-    val MPEG_TS        = "MPEG_TS"
+  @js.native
+  sealed trait ContainerFormat extends js.Any
+  object ContainerFormat extends js.Object {
+    val FRAGMENTED_MP4 = "FRAGMENTED_MP4".asInstanceOf[ContainerFormat]
+    val MPEG_TS        = "MPEG_TS".asInstanceOf[ContainerFormat]
 
     val values = js.Object.freeze(js.Array(FRAGMENTED_MP4, MPEG_TS))
   }
-
-  object DASHDisplayFragmentNumberEnum {
-    val ALWAYS = "ALWAYS"
-    val NEVER  = "NEVER"
+  @js.native
+  sealed trait DASHDisplayFragmentNumber extends js.Any
+  object DASHDisplayFragmentNumber extends js.Object {
+    val ALWAYS = "ALWAYS".asInstanceOf[DASHDisplayFragmentNumber]
+    val NEVER  = "NEVER".asInstanceOf[DASHDisplayFragmentNumber]
 
     val values = js.Object.freeze(js.Array(ALWAYS, NEVER))
   }
-
-  object DASHDisplayFragmentTimestampEnum {
-    val ALWAYS = "ALWAYS"
-    val NEVER  = "NEVER"
+  @js.native
+  sealed trait DASHDisplayFragmentTimestamp extends js.Any
+  object DASHDisplayFragmentTimestamp extends js.Object {
+    val ALWAYS = "ALWAYS".asInstanceOf[DASHDisplayFragmentTimestamp]
+    val NEVER  = "NEVER".asInstanceOf[DASHDisplayFragmentTimestamp]
 
     val values = js.Object.freeze(js.Array(ALWAYS, NEVER))
   }
@@ -103,18 +96,20 @@ package kinesisvideoarchivedmedia {
       __obj.asInstanceOf[DASHFragmentSelector]
     }
   }
-
-  object DASHFragmentSelectorTypeEnum {
-    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP"
-    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP"
+  @js.native
+  sealed trait DASHFragmentSelectorType extends js.Any
+  object DASHFragmentSelectorType extends js.Object {
+    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP".asInstanceOf[DASHFragmentSelectorType]
+    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP".asInstanceOf[DASHFragmentSelectorType]
 
     val values = js.Object.freeze(js.Array(PRODUCER_TIMESTAMP, SERVER_TIMESTAMP))
   }
-
-  object DASHPlaybackModeEnum {
-    val LIVE        = "LIVE"
-    val LIVE_REPLAY = "LIVE_REPLAY"
-    val ON_DEMAND   = "ON_DEMAND"
+  @js.native
+  sealed trait DASHPlaybackMode extends js.Any
+  object DASHPlaybackMode extends js.Object {
+    val LIVE        = "LIVE".asInstanceOf[DASHPlaybackMode]
+    val LIVE_REPLAY = "LIVE_REPLAY".asInstanceOf[DASHPlaybackMode]
+    val ON_DEMAND   = "ON_DEMAND".asInstanceOf[DASHPlaybackMode]
 
     val values = js.Object.freeze(js.Array(LIVE, LIVE_REPLAY, ON_DEMAND))
   }
@@ -206,10 +201,11 @@ package kinesisvideoarchivedmedia {
       __obj.asInstanceOf[FragmentSelector]
     }
   }
-
-  object FragmentSelectorTypeEnum {
-    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP"
-    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP"
+  @js.native
+  sealed trait FragmentSelectorType extends js.Any
+  object FragmentSelectorType extends js.Object {
+    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP".asInstanceOf[FragmentSelectorType]
+    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP".asInstanceOf[FragmentSelectorType]
 
     val values = js.Object.freeze(js.Array(PRODUCER_TIMESTAMP, SERVER_TIMESTAMP))
   }
@@ -366,18 +362,20 @@ package kinesisvideoarchivedmedia {
       __obj.asInstanceOf[GetMediaForFragmentListOutput]
     }
   }
-
-  object HLSDiscontinuityModeEnum {
-    val ALWAYS           = "ALWAYS"
-    val NEVER            = "NEVER"
-    val ON_DISCONTINUITY = "ON_DISCONTINUITY"
+  @js.native
+  sealed trait HLSDiscontinuityMode extends js.Any
+  object HLSDiscontinuityMode extends js.Object {
+    val ALWAYS           = "ALWAYS".asInstanceOf[HLSDiscontinuityMode]
+    val NEVER            = "NEVER".asInstanceOf[HLSDiscontinuityMode]
+    val ON_DISCONTINUITY = "ON_DISCONTINUITY".asInstanceOf[HLSDiscontinuityMode]
 
     val values = js.Object.freeze(js.Array(ALWAYS, NEVER, ON_DISCONTINUITY))
   }
-
-  object HLSDisplayFragmentTimestampEnum {
-    val ALWAYS = "ALWAYS"
-    val NEVER  = "NEVER"
+  @js.native
+  sealed trait HLSDisplayFragmentTimestamp extends js.Any
+  object HLSDisplayFragmentTimestamp extends js.Object {
+    val ALWAYS = "ALWAYS".asInstanceOf[HLSDisplayFragmentTimestamp]
+    val NEVER  = "NEVER".asInstanceOf[HLSDisplayFragmentTimestamp]
 
     val values = js.Object.freeze(js.Array(ALWAYS, NEVER))
   }
@@ -403,18 +401,20 @@ package kinesisvideoarchivedmedia {
       __obj.asInstanceOf[HLSFragmentSelector]
     }
   }
-
-  object HLSFragmentSelectorTypeEnum {
-    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP"
-    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP"
+  @js.native
+  sealed trait HLSFragmentSelectorType extends js.Any
+  object HLSFragmentSelectorType extends js.Object {
+    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP".asInstanceOf[HLSFragmentSelectorType]
+    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP".asInstanceOf[HLSFragmentSelectorType]
 
     val values = js.Object.freeze(js.Array(PRODUCER_TIMESTAMP, SERVER_TIMESTAMP))
   }
-
-  object HLSPlaybackModeEnum {
-    val LIVE        = "LIVE"
-    val LIVE_REPLAY = "LIVE_REPLAY"
-    val ON_DEMAND   = "ON_DEMAND"
+  @js.native
+  sealed trait HLSPlaybackMode extends js.Any
+  object HLSPlaybackMode extends js.Object {
+    val LIVE        = "LIVE".asInstanceOf[HLSPlaybackMode]
+    val LIVE_REPLAY = "LIVE_REPLAY".asInstanceOf[HLSPlaybackMode]
+    val ON_DEMAND   = "ON_DEMAND".asInstanceOf[HLSPlaybackMode]
 
     val values = js.Object.freeze(js.Array(LIVE, LIVE_REPLAY, ON_DEMAND))
   }

--- a/services/kinesisvideomedia/src/main/scala/facade/amazonaws/services/KinesisVideoMedia.scala
+++ b/services/kinesisvideomedia/src/main/scala/facade/amazonaws/services/KinesisVideoMedia.scala
@@ -12,7 +12,6 @@ package object kinesisvideomedia {
   type FragmentNumberString = String
   type Payload              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type ResourceARN          = String
-  type StartSelectorType    = String
   type StreamName           = String
   type Timestamp            = js.Date
 
@@ -107,14 +106,15 @@ package kinesisvideomedia {
       __obj.asInstanceOf[StartSelector]
     }
   }
-
-  object StartSelectorTypeEnum {
-    val FRAGMENT_NUMBER    = "FRAGMENT_NUMBER"
-    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP"
-    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP"
-    val NOW                = "NOW"
-    val EARLIEST           = "EARLIEST"
-    val CONTINUATION_TOKEN = "CONTINUATION_TOKEN"
+  @js.native
+  sealed trait StartSelectorType extends js.Any
+  object StartSelectorType extends js.Object {
+    val FRAGMENT_NUMBER    = "FRAGMENT_NUMBER".asInstanceOf[StartSelectorType]
+    val SERVER_TIMESTAMP   = "SERVER_TIMESTAMP".asInstanceOf[StartSelectorType]
+    val PRODUCER_TIMESTAMP = "PRODUCER_TIMESTAMP".asInstanceOf[StartSelectorType]
+    val NOW                = "NOW".asInstanceOf[StartSelectorType]
+    val EARLIEST           = "EARLIEST".asInstanceOf[StartSelectorType]
+    val CONTINUATION_TOKEN = "CONTINUATION_TOKEN".asInstanceOf[StartSelectorType]
 
     val values = js.Object.freeze(
       js.Array(FRAGMENT_NUMBER, SERVER_TIMESTAMP, PRODUCER_TIMESTAMP, NOW, EARLIEST, CONTINUATION_TOKEN)

--- a/services/kinesisvideosignaling/src/main/scala/facade/amazonaws/services/KinesisVideoSignaling.scala
+++ b/services/kinesisvideosignaling/src/main/scala/facade/amazonaws/services/KinesisVideoSignaling.scala
@@ -13,7 +13,6 @@ package object kinesisvideosignaling {
   type MessagePayload = String
   type Password       = String
   type ResourceARN    = String
-  type Service        = String
   type Ttl            = Int
   type Uri            = String
   type Uris           = js.Array[Uri]
@@ -150,9 +149,10 @@ package kinesisvideosignaling {
       __obj.asInstanceOf[SendAlexaOfferToMasterResponse]
     }
   }
-
-  object ServiceEnum {
-    val TURN = "TURN"
+  @js.native
+  sealed trait Service extends js.Any
+  object Service extends js.Object {
+    val TURN = "TURN".asInstanceOf[Service]
 
     val values = js.Object.freeze(js.Array(TURN))
   }

--- a/services/kms/src/main/scala/facade/amazonaws/services/KMS.scala
+++ b/services/kms/src/main/scala/facade/amazonaws/services/KMS.scala
@@ -8,47 +8,33 @@ import facade.amazonaws._
 
 package object kms {
   type AWSAccountIdType            = String
-  type AlgorithmSpec               = String
   type AliasList                   = js.Array[AliasListEntry]
   type AliasNameType               = String
   type ArnType                     = String
   type BooleanType                 = Boolean
   type CiphertextType              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type CloudHsmClusterIdType       = String
-  type ConnectionErrorCodeType     = String
-  type ConnectionStateType         = String
   type CustomKeyStoreIdType        = String
   type CustomKeyStoreNameType      = String
   type CustomKeyStoresList         = js.Array[CustomKeyStoresListEntry]
-  type CustomerMasterKeySpec       = String
-  type DataKeyPairSpec             = String
-  type DataKeySpec                 = String
   type DateType                    = js.Date
   type DescriptionType             = String
-  type EncryptionAlgorithmSpec     = String
   type EncryptionAlgorithmSpecList = js.Array[EncryptionAlgorithmSpec]
   type EncryptionContextKey        = String
   type EncryptionContextType       = js.Dictionary[EncryptionContextValue]
   type EncryptionContextValue      = String
-  type ExpirationModelType         = String
   type GrantIdType                 = String
   type GrantList                   = js.Array[GrantListEntry]
   type GrantNameType               = String
-  type GrantOperation              = String
   type GrantOperationList          = js.Array[GrantOperation]
   type GrantTokenList              = js.Array[GrantTokenType]
   type GrantTokenType              = String
   type KeyIdType                   = String
   type KeyList                     = js.Array[KeyListEntry]
-  type KeyManagerType              = String
-  type KeyState                    = String
   type KeyStorePasswordType        = String
-  type KeyUsageType                = String
   type LimitType                   = Int
   type MarkerType                  = String
-  type MessageType                 = String
   type NumberOfBytesType           = Int
-  type OriginType                  = String
   type PendingWindowInDaysType     = Int
   type PlaintextType               = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type PolicyNameList              = js.Array[PolicyNameType]
@@ -56,14 +42,12 @@ package object kms {
   type PolicyType                  = String
   type PrincipalIdType             = String
   type PublicKeyType               = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type SigningAlgorithmSpec        = String
   type SigningAlgorithmSpecList    = js.Array[SigningAlgorithmSpec]
   type TagKeyList                  = js.Array[TagKeyType]
   type TagKeyType                  = String
   type TagList                     = js.Array[Tag]
   type TagValueType                = String
   type TrustAnchorCertificateType  = String
-  type WrappingKeySpec             = String
 
   implicit final class KMSOps(private val service: KMS) extends AnyVal {
 
@@ -228,11 +212,12 @@ package kms {
     def updateKeyDescription(params: UpdateKeyDescriptionRequest): Request[js.Object]                    = js.native
     def verify(params: VerifyRequest): Request[VerifyResponse]                                           = js.native
   }
-
-  object AlgorithmSpecEnum {
-    val RSAES_PKCS1_V1_5   = "RSAES_PKCS1_V1_5"
-    val RSAES_OAEP_SHA_1   = "RSAES_OAEP_SHA_1"
-    val RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256"
+  @js.native
+  sealed trait AlgorithmSpec extends js.Any
+  object AlgorithmSpec extends js.Object {
+    val RSAES_PKCS1_V1_5   = "RSAES_PKCS1_V1_5".asInstanceOf[AlgorithmSpec]
+    val RSAES_OAEP_SHA_1   = "RSAES_OAEP_SHA_1".asInstanceOf[AlgorithmSpec]
+    val RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256".asInstanceOf[AlgorithmSpec]
 
     val values = js.Object.freeze(js.Array(RSAES_PKCS1_V1_5, RSAES_OAEP_SHA_1, RSAES_OAEP_SHA_256))
   }
@@ -326,17 +311,18 @@ package kms {
       __obj.asInstanceOf[ConnectCustomKeyStoreResponse]
     }
   }
-
-  object ConnectionErrorCodeTypeEnum {
-    val INVALID_CREDENTIALS        = "INVALID_CREDENTIALS"
-    val CLUSTER_NOT_FOUND          = "CLUSTER_NOT_FOUND"
-    val NETWORK_ERRORS             = "NETWORK_ERRORS"
-    val INTERNAL_ERROR             = "INTERNAL_ERROR"
-    val INSUFFICIENT_CLOUDHSM_HSMS = "INSUFFICIENT_CLOUDHSM_HSMS"
-    val USER_LOCKED_OUT            = "USER_LOCKED_OUT"
-    val USER_NOT_FOUND             = "USER_NOT_FOUND"
-    val USER_LOGGED_IN             = "USER_LOGGED_IN"
-    val SUBNET_NOT_FOUND           = "SUBNET_NOT_FOUND"
+  @js.native
+  sealed trait ConnectionErrorCodeType extends js.Any
+  object ConnectionErrorCodeType extends js.Object {
+    val INVALID_CREDENTIALS        = "INVALID_CREDENTIALS".asInstanceOf[ConnectionErrorCodeType]
+    val CLUSTER_NOT_FOUND          = "CLUSTER_NOT_FOUND".asInstanceOf[ConnectionErrorCodeType]
+    val NETWORK_ERRORS             = "NETWORK_ERRORS".asInstanceOf[ConnectionErrorCodeType]
+    val INTERNAL_ERROR             = "INTERNAL_ERROR".asInstanceOf[ConnectionErrorCodeType]
+    val INSUFFICIENT_CLOUDHSM_HSMS = "INSUFFICIENT_CLOUDHSM_HSMS".asInstanceOf[ConnectionErrorCodeType]
+    val USER_LOCKED_OUT            = "USER_LOCKED_OUT".asInstanceOf[ConnectionErrorCodeType]
+    val USER_NOT_FOUND             = "USER_NOT_FOUND".asInstanceOf[ConnectionErrorCodeType]
+    val USER_LOGGED_IN             = "USER_LOGGED_IN".asInstanceOf[ConnectionErrorCodeType]
+    val SUBNET_NOT_FOUND           = "SUBNET_NOT_FOUND".asInstanceOf[ConnectionErrorCodeType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -352,13 +338,14 @@ package kms {
       )
     )
   }
-
-  object ConnectionStateTypeEnum {
-    val CONNECTED     = "CONNECTED"
-    val CONNECTING    = "CONNECTING"
-    val FAILED        = "FAILED"
-    val DISCONNECTED  = "DISCONNECTED"
-    val DISCONNECTING = "DISCONNECTING"
+  @js.native
+  sealed trait ConnectionStateType extends js.Any
+  object ConnectionStateType extends js.Object {
+    val CONNECTED     = "CONNECTED".asInstanceOf[ConnectionStateType]
+    val CONNECTING    = "CONNECTING".asInstanceOf[ConnectionStateType]
+    val FAILED        = "FAILED".asInstanceOf[ConnectionStateType]
+    val DISCONNECTED  = "DISCONNECTED".asInstanceOf[ConnectionStateType]
+    val DISCONNECTING = "DISCONNECTING".asInstanceOf[ConnectionStateType]
 
     val values = js.Object.freeze(js.Array(CONNECTED, CONNECTING, FAILED, DISCONNECTED, DISCONNECTING))
   }
@@ -573,16 +560,17 @@ package kms {
       __obj.asInstanceOf[CustomKeyStoresListEntry]
     }
   }
-
-  object CustomerMasterKeySpecEnum {
-    val RSA_2048          = "RSA_2048"
-    val RSA_3072          = "RSA_3072"
-    val RSA_4096          = "RSA_4096"
-    val ECC_NIST_P256     = "ECC_NIST_P256"
-    val ECC_NIST_P384     = "ECC_NIST_P384"
-    val ECC_NIST_P521     = "ECC_NIST_P521"
-    val ECC_SECG_P256K1   = "ECC_SECG_P256K1"
-    val SYMMETRIC_DEFAULT = "SYMMETRIC_DEFAULT"
+  @js.native
+  sealed trait CustomerMasterKeySpec extends js.Any
+  object CustomerMasterKeySpec extends js.Object {
+    val RSA_2048          = "RSA_2048".asInstanceOf[CustomerMasterKeySpec]
+    val RSA_3072          = "RSA_3072".asInstanceOf[CustomerMasterKeySpec]
+    val RSA_4096          = "RSA_4096".asInstanceOf[CustomerMasterKeySpec]
+    val ECC_NIST_P256     = "ECC_NIST_P256".asInstanceOf[CustomerMasterKeySpec]
+    val ECC_NIST_P384     = "ECC_NIST_P384".asInstanceOf[CustomerMasterKeySpec]
+    val ECC_NIST_P521     = "ECC_NIST_P521".asInstanceOf[CustomerMasterKeySpec]
+    val ECC_SECG_P256K1   = "ECC_SECG_P256K1".asInstanceOf[CustomerMasterKeySpec]
+    val SYMMETRIC_DEFAULT = "SYMMETRIC_DEFAULT".asInstanceOf[CustomerMasterKeySpec]
 
     val values = js.Object.freeze(
       js.Array(
@@ -597,24 +585,26 @@ package kms {
       )
     )
   }
-
-  object DataKeyPairSpecEnum {
-    val RSA_2048        = "RSA_2048"
-    val RSA_3072        = "RSA_3072"
-    val RSA_4096        = "RSA_4096"
-    val ECC_NIST_P256   = "ECC_NIST_P256"
-    val ECC_NIST_P384   = "ECC_NIST_P384"
-    val ECC_NIST_P521   = "ECC_NIST_P521"
-    val ECC_SECG_P256K1 = "ECC_SECG_P256K1"
+  @js.native
+  sealed trait DataKeyPairSpec extends js.Any
+  object DataKeyPairSpec extends js.Object {
+    val RSA_2048        = "RSA_2048".asInstanceOf[DataKeyPairSpec]
+    val RSA_3072        = "RSA_3072".asInstanceOf[DataKeyPairSpec]
+    val RSA_4096        = "RSA_4096".asInstanceOf[DataKeyPairSpec]
+    val ECC_NIST_P256   = "ECC_NIST_P256".asInstanceOf[DataKeyPairSpec]
+    val ECC_NIST_P384   = "ECC_NIST_P384".asInstanceOf[DataKeyPairSpec]
+    val ECC_NIST_P521   = "ECC_NIST_P521".asInstanceOf[DataKeyPairSpec]
+    val ECC_SECG_P256K1 = "ECC_SECG_P256K1".asInstanceOf[DataKeyPairSpec]
 
     val values = js.Object.freeze(
       js.Array(RSA_2048, RSA_3072, RSA_4096, ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, ECC_SECG_P256K1)
     )
   }
-
-  object DataKeySpecEnum {
-    val AES_256 = "AES_256"
-    val AES_128 = "AES_128"
+  @js.native
+  sealed trait DataKeySpec extends js.Any
+  object DataKeySpec extends js.Object {
+    val AES_256 = "AES_256".asInstanceOf[DataKeySpec]
+    val AES_128 = "AES_128".asInstanceOf[DataKeySpec]
 
     val values = js.Object.freeze(js.Array(AES_256, AES_128))
   }
@@ -976,18 +966,20 @@ package kms {
       __obj.asInstanceOf[EncryptResponse]
     }
   }
-
-  object EncryptionAlgorithmSpecEnum {
-    val SYMMETRIC_DEFAULT  = "SYMMETRIC_DEFAULT"
-    val RSAES_OAEP_SHA_1   = "RSAES_OAEP_SHA_1"
-    val RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256"
+  @js.native
+  sealed trait EncryptionAlgorithmSpec extends js.Any
+  object EncryptionAlgorithmSpec extends js.Object {
+    val SYMMETRIC_DEFAULT  = "SYMMETRIC_DEFAULT".asInstanceOf[EncryptionAlgorithmSpec]
+    val RSAES_OAEP_SHA_1   = "RSAES_OAEP_SHA_1".asInstanceOf[EncryptionAlgorithmSpec]
+    val RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256".asInstanceOf[EncryptionAlgorithmSpec]
 
     val values = js.Object.freeze(js.Array(SYMMETRIC_DEFAULT, RSAES_OAEP_SHA_1, RSAES_OAEP_SHA_256))
   }
-
-  object ExpirationModelTypeEnum {
-    val KEY_MATERIAL_EXPIRES         = "KEY_MATERIAL_EXPIRES"
-    val KEY_MATERIAL_DOES_NOT_EXPIRE = "KEY_MATERIAL_DOES_NOT_EXPIRE"
+  @js.native
+  sealed trait ExpirationModelType extends js.Any
+  object ExpirationModelType extends js.Object {
+    val KEY_MATERIAL_EXPIRES         = "KEY_MATERIAL_EXPIRES".asInstanceOf[ExpirationModelType]
+    val KEY_MATERIAL_DOES_NOT_EXPIRE = "KEY_MATERIAL_DOES_NOT_EXPIRE".asInstanceOf[ExpirationModelType]
 
     val values = js.Object.freeze(js.Array(KEY_MATERIAL_EXPIRES, KEY_MATERIAL_DOES_NOT_EXPIRE))
   }
@@ -1482,22 +1474,23 @@ package kms {
       __obj.asInstanceOf[GrantListEntry]
     }
   }
-
-  object GrantOperationEnum {
-    val Decrypt                             = "Decrypt"
-    val Encrypt                             = "Encrypt"
-    val GenerateDataKey                     = "GenerateDataKey"
-    val GenerateDataKeyWithoutPlaintext     = "GenerateDataKeyWithoutPlaintext"
-    val ReEncryptFrom                       = "ReEncryptFrom"
-    val ReEncryptTo                         = "ReEncryptTo"
-    val Sign                                = "Sign"
-    val Verify                              = "Verify"
-    val GetPublicKey                        = "GetPublicKey"
-    val CreateGrant                         = "CreateGrant"
-    val RetireGrant                         = "RetireGrant"
-    val DescribeKey                         = "DescribeKey"
-    val GenerateDataKeyPair                 = "GenerateDataKeyPair"
-    val GenerateDataKeyPairWithoutPlaintext = "GenerateDataKeyPairWithoutPlaintext"
+  @js.native
+  sealed trait GrantOperation extends js.Any
+  object GrantOperation extends js.Object {
+    val Decrypt                             = "Decrypt".asInstanceOf[GrantOperation]
+    val Encrypt                             = "Encrypt".asInstanceOf[GrantOperation]
+    val GenerateDataKey                     = "GenerateDataKey".asInstanceOf[GrantOperation]
+    val GenerateDataKeyWithoutPlaintext     = "GenerateDataKeyWithoutPlaintext".asInstanceOf[GrantOperation]
+    val ReEncryptFrom                       = "ReEncryptFrom".asInstanceOf[GrantOperation]
+    val ReEncryptTo                         = "ReEncryptTo".asInstanceOf[GrantOperation]
+    val Sign                                = "Sign".asInstanceOf[GrantOperation]
+    val Verify                              = "Verify".asInstanceOf[GrantOperation]
+    val GetPublicKey                        = "GetPublicKey".asInstanceOf[GrantOperation]
+    val CreateGrant                         = "CreateGrant".asInstanceOf[GrantOperation]
+    val RetireGrant                         = "RetireGrant".asInstanceOf[GrantOperation]
+    val DescribeKey                         = "DescribeKey".asInstanceOf[GrantOperation]
+    val GenerateDataKeyPair                 = "GenerateDataKeyPair".asInstanceOf[GrantOperation]
+    val GenerateDataKeyPairWithoutPlaintext = "GenerateDataKeyPairWithoutPlaintext".asInstanceOf[GrantOperation]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1583,10 +1576,11 @@ package kms {
       __obj.asInstanceOf[KeyListEntry]
     }
   }
-
-  object KeyManagerTypeEnum {
-    val AWS      = "AWS"
-    val CUSTOMER = "CUSTOMER"
+  @js.native
+  sealed trait KeyManagerType extends js.Any
+  object KeyManagerType extends js.Object {
+    val AWS      = "AWS".asInstanceOf[KeyManagerType]
+    val CUSTOMER = "CUSTOMER".asInstanceOf[KeyManagerType]
 
     val values = js.Object.freeze(js.Array(AWS, CUSTOMER))
   }
@@ -1663,20 +1657,22 @@ package kms {
       __obj.asInstanceOf[KeyMetadata]
     }
   }
-
-  object KeyStateEnum {
-    val Enabled         = "Enabled"
-    val Disabled        = "Disabled"
-    val PendingDeletion = "PendingDeletion"
-    val PendingImport   = "PendingImport"
-    val Unavailable     = "Unavailable"
+  @js.native
+  sealed trait KeyState extends js.Any
+  object KeyState extends js.Object {
+    val Enabled         = "Enabled".asInstanceOf[KeyState]
+    val Disabled        = "Disabled".asInstanceOf[KeyState]
+    val PendingDeletion = "PendingDeletion".asInstanceOf[KeyState]
+    val PendingImport   = "PendingImport".asInstanceOf[KeyState]
+    val Unavailable     = "Unavailable".asInstanceOf[KeyState]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled, PendingDeletion, PendingImport, Unavailable))
   }
-
-  object KeyUsageTypeEnum {
-    val SIGN_VERIFY     = "SIGN_VERIFY"
-    val ENCRYPT_DECRYPT = "ENCRYPT_DECRYPT"
+  @js.native
+  sealed trait KeyUsageType extends js.Any
+  object KeyUsageType extends js.Object {
+    val SIGN_VERIFY     = "SIGN_VERIFY".asInstanceOf[KeyUsageType]
+    val ENCRYPT_DECRYPT = "ENCRYPT_DECRYPT".asInstanceOf[KeyUsageType]
 
     val values = js.Object.freeze(js.Array(SIGN_VERIFY, ENCRYPT_DECRYPT))
   }
@@ -1927,18 +1923,20 @@ package kms {
       __obj.asInstanceOf[ListRetirableGrantsRequest]
     }
   }
-
-  object MessageTypeEnum {
-    val RAW    = "RAW"
-    val DIGEST = "DIGEST"
+  @js.native
+  sealed trait MessageType extends js.Any
+  object MessageType extends js.Object {
+    val RAW    = "RAW".asInstanceOf[MessageType]
+    val DIGEST = "DIGEST".asInstanceOf[MessageType]
 
     val values = js.Object.freeze(js.Array(RAW, DIGEST))
   }
-
-  object OriginTypeEnum {
-    val AWS_KMS      = "AWS_KMS"
-    val EXTERNAL     = "EXTERNAL"
-    val AWS_CLOUDHSM = "AWS_CLOUDHSM"
+  @js.native
+  sealed trait OriginType extends js.Any
+  object OriginType extends js.Object {
+    val AWS_KMS      = "AWS_KMS".asInstanceOf[OriginType]
+    val EXTERNAL     = "EXTERNAL".asInstanceOf[OriginType]
+    val AWS_CLOUDHSM = "AWS_CLOUDHSM".asInstanceOf[OriginType]
 
     val values = js.Object.freeze(js.Array(AWS_KMS, EXTERNAL, AWS_CLOUDHSM))
   }
@@ -2183,17 +2181,18 @@ package kms {
       __obj.asInstanceOf[SignResponse]
     }
   }
-
-  object SigningAlgorithmSpecEnum {
-    val RSASSA_PSS_SHA_256        = "RSASSA_PSS_SHA_256"
-    val RSASSA_PSS_SHA_384        = "RSASSA_PSS_SHA_384"
-    val RSASSA_PSS_SHA_512        = "RSASSA_PSS_SHA_512"
-    val RSASSA_PKCS1_V1_5_SHA_256 = "RSASSA_PKCS1_V1_5_SHA_256"
-    val RSASSA_PKCS1_V1_5_SHA_384 = "RSASSA_PKCS1_V1_5_SHA_384"
-    val RSASSA_PKCS1_V1_5_SHA_512 = "RSASSA_PKCS1_V1_5_SHA_512"
-    val ECDSA_SHA_256             = "ECDSA_SHA_256"
-    val ECDSA_SHA_384             = "ECDSA_SHA_384"
-    val ECDSA_SHA_512             = "ECDSA_SHA_512"
+  @js.native
+  sealed trait SigningAlgorithmSpec extends js.Any
+  object SigningAlgorithmSpec extends js.Object {
+    val RSASSA_PSS_SHA_256        = "RSASSA_PSS_SHA_256".asInstanceOf[SigningAlgorithmSpec]
+    val RSASSA_PSS_SHA_384        = "RSASSA_PSS_SHA_384".asInstanceOf[SigningAlgorithmSpec]
+    val RSASSA_PSS_SHA_512        = "RSASSA_PSS_SHA_512".asInstanceOf[SigningAlgorithmSpec]
+    val RSASSA_PKCS1_V1_5_SHA_256 = "RSASSA_PKCS1_V1_5_SHA_256".asInstanceOf[SigningAlgorithmSpec]
+    val RSASSA_PKCS1_V1_5_SHA_384 = "RSASSA_PKCS1_V1_5_SHA_384".asInstanceOf[SigningAlgorithmSpec]
+    val RSASSA_PKCS1_V1_5_SHA_512 = "RSASSA_PKCS1_V1_5_SHA_512".asInstanceOf[SigningAlgorithmSpec]
+    val ECDSA_SHA_256             = "ECDSA_SHA_256".asInstanceOf[SigningAlgorithmSpec]
+    val ECDSA_SHA_384             = "ECDSA_SHA_384".asInstanceOf[SigningAlgorithmSpec]
+    val ECDSA_SHA_512             = "ECDSA_SHA_512".asInstanceOf[SigningAlgorithmSpec]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2413,9 +2412,10 @@ package kms {
       __obj.asInstanceOf[VerifyResponse]
     }
   }
-
-  object WrappingKeySpecEnum {
-    val RSA_2048 = "RSA_2048"
+  @js.native
+  sealed trait WrappingKeySpec extends js.Any
+  object WrappingKeySpec extends js.Object {
+    val RSA_2048 = "RSA_2048".asInstanceOf[WrappingKeySpec]
 
     val values = js.Object.freeze(js.Array(RSA_2048))
   }

--- a/services/lakeformation/src/main/scala/facade/amazonaws/services/LakeFormation.scala
+++ b/services/lakeformation/src/main/scala/facade/amazonaws/services/LakeFormation.scala
@@ -11,12 +11,9 @@ package object lakeformation {
   type BatchPermissionsRequestEntryList = js.Array[BatchPermissionsRequestEntry]
   type CatalogIdString                  = String
   type ColumnNames                      = js.Array[NameString]
-  type ComparisonOperator               = String
   type DataLakePrincipalList            = js.Array[DataLakePrincipal]
   type DataLakePrincipalString          = String
-  type DataLakeResourceType             = String
   type DescriptionString                = String
-  type FieldNameString                  = String
   type FilterConditionList              = js.Array[FilterCondition]
   type IAMRoleArn                       = String
   type Identifier                       = String
@@ -24,7 +21,6 @@ package object lakeformation {
   type NameString                       = String
   type NullableBoolean                  = Boolean
   type PageSize                         = Int
-  type Permission                       = String
   type PermissionList                   = js.Array[Permission]
   type PrincipalPermissionsList         = js.Array[PrincipalPermissions]
   type PrincipalResourcePermissionsList = js.Array[PrincipalResourcePermissions]
@@ -257,19 +253,20 @@ package lakeformation {
       __obj.asInstanceOf[ColumnWildcard]
     }
   }
-
-  object ComparisonOperatorEnum {
-    val EQ           = "EQ"
-    val NE           = "NE"
-    val LE           = "LE"
-    val LT           = "LT"
-    val GE           = "GE"
-    val GT           = "GT"
-    val CONTAINS     = "CONTAINS"
-    val NOT_CONTAINS = "NOT_CONTAINS"
-    val BEGINS_WITH  = "BEGINS_WITH"
-    val IN           = "IN"
-    val BETWEEN      = "BETWEEN"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val EQ           = "EQ".asInstanceOf[ComparisonOperator]
+    val NE           = "NE".asInstanceOf[ComparisonOperator]
+    val LE           = "LE".asInstanceOf[ComparisonOperator]
+    val LT           = "LT".asInstanceOf[ComparisonOperator]
+    val GE           = "GE".asInstanceOf[ComparisonOperator]
+    val GT           = "GT".asInstanceOf[ComparisonOperator]
+    val CONTAINS     = "CONTAINS".asInstanceOf[ComparisonOperator]
+    val NOT_CONTAINS = "NOT_CONTAINS".asInstanceOf[ComparisonOperator]
+    val BEGINS_WITH  = "BEGINS_WITH".asInstanceOf[ComparisonOperator]
+    val IN           = "IN".asInstanceOf[ComparisonOperator]
+    val BETWEEN      = "BETWEEN".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(js.Array(EQ, NE, LE, LT, GE, GT, CONTAINS, NOT_CONTAINS, BEGINS_WITH, IN, BETWEEN))
   }
@@ -294,12 +291,13 @@ package lakeformation {
       __obj.asInstanceOf[DataLakePrincipal]
     }
   }
-
-  object DataLakeResourceTypeEnum {
-    val CATALOG       = "CATALOG"
-    val DATABASE      = "DATABASE"
-    val TABLE         = "TABLE"
-    val DATA_LOCATION = "DATA_LOCATION"
+  @js.native
+  sealed trait DataLakeResourceType extends js.Any
+  object DataLakeResourceType extends js.Object {
+    val CATALOG       = "CATALOG".asInstanceOf[DataLakeResourceType]
+    val DATABASE      = "DATABASE".asInstanceOf[DataLakeResourceType]
+    val TABLE         = "TABLE".asInstanceOf[DataLakeResourceType]
+    val DATA_LOCATION = "DATA_LOCATION".asInstanceOf[DataLakeResourceType]
 
     val values = js.Object.freeze(js.Array(CATALOG, DATABASE, TABLE, DATA_LOCATION))
   }
@@ -461,11 +459,12 @@ package lakeformation {
       __obj.asInstanceOf[ErrorDetail]
     }
   }
-
-  object FieldNameStringEnum {
-    val RESOURCE_ARN  = "RESOURCE_ARN"
-    val ROLE_ARN      = "ROLE_ARN"
-    val LAST_MODIFIED = "LAST_MODIFIED"
+  @js.native
+  sealed trait FieldNameString extends js.Any
+  object FieldNameString extends js.Object {
+    val RESOURCE_ARN  = "RESOURCE_ARN".asInstanceOf[FieldNameString]
+    val ROLE_ARN      = "ROLE_ARN".asInstanceOf[FieldNameString]
+    val LAST_MODIFIED = "LAST_MODIFIED".asInstanceOf[FieldNameString]
 
     val values = js.Object.freeze(js.Array(RESOURCE_ARN, ROLE_ARN, LAST_MODIFIED))
   }
@@ -710,17 +709,18 @@ package lakeformation {
       __obj.asInstanceOf[ListResourcesResponse]
     }
   }
-
-  object PermissionEnum {
-    val ALL                  = "ALL"
-    val SELECT               = "SELECT"
-    val ALTER                = "ALTER"
-    val DROP                 = "DROP"
-    val DELETE               = "DELETE"
-    val INSERT               = "INSERT"
-    val CREATE_DATABASE      = "CREATE_DATABASE"
-    val CREATE_TABLE         = "CREATE_TABLE"
-    val DATA_LOCATION_ACCESS = "DATA_LOCATION_ACCESS"
+  @js.native
+  sealed trait Permission extends js.Any
+  object Permission extends js.Object {
+    val ALL                  = "ALL".asInstanceOf[Permission]
+    val SELECT               = "SELECT".asInstanceOf[Permission]
+    val ALTER                = "ALTER".asInstanceOf[Permission]
+    val DROP                 = "DROP".asInstanceOf[Permission]
+    val DELETE               = "DELETE".asInstanceOf[Permission]
+    val INSERT               = "INSERT".asInstanceOf[Permission]
+    val CREATE_DATABASE      = "CREATE_DATABASE".asInstanceOf[Permission]
+    val CREATE_TABLE         = "CREATE_TABLE".asInstanceOf[Permission]
+    val DATA_LOCATION_ACCESS = "DATA_LOCATION_ACCESS".asInstanceOf[Permission]
 
     val values = js.Object.freeze(
       js.Array(ALL, SELECT, ALTER, DROP, DELETE, INSERT, CREATE_DATABASE, CREATE_TABLE, DATA_LOCATION_ACCESS)

--- a/services/lambda/src/main/scala/facade/amazonaws/services/Lambda.scala
+++ b/services/lambda/src/main/scala/facade/amazonaws/services/Lambda.scala
@@ -26,20 +26,15 @@ package object lambda {
   type EnvironmentVariableValue                 = String
   type EnvironmentVariables                     = js.Dictionary[EnvironmentVariableValue]
   type EventSourceMappingsList                  = js.Array[EventSourceMappingConfiguration]
-  type EventSourcePosition                      = String
   type EventSourceToken                         = String
   type FunctionArn                              = String
   type FunctionEventInvokeConfigList            = js.Array[FunctionEventInvokeConfig]
   type FunctionList                             = js.Array[FunctionConfiguration]
   type FunctionName                             = String
-  type FunctionVersion                          = String
   type Handler                                  = String
   type HttpStatus                               = Int
-  type InvocationType                           = String
   type KMSKeyArn                                = String
-  type LastUpdateStatus                         = String
   type LastUpdateStatusReason                   = String
-  type LastUpdateStatusReasonCode               = String
   type LayerArn                                 = String
   type LayerList                                = js.Array[LayerVersionArn]
   type LayerName                                = String
@@ -51,7 +46,6 @@ package object lambda {
   type LayersList                               = js.Array[LayersListItem]
   type LayersReferenceList                      = js.Array[Layer]
   type LicenseInfo                              = String
-  type LogType                                  = String
   type MasterRegion                             = String
   type MaxFunctionEventInvokeConfigListItems    = Int
   type MaxLayerListItems                        = Int
@@ -72,12 +66,10 @@ package object lambda {
   type PositiveInteger                          = Int
   type Principal                                = String
   type ProvisionedConcurrencyConfigList         = js.Array[ProvisionedConcurrencyConfigListItem]
-  type ProvisionedConcurrencyStatusEnum         = String
   type Qualifier                                = String
   type ReservedConcurrentExecutions             = Int
   type ResourceArn                              = String
   type RoleArn                                  = String
-  type Runtime                                  = String
   type S3Bucket                                 = String
   type S3Key                                    = String
   type S3ObjectVersion                          = String
@@ -85,9 +77,7 @@ package object lambda {
   type SecurityGroupIds                         = js.Array[SecurityGroupId]
   type SensitiveString                          = String
   type SourceOwner                              = String
-  type State                                    = String
   type StateReason                              = String
-  type StateReasonCode                          = String
   type StatementId                              = String
   type SubnetId                                 = String
   type SubnetIds                                = js.Array[SubnetId]
@@ -97,7 +87,6 @@ package object lambda {
   type Tags                                     = js.Dictionary[TagValue]
   type Timeout                                  = Int
   type Timestamp                                = String
-  type TracingMode                              = String
   type UnreservedConcurrentExecutions           = Int
   type Version                                  = String
   type VpcId                                    = String
@@ -1007,11 +996,12 @@ package lambda {
       __obj.asInstanceOf[EventSourceMappingConfiguration]
     }
   }
-
-  object EventSourcePositionEnum {
-    val TRIM_HORIZON = "TRIM_HORIZON"
-    val LATEST       = "LATEST"
-    val AT_TIMESTAMP = "AT_TIMESTAMP"
+  @js.native
+  sealed trait EventSourcePosition extends js.Any
+  object EventSourcePosition extends js.Object {
+    val TRIM_HORIZON = "TRIM_HORIZON".asInstanceOf[EventSourcePosition]
+    val LATEST       = "LATEST".asInstanceOf[EventSourcePosition]
+    val AT_TIMESTAMP = "AT_TIMESTAMP".asInstanceOf[EventSourcePosition]
 
     val values = js.Object.freeze(js.Array(TRIM_HORIZON, LATEST, AT_TIMESTAMP))
   }
@@ -1189,9 +1179,10 @@ package lambda {
       __obj.asInstanceOf[FunctionEventInvokeConfig]
     }
   }
-
-  object FunctionVersionEnum {
-    val ALL = "ALL"
+  @js.native
+  sealed trait FunctionVersion extends js.Any
+  object FunctionVersion extends js.Object {
+    val ALL = "ALL".asInstanceOf[FunctionVersion]
 
     val values = js.Object.freeze(js.Array(ALL))
   }
@@ -1665,11 +1656,12 @@ package lambda {
       __obj.asInstanceOf[InvocationResponse]
     }
   }
-
-  object InvocationTypeEnum {
-    val Event           = "Event"
-    val RequestResponse = "RequestResponse"
-    val DryRun          = "DryRun"
+  @js.native
+  sealed trait InvocationType extends js.Any
+  object InvocationType extends js.Object {
+    val Event           = "Event".asInstanceOf[InvocationType]
+    val RequestResponse = "RequestResponse".asInstanceOf[InvocationType]
+    val DryRun          = "DryRun".asInstanceOf[InvocationType]
 
     val values = js.Object.freeze(js.Array(Event, RequestResponse, DryRun))
   }
@@ -1715,23 +1707,25 @@ package lambda {
       __obj.asInstanceOf[InvokeAsyncResponse]
     }
   }
-
-  object LastUpdateStatusEnum {
-    val Successful = "Successful"
-    val Failed     = "Failed"
-    val InProgress = "InProgress"
+  @js.native
+  sealed trait LastUpdateStatus extends js.Any
+  object LastUpdateStatus extends js.Object {
+    val Successful = "Successful".asInstanceOf[LastUpdateStatus]
+    val Failed     = "Failed".asInstanceOf[LastUpdateStatus]
+    val InProgress = "InProgress".asInstanceOf[LastUpdateStatus]
 
     val values = js.Object.freeze(js.Array(Successful, Failed, InProgress))
   }
-
-  object LastUpdateStatusReasonCodeEnum {
-    val EniLimitExceeded            = "EniLimitExceeded"
-    val InsufficientRolePermissions = "InsufficientRolePermissions"
-    val InvalidConfiguration        = "InvalidConfiguration"
-    val InternalError               = "InternalError"
-    val SubnetOutOfIPAddresses      = "SubnetOutOfIPAddresses"
-    val InvalidSubnet               = "InvalidSubnet"
-    val InvalidSecurityGroup        = "InvalidSecurityGroup"
+  @js.native
+  sealed trait LastUpdateStatusReasonCode extends js.Any
+  object LastUpdateStatusReasonCode extends js.Object {
+    val EniLimitExceeded            = "EniLimitExceeded".asInstanceOf[LastUpdateStatusReasonCode]
+    val InsufficientRolePermissions = "InsufficientRolePermissions".asInstanceOf[LastUpdateStatusReasonCode]
+    val InvalidConfiguration        = "InvalidConfiguration".asInstanceOf[LastUpdateStatusReasonCode]
+    val InternalError               = "InternalError".asInstanceOf[LastUpdateStatusReasonCode]
+    val SubnetOutOfIPAddresses      = "SubnetOutOfIPAddresses".asInstanceOf[LastUpdateStatusReasonCode]
+    val InvalidSubnet               = "InvalidSubnet".asInstanceOf[LastUpdateStatusReasonCode]
+    val InvalidSecurityGroup        = "InvalidSecurityGroup".asInstanceOf[LastUpdateStatusReasonCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2270,10 +2264,11 @@ package lambda {
       __obj.asInstanceOf[ListVersionsByFunctionResponse]
     }
   }
-
-  object LogTypeEnum {
-    val None = "None"
-    val Tail = "Tail"
+  @js.native
+  sealed trait LogType extends js.Any
+  object LogType extends js.Object {
+    val None = "None".asInstanceOf[LogType]
+    val Tail = "Tail".asInstanceOf[LogType]
 
     val values = js.Object.freeze(js.Array(None, Tail))
   }
@@ -2358,11 +2353,12 @@ package lambda {
       __obj.asInstanceOf[ProvisionedConcurrencyConfigListItem]
     }
   }
-
-  object ProvisionedConcurrencyStatusEnumEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val READY       = "READY"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait ProvisionedConcurrencyStatusEnum extends js.Any
+  object ProvisionedConcurrencyStatusEnum extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ProvisionedConcurrencyStatusEnum]
+    val READY       = "READY".asInstanceOf[ProvisionedConcurrencyStatusEnum]
+    val FAILED      = "FAILED".asInstanceOf[ProvisionedConcurrencyStatusEnum]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, READY, FAILED))
   }
@@ -2626,28 +2622,29 @@ package lambda {
       __obj.asInstanceOf[RemovePermissionRequest]
     }
   }
-
-  object RuntimeEnum {
-    val nodejs           = "nodejs"
-    val `nodejs4.3`      = "nodejs4.3"
-    val `nodejs6.10`     = "nodejs6.10"
-    val `nodejs8.10`     = "nodejs8.10"
-    val `nodejs10.x`     = "nodejs10.x"
-    val `nodejs12.x`     = "nodejs12.x"
-    val java8            = "java8"
-    val java11           = "java11"
-    val `python2.7`      = "python2.7"
-    val `python3.6`      = "python3.6"
-    val `python3.7`      = "python3.7"
-    val `python3.8`      = "python3.8"
-    val `dotnetcore1.0`  = "dotnetcore1.0"
-    val `dotnetcore2.0`  = "dotnetcore2.0"
-    val `dotnetcore2.1`  = "dotnetcore2.1"
-    val `nodejs4.3-edge` = "nodejs4.3-edge"
-    val `go1.x`          = "go1.x"
-    val `ruby2.5`        = "ruby2.5"
-    val `ruby2.7`        = "ruby2.7"
-    val provided         = "provided"
+  @js.native
+  sealed trait Runtime extends js.Any
+  object Runtime extends js.Object {
+    val nodejs           = "nodejs".asInstanceOf[Runtime]
+    val `nodejs4.3`      = "nodejs4.3".asInstanceOf[Runtime]
+    val `nodejs6.10`     = "nodejs6.10".asInstanceOf[Runtime]
+    val `nodejs8.10`     = "nodejs8.10".asInstanceOf[Runtime]
+    val `nodejs10.x`     = "nodejs10.x".asInstanceOf[Runtime]
+    val `nodejs12.x`     = "nodejs12.x".asInstanceOf[Runtime]
+    val java8            = "java8".asInstanceOf[Runtime]
+    val java11           = "java11".asInstanceOf[Runtime]
+    val `python2.7`      = "python2.7".asInstanceOf[Runtime]
+    val `python3.6`      = "python3.6".asInstanceOf[Runtime]
+    val `python3.7`      = "python3.7".asInstanceOf[Runtime]
+    val `python3.8`      = "python3.8".asInstanceOf[Runtime]
+    val `dotnetcore1.0`  = "dotnetcore1.0".asInstanceOf[Runtime]
+    val `dotnetcore2.0`  = "dotnetcore2.0".asInstanceOf[Runtime]
+    val `dotnetcore2.1`  = "dotnetcore2.1".asInstanceOf[Runtime]
+    val `nodejs4.3-edge` = "nodejs4.3-edge".asInstanceOf[Runtime]
+    val `go1.x`          = "go1.x".asInstanceOf[Runtime]
+    val `ruby2.5`        = "ruby2.5".asInstanceOf[Runtime]
+    val `ruby2.7`        = "ruby2.7".asInstanceOf[Runtime]
+    val provided         = "provided".asInstanceOf[Runtime]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2674,27 +2671,29 @@ package lambda {
       )
     )
   }
-
-  object StateEnum {
-    val Pending  = "Pending"
-    val Active   = "Active"
-    val Inactive = "Inactive"
-    val Failed   = "Failed"
+  @js.native
+  sealed trait State extends js.Any
+  object State extends js.Object {
+    val Pending  = "Pending".asInstanceOf[State]
+    val Active   = "Active".asInstanceOf[State]
+    val Inactive = "Inactive".asInstanceOf[State]
+    val Failed   = "Failed".asInstanceOf[State]
 
     val values = js.Object.freeze(js.Array(Pending, Active, Inactive, Failed))
   }
-
-  object StateReasonCodeEnum {
-    val Idle                        = "Idle"
-    val Creating                    = "Creating"
-    val Restoring                   = "Restoring"
-    val EniLimitExceeded            = "EniLimitExceeded"
-    val InsufficientRolePermissions = "InsufficientRolePermissions"
-    val InvalidConfiguration        = "InvalidConfiguration"
-    val InternalError               = "InternalError"
-    val SubnetOutOfIPAddresses      = "SubnetOutOfIPAddresses"
-    val InvalidSubnet               = "InvalidSubnet"
-    val InvalidSecurityGroup        = "InvalidSecurityGroup"
+  @js.native
+  sealed trait StateReasonCode extends js.Any
+  object StateReasonCode extends js.Object {
+    val Idle                        = "Idle".asInstanceOf[StateReasonCode]
+    val Creating                    = "Creating".asInstanceOf[StateReasonCode]
+    val Restoring                   = "Restoring".asInstanceOf[StateReasonCode]
+    val EniLimitExceeded            = "EniLimitExceeded".asInstanceOf[StateReasonCode]
+    val InsufficientRolePermissions = "InsufficientRolePermissions".asInstanceOf[StateReasonCode]
+    val InvalidConfiguration        = "InvalidConfiguration".asInstanceOf[StateReasonCode]
+    val InternalError               = "InternalError".asInstanceOf[StateReasonCode]
+    val SubnetOutOfIPAddresses      = "SubnetOutOfIPAddresses".asInstanceOf[StateReasonCode]
+    val InvalidSubnet               = "InvalidSubnet".asInstanceOf[StateReasonCode]
+    val InvalidSecurityGroup        = "InvalidSecurityGroup".asInstanceOf[StateReasonCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2770,10 +2769,11 @@ package lambda {
       __obj.asInstanceOf[TracingConfigResponse]
     }
   }
-
-  object TracingModeEnum {
-    val Active      = "Active"
-    val PassThrough = "PassThrough"
+  @js.native
+  sealed trait TracingMode extends js.Any
+  object TracingMode extends js.Object {
+    val Active      = "Active".asInstanceOf[TracingMode]
+    val PassThrough = "PassThrough".asInstanceOf[TracingMode]
 
     val values = js.Object.freeze(js.Array(Active, PassThrough))
   }

--- a/services/lexmodelbuildingservice/src/main/scala/facade/amazonaws/services/LexModelBuildingService.scala
+++ b/services/lexmodelbuildingservice/src/main/scala/facade/amazonaws/services/LexModelBuildingService.scala
@@ -22,21 +22,13 @@ package object lexmodelbuildingservice {
   type BuiltinSlotTypeMetadataList = js.Array[BuiltinSlotTypeMetadata]
   type BuiltinSlotTypeSignature    = String
   type ChannelConfigurationMap     = js.Dictionary[String]
-  type ChannelStatus               = String
-  type ChannelType                 = String
   type ContentString               = String
-  type ContentType                 = String
   type Count                       = Int
   type CustomOrBuiltinSlotTypeName = String
   type Description                 = String
-  type Destination                 = String
   type EnumerationValues           = js.Array[EnumerationValue]
-  type ExportStatus                = String
-  type ExportType                  = String
-  type FulfillmentActivityType     = String
   type GroupNumber                 = Int
   type IamRoleArn                  = String
-  type ImportStatus                = String
   type IntentList                  = js.Array[Intent]
   type IntentMetadataList          = js.Array[IntentMetadata]
   type IntentName                  = String
@@ -45,38 +37,28 @@ package object lexmodelbuildingservice {
   type LambdaARN                   = String
   type ListOfUtterance             = js.Array[UtteranceData]
   type ListsOfUtterances           = js.Array[UtteranceList]
-  type Locale                      = String
   type LocaleList                  = js.Array[Locale]
   type LogSettingsRequestList      = js.Array[LogSettingsRequest]
   type LogSettingsResponseList     = js.Array[LogSettingsResponse]
-  type LogType                     = String
   type MaxResults                  = Int
-  type MergeStrategy               = String
   type MessageList                 = js.Array[Message]
   type MessageVersion              = String
   type Name                        = String
   type NextToken                   = String
   type NumericalVersion            = String
-  type ObfuscationSetting          = String
   type Priority                    = Int
-  type ProcessBehavior             = String
   type PromptMaxAttempts           = Int
   type RegexPattern                = String
   type ResourceArn                 = String
   type ResourcePrefix              = String
-  type ResourceType                = String
   type ResponseCard                = String
   type SessionTTL                  = Int
-  type SlotConstraint              = String
   type SlotList                    = js.Array[Slot]
   type SlotName                    = String
   type SlotTypeConfigurations      = js.Array[SlotTypeConfiguration]
   type SlotTypeMetadataList        = js.Array[SlotTypeMetadata]
   type SlotTypeName                = String
   type SlotUtteranceList           = js.Array[Utterance]
-  type SlotValueSelectionStrategy  = String
-  type Status                      = String
-  type StatusType                  = String
   type StringList                  = js.Array[String]
   type SynonymList                 = js.Array[Value]
   type Timestamp                   = js.Date
@@ -390,20 +372,22 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[BuiltinSlotTypeMetadata]
     }
   }
-
-  object ChannelStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val CREATED     = "CREATED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait ChannelStatus extends js.Any
+  object ChannelStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ChannelStatus]
+    val CREATED     = "CREATED".asInstanceOf[ChannelStatus]
+    val FAILED      = "FAILED".asInstanceOf[ChannelStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, CREATED, FAILED))
   }
-
-  object ChannelTypeEnum {
-    val Facebook     = "Facebook"
-    val Slack        = "Slack"
-    val `Twilio-Sms` = "Twilio-Sms"
-    val Kik          = "Kik"
+  @js.native
+  sealed trait ChannelType extends js.Any
+  object ChannelType extends js.Object {
+    val Facebook     = "Facebook".asInstanceOf[ChannelType]
+    val Slack        = "Slack".asInstanceOf[ChannelType]
+    val `Twilio-Sms` = "Twilio-Sms".asInstanceOf[ChannelType]
+    val Kik          = "Kik".asInstanceOf[ChannelType]
 
     val values = js.Object.freeze(js.Array(Facebook, Slack, `Twilio-Sms`, Kik))
   }
@@ -431,11 +415,12 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[CodeHook]
     }
   }
-
-  object ContentTypeEnum {
-    val PlainText     = "PlainText"
-    val SSML          = "SSML"
-    val CustomPayload = "CustomPayload"
+  @js.native
+  sealed trait ContentType extends js.Any
+  object ContentType extends js.Object {
+    val PlainText     = "PlainText".asInstanceOf[ContentType]
+    val SSML          = "SSML".asInstanceOf[ContentType]
+    val CustomPayload = "CustomPayload".asInstanceOf[ContentType]
 
     val values = js.Object.freeze(js.Array(PlainText, SSML, CustomPayload))
   }
@@ -893,10 +878,11 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[DeleteUtterancesRequest]
     }
   }
-
-  object DestinationEnum {
-    val CLOUDWATCH_LOGS = "CLOUDWATCH_LOGS"
-    val S3              = "S3"
+  @js.native
+  sealed trait Destination extends js.Any
+  object Destination extends js.Object {
+    val CLOUDWATCH_LOGS = "CLOUDWATCH_LOGS".asInstanceOf[Destination]
+    val S3              = "S3".asInstanceOf[Destination]
 
     val values = js.Object.freeze(js.Array(CLOUDWATCH_LOGS, S3))
   }
@@ -928,18 +914,20 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[EnumerationValue]
     }
   }
-
-  object ExportStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val READY       = "READY"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait ExportStatus extends js.Any
+  object ExportStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ExportStatus]
+    val READY       = "READY".asInstanceOf[ExportStatus]
+    val FAILED      = "FAILED".asInstanceOf[ExportStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, READY, FAILED))
   }
-
-  object ExportTypeEnum {
-    val ALEXA_SKILLS_KIT = "ALEXA_SKILLS_KIT"
-    val LEX              = "LEX"
+  @js.native
+  sealed trait ExportType extends js.Any
+  object ExportType extends js.Object {
+    val ALEXA_SKILLS_KIT = "ALEXA_SKILLS_KIT".asInstanceOf[ExportType]
+    val LEX              = "LEX".asInstanceOf[ExportType]
 
     val values = js.Object.freeze(js.Array(ALEXA_SKILLS_KIT, LEX))
   }
@@ -994,10 +982,11 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[FulfillmentActivity]
     }
   }
-
-  object FulfillmentActivityTypeEnum {
-    val ReturnIntent = "ReturnIntent"
-    val CodeHook     = "CodeHook"
+  @js.native
+  sealed trait FulfillmentActivityType extends js.Any
+  object FulfillmentActivityType extends js.Object {
+    val ReturnIntent = "ReturnIntent".asInstanceOf[FulfillmentActivityType]
+    val CodeHook     = "CodeHook".asInstanceOf[FulfillmentActivityType]
 
     val values = js.Object.freeze(js.Array(ReturnIntent, CodeHook))
   }
@@ -1979,11 +1968,12 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[GetUtterancesViewResponse]
     }
   }
-
-  object ImportStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETE    = "COMPLETE"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait ImportStatus extends js.Any
+  object ImportStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ImportStatus]
+    val COMPLETE    = "COMPLETE".asInstanceOf[ImportStatus]
+    val FAILED      = "FAILED".asInstanceOf[ImportStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETE, FAILED))
   }
@@ -2042,11 +2032,12 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[IntentMetadata]
     }
   }
-
-  object LocaleEnum {
-    val `en-US` = "en-US"
-    val `en-GB` = "en-GB"
-    val `de-DE` = "de-DE"
+  @js.native
+  sealed trait Locale extends js.Any
+  object Locale extends js.Object {
+    val `en-US` = "en-US".asInstanceOf[Locale]
+    val `en-GB` = "en-GB".asInstanceOf[Locale]
+    val `de-DE` = "de-DE".asInstanceOf[Locale]
 
     val values = js.Object.freeze(js.Array(`en-US`, `en-GB`, `de-DE`))
   }
@@ -2111,17 +2102,19 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[LogSettingsResponse]
     }
   }
-
-  object LogTypeEnum {
-    val AUDIO = "AUDIO"
-    val TEXT  = "TEXT"
+  @js.native
+  sealed trait LogType extends js.Any
+  object LogType extends js.Object {
+    val AUDIO = "AUDIO".asInstanceOf[LogType]
+    val TEXT  = "TEXT".asInstanceOf[LogType]
 
     val values = js.Object.freeze(js.Array(AUDIO, TEXT))
   }
-
-  object MergeStrategyEnum {
-    val OVERWRITE_LATEST = "OVERWRITE_LATEST"
-    val FAIL_ON_CONFLICT = "FAIL_ON_CONFLICT"
+  @js.native
+  sealed trait MergeStrategy extends js.Any
+  object MergeStrategy extends js.Object {
+    val OVERWRITE_LATEST = "OVERWRITE_LATEST".asInstanceOf[MergeStrategy]
+    val FAIL_ON_CONFLICT = "FAIL_ON_CONFLICT".asInstanceOf[MergeStrategy]
 
     val values = js.Object.freeze(js.Array(OVERWRITE_LATEST, FAIL_ON_CONFLICT))
   }
@@ -2152,17 +2145,19 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[Message]
     }
   }
-
-  object ObfuscationSettingEnum {
-    val NONE                = "NONE"
-    val DEFAULT_OBFUSCATION = "DEFAULT_OBFUSCATION"
+  @js.native
+  sealed trait ObfuscationSetting extends js.Any
+  object ObfuscationSetting extends js.Object {
+    val NONE                = "NONE".asInstanceOf[ObfuscationSetting]
+    val DEFAULT_OBFUSCATION = "DEFAULT_OBFUSCATION".asInstanceOf[ObfuscationSetting]
 
     val values = js.Object.freeze(js.Array(NONE, DEFAULT_OBFUSCATION))
   }
-
-  object ProcessBehaviorEnum {
-    val SAVE  = "SAVE"
-    val BUILD = "BUILD"
+  @js.native
+  sealed trait ProcessBehavior extends js.Any
+  object ProcessBehavior extends js.Object {
+    val SAVE  = "SAVE".asInstanceOf[ProcessBehavior]
+    val BUILD = "BUILD".asInstanceOf[ProcessBehavior]
 
     val values = js.Object.freeze(js.Array(SAVE, BUILD))
   }
@@ -2581,11 +2576,12 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[PutSlotTypeResponse]
     }
   }
-
-  object ResourceTypeEnum {
-    val BOT       = "BOT"
-    val INTENT    = "INTENT"
-    val SLOT_TYPE = "SLOT_TYPE"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val BOT       = "BOT".asInstanceOf[ResourceType]
+    val INTENT    = "INTENT".asInstanceOf[ResourceType]
+    val SLOT_TYPE = "SLOT_TYPE".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(BOT, INTENT, SLOT_TYPE))
   }
@@ -2637,10 +2633,11 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[Slot]
     }
   }
-
-  object SlotConstraintEnum {
-    val Required = "Required"
-    val Optional = "Optional"
+  @js.native
+  sealed trait SlotConstraint extends js.Any
+  object SlotConstraint extends js.Object {
+    val Required = "Required".asInstanceOf[SlotConstraint]
+    val Optional = "Optional".asInstanceOf[SlotConstraint]
 
     val values = js.Object.freeze(js.Array(Required, Optional))
   }
@@ -2715,10 +2712,11 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[SlotTypeRegexConfiguration]
     }
   }
-
-  object SlotValueSelectionStrategyEnum {
-    val ORIGINAL_VALUE = "ORIGINAL_VALUE"
-    val TOP_RESOLUTION = "TOP_RESOLUTION"
+  @js.native
+  sealed trait SlotValueSelectionStrategy extends js.Any
+  object SlotValueSelectionStrategy extends js.Object {
+    val ORIGINAL_VALUE = "ORIGINAL_VALUE".asInstanceOf[SlotValueSelectionStrategy]
+    val TOP_RESOLUTION = "TOP_RESOLUTION".asInstanceOf[SlotValueSelectionStrategy]
 
     val values = js.Object.freeze(js.Array(ORIGINAL_VALUE, TOP_RESOLUTION))
   }
@@ -2801,20 +2799,22 @@ package lexmodelbuildingservice {
       __obj.asInstanceOf[Statement]
     }
   }
-
-  object StatusEnum {
-    val BUILDING            = "BUILDING"
-    val READY               = "READY"
-    val READY_BASIC_TESTING = "READY_BASIC_TESTING"
-    val FAILED              = "FAILED"
-    val NOT_BUILT           = "NOT_BUILT"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val BUILDING            = "BUILDING".asInstanceOf[Status]
+    val READY               = "READY".asInstanceOf[Status]
+    val READY_BASIC_TESTING = "READY_BASIC_TESTING".asInstanceOf[Status]
+    val FAILED              = "FAILED".asInstanceOf[Status]
+    val NOT_BUILT           = "NOT_BUILT".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(BUILDING, READY, READY_BASIC_TESTING, FAILED, NOT_BUILT))
   }
-
-  object StatusTypeEnum {
-    val Detected = "Detected"
-    val Missed   = "Missed"
+  @js.native
+  sealed trait StatusType extends js.Any
+  object StatusType extends js.Object {
+    val Detected = "Detected".asInstanceOf[StatusType]
+    val Missed   = "Missed".asInstanceOf[StatusType]
 
     val values = js.Object.freeze(js.Array(Detected, Missed))
   }

--- a/services/lexruntime/src/main/scala/facade/amazonaws/services/LexRuntime.scala
+++ b/services/lexruntime/src/main/scala/facade/amazonaws/services/LexRuntime.scala
@@ -14,16 +14,10 @@ package object lexruntime {
   type BotName                      = String
   type ButtonTextStringWithLength   = String
   type ButtonValueStringWithLength  = String
-  type ConfirmationStatus           = String
-  type ContentType                  = String
-  type DialogActionType             = String
-  type DialogState                  = String
-  type FulfillmentState             = String
   type HttpContentType              = String
   type IntentName                   = String
   type IntentSummaryCheckpointLabel = String
   type IntentSummaryList            = js.Array[IntentSummary]
-  type MessageFormatType            = String
   type SentimentLabel               = String
   type SentimentScore               = String
   type StringMap                    = js.Dictionary[String]
@@ -85,17 +79,19 @@ package lexruntime {
       __obj.asInstanceOf[Button]
     }
   }
-
-  object ConfirmationStatusEnum {
-    val None      = "None"
-    val Confirmed = "Confirmed"
-    val Denied    = "Denied"
+  @js.native
+  sealed trait ConfirmationStatus extends js.Any
+  object ConfirmationStatus extends js.Object {
+    val None      = "None".asInstanceOf[ConfirmationStatus]
+    val Confirmed = "Confirmed".asInstanceOf[ConfirmationStatus]
+    val Denied    = "Denied".asInstanceOf[ConfirmationStatus]
 
     val values = js.Object.freeze(js.Array(None, Confirmed, Denied))
   }
-
-  object ContentTypeEnum {
-    val `application/vnd.amazonaws.card.generic` = "application/vnd.amazonaws.card.generic"
+  @js.native
+  sealed trait ContentType extends js.Any
+  object ContentType extends js.Object {
+    val `application/vnd.amazonaws.card.generic` = "application/vnd.amazonaws.card.generic".asInstanceOf[ContentType]
 
     val values = js.Object.freeze(js.Array(`application/vnd.amazonaws.card.generic`))
   }
@@ -187,33 +183,36 @@ package lexruntime {
       __obj.asInstanceOf[DialogAction]
     }
   }
-
-  object DialogActionTypeEnum {
-    val ElicitIntent  = "ElicitIntent"
-    val ConfirmIntent = "ConfirmIntent"
-    val ElicitSlot    = "ElicitSlot"
-    val Close         = "Close"
-    val Delegate      = "Delegate"
+  @js.native
+  sealed trait DialogActionType extends js.Any
+  object DialogActionType extends js.Object {
+    val ElicitIntent  = "ElicitIntent".asInstanceOf[DialogActionType]
+    val ConfirmIntent = "ConfirmIntent".asInstanceOf[DialogActionType]
+    val ElicitSlot    = "ElicitSlot".asInstanceOf[DialogActionType]
+    val Close         = "Close".asInstanceOf[DialogActionType]
+    val Delegate      = "Delegate".asInstanceOf[DialogActionType]
 
     val values = js.Object.freeze(js.Array(ElicitIntent, ConfirmIntent, ElicitSlot, Close, Delegate))
   }
-
-  object DialogStateEnum {
-    val ElicitIntent        = "ElicitIntent"
-    val ConfirmIntent       = "ConfirmIntent"
-    val ElicitSlot          = "ElicitSlot"
-    val Fulfilled           = "Fulfilled"
-    val ReadyForFulfillment = "ReadyForFulfillment"
-    val Failed              = "Failed"
+  @js.native
+  sealed trait DialogState extends js.Any
+  object DialogState extends js.Object {
+    val ElicitIntent        = "ElicitIntent".asInstanceOf[DialogState]
+    val ConfirmIntent       = "ConfirmIntent".asInstanceOf[DialogState]
+    val ElicitSlot          = "ElicitSlot".asInstanceOf[DialogState]
+    val Fulfilled           = "Fulfilled".asInstanceOf[DialogState]
+    val ReadyForFulfillment = "ReadyForFulfillment".asInstanceOf[DialogState]
+    val Failed              = "Failed".asInstanceOf[DialogState]
 
     val values =
       js.Object.freeze(js.Array(ElicitIntent, ConfirmIntent, ElicitSlot, Fulfilled, ReadyForFulfillment, Failed))
   }
-
-  object FulfillmentStateEnum {
-    val Fulfilled           = "Fulfilled"
-    val Failed              = "Failed"
-    val ReadyForFulfillment = "ReadyForFulfillment"
+  @js.native
+  sealed trait FulfillmentState extends js.Any
+  object FulfillmentState extends js.Object {
+    val Fulfilled           = "Fulfilled".asInstanceOf[FulfillmentState]
+    val Failed              = "Failed".asInstanceOf[FulfillmentState]
+    val ReadyForFulfillment = "ReadyForFulfillment".asInstanceOf[FulfillmentState]
 
     val values = js.Object.freeze(js.Array(Fulfilled, Failed, ReadyForFulfillment))
   }
@@ -339,12 +338,13 @@ package lexruntime {
       __obj.asInstanceOf[IntentSummary]
     }
   }
-
-  object MessageFormatTypeEnum {
-    val PlainText     = "PlainText"
-    val CustomPayload = "CustomPayload"
-    val SSML          = "SSML"
-    val Composite     = "Composite"
+  @js.native
+  sealed trait MessageFormatType extends js.Any
+  object MessageFormatType extends js.Object {
+    val PlainText     = "PlainText".asInstanceOf[MessageFormatType]
+    val CustomPayload = "CustomPayload".asInstanceOf[MessageFormatType]
+    val SSML          = "SSML".asInstanceOf[MessageFormatType]
+    val Composite     = "Composite".asInstanceOf[MessageFormatType]
 
     val values = js.Object.freeze(js.Array(PlainText, CustomPayload, SSML, Composite))
   }

--- a/services/licensemanager/src/main/scala/facade/amazonaws/services/LicenseManager.scala
+++ b/services/licensemanager/src/main/scala/facade/amazonaws/services/LicenseManager.scala
@@ -16,13 +16,10 @@ package object licensemanager {
   type FilterValue                      = String
   type FilterValues                     = js.Array[FilterValue]
   type Filters                          = js.Array[Filter]
-  type InventoryFilterCondition         = String
   type InventoryFilterList              = js.Array[InventoryFilter]
   type LicenseConfigurationAssociations = js.Array[LicenseConfigurationAssociation]
-  type LicenseConfigurationStatus       = String
   type LicenseConfigurationUsageList    = js.Array[LicenseConfigurationUsage]
   type LicenseConfigurations            = js.Array[LicenseConfiguration]
-  type LicenseCountingType              = String
   type LicenseOperationFailureList      = js.Array[LicenseOperationFailure]
   type LicenseSpecifications            = js.Array[LicenseSpecification]
   type ManagedResourceSummaryList       = js.Array[ManagedResourceSummary]
@@ -30,7 +27,6 @@ package object licensemanager {
   type ProductInformationFilterList     = js.Array[ProductInformationFilter]
   type ProductInformationList           = js.Array[ProductInformation]
   type ResourceInventoryList            = js.Array[ResourceInventory]
-  type ResourceType                     = String
   type StringList                       = js.Array[String]
   type TagKeyList                       = js.Array[String]
   type TagList                          = js.Array[Tag]
@@ -439,12 +435,13 @@ package licensemanager {
       __obj.asInstanceOf[InventoryFilter]
     }
   }
-
-  object InventoryFilterConditionEnum {
-    val EQUALS      = "EQUALS"
-    val NOT_EQUALS  = "NOT_EQUALS"
-    val BEGINS_WITH = "BEGINS_WITH"
-    val CONTAINS    = "CONTAINS"
+  @js.native
+  sealed trait InventoryFilterCondition extends js.Any
+  object InventoryFilterCondition extends js.Object {
+    val EQUALS      = "EQUALS".asInstanceOf[InventoryFilterCondition]
+    val NOT_EQUALS  = "NOT_EQUALS".asInstanceOf[InventoryFilterCondition]
+    val BEGINS_WITH = "BEGINS_WITH".asInstanceOf[InventoryFilterCondition]
+    val CONTAINS    = "CONTAINS".asInstanceOf[InventoryFilterCondition]
 
     val values = js.Object.freeze(js.Array(EQUALS, NOT_EQUALS, BEGINS_WITH, CONTAINS))
   }
@@ -543,10 +540,11 @@ package licensemanager {
       __obj.asInstanceOf[LicenseConfigurationAssociation]
     }
   }
-
-  object LicenseConfigurationStatusEnum {
-    val AVAILABLE = "AVAILABLE"
-    val DISABLED  = "DISABLED"
+  @js.native
+  sealed trait LicenseConfigurationStatus extends js.Any
+  object LicenseConfigurationStatus extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[LicenseConfigurationStatus]
+    val DISABLED  = "DISABLED".asInstanceOf[LicenseConfigurationStatus]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, DISABLED))
   }
@@ -584,12 +582,13 @@ package licensemanager {
       __obj.asInstanceOf[LicenseConfigurationUsage]
     }
   }
-
-  object LicenseCountingTypeEnum {
-    val vCPU     = "vCPU"
-    val Instance = "Instance"
-    val Core     = "Core"
-    val Socket   = "Socket"
+  @js.native
+  sealed trait LicenseCountingType extends js.Any
+  object LicenseCountingType extends js.Object {
+    val vCPU     = "vCPU".asInstanceOf[LicenseCountingType]
+    val Instance = "Instance".asInstanceOf[LicenseCountingType]
+    val Core     = "Core".asInstanceOf[LicenseCountingType]
+    val Socket   = "Socket".asInstanceOf[LicenseCountingType]
 
     val values = js.Object.freeze(js.Array(vCPU, Instance, Core, Socket))
   }
@@ -1104,13 +1103,14 @@ package licensemanager {
       __obj.asInstanceOf[ResourceInventory]
     }
   }
-
-  object ResourceTypeEnum {
-    val EC2_INSTANCE                     = "EC2_INSTANCE"
-    val EC2_HOST                         = "EC2_HOST"
-    val EC2_AMI                          = "EC2_AMI"
-    val RDS                              = "RDS"
-    val SYSTEMS_MANAGER_MANAGED_INSTANCE = "SYSTEMS_MANAGER_MANAGED_INSTANCE"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val EC2_INSTANCE                     = "EC2_INSTANCE".asInstanceOf[ResourceType]
+    val EC2_HOST                         = "EC2_HOST".asInstanceOf[ResourceType]
+    val EC2_AMI                          = "EC2_AMI".asInstanceOf[ResourceType]
+    val RDS                              = "RDS".asInstanceOf[ResourceType]
+    val SYSTEMS_MANAGER_MANAGED_INSTANCE = "SYSTEMS_MANAGER_MANAGED_INSTANCE".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(EC2_INSTANCE, EC2_HOST, EC2_AMI, RDS, SYSTEMS_MANAGER_MANAGED_INSTANCE))
   }

--- a/services/lightsail/src/main/scala/facade/amazonaws/services/Lightsail.scala
+++ b/services/lightsail/src/main/scala/facade/amazonaws/services/Lightsail.scala
@@ -7,29 +7,22 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object lightsail {
-  type AccessDirection                                      = String
   type AddOnList                                            = js.Array[AddOn]
   type AddOnRequestList                                     = js.Array[AddOnRequest]
-  type AddOnType                                            = String
   type AttachedDiskList                                     = js.Array[AttachedDisk]
   type AttachedDiskMap                                      = js.Dictionary[DiskMapList]
   type AutoSnapshotDate                                     = String
   type AutoSnapshotDetailsList                              = js.Array[AutoSnapshotDetails]
-  type AutoSnapshotStatus                                   = String
   type AvailabilityZoneList                                 = js.Array[AvailabilityZone]
   type Base64                                               = String
   type BlueprintList                                        = js.Array[Blueprint]
-  type BlueprintType                                        = String
   type BundleList                                           = js.Array[Bundle]
   type CloudFormationStackRecordList                        = js.Array[CloudFormationStackRecord]
   type CloudFormationStackRecordSourceInfoList              = js.Array[CloudFormationStackRecordSourceInfo]
-  type CloudFormationStackRecordSourceType                  = String
   type DiskInfoList                                         = js.Array[DiskInfo]
   type DiskList                                             = js.Array[Disk]
   type DiskMapList                                          = js.Array[DiskMap]
   type DiskSnapshotList                                     = js.Array[DiskSnapshot]
-  type DiskSnapshotState                                    = String
-  type DiskState                                            = String
   type DomainEntryList                                      = js.Array[DomainEntry]
   type DomainEntryOptions                                   = js.Dictionary[String]
   type DomainEntryOptionsKeys                               = String
@@ -38,74 +31,44 @@ package object lightsail {
   type DomainName                                           = String
   type DomainNameList                                       = js.Array[DomainName]
   type ExportSnapshotRecordList                             = js.Array[ExportSnapshotRecord]
-  type ExportSnapshotRecordSourceType                       = String
   type HostKeysList                                         = js.Array[HostKeyAttributes]
-  type InstanceAccessProtocol                               = String
   type InstanceEntryList                                    = js.Array[InstanceEntry]
-  type InstanceHealthReason                                 = String
-  type InstanceHealthState                                  = String
   type InstanceHealthSummaryList                            = js.Array[InstanceHealthSummary]
   type InstanceList                                         = js.Array[Instance]
-  type InstanceMetricName                                   = String
-  type InstancePlatform                                     = String
   type InstancePlatformList                                 = js.Array[InstancePlatform]
   type InstancePortInfoList                                 = js.Array[InstancePortInfo]
   type InstancePortStateList                                = js.Array[InstancePortState]
   type InstanceSnapshotList                                 = js.Array[InstanceSnapshot]
-  type InstanceSnapshotState                                = String
   type IpAddress                                            = String
   type IpV6Address                                          = String
   type IsoDate                                              = js.Date
   type KeyPairList                                          = js.Array[KeyPair]
-  type LoadBalancerAttributeName                            = String
   type LoadBalancerConfigurationOptions                     = js.Dictionary[String]
   type LoadBalancerList                                     = js.Array[LoadBalancer]
-  type LoadBalancerMetricName                               = String
-  type LoadBalancerProtocol                                 = String
-  type LoadBalancerState                                    = String
-  type LoadBalancerTlsCertificateDomainStatus               = String
   type LoadBalancerTlsCertificateDomainValidationOptionList = js.Array[LoadBalancerTlsCertificateDomainValidationOption]
   type LoadBalancerTlsCertificateDomainValidationRecordList = js.Array[LoadBalancerTlsCertificateDomainValidationRecord]
-  type LoadBalancerTlsCertificateFailureReason              = String
   type LoadBalancerTlsCertificateList                       = js.Array[LoadBalancerTlsCertificate]
-  type LoadBalancerTlsCertificateRenewalStatus              = String
-  type LoadBalancerTlsCertificateRevocationReason           = String
-  type LoadBalancerTlsCertificateStatus                     = String
   type LoadBalancerTlsCertificateSummaryList                = js.Array[LoadBalancerTlsCertificateSummary]
   type LogEventList                                         = js.Array[LogEvent]
   type MetricDatapointList                                  = js.Array[MetricDatapoint]
   type MetricPeriod                                         = Int
-  type MetricStatistic                                      = String
   type MetricStatisticList                                  = js.Array[MetricStatistic]
-  type MetricUnit                                           = String
-  type NetworkProtocol                                      = String
   type NonEmptyString                                       = String
   type OperationList                                        = js.Array[Operation]
-  type OperationStatus                                      = String
-  type OperationType                                        = String
   type PendingMaintenanceActionList                         = js.Array[PendingMaintenanceAction]
   type Port                                                 = Int
-  type PortAccessType                                       = String
   type PortInfoList                                         = js.Array[PortInfo]
-  type PortInfoSourceType                                   = String
   type PortList                                             = js.Array[Port]
-  type PortState                                            = String
-  type RecordState                                          = String
   type RegionList                                           = js.Array[Region]
-  type RegionName                                           = String
   type RelationalDatabaseBlueprintList                      = js.Array[RelationalDatabaseBlueprint]
   type RelationalDatabaseBundleList                         = js.Array[RelationalDatabaseBundle]
-  type RelationalDatabaseEngine                             = String
   type RelationalDatabaseEventList                          = js.Array[RelationalDatabaseEvent]
   type RelationalDatabaseList                               = js.Array[RelationalDatabase]
-  type RelationalDatabaseMetricName                         = String
   type RelationalDatabaseParameterList                      = js.Array[RelationalDatabaseParameter]
-  type RelationalDatabasePasswordVersion                    = String
   type RelationalDatabaseSnapshotList                       = js.Array[RelationalDatabaseSnapshot]
   type ResourceArn                                          = String
   type ResourceName                                         = String
   type ResourceNameList                                     = js.Array[ResourceName]
-  type ResourceType                                         = String
   type SensitiveString                                      = String
   type StaticIpList                                         = js.Array[StaticIp]
   type StringList                                           = js.Array[String]
@@ -551,10 +514,11 @@ package lightsail {
         params: UpdateRelationalDatabaseParametersRequest
     ): Request[UpdateRelationalDatabaseParametersResult] = js.native
   }
-
-  object AccessDirectionEnum {
-    val inbound  = "inbound"
-    val outbound = "outbound"
+  @js.native
+  sealed trait AccessDirection extends js.Any
+  object AccessDirection extends js.Object {
+    val inbound  = "inbound".asInstanceOf[AccessDirection]
+    val outbound = "outbound".asInstanceOf[AccessDirection]
 
     val values = js.Object.freeze(js.Array(inbound, outbound))
   }
@@ -612,9 +576,10 @@ package lightsail {
       __obj.asInstanceOf[AddOnRequest]
     }
   }
-
-  object AddOnTypeEnum {
-    val AutoSnapshot = "AutoSnapshot"
+  @js.native
+  sealed trait AddOnType extends js.Any
+  object AddOnType extends js.Object {
+    val AutoSnapshot = "AutoSnapshot".asInstanceOf[AddOnType]
 
     val values = js.Object.freeze(js.Array(AutoSnapshot))
   }
@@ -877,12 +842,13 @@ package lightsail {
       __obj.asInstanceOf[AutoSnapshotDetails]
     }
   }
-
-  object AutoSnapshotStatusEnum {
-    val Success    = "Success"
-    val Failed     = "Failed"
-    val InProgress = "InProgress"
-    val NotFound   = "NotFound"
+  @js.native
+  sealed trait AutoSnapshotStatus extends js.Any
+  object AutoSnapshotStatus extends js.Object {
+    val Success    = "Success".asInstanceOf[AutoSnapshotStatus]
+    val Failed     = "Failed".asInstanceOf[AutoSnapshotStatus]
+    val InProgress = "InProgress".asInstanceOf[AutoSnapshotStatus]
+    val NotFound   = "NotFound".asInstanceOf[AutoSnapshotStatus]
 
     val values = js.Object.freeze(js.Array(Success, Failed, InProgress, NotFound))
   }
@@ -960,10 +926,11 @@ package lightsail {
       __obj.asInstanceOf[Blueprint]
     }
   }
-
-  object BlueprintTypeEnum {
-    val os  = "os"
-    val app = "app"
+  @js.native
+  sealed trait BlueprintType extends js.Any
+  object BlueprintType extends js.Object {
+    val os  = "os".asInstanceOf[BlueprintType]
+    val app = "app".asInstanceOf[BlueprintType]
 
     val values = js.Object.freeze(js.Array(os, app))
   }
@@ -1119,9 +1086,10 @@ package lightsail {
       __obj.asInstanceOf[CloudFormationStackRecordSourceInfo]
     }
   }
-
-  object CloudFormationStackRecordSourceTypeEnum {
-    val ExportSnapshotRecord = "ExportSnapshotRecord"
+  @js.native
+  sealed trait CloudFormationStackRecordSourceType extends js.Any
+  object CloudFormationStackRecordSourceType extends js.Object {
+    val ExportSnapshotRecord = "ExportSnapshotRecord".asInstanceOf[CloudFormationStackRecordSourceType]
 
     val values = js.Object.freeze(js.Array(ExportSnapshotRecord))
   }
@@ -2747,22 +2715,24 @@ package lightsail {
       __obj.asInstanceOf[DiskSnapshotInfo]
     }
   }
-
-  object DiskSnapshotStateEnum {
-    val pending   = "pending"
-    val completed = "completed"
-    val error     = "error"
-    val unknown   = "unknown"
+  @js.native
+  sealed trait DiskSnapshotState extends js.Any
+  object DiskSnapshotState extends js.Object {
+    val pending   = "pending".asInstanceOf[DiskSnapshotState]
+    val completed = "completed".asInstanceOf[DiskSnapshotState]
+    val error     = "error".asInstanceOf[DiskSnapshotState]
+    val unknown   = "unknown".asInstanceOf[DiskSnapshotState]
 
     val values = js.Object.freeze(js.Array(pending, completed, error, unknown))
   }
-
-  object DiskStateEnum {
-    val pending   = "pending"
-    val error     = "error"
-    val available = "available"
-    val `in-use`  = "in-use"
-    val unknown   = "unknown"
+  @js.native
+  sealed trait DiskState extends js.Any
+  object DiskState extends js.Object {
+    val pending   = "pending".asInstanceOf[DiskState]
+    val error     = "error".asInstanceOf[DiskState]
+    val available = "available".asInstanceOf[DiskState]
+    val `in-use`  = "in-use".asInstanceOf[DiskState]
+    val unknown   = "unknown".asInstanceOf[DiskState]
 
     val values = js.Object.freeze(js.Array(pending, error, available, `in-use`, unknown))
   }
@@ -2989,10 +2959,11 @@ package lightsail {
       __obj.asInstanceOf[ExportSnapshotRecordSourceInfo]
     }
   }
-
-  object ExportSnapshotRecordSourceTypeEnum {
-    val InstanceSnapshot = "InstanceSnapshot"
-    val DiskSnapshot     = "DiskSnapshot"
+  @js.native
+  sealed trait ExportSnapshotRecordSourceType extends js.Any
+  object ExportSnapshotRecordSourceType extends js.Object {
+    val InstanceSnapshot = "InstanceSnapshot".asInstanceOf[ExportSnapshotRecordSourceType]
+    val DiskSnapshot     = "DiskSnapshot".asInstanceOf[ExportSnapshotRecordSourceType]
 
     val values = js.Object.freeze(js.Array(InstanceSnapshot, DiskSnapshot))
   }
@@ -4878,10 +4849,11 @@ package lightsail {
       __obj.asInstanceOf[InstanceAccessDetails]
     }
   }
-
-  object InstanceAccessProtocolEnum {
-    val ssh = "ssh"
-    val rdp = "rdp"
+  @js.native
+  sealed trait InstanceAccessProtocol extends js.Any
+  object InstanceAccessProtocol extends js.Object {
+    val ssh = "ssh".asInstanceOf[InstanceAccessProtocol]
+    val rdp = "rdp".asInstanceOf[InstanceAccessProtocol]
 
     val values = js.Object.freeze(js.Array(ssh, rdp))
   }
@@ -4943,19 +4915,20 @@ package lightsail {
       __obj.asInstanceOf[InstanceHardware]
     }
   }
-
-  object InstanceHealthReasonEnum {
-    val `Lb.RegistrationInProgress`         = "Lb.RegistrationInProgress"
-    val `Lb.InitialHealthChecking`          = "Lb.InitialHealthChecking"
-    val `Lb.InternalError`                  = "Lb.InternalError"
-    val `Instance.ResponseCodeMismatch`     = "Instance.ResponseCodeMismatch"
-    val `Instance.Timeout`                  = "Instance.Timeout"
-    val `Instance.FailedHealthChecks`       = "Instance.FailedHealthChecks"
-    val `Instance.NotRegistered`            = "Instance.NotRegistered"
-    val `Instance.NotInUse`                 = "Instance.NotInUse"
-    val `Instance.DeregistrationInProgress` = "Instance.DeregistrationInProgress"
-    val `Instance.InvalidState`             = "Instance.InvalidState"
-    val `Instance.IpUnusable`               = "Instance.IpUnusable"
+  @js.native
+  sealed trait InstanceHealthReason extends js.Any
+  object InstanceHealthReason extends js.Object {
+    val `Lb.RegistrationInProgress`         = "Lb.RegistrationInProgress".asInstanceOf[InstanceHealthReason]
+    val `Lb.InitialHealthChecking`          = "Lb.InitialHealthChecking".asInstanceOf[InstanceHealthReason]
+    val `Lb.InternalError`                  = "Lb.InternalError".asInstanceOf[InstanceHealthReason]
+    val `Instance.ResponseCodeMismatch`     = "Instance.ResponseCodeMismatch".asInstanceOf[InstanceHealthReason]
+    val `Instance.Timeout`                  = "Instance.Timeout".asInstanceOf[InstanceHealthReason]
+    val `Instance.FailedHealthChecks`       = "Instance.FailedHealthChecks".asInstanceOf[InstanceHealthReason]
+    val `Instance.NotRegistered`            = "Instance.NotRegistered".asInstanceOf[InstanceHealthReason]
+    val `Instance.NotInUse`                 = "Instance.NotInUse".asInstanceOf[InstanceHealthReason]
+    val `Instance.DeregistrationInProgress` = "Instance.DeregistrationInProgress".asInstanceOf[InstanceHealthReason]
+    val `Instance.InvalidState`             = "Instance.InvalidState".asInstanceOf[InstanceHealthReason]
+    val `Instance.IpUnusable`               = "Instance.IpUnusable".asInstanceOf[InstanceHealthReason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4973,14 +4946,15 @@ package lightsail {
       )
     )
   }
-
-  object InstanceHealthStateEnum {
-    val initial     = "initial"
-    val healthy     = "healthy"
-    val unhealthy   = "unhealthy"
-    val unused      = "unused"
-    val draining    = "draining"
-    val unavailable = "unavailable"
+  @js.native
+  sealed trait InstanceHealthState extends js.Any
+  object InstanceHealthState extends js.Object {
+    val initial     = "initial".asInstanceOf[InstanceHealthState]
+    val healthy     = "healthy".asInstanceOf[InstanceHealthState]
+    val unhealthy   = "unhealthy".asInstanceOf[InstanceHealthState]
+    val unused      = "unused".asInstanceOf[InstanceHealthState]
+    val draining    = "draining".asInstanceOf[InstanceHealthState]
+    val unavailable = "unavailable".asInstanceOf[InstanceHealthState]
 
     val values = js.Object.freeze(js.Array(initial, healthy, unhealthy, unused, draining, unavailable))
   }
@@ -5009,14 +4983,15 @@ package lightsail {
       __obj.asInstanceOf[InstanceHealthSummary]
     }
   }
-
-  object InstanceMetricNameEnum {
-    val CPUUtilization             = "CPUUtilization"
-    val NetworkIn                  = "NetworkIn"
-    val NetworkOut                 = "NetworkOut"
-    val StatusCheckFailed          = "StatusCheckFailed"
-    val StatusCheckFailed_Instance = "StatusCheckFailed_Instance"
-    val StatusCheckFailed_System   = "StatusCheckFailed_System"
+  @js.native
+  sealed trait InstanceMetricName extends js.Any
+  object InstanceMetricName extends js.Object {
+    val CPUUtilization             = "CPUUtilization".asInstanceOf[InstanceMetricName]
+    val NetworkIn                  = "NetworkIn".asInstanceOf[InstanceMetricName]
+    val NetworkOut                 = "NetworkOut".asInstanceOf[InstanceMetricName]
+    val StatusCheckFailed          = "StatusCheckFailed".asInstanceOf[InstanceMetricName]
+    val StatusCheckFailed_Instance = "StatusCheckFailed_Instance".asInstanceOf[InstanceMetricName]
+    val StatusCheckFailed_System   = "StatusCheckFailed_System".asInstanceOf[InstanceMetricName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5051,10 +5026,11 @@ package lightsail {
       __obj.asInstanceOf[InstanceNetworking]
     }
   }
-
-  object InstancePlatformEnum {
-    val LINUX_UNIX = "LINUX_UNIX"
-    val WINDOWS    = "WINDOWS"
+  @js.native
+  sealed trait InstancePlatform extends js.Any
+  object InstancePlatform extends js.Object {
+    val LINUX_UNIX = "LINUX_UNIX".asInstanceOf[InstancePlatform]
+    val WINDOWS    = "WINDOWS".asInstanceOf[InstancePlatform]
 
     val values = js.Object.freeze(js.Array(LINUX_UNIX, WINDOWS))
   }
@@ -5212,11 +5188,12 @@ package lightsail {
       __obj.asInstanceOf[InstanceSnapshotInfo]
     }
   }
-
-  object InstanceSnapshotStateEnum {
-    val pending   = "pending"
-    val error     = "error"
-    val available = "available"
+  @js.native
+  sealed trait InstanceSnapshotState extends js.Any
+  object InstanceSnapshotState extends js.Object {
+    val pending   = "pending".asInstanceOf[InstanceSnapshotState]
+    val error     = "error".asInstanceOf[InstanceSnapshotState]
+    val available = "available".asInstanceOf[InstanceSnapshotState]
 
     val values = js.Object.freeze(js.Array(pending, error, available))
   }
@@ -5375,29 +5352,32 @@ package lightsail {
       __obj.asInstanceOf[LoadBalancer]
     }
   }
-
-  object LoadBalancerAttributeNameEnum {
-    val HealthCheckPath                            = "HealthCheckPath"
-    val SessionStickinessEnabled                   = "SessionStickinessEnabled"
-    val SessionStickiness_LB_CookieDurationSeconds = "SessionStickiness_LB_CookieDurationSeconds"
+  @js.native
+  sealed trait LoadBalancerAttributeName extends js.Any
+  object LoadBalancerAttributeName extends js.Object {
+    val HealthCheckPath          = "HealthCheckPath".asInstanceOf[LoadBalancerAttributeName]
+    val SessionStickinessEnabled = "SessionStickinessEnabled".asInstanceOf[LoadBalancerAttributeName]
+    val SessionStickiness_LB_CookieDurationSeconds =
+      "SessionStickiness_LB_CookieDurationSeconds".asInstanceOf[LoadBalancerAttributeName]
 
     val values =
       js.Object.freeze(js.Array(HealthCheckPath, SessionStickinessEnabled, SessionStickiness_LB_CookieDurationSeconds))
   }
-
-  object LoadBalancerMetricNameEnum {
-    val ClientTLSNegotiationErrorCount = "ClientTLSNegotiationErrorCount"
-    val HealthyHostCount               = "HealthyHostCount"
-    val UnhealthyHostCount             = "UnhealthyHostCount"
-    val HTTPCode_LB_4XX_Count          = "HTTPCode_LB_4XX_Count"
-    val HTTPCode_LB_5XX_Count          = "HTTPCode_LB_5XX_Count"
-    val HTTPCode_Instance_2XX_Count    = "HTTPCode_Instance_2XX_Count"
-    val HTTPCode_Instance_3XX_Count    = "HTTPCode_Instance_3XX_Count"
-    val HTTPCode_Instance_4XX_Count    = "HTTPCode_Instance_4XX_Count"
-    val HTTPCode_Instance_5XX_Count    = "HTTPCode_Instance_5XX_Count"
-    val InstanceResponseTime           = "InstanceResponseTime"
-    val RejectedConnectionCount        = "RejectedConnectionCount"
-    val RequestCount                   = "RequestCount"
+  @js.native
+  sealed trait LoadBalancerMetricName extends js.Any
+  object LoadBalancerMetricName extends js.Object {
+    val ClientTLSNegotiationErrorCount = "ClientTLSNegotiationErrorCount".asInstanceOf[LoadBalancerMetricName]
+    val HealthyHostCount               = "HealthyHostCount".asInstanceOf[LoadBalancerMetricName]
+    val UnhealthyHostCount             = "UnhealthyHostCount".asInstanceOf[LoadBalancerMetricName]
+    val HTTPCode_LB_4XX_Count          = "HTTPCode_LB_4XX_Count".asInstanceOf[LoadBalancerMetricName]
+    val HTTPCode_LB_5XX_Count          = "HTTPCode_LB_5XX_Count".asInstanceOf[LoadBalancerMetricName]
+    val HTTPCode_Instance_2XX_Count    = "HTTPCode_Instance_2XX_Count".asInstanceOf[LoadBalancerMetricName]
+    val HTTPCode_Instance_3XX_Count    = "HTTPCode_Instance_3XX_Count".asInstanceOf[LoadBalancerMetricName]
+    val HTTPCode_Instance_4XX_Count    = "HTTPCode_Instance_4XX_Count".asInstanceOf[LoadBalancerMetricName]
+    val HTTPCode_Instance_5XX_Count    = "HTTPCode_Instance_5XX_Count".asInstanceOf[LoadBalancerMetricName]
+    val InstanceResponseTime           = "InstanceResponseTime".asInstanceOf[LoadBalancerMetricName]
+    val RejectedConnectionCount        = "RejectedConnectionCount".asInstanceOf[LoadBalancerMetricName]
+    val RequestCount                   = "RequestCount".asInstanceOf[LoadBalancerMetricName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5416,20 +5396,22 @@ package lightsail {
       )
     )
   }
-
-  object LoadBalancerProtocolEnum {
-    val HTTP_HTTPS = "HTTP_HTTPS"
-    val HTTP       = "HTTP"
+  @js.native
+  sealed trait LoadBalancerProtocol extends js.Any
+  object LoadBalancerProtocol extends js.Object {
+    val HTTP_HTTPS = "HTTP_HTTPS".asInstanceOf[LoadBalancerProtocol]
+    val HTTP       = "HTTP".asInstanceOf[LoadBalancerProtocol]
 
     val values = js.Object.freeze(js.Array(HTTP_HTTPS, HTTP))
   }
-
-  object LoadBalancerStateEnum {
-    val active          = "active"
-    val provisioning    = "provisioning"
-    val active_impaired = "active_impaired"
-    val failed          = "failed"
-    val unknown         = "unknown"
+  @js.native
+  sealed trait LoadBalancerState extends js.Any
+  object LoadBalancerState extends js.Object {
+    val active          = "active".asInstanceOf[LoadBalancerState]
+    val provisioning    = "provisioning".asInstanceOf[LoadBalancerState]
+    val active_impaired = "active_impaired".asInstanceOf[LoadBalancerState]
+    val failed          = "failed".asInstanceOf[LoadBalancerState]
+    val unknown         = "unknown".asInstanceOf[LoadBalancerState]
 
     val values = js.Object.freeze(js.Array(active, provisioning, active_impaired, failed, unknown))
   }
@@ -5525,11 +5507,12 @@ package lightsail {
       __obj.asInstanceOf[LoadBalancerTlsCertificate]
     }
   }
-
-  object LoadBalancerTlsCertificateDomainStatusEnum {
-    val PENDING_VALIDATION = "PENDING_VALIDATION"
-    val FAILED             = "FAILED"
-    val SUCCESS            = "SUCCESS"
+  @js.native
+  sealed trait LoadBalancerTlsCertificateDomainStatus extends js.Any
+  object LoadBalancerTlsCertificateDomainStatus extends js.Object {
+    val PENDING_VALIDATION = "PENDING_VALIDATION".asInstanceOf[LoadBalancerTlsCertificateDomainStatus]
+    val FAILED             = "FAILED".asInstanceOf[LoadBalancerTlsCertificateDomainStatus]
+    val SUCCESS            = "SUCCESS".asInstanceOf[LoadBalancerTlsCertificateDomainStatus]
 
     val values = js.Object.freeze(js.Array(PENDING_VALIDATION, FAILED, SUCCESS))
   }
@@ -5586,13 +5569,15 @@ package lightsail {
       __obj.asInstanceOf[LoadBalancerTlsCertificateDomainValidationRecord]
     }
   }
-
-  object LoadBalancerTlsCertificateFailureReasonEnum {
-    val NO_AVAILABLE_CONTACTS            = "NO_AVAILABLE_CONTACTS"
-    val ADDITIONAL_VERIFICATION_REQUIRED = "ADDITIONAL_VERIFICATION_REQUIRED"
-    val DOMAIN_NOT_ALLOWED               = "DOMAIN_NOT_ALLOWED"
-    val INVALID_PUBLIC_DOMAIN            = "INVALID_PUBLIC_DOMAIN"
-    val OTHER                            = "OTHER"
+  @js.native
+  sealed trait LoadBalancerTlsCertificateFailureReason extends js.Any
+  object LoadBalancerTlsCertificateFailureReason extends js.Object {
+    val NO_AVAILABLE_CONTACTS = "NO_AVAILABLE_CONTACTS".asInstanceOf[LoadBalancerTlsCertificateFailureReason]
+    val ADDITIONAL_VERIFICATION_REQUIRED =
+      "ADDITIONAL_VERIFICATION_REQUIRED".asInstanceOf[LoadBalancerTlsCertificateFailureReason]
+    val DOMAIN_NOT_ALLOWED    = "DOMAIN_NOT_ALLOWED".asInstanceOf[LoadBalancerTlsCertificateFailureReason]
+    val INVALID_PUBLIC_DOMAIN = "INVALID_PUBLIC_DOMAIN".asInstanceOf[LoadBalancerTlsCertificateFailureReason]
+    val OTHER                 = "OTHER".asInstanceOf[LoadBalancerTlsCertificateFailureReason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5604,12 +5589,13 @@ package lightsail {
       )
     )
   }
-
-  object LoadBalancerTlsCertificateRenewalStatusEnum {
-    val PENDING_AUTO_RENEWAL = "PENDING_AUTO_RENEWAL"
-    val PENDING_VALIDATION   = "PENDING_VALIDATION"
-    val SUCCESS              = "SUCCESS"
-    val FAILED               = "FAILED"
+  @js.native
+  sealed trait LoadBalancerTlsCertificateRenewalStatus extends js.Any
+  object LoadBalancerTlsCertificateRenewalStatus extends js.Object {
+    val PENDING_AUTO_RENEWAL = "PENDING_AUTO_RENEWAL".asInstanceOf[LoadBalancerTlsCertificateRenewalStatus]
+    val PENDING_VALIDATION   = "PENDING_VALIDATION".asInstanceOf[LoadBalancerTlsCertificateRenewalStatus]
+    val SUCCESS              = "SUCCESS".asInstanceOf[LoadBalancerTlsCertificateRenewalStatus]
+    val FAILED               = "FAILED".asInstanceOf[LoadBalancerTlsCertificateRenewalStatus]
 
     val values = js.Object.freeze(js.Array(PENDING_AUTO_RENEWAL, PENDING_VALIDATION, SUCCESS, FAILED))
   }
@@ -5635,18 +5621,19 @@ package lightsail {
       __obj.asInstanceOf[LoadBalancerTlsCertificateRenewalSummary]
     }
   }
-
-  object LoadBalancerTlsCertificateRevocationReasonEnum {
-    val UNSPECIFIED            = "UNSPECIFIED"
-    val KEY_COMPROMISE         = "KEY_COMPROMISE"
-    val CA_COMPROMISE          = "CA_COMPROMISE"
-    val AFFILIATION_CHANGED    = "AFFILIATION_CHANGED"
-    val SUPERCEDED             = "SUPERCEDED"
-    val CESSATION_OF_OPERATION = "CESSATION_OF_OPERATION"
-    val CERTIFICATE_HOLD       = "CERTIFICATE_HOLD"
-    val REMOVE_FROM_CRL        = "REMOVE_FROM_CRL"
-    val PRIVILEGE_WITHDRAWN    = "PRIVILEGE_WITHDRAWN"
-    val A_A_COMPROMISE         = "A_A_COMPROMISE"
+  @js.native
+  sealed trait LoadBalancerTlsCertificateRevocationReason extends js.Any
+  object LoadBalancerTlsCertificateRevocationReason extends js.Object {
+    val UNSPECIFIED            = "UNSPECIFIED".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val KEY_COMPROMISE         = "KEY_COMPROMISE".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val CA_COMPROMISE          = "CA_COMPROMISE".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val AFFILIATION_CHANGED    = "AFFILIATION_CHANGED".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val SUPERCEDED             = "SUPERCEDED".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val CESSATION_OF_OPERATION = "CESSATION_OF_OPERATION".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val CERTIFICATE_HOLD       = "CERTIFICATE_HOLD".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val REMOVE_FROM_CRL        = "REMOVE_FROM_CRL".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val PRIVILEGE_WITHDRAWN    = "PRIVILEGE_WITHDRAWN".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
+    val A_A_COMPROMISE         = "A_A_COMPROMISE".asInstanceOf[LoadBalancerTlsCertificateRevocationReason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5663,16 +5650,17 @@ package lightsail {
       )
     )
   }
-
-  object LoadBalancerTlsCertificateStatusEnum {
-    val PENDING_VALIDATION   = "PENDING_VALIDATION"
-    val ISSUED               = "ISSUED"
-    val INACTIVE             = "INACTIVE"
-    val EXPIRED              = "EXPIRED"
-    val VALIDATION_TIMED_OUT = "VALIDATION_TIMED_OUT"
-    val REVOKED              = "REVOKED"
-    val FAILED               = "FAILED"
-    val UNKNOWN              = "UNKNOWN"
+  @js.native
+  sealed trait LoadBalancerTlsCertificateStatus extends js.Any
+  object LoadBalancerTlsCertificateStatus extends js.Object {
+    val PENDING_VALIDATION   = "PENDING_VALIDATION".asInstanceOf[LoadBalancerTlsCertificateStatus]
+    val ISSUED               = "ISSUED".asInstanceOf[LoadBalancerTlsCertificateStatus]
+    val INACTIVE             = "INACTIVE".asInstanceOf[LoadBalancerTlsCertificateStatus]
+    val EXPIRED              = "EXPIRED".asInstanceOf[LoadBalancerTlsCertificateStatus]
+    val VALIDATION_TIMED_OUT = "VALIDATION_TIMED_OUT".asInstanceOf[LoadBalancerTlsCertificateStatus]
+    val REVOKED              = "REVOKED".asInstanceOf[LoadBalancerTlsCertificateStatus]
+    val FAILED               = "FAILED".asInstanceOf[LoadBalancerTlsCertificateStatus]
+    val UNKNOWN              = "UNKNOWN".asInstanceOf[LoadBalancerTlsCertificateStatus]
 
     val values = js.Object.freeze(
       js.Array(PENDING_VALIDATION, ISSUED, INACTIVE, EXPIRED, VALIDATION_TIMED_OUT, REVOKED, FAILED, UNKNOWN)
@@ -5759,45 +5747,47 @@ package lightsail {
       __obj.asInstanceOf[MetricDatapoint]
     }
   }
-
-  object MetricStatisticEnum {
-    val Minimum     = "Minimum"
-    val Maximum     = "Maximum"
-    val Sum         = "Sum"
-    val Average     = "Average"
-    val SampleCount = "SampleCount"
+  @js.native
+  sealed trait MetricStatistic extends js.Any
+  object MetricStatistic extends js.Object {
+    val Minimum     = "Minimum".asInstanceOf[MetricStatistic]
+    val Maximum     = "Maximum".asInstanceOf[MetricStatistic]
+    val Sum         = "Sum".asInstanceOf[MetricStatistic]
+    val Average     = "Average".asInstanceOf[MetricStatistic]
+    val SampleCount = "SampleCount".asInstanceOf[MetricStatistic]
 
     val values = js.Object.freeze(js.Array(Minimum, Maximum, Sum, Average, SampleCount))
   }
-
-  object MetricUnitEnum {
-    val Seconds            = "Seconds"
-    val Microseconds       = "Microseconds"
-    val Milliseconds       = "Milliseconds"
-    val Bytes              = "Bytes"
-    val Kilobytes          = "Kilobytes"
-    val Megabytes          = "Megabytes"
-    val Gigabytes          = "Gigabytes"
-    val Terabytes          = "Terabytes"
-    val Bits               = "Bits"
-    val Kilobits           = "Kilobits"
-    val Megabits           = "Megabits"
-    val Gigabits           = "Gigabits"
-    val Terabits           = "Terabits"
-    val Percent            = "Percent"
-    val Count              = "Count"
-    val `Bytes/Second`     = "Bytes/Second"
-    val `Kilobytes/Second` = "Kilobytes/Second"
-    val `Megabytes/Second` = "Megabytes/Second"
-    val `Gigabytes/Second` = "Gigabytes/Second"
-    val `Terabytes/Second` = "Terabytes/Second"
-    val `Bits/Second`      = "Bits/Second"
-    val `Kilobits/Second`  = "Kilobits/Second"
-    val `Megabits/Second`  = "Megabits/Second"
-    val `Gigabits/Second`  = "Gigabits/Second"
-    val `Terabits/Second`  = "Terabits/Second"
-    val `Count/Second`     = "Count/Second"
-    val None               = "None"
+  @js.native
+  sealed trait MetricUnit extends js.Any
+  object MetricUnit extends js.Object {
+    val Seconds            = "Seconds".asInstanceOf[MetricUnit]
+    val Microseconds       = "Microseconds".asInstanceOf[MetricUnit]
+    val Milliseconds       = "Milliseconds".asInstanceOf[MetricUnit]
+    val Bytes              = "Bytes".asInstanceOf[MetricUnit]
+    val Kilobytes          = "Kilobytes".asInstanceOf[MetricUnit]
+    val Megabytes          = "Megabytes".asInstanceOf[MetricUnit]
+    val Gigabytes          = "Gigabytes".asInstanceOf[MetricUnit]
+    val Terabytes          = "Terabytes".asInstanceOf[MetricUnit]
+    val Bits               = "Bits".asInstanceOf[MetricUnit]
+    val Kilobits           = "Kilobits".asInstanceOf[MetricUnit]
+    val Megabits           = "Megabits".asInstanceOf[MetricUnit]
+    val Gigabits           = "Gigabits".asInstanceOf[MetricUnit]
+    val Terabits           = "Terabits".asInstanceOf[MetricUnit]
+    val Percent            = "Percent".asInstanceOf[MetricUnit]
+    val Count              = "Count".asInstanceOf[MetricUnit]
+    val `Bytes/Second`     = "Bytes/Second".asInstanceOf[MetricUnit]
+    val `Kilobytes/Second` = "Kilobytes/Second".asInstanceOf[MetricUnit]
+    val `Megabytes/Second` = "Megabytes/Second".asInstanceOf[MetricUnit]
+    val `Gigabytes/Second` = "Gigabytes/Second".asInstanceOf[MetricUnit]
+    val `Terabytes/Second` = "Terabytes/Second".asInstanceOf[MetricUnit]
+    val `Bits/Second`      = "Bits/Second".asInstanceOf[MetricUnit]
+    val `Kilobits/Second`  = "Kilobits/Second".asInstanceOf[MetricUnit]
+    val `Megabits/Second`  = "Megabits/Second".asInstanceOf[MetricUnit]
+    val `Gigabits/Second`  = "Gigabits/Second".asInstanceOf[MetricUnit]
+    val `Terabits/Second`  = "Terabits/Second".asInstanceOf[MetricUnit]
+    val `Count/Second`     = "Count/Second".asInstanceOf[MetricUnit]
+    val None               = "None".asInstanceOf[MetricUnit]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5850,11 +5840,12 @@ package lightsail {
       __obj.asInstanceOf[MonthlyTransfer]
     }
   }
-
-  object NetworkProtocolEnum {
-    val tcp = "tcp"
-    val all = "all"
-    val udp = "udp"
+  @js.native
+  sealed trait NetworkProtocol extends js.Any
+  object NetworkProtocol extends js.Object {
+    val tcp = "tcp".asInstanceOf[NetworkProtocol]
+    val all = "all".asInstanceOf[NetworkProtocol]
+    val udp = "udp".asInstanceOf[NetworkProtocol]
 
     val values = js.Object.freeze(js.Array(tcp, all, udp))
   }
@@ -5947,65 +5938,67 @@ package lightsail {
       __obj.asInstanceOf[Operation]
     }
   }
-
-  object OperationStatusEnum {
-    val NotStarted = "NotStarted"
-    val Started    = "Started"
-    val Failed     = "Failed"
-    val Completed  = "Completed"
-    val Succeeded  = "Succeeded"
+  @js.native
+  sealed trait OperationStatus extends js.Any
+  object OperationStatus extends js.Object {
+    val NotStarted = "NotStarted".asInstanceOf[OperationStatus]
+    val Started    = "Started".asInstanceOf[OperationStatus]
+    val Failed     = "Failed".asInstanceOf[OperationStatus]
+    val Completed  = "Completed".asInstanceOf[OperationStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[OperationStatus]
 
     val values = js.Object.freeze(js.Array(NotStarted, Started, Failed, Completed, Succeeded))
   }
-
-  object OperationTypeEnum {
-    val DeleteKnownHostKeys                  = "DeleteKnownHostKeys"
-    val DeleteInstance                       = "DeleteInstance"
-    val CreateInstance                       = "CreateInstance"
-    val StopInstance                         = "StopInstance"
-    val StartInstance                        = "StartInstance"
-    val RebootInstance                       = "RebootInstance"
-    val OpenInstancePublicPorts              = "OpenInstancePublicPorts"
-    val PutInstancePublicPorts               = "PutInstancePublicPorts"
-    val CloseInstancePublicPorts             = "CloseInstancePublicPorts"
-    val AllocateStaticIp                     = "AllocateStaticIp"
-    val ReleaseStaticIp                      = "ReleaseStaticIp"
-    val AttachStaticIp                       = "AttachStaticIp"
-    val DetachStaticIp                       = "DetachStaticIp"
-    val UpdateDomainEntry                    = "UpdateDomainEntry"
-    val DeleteDomainEntry                    = "DeleteDomainEntry"
-    val CreateDomain                         = "CreateDomain"
-    val DeleteDomain                         = "DeleteDomain"
-    val CreateInstanceSnapshot               = "CreateInstanceSnapshot"
-    val DeleteInstanceSnapshot               = "DeleteInstanceSnapshot"
-    val CreateInstancesFromSnapshot          = "CreateInstancesFromSnapshot"
-    val CreateLoadBalancer                   = "CreateLoadBalancer"
-    val DeleteLoadBalancer                   = "DeleteLoadBalancer"
-    val AttachInstancesToLoadBalancer        = "AttachInstancesToLoadBalancer"
-    val DetachInstancesFromLoadBalancer      = "DetachInstancesFromLoadBalancer"
-    val UpdateLoadBalancerAttribute          = "UpdateLoadBalancerAttribute"
-    val CreateLoadBalancerTlsCertificate     = "CreateLoadBalancerTlsCertificate"
-    val DeleteLoadBalancerTlsCertificate     = "DeleteLoadBalancerTlsCertificate"
-    val AttachLoadBalancerTlsCertificate     = "AttachLoadBalancerTlsCertificate"
-    val CreateDisk                           = "CreateDisk"
-    val DeleteDisk                           = "DeleteDisk"
-    val AttachDisk                           = "AttachDisk"
-    val DetachDisk                           = "DetachDisk"
-    val CreateDiskSnapshot                   = "CreateDiskSnapshot"
-    val DeleteDiskSnapshot                   = "DeleteDiskSnapshot"
-    val CreateDiskFromSnapshot               = "CreateDiskFromSnapshot"
-    val CreateRelationalDatabase             = "CreateRelationalDatabase"
-    val UpdateRelationalDatabase             = "UpdateRelationalDatabase"
-    val DeleteRelationalDatabase             = "DeleteRelationalDatabase"
-    val CreateRelationalDatabaseFromSnapshot = "CreateRelationalDatabaseFromSnapshot"
-    val CreateRelationalDatabaseSnapshot     = "CreateRelationalDatabaseSnapshot"
-    val DeleteRelationalDatabaseSnapshot     = "DeleteRelationalDatabaseSnapshot"
-    val UpdateRelationalDatabaseParameters   = "UpdateRelationalDatabaseParameters"
-    val StartRelationalDatabase              = "StartRelationalDatabase"
-    val RebootRelationalDatabase             = "RebootRelationalDatabase"
-    val StopRelationalDatabase               = "StopRelationalDatabase"
-    val EnableAddOn                          = "EnableAddOn"
-    val DisableAddOn                         = "DisableAddOn"
+  @js.native
+  sealed trait OperationType extends js.Any
+  object OperationType extends js.Object {
+    val DeleteKnownHostKeys                  = "DeleteKnownHostKeys".asInstanceOf[OperationType]
+    val DeleteInstance                       = "DeleteInstance".asInstanceOf[OperationType]
+    val CreateInstance                       = "CreateInstance".asInstanceOf[OperationType]
+    val StopInstance                         = "StopInstance".asInstanceOf[OperationType]
+    val StartInstance                        = "StartInstance".asInstanceOf[OperationType]
+    val RebootInstance                       = "RebootInstance".asInstanceOf[OperationType]
+    val OpenInstancePublicPorts              = "OpenInstancePublicPorts".asInstanceOf[OperationType]
+    val PutInstancePublicPorts               = "PutInstancePublicPorts".asInstanceOf[OperationType]
+    val CloseInstancePublicPorts             = "CloseInstancePublicPorts".asInstanceOf[OperationType]
+    val AllocateStaticIp                     = "AllocateStaticIp".asInstanceOf[OperationType]
+    val ReleaseStaticIp                      = "ReleaseStaticIp".asInstanceOf[OperationType]
+    val AttachStaticIp                       = "AttachStaticIp".asInstanceOf[OperationType]
+    val DetachStaticIp                       = "DetachStaticIp".asInstanceOf[OperationType]
+    val UpdateDomainEntry                    = "UpdateDomainEntry".asInstanceOf[OperationType]
+    val DeleteDomainEntry                    = "DeleteDomainEntry".asInstanceOf[OperationType]
+    val CreateDomain                         = "CreateDomain".asInstanceOf[OperationType]
+    val DeleteDomain                         = "DeleteDomain".asInstanceOf[OperationType]
+    val CreateInstanceSnapshot               = "CreateInstanceSnapshot".asInstanceOf[OperationType]
+    val DeleteInstanceSnapshot               = "DeleteInstanceSnapshot".asInstanceOf[OperationType]
+    val CreateInstancesFromSnapshot          = "CreateInstancesFromSnapshot".asInstanceOf[OperationType]
+    val CreateLoadBalancer                   = "CreateLoadBalancer".asInstanceOf[OperationType]
+    val DeleteLoadBalancer                   = "DeleteLoadBalancer".asInstanceOf[OperationType]
+    val AttachInstancesToLoadBalancer        = "AttachInstancesToLoadBalancer".asInstanceOf[OperationType]
+    val DetachInstancesFromLoadBalancer      = "DetachInstancesFromLoadBalancer".asInstanceOf[OperationType]
+    val UpdateLoadBalancerAttribute          = "UpdateLoadBalancerAttribute".asInstanceOf[OperationType]
+    val CreateLoadBalancerTlsCertificate     = "CreateLoadBalancerTlsCertificate".asInstanceOf[OperationType]
+    val DeleteLoadBalancerTlsCertificate     = "DeleteLoadBalancerTlsCertificate".asInstanceOf[OperationType]
+    val AttachLoadBalancerTlsCertificate     = "AttachLoadBalancerTlsCertificate".asInstanceOf[OperationType]
+    val CreateDisk                           = "CreateDisk".asInstanceOf[OperationType]
+    val DeleteDisk                           = "DeleteDisk".asInstanceOf[OperationType]
+    val AttachDisk                           = "AttachDisk".asInstanceOf[OperationType]
+    val DetachDisk                           = "DetachDisk".asInstanceOf[OperationType]
+    val CreateDiskSnapshot                   = "CreateDiskSnapshot".asInstanceOf[OperationType]
+    val DeleteDiskSnapshot                   = "DeleteDiskSnapshot".asInstanceOf[OperationType]
+    val CreateDiskFromSnapshot               = "CreateDiskFromSnapshot".asInstanceOf[OperationType]
+    val CreateRelationalDatabase             = "CreateRelationalDatabase".asInstanceOf[OperationType]
+    val UpdateRelationalDatabase             = "UpdateRelationalDatabase".asInstanceOf[OperationType]
+    val DeleteRelationalDatabase             = "DeleteRelationalDatabase".asInstanceOf[OperationType]
+    val CreateRelationalDatabaseFromSnapshot = "CreateRelationalDatabaseFromSnapshot".asInstanceOf[OperationType]
+    val CreateRelationalDatabaseSnapshot     = "CreateRelationalDatabaseSnapshot".asInstanceOf[OperationType]
+    val DeleteRelationalDatabaseSnapshot     = "DeleteRelationalDatabaseSnapshot".asInstanceOf[OperationType]
+    val UpdateRelationalDatabaseParameters   = "UpdateRelationalDatabaseParameters".asInstanceOf[OperationType]
+    val StartRelationalDatabase              = "StartRelationalDatabase".asInstanceOf[OperationType]
+    val RebootRelationalDatabase             = "RebootRelationalDatabase".asInstanceOf[OperationType]
+    val StopRelationalDatabase               = "StopRelationalDatabase".asInstanceOf[OperationType]
+    val EnableAddOn                          = "EnableAddOn".asInstanceOf[OperationType]
+    val DisableAddOn                         = "DisableAddOn".asInstanceOf[OperationType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -6160,10 +6153,11 @@ package lightsail {
       __obj.asInstanceOf[PendingModifiedRelationalDatabaseValues]
     }
   }
-
-  object PortAccessTypeEnum {
-    val Public  = "Public"
-    val Private = "Private"
+  @js.native
+  sealed trait PortAccessType extends js.Any
+  object PortAccessType extends js.Object {
+    val Public  = "Public".asInstanceOf[PortAccessType]
+    val Private = "Private".asInstanceOf[PortAccessType]
 
     val values = js.Object.freeze(js.Array(Public, Private))
   }
@@ -6192,19 +6186,21 @@ package lightsail {
       __obj.asInstanceOf[PortInfo]
     }
   }
-
-  object PortInfoSourceTypeEnum {
-    val DEFAULT  = "DEFAULT"
-    val INSTANCE = "INSTANCE"
-    val NONE     = "NONE"
-    val CLOSED   = "CLOSED"
+  @js.native
+  sealed trait PortInfoSourceType extends js.Any
+  object PortInfoSourceType extends js.Object {
+    val DEFAULT  = "DEFAULT".asInstanceOf[PortInfoSourceType]
+    val INSTANCE = "INSTANCE".asInstanceOf[PortInfoSourceType]
+    val NONE     = "NONE".asInstanceOf[PortInfoSourceType]
+    val CLOSED   = "CLOSED".asInstanceOf[PortInfoSourceType]
 
     val values = js.Object.freeze(js.Array(DEFAULT, INSTANCE, NONE, CLOSED))
   }
-
-  object PortStateEnum {
-    val open   = "open"
-    val closed = "closed"
+  @js.native
+  sealed trait PortState extends js.Any
+  object PortState extends js.Object {
+    val open   = "open".asInstanceOf[PortState]
+    val closed = "closed".asInstanceOf[PortState]
 
     val values = js.Object.freeze(js.Array(open, closed))
   }
@@ -6313,11 +6309,12 @@ package lightsail {
       __obj.asInstanceOf[RebootRelationalDatabaseResult]
     }
   }
-
-  object RecordStateEnum {
-    val Started   = "Started"
-    val Succeeded = "Succeeded"
-    val Failed    = "Failed"
+  @js.native
+  sealed trait RecordState extends js.Any
+  object RecordState extends js.Object {
+    val Started   = "Started".asInstanceOf[RecordState]
+    val Succeeded = "Succeeded".asInstanceOf[RecordState]
+    val Failed    = "Failed".asInstanceOf[RecordState]
 
     val values = js.Object.freeze(js.Array(Started, Succeeded, Failed))
   }
@@ -6357,22 +6354,23 @@ package lightsail {
       __obj.asInstanceOf[Region]
     }
   }
-
-  object RegionNameEnum {
-    val `us-east-1`      = "us-east-1"
-    val `us-east-2`      = "us-east-2"
-    val `us-west-1`      = "us-west-1"
-    val `us-west-2`      = "us-west-2"
-    val `eu-west-1`      = "eu-west-1"
-    val `eu-west-2`      = "eu-west-2"
-    val `eu-west-3`      = "eu-west-3"
-    val `eu-central-1`   = "eu-central-1"
-    val `ca-central-1`   = "ca-central-1"
-    val `ap-south-1`     = "ap-south-1"
-    val `ap-southeast-1` = "ap-southeast-1"
-    val `ap-southeast-2` = "ap-southeast-2"
-    val `ap-northeast-1` = "ap-northeast-1"
-    val `ap-northeast-2` = "ap-northeast-2"
+  @js.native
+  sealed trait RegionName extends js.Any
+  object RegionName extends js.Object {
+    val `us-east-1`      = "us-east-1".asInstanceOf[RegionName]
+    val `us-east-2`      = "us-east-2".asInstanceOf[RegionName]
+    val `us-west-1`      = "us-west-1".asInstanceOf[RegionName]
+    val `us-west-2`      = "us-west-2".asInstanceOf[RegionName]
+    val `eu-west-1`      = "eu-west-1".asInstanceOf[RegionName]
+    val `eu-west-2`      = "eu-west-2".asInstanceOf[RegionName]
+    val `eu-west-3`      = "eu-west-3".asInstanceOf[RegionName]
+    val `eu-central-1`   = "eu-central-1".asInstanceOf[RegionName]
+    val `ca-central-1`   = "ca-central-1".asInstanceOf[RegionName]
+    val `ap-south-1`     = "ap-south-1".asInstanceOf[RegionName]
+    val `ap-southeast-1` = "ap-southeast-1".asInstanceOf[RegionName]
+    val `ap-southeast-2` = "ap-southeast-2".asInstanceOf[RegionName]
+    val `ap-northeast-1` = "ap-northeast-1".asInstanceOf[RegionName]
+    val `ap-northeast-2` = "ap-northeast-2".asInstanceOf[RegionName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -6596,9 +6594,10 @@ package lightsail {
       __obj.asInstanceOf[RelationalDatabaseEndpoint]
     }
   }
-
-  object RelationalDatabaseEngineEnum {
-    val mysql = "mysql"
+  @js.native
+  sealed trait RelationalDatabaseEngine extends js.Any
+  object RelationalDatabaseEngine extends js.Object {
+    val mysql = "mysql".asInstanceOf[RelationalDatabaseEngine]
 
     val values = js.Object.freeze(js.Array(mysql))
   }
@@ -6655,14 +6654,15 @@ package lightsail {
       __obj.asInstanceOf[RelationalDatabaseHardware]
     }
   }
-
-  object RelationalDatabaseMetricNameEnum {
-    val CPUUtilization            = "CPUUtilization"
-    val DatabaseConnections       = "DatabaseConnections"
-    val DiskQueueDepth            = "DiskQueueDepth"
-    val FreeStorageSpace          = "FreeStorageSpace"
-    val NetworkReceiveThroughput  = "NetworkReceiveThroughput"
-    val NetworkTransmitThroughput = "NetworkTransmitThroughput"
+  @js.native
+  sealed trait RelationalDatabaseMetricName extends js.Any
+  object RelationalDatabaseMetricName extends js.Object {
+    val CPUUtilization            = "CPUUtilization".asInstanceOf[RelationalDatabaseMetricName]
+    val DatabaseConnections       = "DatabaseConnections".asInstanceOf[RelationalDatabaseMetricName]
+    val DiskQueueDepth            = "DiskQueueDepth".asInstanceOf[RelationalDatabaseMetricName]
+    val FreeStorageSpace          = "FreeStorageSpace".asInstanceOf[RelationalDatabaseMetricName]
+    val NetworkReceiveThroughput  = "NetworkReceiveThroughput".asInstanceOf[RelationalDatabaseMetricName]
+    val NetworkTransmitThroughput = "NetworkTransmitThroughput".asInstanceOf[RelationalDatabaseMetricName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -6715,11 +6715,12 @@ package lightsail {
       __obj.asInstanceOf[RelationalDatabaseParameter]
     }
   }
-
-  object RelationalDatabasePasswordVersionEnum {
-    val CURRENT  = "CURRENT"
-    val PREVIOUS = "PREVIOUS"
-    val PENDING  = "PENDING"
+  @js.native
+  sealed trait RelationalDatabasePasswordVersion extends js.Any
+  object RelationalDatabasePasswordVersion extends js.Object {
+    val CURRENT  = "CURRENT".asInstanceOf[RelationalDatabasePasswordVersion]
+    val PREVIOUS = "PREVIOUS".asInstanceOf[RelationalDatabasePasswordVersion]
+    val PENDING  = "PENDING".asInstanceOf[RelationalDatabasePasswordVersion]
 
     val values = js.Object.freeze(js.Array(CURRENT, PREVIOUS, PENDING))
   }
@@ -6848,22 +6849,23 @@ package lightsail {
       __obj.asInstanceOf[ResourceLocation]
     }
   }
-
-  object ResourceTypeEnum {
-    val Instance                   = "Instance"
-    val StaticIp                   = "StaticIp"
-    val KeyPair                    = "KeyPair"
-    val InstanceSnapshot           = "InstanceSnapshot"
-    val Domain                     = "Domain"
-    val PeeredVpc                  = "PeeredVpc"
-    val LoadBalancer               = "LoadBalancer"
-    val LoadBalancerTlsCertificate = "LoadBalancerTlsCertificate"
-    val Disk                       = "Disk"
-    val DiskSnapshot               = "DiskSnapshot"
-    val RelationalDatabase         = "RelationalDatabase"
-    val RelationalDatabaseSnapshot = "RelationalDatabaseSnapshot"
-    val ExportSnapshotRecord       = "ExportSnapshotRecord"
-    val CloudFormationStackRecord  = "CloudFormationStackRecord"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val Instance                   = "Instance".asInstanceOf[ResourceType]
+    val StaticIp                   = "StaticIp".asInstanceOf[ResourceType]
+    val KeyPair                    = "KeyPair".asInstanceOf[ResourceType]
+    val InstanceSnapshot           = "InstanceSnapshot".asInstanceOf[ResourceType]
+    val Domain                     = "Domain".asInstanceOf[ResourceType]
+    val PeeredVpc                  = "PeeredVpc".asInstanceOf[ResourceType]
+    val LoadBalancer               = "LoadBalancer".asInstanceOf[ResourceType]
+    val LoadBalancerTlsCertificate = "LoadBalancerTlsCertificate".asInstanceOf[ResourceType]
+    val Disk                       = "Disk".asInstanceOf[ResourceType]
+    val DiskSnapshot               = "DiskSnapshot".asInstanceOf[ResourceType]
+    val RelationalDatabase         = "RelationalDatabase".asInstanceOf[ResourceType]
+    val RelationalDatabaseSnapshot = "RelationalDatabaseSnapshot".asInstanceOf[ResourceType]
+    val ExportSnapshotRecord       = "ExportSnapshotRecord".asInstanceOf[ResourceType]
+    val CloudFormationStackRecord  = "CloudFormationStackRecord".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/machinelearning/src/main/scala/facade/amazonaws/services/MachineLearning.scala
+++ b/services/machinelearning/src/main/scala/facade/amazonaws/services/MachineLearning.scala
@@ -7,17 +7,13 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object machinelearning {
-  type Algorithm                       = String
   type AwsUserArn                      = String
-  type BatchPredictionFilterVariable   = String
   type BatchPredictions                = js.Array[BatchPrediction]
   type ComparatorValue                 = String
   type ComputeStatistics               = Boolean
   type DataRearrangement               = String
   type DataSchema                      = String
-  type DataSourceFilterVariable        = String
   type DataSources                     = js.Array[DataSource]
-  type DetailsAttributes               = String
   type DetailsMap                      = js.Dictionary[DetailsValue]
   type DetailsValue                    = String
   type EDPPipelineId                   = String
@@ -28,18 +24,14 @@ package object machinelearning {
   type EDPSubnetId                     = String
   type EntityId                        = String
   type EntityName                      = String
-  type EntityStatus                    = String
   type EpochTime                       = js.Date
   type ErrorCode                       = Int
   type ErrorMessage                    = String
-  type EvaluationFilterVariable        = String
   type Evaluations                     = js.Array[Evaluation]
   type IntegerType                     = Int
   type Label                           = String
   type LongType                        = Double
-  type MLModelFilterVariable           = String
   type MLModelName                     = String
-  type MLModelType                     = String
   type MLModels                        = js.Array[MLModel]
   type Message                         = String
   type PageLimit                       = Int
@@ -52,7 +44,6 @@ package object machinelearning {
   type RDSDatabaseUsername             = String
   type RDSInstanceIdentifier           = String
   type RDSSelectSqlQuery               = String
-  type RealtimeEndpointStatus          = String
   type Recipe                          = String
   type Record                          = js.Dictionary[VariableValue]
   type RedshiftClusterIdentifier       = String
@@ -65,13 +56,11 @@ package object machinelearning {
   type ScoreThreshold                  = Float
   type ScoreValue                      = Float
   type ScoreValuePerLabelMap           = js.Dictionary[ScoreValue]
-  type SortOrder                       = String
   type StringType                      = String
   type TagKey                          = String
   type TagKeyList                      = js.Array[TagKey]
   type TagList                         = js.Array[Tag]
   type TagValue                        = String
-  type TaggableResourceType            = String
   type TrainingParameters              = js.Dictionary[StringType]
   type VariableName                    = String
   type VariableValue                   = String
@@ -235,8 +224,10 @@ package machinelearning {
     * * <code>SGD</code> - Stochastic Gradient Descent.
     *  * <code>RandomForest</code> - Random forest of decision trees.
     */
-  object AlgorithmEnum {
-    val sgd = "sgd"
+  @js.native
+  sealed trait Algorithm extends js.Any
+  object Algorithm extends js.Object {
+    val sgd = "sgd".asInstanceOf[Algorithm]
 
     val values = js.Object.freeze(js.Array(sgd))
   }
@@ -318,15 +309,17 @@ package machinelearning {
     *  * <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in the <code>BatchPrediction</code>.
     *  * <code>DataURI</code> - Sets the search criteria to the data file(s) used in the <code>BatchPrediction</code>. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.
     */
-  object BatchPredictionFilterVariableEnum {
-    val CreatedAt     = "CreatedAt"
-    val LastUpdatedAt = "LastUpdatedAt"
-    val Status        = "Status"
-    val Name          = "Name"
-    val IAMUser       = "IAMUser"
-    val MLModelId     = "MLModelId"
-    val DataSourceId  = "DataSourceId"
-    val DataURI       = "DataURI"
+  @js.native
+  sealed trait BatchPredictionFilterVariable extends js.Any
+  object BatchPredictionFilterVariable extends js.Object {
+    val CreatedAt     = "CreatedAt".asInstanceOf[BatchPredictionFilterVariable]
+    val LastUpdatedAt = "LastUpdatedAt".asInstanceOf[BatchPredictionFilterVariable]
+    val Status        = "Status".asInstanceOf[BatchPredictionFilterVariable]
+    val Name          = "Name".asInstanceOf[BatchPredictionFilterVariable]
+    val IAMUser       = "IAMUser".asInstanceOf[BatchPredictionFilterVariable]
+    val MLModelId     = "MLModelId".asInstanceOf[BatchPredictionFilterVariable]
+    val DataSourceId  = "DataSourceId".asInstanceOf[BatchPredictionFilterVariable]
+    val DataURI       = "DataURI".asInstanceOf[BatchPredictionFilterVariable]
 
     val values =
       js.Object.freeze(js.Array(CreatedAt, LastUpdatedAt, Status, Name, IAMUser, MLModelId, DataSourceId, DataURI))
@@ -755,13 +748,15 @@ package machinelearning {
     *  * <code>IAMUser</code> - Sets the search criteria to the user account that invoked the <code>DataSource</code> creation.
     * '''Note:'''<title>Note</title> The variable names should match the variable names in the <code>DataSource</code>.
     */
-  object DataSourceFilterVariableEnum {
-    val CreatedAt      = "CreatedAt"
-    val LastUpdatedAt  = "LastUpdatedAt"
-    val Status         = "Status"
-    val Name           = "Name"
-    val DataLocationS3 = "DataLocationS3"
-    val IAMUser        = "IAMUser"
+  @js.native
+  sealed trait DataSourceFilterVariable extends js.Any
+  object DataSourceFilterVariable extends js.Object {
+    val CreatedAt      = "CreatedAt".asInstanceOf[DataSourceFilterVariable]
+    val LastUpdatedAt  = "LastUpdatedAt".asInstanceOf[DataSourceFilterVariable]
+    val Status         = "Status".asInstanceOf[DataSourceFilterVariable]
+    val Name           = "Name".asInstanceOf[DataSourceFilterVariable]
+    val DataLocationS3 = "DataLocationS3".asInstanceOf[DataSourceFilterVariable]
+    val IAMUser        = "IAMUser".asInstanceOf[DataSourceFilterVariable]
 
     val values = js.Object.freeze(js.Array(CreatedAt, LastUpdatedAt, Status, Name, DataLocationS3, IAMUser))
   }
@@ -1325,9 +1320,11 @@ package machinelearning {
   /**
     * Contains the key values of <code>DetailsMap</code>: <code>PredictiveModelType</code> - Indicates the type of the <code>MLModel</code>. <code>Algorithm</code> - Indicates the algorithm that was used for the <code>MLModel</code>.
     */
-  object DetailsAttributesEnum {
-    val PredictiveModelType = "PredictiveModelType"
-    val Algorithm           = "Algorithm"
+  @js.native
+  sealed trait DetailsAttributes extends js.Any
+  object DetailsAttributes extends js.Object {
+    val PredictiveModelType = "PredictiveModelType".asInstanceOf[DetailsAttributes]
+    val Algorithm           = "Algorithm".asInstanceOf[DetailsAttributes]
 
     val values = js.Object.freeze(js.Array(PredictiveModelType, Algorithm))
   }
@@ -1340,12 +1337,14 @@ package machinelearning {
     *  * <code>COMPLETED</code>
     *  * <code>DELETED</code>
     */
-  object EntityStatusEnum {
-    val PENDING    = "PENDING"
-    val INPROGRESS = "INPROGRESS"
-    val FAILED     = "FAILED"
-    val COMPLETED  = "COMPLETED"
-    val DELETED    = "DELETED"
+  @js.native
+  sealed trait EntityStatus extends js.Any
+  object EntityStatus extends js.Object {
+    val PENDING    = "PENDING".asInstanceOf[EntityStatus]
+    val INPROGRESS = "INPROGRESS".asInstanceOf[EntityStatus]
+    val FAILED     = "FAILED".asInstanceOf[EntityStatus]
+    val COMPLETED  = "COMPLETED".asInstanceOf[EntityStatus]
+    val DELETED    = "DELETED".asInstanceOf[EntityStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, INPROGRESS, FAILED, COMPLETED, DELETED))
   }
@@ -1419,15 +1418,17 @@ package machinelearning {
     *  * <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in evaluation.
     *  * <code>DataUri</code> - Sets the search criteria to the data file(s) used in evaluation. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.
     */
-  object EvaluationFilterVariableEnum {
-    val CreatedAt     = "CreatedAt"
-    val LastUpdatedAt = "LastUpdatedAt"
-    val Status        = "Status"
-    val Name          = "Name"
-    val IAMUser       = "IAMUser"
-    val MLModelId     = "MLModelId"
-    val DataSourceId  = "DataSourceId"
-    val DataURI       = "DataURI"
+  @js.native
+  sealed trait EvaluationFilterVariable extends js.Any
+  object EvaluationFilterVariable extends js.Object {
+    val CreatedAt     = "CreatedAt".asInstanceOf[EvaluationFilterVariable]
+    val LastUpdatedAt = "LastUpdatedAt".asInstanceOf[EvaluationFilterVariable]
+    val Status        = "Status".asInstanceOf[EvaluationFilterVariable]
+    val Name          = "Name".asInstanceOf[EvaluationFilterVariable]
+    val IAMUser       = "IAMUser".asInstanceOf[EvaluationFilterVariable]
+    val MLModelId     = "MLModelId".asInstanceOf[EvaluationFilterVariable]
+    val DataSourceId  = "DataSourceId".asInstanceOf[EvaluationFilterVariable]
+    val DataURI       = "DataURI".asInstanceOf[EvaluationFilterVariable]
 
     val values =
       js.Object.freeze(js.Array(CreatedAt, LastUpdatedAt, Status, Name, IAMUser, MLModelId, DataSourceId, DataURI))
@@ -1914,18 +1915,19 @@ package machinelearning {
       __obj.asInstanceOf[MLModel]
     }
   }
-
-  object MLModelFilterVariableEnum {
-    val CreatedAt              = "CreatedAt"
-    val LastUpdatedAt          = "LastUpdatedAt"
-    val Status                 = "Status"
-    val Name                   = "Name"
-    val IAMUser                = "IAMUser"
-    val TrainingDataSourceId   = "TrainingDataSourceId"
-    val RealtimeEndpointStatus = "RealtimeEndpointStatus"
-    val MLModelType            = "MLModelType"
-    val Algorithm              = "Algorithm"
-    val TrainingDataURI        = "TrainingDataURI"
+  @js.native
+  sealed trait MLModelFilterVariable extends js.Any
+  object MLModelFilterVariable extends js.Object {
+    val CreatedAt              = "CreatedAt".asInstanceOf[MLModelFilterVariable]
+    val LastUpdatedAt          = "LastUpdatedAt".asInstanceOf[MLModelFilterVariable]
+    val Status                 = "Status".asInstanceOf[MLModelFilterVariable]
+    val Name                   = "Name".asInstanceOf[MLModelFilterVariable]
+    val IAMUser                = "IAMUser".asInstanceOf[MLModelFilterVariable]
+    val TrainingDataSourceId   = "TrainingDataSourceId".asInstanceOf[MLModelFilterVariable]
+    val RealtimeEndpointStatus = "RealtimeEndpointStatus".asInstanceOf[MLModelFilterVariable]
+    val MLModelType            = "MLModelType".asInstanceOf[MLModelFilterVariable]
+    val Algorithm              = "Algorithm".asInstanceOf[MLModelFilterVariable]
+    val TrainingDataURI        = "TrainingDataURI".asInstanceOf[MLModelFilterVariable]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1942,11 +1944,12 @@ package machinelearning {
       )
     )
   }
-
-  object MLModelTypeEnum {
-    val REGRESSION = "REGRESSION"
-    val BINARY     = "BINARY"
-    val MULTICLASS = "MULTICLASS"
+  @js.native
+  sealed trait MLModelType extends js.Any
+  object MLModelType extends js.Object {
+    val REGRESSION = "REGRESSION".asInstanceOf[MLModelType]
+    val BINARY     = "BINARY".asInstanceOf[MLModelType]
+    val MULTICLASS = "MULTICLASS".asInstanceOf[MLModelType]
 
     val values = js.Object.freeze(js.Array(REGRESSION, BINARY, MULTICLASS))
   }
@@ -2214,12 +2217,13 @@ package machinelearning {
       __obj.asInstanceOf[RealtimeEndpointInfo]
     }
   }
-
-  object RealtimeEndpointStatusEnum {
-    val NONE     = "NONE"
-    val READY    = "READY"
-    val UPDATING = "UPDATING"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait RealtimeEndpointStatus extends js.Any
+  object RealtimeEndpointStatus extends js.Object {
+    val NONE     = "NONE".asInstanceOf[RealtimeEndpointStatus]
+    val READY    = "READY".asInstanceOf[RealtimeEndpointStatus]
+    val UPDATING = "UPDATING".asInstanceOf[RealtimeEndpointStatus]
+    val FAILED   = "FAILED".asInstanceOf[RealtimeEndpointStatus]
 
     val values = js.Object.freeze(js.Array(NONE, READY, UPDATING, FAILED))
   }
@@ -2380,9 +2384,11 @@ package machinelearning {
     * * <code>asc</code> - Present the information in ascending order (from A-Z).
     *  * <code>dsc</code> - Present the information in descending order (from Z-A).
     */
-  object SortOrderEnum {
-    val asc = "asc"
-    val dsc = "dsc"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val asc = "asc".asInstanceOf[SortOrder]
+    val dsc = "dsc".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(asc, dsc))
   }
@@ -2413,12 +2419,13 @@ package machinelearning {
   trait TagLimitExceededExceptionException extends js.Object {
     val message: ErrorMessage
   }
-
-  object TaggableResourceTypeEnum {
-    val BatchPrediction = "BatchPrediction"
-    val DataSource      = "DataSource"
-    val Evaluation      = "Evaluation"
-    val MLModel         = "MLModel"
+  @js.native
+  sealed trait TaggableResourceType extends js.Any
+  object TaggableResourceType extends js.Object {
+    val BatchPrediction = "BatchPrediction".asInstanceOf[TaggableResourceType]
+    val DataSource      = "DataSource".asInstanceOf[TaggableResourceType]
+    val Evaluation      = "Evaluation".asInstanceOf[TaggableResourceType]
+    val MLModel         = "MLModel".asInstanceOf[TaggableResourceType]
 
     val values = js.Object.freeze(js.Array(BatchPrediction, DataSource, Evaluation, MLModel))
   }

--- a/services/macie/src/main/scala/facade/amazonaws/services/Macie.scala
+++ b/services/macie/src/main/scala/facade/amazonaws/services/Macie.scala
@@ -18,8 +18,6 @@ package object macie {
   type NextToken                       = String
   type Prefix                          = String
   type ResourceType                    = String
-  type S3ContinuousClassificationType  = String
-  type S3OneTimeClassificationType     = String
   type S3Resources                     = js.Array[S3Resource]
   type S3ResourcesClassification       = js.Array[S3ResourceClassification]
   type S3ResourcesClassificationUpdate = js.Array[S3ResourceClassificationUpdate]
@@ -376,16 +374,18 @@ package macie {
       __obj.asInstanceOf[MemberAccount]
     }
   }
-
-  object S3ContinuousClassificationTypeEnum {
-    val FULL = "FULL"
+  @js.native
+  sealed trait S3ContinuousClassificationType extends js.Any
+  object S3ContinuousClassificationType extends js.Object {
+    val FULL = "FULL".asInstanceOf[S3ContinuousClassificationType]
 
     val values = js.Object.freeze(js.Array(FULL))
   }
-
-  object S3OneTimeClassificationTypeEnum {
-    val FULL = "FULL"
-    val NONE = "NONE"
+  @js.native
+  sealed trait S3OneTimeClassificationType extends js.Any
+  object S3OneTimeClassificationType extends js.Object {
+    val FULL = "FULL".asInstanceOf[S3OneTimeClassificationType]
+    val NONE = "NONE".asInstanceOf[S3OneTimeClassificationType]
 
     val values = js.Object.freeze(js.Array(FULL, NONE))
   }

--- a/services/managedblockchain/src/main/scala/facade/amazonaws/services/ManagedBlockchain.scala
+++ b/services/managedblockchain/src/main/scala/facade/amazonaws/services/ManagedBlockchain.scala
@@ -10,41 +10,32 @@ package object managedblockchain {
   type AvailabilityZoneString   = String
   type ClientRequestTokenString = String
   type DescriptionString        = String
-  type Edition                  = String
-  type Framework                = String
   type FrameworkVersionString   = String
   type InstanceTypeString       = String
   type InvitationList           = js.Array[Invitation]
-  type InvitationStatus         = String
   type InviteActionList         = js.Array[InviteAction]
   type IsOwned                  = Boolean
   type MemberListMaxResults     = Int
-  type MemberStatus             = String
   type MemberSummaryList        = js.Array[MemberSummary]
   type NameString               = String
   type NetworkListMaxResults    = Int
   type NetworkMemberNameString  = String
-  type NetworkStatus            = String
   type NetworkSummaryList       = js.Array[NetworkSummary]
   type NodeListMaxResults       = Int
-  type NodeStatus               = String
   type NodeSummaryList          = js.Array[NodeSummary]
   type PaginationToken          = String
   type PasswordString           = String
   type PrincipalString          = String
   type ProposalDurationInt      = Int
   type ProposalListMaxResults   = Int
-  type ProposalStatus           = String
   type ProposalSummaryList      = js.Array[ProposalSummary]
   type ProposalVoteList         = js.Array[VoteSummary]
   type RemoveActionList         = js.Array[RemoveAction]
   type ResourceIdString         = String
-  type ThresholdComparator      = String
   type ThresholdPercentageInt   = Int
   type Timestamp                = js.Date
   type UsernameString           = String
   type VoteCount                = Int
-  type VoteValue                = String
 
   implicit final class ManagedBlockchainOps(private val service: ManagedBlockchain) extends AnyVal {
 
@@ -397,16 +388,18 @@ package managedblockchain {
       __obj.asInstanceOf[DeleteNodeOutput]
     }
   }
-
-  object EditionEnum {
-    val STARTER  = "STARTER"
-    val STANDARD = "STANDARD"
+  @js.native
+  sealed trait Edition extends js.Any
+  object Edition extends js.Object {
+    val STARTER  = "STARTER".asInstanceOf[Edition]
+    val STANDARD = "STANDARD".asInstanceOf[Edition]
 
     val values = js.Object.freeze(js.Array(STARTER, STANDARD))
   }
-
-  object FrameworkEnum {
-    val HYPERLEDGER_FABRIC = "HYPERLEDGER_FABRIC"
+  @js.native
+  sealed trait Framework extends js.Any
+  object Framework extends js.Object {
+    val HYPERLEDGER_FABRIC = "HYPERLEDGER_FABRIC".asInstanceOf[Framework]
 
     val values = js.Object.freeze(js.Array(HYPERLEDGER_FABRIC))
   }
@@ -589,13 +582,14 @@ package managedblockchain {
       __obj.asInstanceOf[Invitation]
     }
   }
-
-  object InvitationStatusEnum {
-    val PENDING   = "PENDING"
-    val ACCEPTED  = "ACCEPTED"
-    val ACCEPTING = "ACCEPTING"
-    val REJECTED  = "REJECTED"
-    val EXPIRED   = "EXPIRED"
+  @js.native
+  sealed trait InvitationStatus extends js.Any
+  object InvitationStatus extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[InvitationStatus]
+    val ACCEPTED  = "ACCEPTED".asInstanceOf[InvitationStatus]
+    val ACCEPTING = "ACCEPTING".asInstanceOf[InvitationStatus]
+    val REJECTED  = "REJECTED".asInstanceOf[InvitationStatus]
+    val EXPIRED   = "EXPIRED".asInstanceOf[InvitationStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, ACCEPTED, ACCEPTING, REJECTED, EXPIRED))
   }
@@ -1043,13 +1037,14 @@ package managedblockchain {
       __obj.asInstanceOf[MemberFrameworkConfiguration]
     }
   }
-
-  object MemberStatusEnum {
-    val CREATING      = "CREATING"
-    val AVAILABLE     = "AVAILABLE"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val DELETING      = "DELETING"
-    val DELETED       = "DELETED"
+  @js.native
+  sealed trait MemberStatus extends js.Any
+  object MemberStatus extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[MemberStatus]
+    val AVAILABLE     = "AVAILABLE".asInstanceOf[MemberStatus]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[MemberStatus]
+    val DELETING      = "DELETING".asInstanceOf[MemberStatus]
+    val DELETED       = "DELETED".asInstanceOf[MemberStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, AVAILABLE, CREATE_FAILED, DELETING, DELETED))
   }
@@ -1214,13 +1209,14 @@ package managedblockchain {
       __obj.asInstanceOf[NetworkFrameworkConfiguration]
     }
   }
-
-  object NetworkStatusEnum {
-    val CREATING      = "CREATING"
-    val AVAILABLE     = "AVAILABLE"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val DELETING      = "DELETING"
-    val DELETED       = "DELETED"
+  @js.native
+  sealed trait NetworkStatus extends js.Any
+  object NetworkStatus extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[NetworkStatus]
+    val AVAILABLE     = "AVAILABLE".asInstanceOf[NetworkStatus]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[NetworkStatus]
+    val DELETING      = "DELETING".asInstanceOf[NetworkStatus]
+    val DELETED       = "DELETED".asInstanceOf[NetworkStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, AVAILABLE, CREATE_FAILED, DELETING, DELETED))
   }
@@ -1366,14 +1362,15 @@ package managedblockchain {
       __obj.asInstanceOf[NodeFrameworkAttributes]
     }
   }
-
-  object NodeStatusEnum {
-    val CREATING      = "CREATING"
-    val AVAILABLE     = "AVAILABLE"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val DELETING      = "DELETING"
-    val DELETED       = "DELETED"
-    val FAILED        = "FAILED"
+  @js.native
+  sealed trait NodeStatus extends js.Any
+  object NodeStatus extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[NodeStatus]
+    val AVAILABLE     = "AVAILABLE".asInstanceOf[NodeStatus]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[NodeStatus]
+    val DELETING      = "DELETING".asInstanceOf[NodeStatus]
+    val DELETED       = "DELETED".asInstanceOf[NodeStatus]
+    val FAILED        = "FAILED".asInstanceOf[NodeStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, AVAILABLE, CREATE_FAILED, DELETING, DELETED, FAILED))
   }
@@ -1482,13 +1479,14 @@ package managedblockchain {
       __obj.asInstanceOf[ProposalActions]
     }
   }
-
-  object ProposalStatusEnum {
-    val IN_PROGRESS   = "IN_PROGRESS"
-    val APPROVED      = "APPROVED"
-    val REJECTED      = "REJECTED"
-    val EXPIRED       = "EXPIRED"
-    val ACTION_FAILED = "ACTION_FAILED"
+  @js.native
+  sealed trait ProposalStatus extends js.Any
+  object ProposalStatus extends js.Object {
+    val IN_PROGRESS   = "IN_PROGRESS".asInstanceOf[ProposalStatus]
+    val APPROVED      = "APPROVED".asInstanceOf[ProposalStatus]
+    val REJECTED      = "REJECTED".asInstanceOf[ProposalStatus]
+    val EXPIRED       = "EXPIRED".asInstanceOf[ProposalStatus]
+    val ACTION_FAILED = "ACTION_FAILED".asInstanceOf[ProposalStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, APPROVED, REJECTED, EXPIRED, ACTION_FAILED))
   }
@@ -1581,10 +1579,11 @@ package managedblockchain {
       __obj.asInstanceOf[RemoveAction]
     }
   }
-
-  object ThresholdComparatorEnum {
-    val GREATER_THAN             = "GREATER_THAN"
-    val GREATER_THAN_OR_EQUAL_TO = "GREATER_THAN_OR_EQUAL_TO"
+  @js.native
+  sealed trait ThresholdComparator extends js.Any
+  object ThresholdComparator extends js.Object {
+    val GREATER_THAN             = "GREATER_THAN".asInstanceOf[ThresholdComparator]
+    val GREATER_THAN_OR_EQUAL_TO = "GREATER_THAN_OR_EQUAL_TO".asInstanceOf[ThresholdComparator]
 
     val values = js.Object.freeze(js.Array(GREATER_THAN, GREATER_THAN_OR_EQUAL_TO))
   }
@@ -1653,10 +1652,11 @@ package managedblockchain {
       __obj.asInstanceOf[VoteSummary]
     }
   }
-
-  object VoteValueEnum {
-    val YES = "YES"
-    val NO  = "NO"
+  @js.native
+  sealed trait VoteValue extends js.Any
+  object VoteValue extends js.Object {
+    val YES = "YES".asInstanceOf[VoteValue]
+    val NO  = "NO".asInstanceOf[VoteValue]
 
     val values = js.Object.freeze(js.Array(YES, NO))
   }

--- a/services/marketplacecatalog/src/main/scala/facade/amazonaws/services/MarketplaceCatalog.scala
+++ b/services/marketplacecatalog/src/main/scala/facade/amazonaws/services/MarketplaceCatalog.scala
@@ -12,7 +12,6 @@ package object marketplacecatalog {
   type ChangeSetDescription = js.Array[ChangeSummary]
   type ChangeSetName        = String
   type ChangeSetSummaryList = js.Array[ChangeSetSummaryListItem]
-  type ChangeStatus         = String
   type ChangeType           = String
   type ClientRequestToken   = String
   type DateTimeISO8601      = String
@@ -29,7 +28,6 @@ package object marketplacecatalog {
   type ResourceId           = String
   type ResourceIdList       = js.Array[ResourceId]
   type SortBy               = String
-  type SortOrder            = String
   type StringValue          = String
   type ValueList            = js.Array[StringValue]
 
@@ -167,13 +165,14 @@ package marketplacecatalog {
       __obj.asInstanceOf[ChangeSetSummaryListItem]
     }
   }
-
-  object ChangeStatusEnum {
-    val PREPARING = "PREPARING"
-    val APPLYING  = "APPLYING"
-    val SUCCEEDED = "SUCCEEDED"
-    val CANCELLED = "CANCELLED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait ChangeStatus extends js.Any
+  object ChangeStatus extends js.Object {
+    val PREPARING = "PREPARING".asInstanceOf[ChangeStatus]
+    val APPLYING  = "APPLYING".asInstanceOf[ChangeStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[ChangeStatus]
+    val CANCELLED = "CANCELLED".asInstanceOf[ChangeStatus]
+    val FAILED    = "FAILED".asInstanceOf[ChangeStatus]
 
     val values = js.Object.freeze(js.Array(PREPARING, APPLYING, SUCCEEDED, CANCELLED, FAILED))
   }
@@ -534,10 +533,11 @@ package marketplacecatalog {
       __obj.asInstanceOf[Sort]
     }
   }
-
-  object SortOrderEnum {
-    val ASCENDING  = "ASCENDING"
-    val DESCENDING = "DESCENDING"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val ASCENDING  = "ASCENDING".asInstanceOf[SortOrder]
+    val DESCENDING = "DESCENDING".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(ASCENDING, DESCENDING))
   }

--- a/services/marketplacecommerceanalytics/src/main/scala/facade/amazonaws/services/MarketplaceCommerceAnalytics.scala
+++ b/services/marketplacecommerceanalytics/src/main/scala/facade/amazonaws/services/MarketplaceCommerceAnalytics.scala
@@ -10,7 +10,6 @@ package object marketplacecommerceanalytics {
   type CustomerDefinedValues   = js.Dictionary[OptionalValue]
   type DataSetPublicationDate  = js.Date
   type DataSetRequestId        = String
-  type DataSetType             = String
   type DestinationS3BucketName = String
   type DestinationS3Prefix     = String
   type FromDate                = js.Date
@@ -18,7 +17,6 @@ package object marketplacecommerceanalytics {
   type OptionalValue           = String
   type RoleNameArn             = String
   type SnsTopicArn             = String
-  type SupportDataSetType      = String
 
   implicit final class MarketplaceCommerceAnalyticsOps(private val service: MarketplaceCommerceAnalytics)
       extends AnyVal {
@@ -40,33 +38,43 @@ package marketplacecommerceanalytics {
     def generateDataSet(params: GenerateDataSetRequest): Request[GenerateDataSetResult]                      = js.native
     def startSupportDataExport(params: StartSupportDataExportRequest): Request[StartSupportDataExportResult] = js.native
   }
-
-  object DataSetTypeEnum {
-    val customer_subscriber_hourly_monthly_subscriptions   = "customer_subscriber_hourly_monthly_subscriptions"
-    val customer_subscriber_annual_subscriptions           = "customer_subscriber_annual_subscriptions"
-    val daily_business_usage_by_instance_type              = "daily_business_usage_by_instance_type"
-    val daily_business_fees                                = "daily_business_fees"
-    val daily_business_free_trial_conversions              = "daily_business_free_trial_conversions"
-    val daily_business_new_instances                       = "daily_business_new_instances"
-    val daily_business_new_product_subscribers             = "daily_business_new_product_subscribers"
-    val daily_business_canceled_product_subscribers        = "daily_business_canceled_product_subscribers"
-    val monthly_revenue_billing_and_revenue_data           = "monthly_revenue_billing_and_revenue_data"
-    val monthly_revenue_annual_subscriptions               = "monthly_revenue_annual_subscriptions"
-    val monthly_revenue_field_demonstration_usage          = "monthly_revenue_field_demonstration_usage"
-    val monthly_revenue_flexible_payment_schedule          = "monthly_revenue_flexible_payment_schedule"
-    val disbursed_amount_by_product                        = "disbursed_amount_by_product"
-    val disbursed_amount_by_product_with_uncollected_funds = "disbursed_amount_by_product_with_uncollected_funds"
-    val disbursed_amount_by_instance_hours                 = "disbursed_amount_by_instance_hours"
-    val disbursed_amount_by_customer_geo                   = "disbursed_amount_by_customer_geo"
-    val disbursed_amount_by_age_of_uncollected_funds       = "disbursed_amount_by_age_of_uncollected_funds"
-    val disbursed_amount_by_age_of_disbursed_funds         = "disbursed_amount_by_age_of_disbursed_funds"
-    val disbursed_amount_by_age_of_past_due_funds          = "disbursed_amount_by_age_of_past_due_funds"
-    val disbursed_amount_by_uncollected_funds_breakdown    = "disbursed_amount_by_uncollected_funds_breakdown"
-    val customer_profile_by_industry                       = "customer_profile_by_industry"
-    val customer_profile_by_revenue                        = "customer_profile_by_revenue"
-    val customer_profile_by_geography                      = "customer_profile_by_geography"
-    val sales_compensation_billed_revenue                  = "sales_compensation_billed_revenue"
-    val us_sales_and_use_tax_records                       = "us_sales_and_use_tax_records"
+  @js.native
+  sealed trait DataSetType extends js.Any
+  object DataSetType extends js.Object {
+    val customer_subscriber_hourly_monthly_subscriptions =
+      "customer_subscriber_hourly_monthly_subscriptions".asInstanceOf[DataSetType]
+    val customer_subscriber_annual_subscriptions = "customer_subscriber_annual_subscriptions".asInstanceOf[DataSetType]
+    val daily_business_usage_by_instance_type    = "daily_business_usage_by_instance_type".asInstanceOf[DataSetType]
+    val daily_business_fees                      = "daily_business_fees".asInstanceOf[DataSetType]
+    val daily_business_free_trial_conversions    = "daily_business_free_trial_conversions".asInstanceOf[DataSetType]
+    val daily_business_new_instances             = "daily_business_new_instances".asInstanceOf[DataSetType]
+    val daily_business_new_product_subscribers   = "daily_business_new_product_subscribers".asInstanceOf[DataSetType]
+    val daily_business_canceled_product_subscribers =
+      "daily_business_canceled_product_subscribers".asInstanceOf[DataSetType]
+    val monthly_revenue_billing_and_revenue_data = "monthly_revenue_billing_and_revenue_data".asInstanceOf[DataSetType]
+    val monthly_revenue_annual_subscriptions     = "monthly_revenue_annual_subscriptions".asInstanceOf[DataSetType]
+    val monthly_revenue_field_demonstration_usage =
+      "monthly_revenue_field_demonstration_usage".asInstanceOf[DataSetType]
+    val monthly_revenue_flexible_payment_schedule =
+      "monthly_revenue_flexible_payment_schedule".asInstanceOf[DataSetType]
+    val disbursed_amount_by_product = "disbursed_amount_by_product".asInstanceOf[DataSetType]
+    val disbursed_amount_by_product_with_uncollected_funds =
+      "disbursed_amount_by_product_with_uncollected_funds".asInstanceOf[DataSetType]
+    val disbursed_amount_by_instance_hours = "disbursed_amount_by_instance_hours".asInstanceOf[DataSetType]
+    val disbursed_amount_by_customer_geo   = "disbursed_amount_by_customer_geo".asInstanceOf[DataSetType]
+    val disbursed_amount_by_age_of_uncollected_funds =
+      "disbursed_amount_by_age_of_uncollected_funds".asInstanceOf[DataSetType]
+    val disbursed_amount_by_age_of_disbursed_funds =
+      "disbursed_amount_by_age_of_disbursed_funds".asInstanceOf[DataSetType]
+    val disbursed_amount_by_age_of_past_due_funds =
+      "disbursed_amount_by_age_of_past_due_funds".asInstanceOf[DataSetType]
+    val disbursed_amount_by_uncollected_funds_breakdown =
+      "disbursed_amount_by_uncollected_funds_breakdown".asInstanceOf[DataSetType]
+    val customer_profile_by_industry      = "customer_profile_by_industry".asInstanceOf[DataSetType]
+    val customer_profile_by_revenue       = "customer_profile_by_revenue".asInstanceOf[DataSetType]
+    val customer_profile_by_geography     = "customer_profile_by_geography".asInstanceOf[DataSetType]
+    val sales_compensation_billed_revenue = "sales_compensation_billed_revenue".asInstanceOf[DataSetType]
+    val us_sales_and_use_tax_records      = "us_sales_and_use_tax_records".asInstanceOf[DataSetType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -214,10 +222,11 @@ package marketplacecommerceanalytics {
       __obj.asInstanceOf[StartSupportDataExportResult]
     }
   }
-
-  object SupportDataSetTypeEnum {
-    val customer_support_contacts_data      = "customer_support_contacts_data"
-    val test_customer_support_contacts_data = "test_customer_support_contacts_data"
+  @js.native
+  sealed trait SupportDataSetType extends js.Any
+  object SupportDataSetType extends js.Object {
+    val customer_support_contacts_data      = "customer_support_contacts_data".asInstanceOf[SupportDataSetType]
+    val test_customer_support_contacts_data = "test_customer_support_contacts_data".asInstanceOf[SupportDataSetType]
 
     val values = js.Object.freeze(js.Array(customer_support_contacts_data, test_customer_support_contacts_data))
   }

--- a/services/marketplaceentitlementservice/src/main/scala/facade/amazonaws/services/MarketplaceEntitlementService.scala
+++ b/services/marketplaceentitlementservice/src/main/scala/facade/amazonaws/services/MarketplaceEntitlementService.scala
@@ -7,15 +7,14 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object marketplaceentitlementservice {
-  type EntitlementList          = js.Array[Entitlement]
-  type ErrorMessage             = String
-  type FilterValue              = String
-  type FilterValueList          = js.Array[FilterValue]
-  type GetEntitlementFilterName = String
-  type GetEntitlementFilters    = js.Dictionary[FilterValueList]
-  type NonEmptyString           = String
-  type ProductCode              = String
-  type Timestamp                = js.Date
+  type EntitlementList       = js.Array[Entitlement]
+  type ErrorMessage          = String
+  type FilterValue           = String
+  type FilterValueList       = js.Array[FilterValue]
+  type GetEntitlementFilters = js.Dictionary[FilterValueList]
+  type NonEmptyString        = String
+  type ProductCode           = String
+  type Timestamp             = js.Date
 
   implicit final class MarketplaceEntitlementServiceOps(private val service: MarketplaceEntitlementService)
       extends AnyVal {
@@ -92,10 +91,11 @@ package marketplaceentitlementservice {
       __obj.asInstanceOf[EntitlementValue]
     }
   }
-
-  object GetEntitlementFilterNameEnum {
-    val CUSTOMER_IDENTIFIER = "CUSTOMER_IDENTIFIER"
-    val DIMENSION           = "DIMENSION"
+  @js.native
+  sealed trait GetEntitlementFilterName extends js.Any
+  object GetEntitlementFilterName extends js.Object {
+    val CUSTOMER_IDENTIFIER = "CUSTOMER_IDENTIFIER".asInstanceOf[GetEntitlementFilterName]
+    val DIMENSION           = "DIMENSION".asInstanceOf[GetEntitlementFilterName]
 
     val values = js.Object.freeze(js.Array(CUSTOMER_IDENTIFIER, DIMENSION))
   }

--- a/services/marketplacemetering/src/main/scala/facade/amazonaws/services/MarketplaceMetering.scala
+++ b/services/marketplacemetering/src/main/scala/facade/amazonaws/services/MarketplaceMetering.scala
@@ -7,17 +7,16 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object marketplacemetering {
-  type CustomerIdentifier      = String
-  type NonEmptyString          = String
-  type Nonce                   = String
-  type ProductCode             = String
-  type Timestamp               = js.Date
-  type UsageDimension          = String
-  type UsageQuantity           = Int
-  type UsageRecordList         = js.Array[UsageRecord]
-  type UsageRecordResultList   = js.Array[UsageRecordResult]
-  type UsageRecordResultStatus = String
-  type VersionInteger          = Int
+  type CustomerIdentifier    = String
+  type NonEmptyString        = String
+  type Nonce                 = String
+  type ProductCode           = String
+  type Timestamp             = js.Date
+  type UsageDimension        = String
+  type UsageQuantity         = Int
+  type UsageRecordList       = js.Array[UsageRecord]
+  type UsageRecordResultList = js.Array[UsageRecordResult]
+  type VersionInteger        = Int
 
   implicit final class MarketplaceMeteringOps(private val service: MarketplaceMetering) extends AnyVal {
 
@@ -279,11 +278,12 @@ package marketplacemetering {
       __obj.asInstanceOf[UsageRecordResult]
     }
   }
-
-  object UsageRecordResultStatusEnum {
-    val Success               = "Success"
-    val CustomerNotSubscribed = "CustomerNotSubscribed"
-    val DuplicateRecord       = "DuplicateRecord"
+  @js.native
+  sealed trait UsageRecordResultStatus extends js.Any
+  object UsageRecordResultStatus extends js.Object {
+    val Success               = "Success".asInstanceOf[UsageRecordResultStatus]
+    val CustomerNotSubscribed = "CustomerNotSubscribed".asInstanceOf[UsageRecordResultStatus]
+    val DuplicateRecord       = "DuplicateRecord".asInstanceOf[UsageRecordResultStatus]
 
     val values = js.Object.freeze(js.Array(Success, CustomerNotSubscribed, DuplicateRecord))
   }

--- a/services/mediaconnect/src/main/scala/facade/amazonaws/services/MediaConnect.scala
+++ b/services/mediaconnect/src/main/scala/facade/amazonaws/services/MediaConnect.scala
@@ -7,12 +7,7 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object mediaconnect {
-  type Algorithm                       = String
-  type KeyType                         = String
   type MaxResults                      = Int
-  type Protocol                        = String
-  type SourceType                      = String
-  type Status                          = String
   type __integer                       = Int
   type __listOfAddOutputRequest        = js.Array[AddOutputRequest]
   type __listOfEntitlement             = js.Array[Entitlement]
@@ -184,11 +179,12 @@ package mediaconnect {
       __obj.asInstanceOf[AddOutputRequest]
     }
   }
-
-  object AlgorithmEnum {
-    val aes128 = "aes128"
-    val aes192 = "aes192"
-    val aes256 = "aes256"
+  @js.native
+  sealed trait Algorithm extends js.Any
+  object Algorithm extends js.Object {
+    val aes128 = "aes128".asInstanceOf[Algorithm]
+    val aes192 = "aes192".asInstanceOf[Algorithm]
+    val aes256 = "aes256".asInstanceOf[Algorithm]
 
     val values = js.Object.freeze(js.Array(aes128, aes192, aes256))
   }
@@ -523,10 +519,11 @@ package mediaconnect {
       __obj.asInstanceOf[GrantFlowEntitlementsResponse]
     }
   }
-
-  object KeyTypeEnum {
-    val speke        = "speke"
-    val `static-key` = "static-key"
+  @js.native
+  sealed trait KeyType extends js.Any
+  object KeyType extends js.Object {
+    val speke        = "speke".asInstanceOf[KeyType]
+    val `static-key` = "static-key".asInstanceOf[KeyType]
 
     val values = js.Object.freeze(js.Array(speke, `static-key`))
   }
@@ -776,13 +773,14 @@ package mediaconnect {
       __obj.asInstanceOf[Output]
     }
   }
-
-  object ProtocolEnum {
-    val `zixi-push` = "zixi-push"
-    val `rtp-fec`   = "rtp-fec"
-    val rtp         = "rtp"
-    val `zixi-pull` = "zixi-pull"
-    val rist        = "rist"
+  @js.native
+  sealed trait Protocol extends js.Any
+  object Protocol extends js.Object {
+    val `zixi-push` = "zixi-push".asInstanceOf[Protocol]
+    val `rtp-fec`   = "rtp-fec".asInstanceOf[Protocol]
+    val rtp         = "rtp".asInstanceOf[Protocol]
+    val `zixi-pull` = "zixi-pull".asInstanceOf[Protocol]
+    val rist        = "rist".asInstanceOf[Protocol]
 
     val values = js.Object.freeze(js.Array(`zixi-push`, `rtp-fec`, rtp, `zixi-pull`, rist))
   }
@@ -962,10 +960,11 @@ package mediaconnect {
       __obj.asInstanceOf[Source]
     }
   }
-
-  object SourceTypeEnum {
-    val OWNED    = "OWNED"
-    val ENTITLED = "ENTITLED"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val OWNED    = "OWNED".asInstanceOf[SourceType]
+    val ENTITLED = "ENTITLED".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(js.Array(OWNED, ENTITLED))
   }
@@ -1006,15 +1005,16 @@ package mediaconnect {
       __obj.asInstanceOf[StartFlowResponse]
     }
   }
-
-  object StatusEnum {
-    val STANDBY  = "STANDBY"
-    val ACTIVE   = "ACTIVE"
-    val UPDATING = "UPDATING"
-    val DELETING = "DELETING"
-    val STARTING = "STARTING"
-    val STOPPING = "STOPPING"
-    val ERROR    = "ERROR"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val STANDBY  = "STANDBY".asInstanceOf[Status]
+    val ACTIVE   = "ACTIVE".asInstanceOf[Status]
+    val UPDATING = "UPDATING".asInstanceOf[Status]
+    val DELETING = "DELETING".asInstanceOf[Status]
+    val STARTING = "STARTING".asInstanceOf[Status]
+    val STOPPING = "STOPPING".asInstanceOf[Status]
+    val ERROR    = "ERROR".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(STANDBY, ACTIVE, UPDATING, DELETING, STARTING, STOPPING, ERROR))
   }

--- a/services/mediaconvert/src/main/scala/facade/amazonaws/services/MediaConvert.scala
+++ b/services/mediaconvert/src/main/scala/facade/amazonaws/services/MediaConvert.scala
@@ -7,270 +7,6 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object mediaconvert {
-  type AacAudioDescriptionBroadcasterMix           = String
-  type AacCodecProfile                             = String
-  type AacCodingMode                               = String
-  type AacRateControlMode                          = String
-  type AacRawFormat                                = String
-  type AacSpecification                            = String
-  type AacVbrQuality                               = String
-  type Ac3BitstreamMode                            = String
-  type Ac3CodingMode                               = String
-  type Ac3DynamicRangeCompressionProfile           = String
-  type Ac3LfeFilter                                = String
-  type Ac3MetadataControl                          = String
-  type AccelerationMode                            = String
-  type AccelerationStatus                          = String
-  type AfdSignaling                                = String
-  type AlphaBehavior                               = String
-  type AncillaryConvert608To708                    = String
-  type AncillaryTerminateCaptions                  = String
-  type AntiAlias                                   = String
-  type AudioCodec                                  = String
-  type AudioDefaultSelection                       = String
-  type AudioLanguageCodeControl                    = String
-  type AudioNormalizationAlgorithm                 = String
-  type AudioNormalizationAlgorithmControl          = String
-  type AudioNormalizationLoudnessLogging           = String
-  type AudioNormalizationPeakCalculation           = String
-  type AudioSelectorType                           = String
-  type AudioTypeControl                            = String
-  type BillingTagsSource                           = String
-  type BurninSubtitleAlignment                     = String
-  type BurninSubtitleBackgroundColor               = String
-  type BurninSubtitleFontColor                     = String
-  type BurninSubtitleOutlineColor                  = String
-  type BurninSubtitleShadowColor                   = String
-  type BurninSubtitleTeletextSpacing               = String
-  type CaptionDestinationType                      = String
-  type CaptionSourceType                           = String
-  type CmafClientCache                             = String
-  type CmafCodecSpecification                      = String
-  type CmafEncryptionType                          = String
-  type CmafInitializationVectorInManifest          = String
-  type CmafKeyProviderType                         = String
-  type CmafManifestCompression                     = String
-  type CmafManifestDurationFormat                  = String
-  type CmafMpdProfile                              = String
-  type CmafSegmentControl                          = String
-  type CmafStreamInfResolution                     = String
-  type CmafWriteDASHManifest                       = String
-  type CmafWriteHLSManifest                        = String
-  type CmafWriteSegmentTimelineInRepresentation    = String
-  type CmfcScte35Esam                              = String
-  type CmfcScte35Source                            = String
-  type ColorMetadata                               = String
-  type ColorSpace                                  = String
-  type ColorSpaceConversion                        = String
-  type ColorSpaceUsage                             = String
-  type Commitment                                  = String
-  type ContainerType                               = String
-  type DashIsoHbbtvCompliance                      = String
-  type DashIsoMpdProfile                           = String
-  type DashIsoPlaybackDeviceCompatibility          = String
-  type DashIsoSegmentControl                       = String
-  type DashIsoWriteSegmentTimelineInRepresentation = String
-  type DecryptionMode                              = String
-  type DeinterlaceAlgorithm                        = String
-  type DeinterlacerControl                         = String
-  type DeinterlacerMode                            = String
-  type DescribeEndpointsMode                       = String
-  type DolbyVisionLevel6Mode                       = String
-  type DolbyVisionProfile                          = String
-  type DropFrameTimecode                           = String
-  type DvbSubtitleAlignment                        = String
-  type DvbSubtitleBackgroundColor                  = String
-  type DvbSubtitleFontColor                        = String
-  type DvbSubtitleOutlineColor                     = String
-  type DvbSubtitleShadowColor                      = String
-  type DvbSubtitleTeletextSpacing                  = String
-  type DvbSubtitlingType                           = String
-  type Eac3AtmosBitstreamMode                      = String
-  type Eac3AtmosCodingMode                         = String
-  type Eac3AtmosDialogueIntelligence               = String
-  type Eac3AtmosDynamicRangeCompressionLine        = String
-  type Eac3AtmosDynamicRangeCompressionRf          = String
-  type Eac3AtmosMeteringMode                       = String
-  type Eac3AtmosStereoDownmix                      = String
-  type Eac3AtmosSurroundExMode                     = String
-  type Eac3AttenuationControl                      = String
-  type Eac3BitstreamMode                           = String
-  type Eac3CodingMode                              = String
-  type Eac3DcFilter                                = String
-  type Eac3DynamicRangeCompressionLine             = String
-  type Eac3DynamicRangeCompressionRf               = String
-  type Eac3LfeControl                              = String
-  type Eac3LfeFilter                               = String
-  type Eac3MetadataControl                         = String
-  type Eac3PassthroughControl                      = String
-  type Eac3PhaseControl                            = String
-  type Eac3StereoDownmix                           = String
-  type Eac3SurroundExMode                          = String
-  type Eac3SurroundMode                            = String
-  type EmbeddedConvert608To708                     = String
-  type EmbeddedTerminateCaptions                   = String
-  type F4vMoovPlacement                            = String
-  type FileSourceConvert608To708                   = String
-  type FontScript                                  = String
-  type H264AdaptiveQuantization                    = String
-  type H264CodecLevel                              = String
-  type H264CodecProfile                            = String
-  type H264DynamicSubGop                           = String
-  type H264EntropyEncoding                         = String
-  type H264FieldEncoding                           = String
-  type H264FlickerAdaptiveQuantization             = String
-  type H264FramerateControl                        = String
-  type H264FramerateConversionAlgorithm            = String
-  type H264GopBReference                           = String
-  type H264GopSizeUnits                            = String
-  type H264InterlaceMode                           = String
-  type H264ParControl                              = String
-  type H264QualityTuningLevel                      = String
-  type H264RateControlMode                         = String
-  type H264RepeatPps                               = String
-  type H264SceneChangeDetect                       = String
-  type H264SlowPal                                 = String
-  type H264SpatialAdaptiveQuantization             = String
-  type H264Syntax                                  = String
-  type H264Telecine                                = String
-  type H264TemporalAdaptiveQuantization            = String
-  type H264UnregisteredSeiTimecode                 = String
-  type H265AdaptiveQuantization                    = String
-  type H265AlternateTransferFunctionSei            = String
-  type H265CodecLevel                              = String
-  type H265CodecProfile                            = String
-  type H265DynamicSubGop                           = String
-  type H265FlickerAdaptiveQuantization             = String
-  type H265FramerateControl                        = String
-  type H265FramerateConversionAlgorithm            = String
-  type H265GopBReference                           = String
-  type H265GopSizeUnits                            = String
-  type H265InterlaceMode                           = String
-  type H265ParControl                              = String
-  type H265QualityTuningLevel                      = String
-  type H265RateControlMode                         = String
-  type H265SampleAdaptiveOffsetFilterMode          = String
-  type H265SceneChangeDetect                       = String
-  type H265SlowPal                                 = String
-  type H265SpatialAdaptiveQuantization             = String
-  type H265Telecine                                = String
-  type H265TemporalAdaptiveQuantization            = String
-  type H265TemporalIds                             = String
-  type H265Tiles                                   = String
-  type H265UnregisteredSeiTimecode                 = String
-  type H265WriteMp4PackagingType                   = String
-  type HlsAdMarkers                                = String
-  type HlsAudioOnlyContainer                       = String
-  type HlsAudioTrackType                           = String
-  type HlsCaptionLanguageSetting                   = String
-  type HlsClientCache                              = String
-  type HlsCodecSpecification                       = String
-  type HlsDirectoryStructure                       = String
-  type HlsEncryptionType                           = String
-  type HlsIFrameOnlyManifest                       = String
-  type HlsInitializationVectorInManifest           = String
-  type HlsKeyProviderType                          = String
-  type HlsManifestCompression                      = String
-  type HlsManifestDurationFormat                   = String
-  type HlsOfflineEncrypted                         = String
-  type HlsOutputSelection                          = String
-  type HlsProgramDateTime                          = String
-  type HlsSegmentControl                           = String
-  type HlsStreamInfResolution                      = String
-  type HlsTimedMetadataId3Frame                    = String
-  type ImscStylePassthrough                        = String
-  type InputDeblockFilter                          = String
-  type InputDenoiseFilter                          = String
-  type InputFilterEnable                           = String
-  type InputPsiControl                             = String
-  type InputRotate                                 = String
-  type InputTimecodeSource                         = String
-  type JobPhase                                    = String
-  type JobStatus                                   = String
-  type JobTemplateListBy                           = String
-  type LanguageCode                                = String
-  type M2tsAudioBufferModel                        = String
-  type M2tsBufferModel                             = String
-  type M2tsEbpAudioInterval                        = String
-  type M2tsEbpPlacement                            = String
-  type M2tsEsRateInPes                             = String
-  type M2tsForceTsVideoEbpOrder                    = String
-  type M2tsNielsenId3                              = String
-  type M2tsPcrControl                              = String
-  type M2tsRateMode                                = String
-  type M2tsScte35Source                            = String
-  type M2tsSegmentationMarkers                     = String
-  type M2tsSegmentationStyle                       = String
-  type M3u8NielsenId3                              = String
-  type M3u8PcrControl                              = String
-  type M3u8Scte35Source                            = String
-  type MotionImageInsertionMode                    = String
-  type MotionImagePlayback                         = String
-  type MovClapAtom                                 = String
-  type MovCslgAtom                                 = String
-  type MovMpeg2FourCCControl                       = String
-  type MovPaddingControl                           = String
-  type MovReference                                = String
-  type Mp3RateControlMode                          = String
-  type Mp4CslgAtom                                 = String
-  type Mp4FreeSpaceBox                             = String
-  type Mp4MoovPlacement                            = String
-  type MpdCaptionContainerType                     = String
-  type MpdScte35Esam                               = String
-  type MpdScte35Source                             = String
-  type Mpeg2AdaptiveQuantization                   = String
-  type Mpeg2CodecLevel                             = String
-  type Mpeg2CodecProfile                           = String
-  type Mpeg2DynamicSubGop                          = String
-  type Mpeg2FramerateControl                       = String
-  type Mpeg2FramerateConversionAlgorithm           = String
-  type Mpeg2GopSizeUnits                           = String
-  type Mpeg2InterlaceMode                          = String
-  type Mpeg2IntraDcPrecision                       = String
-  type Mpeg2ParControl                             = String
-  type Mpeg2QualityTuningLevel                     = String
-  type Mpeg2RateControlMode                        = String
-  type Mpeg2SceneChangeDetect                      = String
-  type Mpeg2SlowPal                                = String
-  type Mpeg2SpatialAdaptiveQuantization            = String
-  type Mpeg2Syntax                                 = String
-  type Mpeg2Telecine                               = String
-  type Mpeg2TemporalAdaptiveQuantization           = String
-  type MsSmoothAudioDeduplication                  = String
-  type MsSmoothManifestEncoding                    = String
-  type NoiseReducerFilter                          = String
-  type Order                                       = String
-  type OutputGroupType                             = String
-  type OutputSdt                                   = String
-  type PresetListBy                                = String
-  type PricingPlan                                 = String
-  type ProresCodecProfile                          = String
-  type ProresFramerateControl                      = String
-  type ProresFramerateConversionAlgorithm          = String
-  type ProresInterlaceMode                         = String
-  type ProresParControl                            = String
-  type ProresSlowPal                               = String
-  type ProresTelecine                              = String
-  type QueueListBy                                 = String
-  type QueueStatus                                 = String
-  type RenewalType                                 = String
-  type ReservationPlanStatus                       = String
-  type RespondToAfd                                = String
-  type S3ObjectCannedAcl                           = String
-  type S3ServerSideEncryptionType                  = String
-  type ScalingBehavior                             = String
-  type SccDestinationFramerate                     = String
-  type SimulateReservedQueue                       = String
-  type StatusUpdateInterval                        = String
-  type TeletextPageType                            = String
-  type TimecodeBurninPosition                      = String
-  type TimecodeSource                              = String
-  type TimedMetadata                               = String
-  type TtmlStylePassthrough                        = String
-  type Type                                        = String
-  type VideoCodec                                  = String
-  type VideoTimecodeInsertion                      = String
-  type WavFormat                                   = String
   type __doubleMin0                                = Double
   type __doubleMin0Max1                            = Double
   type __doubleMin0Max2147483647                   = Double
@@ -528,9 +264,11 @@ package mediaconvert {
   /**
     * Choose BROADCASTER_MIXED_AD when the input contains pre-mixed main audio + audio description (AD) as a stereo pair. The value for AudioType will be set to 3, which signals to downstream systems that this stream contains "broadcaster mixed AD". Note that the input received by the encoder must contain pre-mixed audio; the encoder does not perform the mixing. When you choose BROADCASTER_MIXED_AD, the encoder ignores any values you provide in AudioType and  FollowInputAudioType. Choose NORMAL when the input does not contain pre-mixed audio + audio description (AD). In this case, the encoder will use any values you provide for AudioType and FollowInputAudioType.
     */
-  object AacAudioDescriptionBroadcasterMixEnum {
-    val BROADCASTER_MIXED_AD = "BROADCASTER_MIXED_AD"
-    val NORMAL               = "NORMAL"
+  @js.native
+  sealed trait AacAudioDescriptionBroadcasterMix extends js.Any
+  object AacAudioDescriptionBroadcasterMix extends js.Object {
+    val BROADCASTER_MIXED_AD = "BROADCASTER_MIXED_AD".asInstanceOf[AacAudioDescriptionBroadcasterMix]
+    val NORMAL               = "NORMAL".asInstanceOf[AacAudioDescriptionBroadcasterMix]
 
     val values = js.Object.freeze(js.Array(BROADCASTER_MIXED_AD, NORMAL))
   }
@@ -538,10 +276,12 @@ package mediaconvert {
   /**
     * AAC Profile.
     */
-  object AacCodecProfileEnum {
-    val LC   = "LC"
-    val HEV1 = "HEV1"
-    val HEV2 = "HEV2"
+  @js.native
+  sealed trait AacCodecProfile extends js.Any
+  object AacCodecProfile extends js.Object {
+    val LC   = "LC".asInstanceOf[AacCodecProfile]
+    val HEV1 = "HEV1".asInstanceOf[AacCodecProfile]
+    val HEV2 = "HEV2".asInstanceOf[AacCodecProfile]
 
     val values = js.Object.freeze(js.Array(LC, HEV1, HEV2))
   }
@@ -549,12 +289,14 @@ package mediaconvert {
   /**
     * Mono (Audio Description), Mono, Stereo, or 5.1 channel layout. Valid values depend on rate control mode and profile. "1.0 - Audio Description (Receiver Mix)" setting receives a stereo description plus control track and emits a mono AAC encode of the description track, with control data emitted in the PES header as per ETSI TS 101 154 Annex E.
     */
-  object AacCodingModeEnum {
-    val AD_RECEIVER_MIX = "AD_RECEIVER_MIX"
-    val CODING_MODE_1_0 = "CODING_MODE_1_0"
-    val CODING_MODE_1_1 = "CODING_MODE_1_1"
-    val CODING_MODE_2_0 = "CODING_MODE_2_0"
-    val CODING_MODE_5_1 = "CODING_MODE_5_1"
+  @js.native
+  sealed trait AacCodingMode extends js.Any
+  object AacCodingMode extends js.Object {
+    val AD_RECEIVER_MIX = "AD_RECEIVER_MIX".asInstanceOf[AacCodingMode]
+    val CODING_MODE_1_0 = "CODING_MODE_1_0".asInstanceOf[AacCodingMode]
+    val CODING_MODE_1_1 = "CODING_MODE_1_1".asInstanceOf[AacCodingMode]
+    val CODING_MODE_2_0 = "CODING_MODE_2_0".asInstanceOf[AacCodingMode]
+    val CODING_MODE_5_1 = "CODING_MODE_5_1".asInstanceOf[AacCodingMode]
 
     val values =
       js.Object.freeze(js.Array(AD_RECEIVER_MIX, CODING_MODE_1_0, CODING_MODE_1_1, CODING_MODE_2_0, CODING_MODE_5_1))
@@ -563,9 +305,11 @@ package mediaconvert {
   /**
     * Rate Control Mode.
     */
-  object AacRateControlModeEnum {
-    val CBR = "CBR"
-    val VBR = "VBR"
+  @js.native
+  sealed trait AacRateControlMode extends js.Any
+  object AacRateControlMode extends js.Object {
+    val CBR = "CBR".asInstanceOf[AacRateControlMode]
+    val VBR = "VBR".asInstanceOf[AacRateControlMode]
 
     val values = js.Object.freeze(js.Array(CBR, VBR))
   }
@@ -573,9 +317,11 @@ package mediaconvert {
   /**
     * Enables LATM/LOAS AAC output. Note that if you use LATM/LOAS AAC in an output, you must choose "No container" for the output container.
     */
-  object AacRawFormatEnum {
-    val LATM_LOAS = "LATM_LOAS"
-    val NONE      = "NONE"
+  @js.native
+  sealed trait AacRawFormat extends js.Any
+  object AacRawFormat extends js.Object {
+    val LATM_LOAS = "LATM_LOAS".asInstanceOf[AacRawFormat]
+    val NONE      = "NONE".asInstanceOf[AacRawFormat]
 
     val values = js.Object.freeze(js.Array(LATM_LOAS, NONE))
   }
@@ -628,9 +374,11 @@ package mediaconvert {
   /**
     * Use MPEG-2 AAC instead of MPEG-4 AAC audio for raw or MPEG-2 Transport Stream containers.
     */
-  object AacSpecificationEnum {
-    val MPEG2 = "MPEG2"
-    val MPEG4 = "MPEG4"
+  @js.native
+  sealed trait AacSpecification extends js.Any
+  object AacSpecification extends js.Object {
+    val MPEG2 = "MPEG2".asInstanceOf[AacSpecification]
+    val MPEG4 = "MPEG4".asInstanceOf[AacSpecification]
 
     val values = js.Object.freeze(js.Array(MPEG2, MPEG4))
   }
@@ -638,11 +386,13 @@ package mediaconvert {
   /**
     * VBR Quality Level - Only used if rate_control_mode is VBR.
     */
-  object AacVbrQualityEnum {
-    val LOW         = "LOW"
-    val MEDIUM_LOW  = "MEDIUM_LOW"
-    val MEDIUM_HIGH = "MEDIUM_HIGH"
-    val HIGH        = "HIGH"
+  @js.native
+  sealed trait AacVbrQuality extends js.Any
+  object AacVbrQuality extends js.Object {
+    val LOW         = "LOW".asInstanceOf[AacVbrQuality]
+    val MEDIUM_LOW  = "MEDIUM_LOW".asInstanceOf[AacVbrQuality]
+    val MEDIUM_HIGH = "MEDIUM_HIGH".asInstanceOf[AacVbrQuality]
+    val HIGH        = "HIGH".asInstanceOf[AacVbrQuality]
 
     val values = js.Object.freeze(js.Array(LOW, MEDIUM_LOW, MEDIUM_HIGH, HIGH))
   }
@@ -650,15 +400,17 @@ package mediaconvert {
   /**
     * Specify the bitstream mode for the AC-3 stream that the encoder emits. For more information about the AC3 bitstream mode, see ATSC A/52-2012 (Annex E).
     */
-  object Ac3BitstreamModeEnum {
-    val COMPLETE_MAIN     = "COMPLETE_MAIN"
-    val COMMENTARY        = "COMMENTARY"
-    val DIALOGUE          = "DIALOGUE"
-    val EMERGENCY         = "EMERGENCY"
-    val HEARING_IMPAIRED  = "HEARING_IMPAIRED"
-    val MUSIC_AND_EFFECTS = "MUSIC_AND_EFFECTS"
-    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED"
-    val VOICE_OVER        = "VOICE_OVER"
+  @js.native
+  sealed trait Ac3BitstreamMode extends js.Any
+  object Ac3BitstreamMode extends js.Object {
+    val COMPLETE_MAIN     = "COMPLETE_MAIN".asInstanceOf[Ac3BitstreamMode]
+    val COMMENTARY        = "COMMENTARY".asInstanceOf[Ac3BitstreamMode]
+    val DIALOGUE          = "DIALOGUE".asInstanceOf[Ac3BitstreamMode]
+    val EMERGENCY         = "EMERGENCY".asInstanceOf[Ac3BitstreamMode]
+    val HEARING_IMPAIRED  = "HEARING_IMPAIRED".asInstanceOf[Ac3BitstreamMode]
+    val MUSIC_AND_EFFECTS = "MUSIC_AND_EFFECTS".asInstanceOf[Ac3BitstreamMode]
+    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED".asInstanceOf[Ac3BitstreamMode]
+    val VOICE_OVER        = "VOICE_OVER".asInstanceOf[Ac3BitstreamMode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -677,11 +429,13 @@ package mediaconvert {
   /**
     * Dolby Digital coding mode. Determines number of channels.
     */
-  object Ac3CodingModeEnum {
-    val CODING_MODE_1_0     = "CODING_MODE_1_0"
-    val CODING_MODE_1_1     = "CODING_MODE_1_1"
-    val CODING_MODE_2_0     = "CODING_MODE_2_0"
-    val CODING_MODE_3_2_LFE = "CODING_MODE_3_2_LFE"
+  @js.native
+  sealed trait Ac3CodingMode extends js.Any
+  object Ac3CodingMode extends js.Object {
+    val CODING_MODE_1_0     = "CODING_MODE_1_0".asInstanceOf[Ac3CodingMode]
+    val CODING_MODE_1_1     = "CODING_MODE_1_1".asInstanceOf[Ac3CodingMode]
+    val CODING_MODE_2_0     = "CODING_MODE_2_0".asInstanceOf[Ac3CodingMode]
+    val CODING_MODE_3_2_LFE = "CODING_MODE_3_2_LFE".asInstanceOf[Ac3CodingMode]
 
     val values = js.Object.freeze(js.Array(CODING_MODE_1_0, CODING_MODE_1_1, CODING_MODE_2_0, CODING_MODE_3_2_LFE))
   }
@@ -689,9 +443,11 @@ package mediaconvert {
   /**
     * If set to FILM_STANDARD, adds dynamic range compression signaling to the output bitstream as defined in the Dolby Digital specification.
     */
-  object Ac3DynamicRangeCompressionProfileEnum {
-    val FILM_STANDARD = "FILM_STANDARD"
-    val NONE          = "NONE"
+  @js.native
+  sealed trait Ac3DynamicRangeCompressionProfile extends js.Any
+  object Ac3DynamicRangeCompressionProfile extends js.Object {
+    val FILM_STANDARD = "FILM_STANDARD".asInstanceOf[Ac3DynamicRangeCompressionProfile]
+    val NONE          = "NONE".asInstanceOf[Ac3DynamicRangeCompressionProfile]
 
     val values = js.Object.freeze(js.Array(FILM_STANDARD, NONE))
   }
@@ -699,9 +455,11 @@ package mediaconvert {
   /**
     * Applies a 120Hz lowpass filter to the LFE channel prior to encoding. Only valid with 3_2_LFE coding mode.
     */
-  object Ac3LfeFilterEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait Ac3LfeFilter extends js.Any
+  object Ac3LfeFilter extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[Ac3LfeFilter]
+    val DISABLED = "DISABLED".asInstanceOf[Ac3LfeFilter]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -709,9 +467,11 @@ package mediaconvert {
   /**
     * When set to FOLLOW_INPUT, encoder metadata will be sourced from the DD, DD+, or DolbyE decoder that supplied this audio data. If audio was not supplied from one of these streams, then the static metadata settings will be used.
     */
-  object Ac3MetadataControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait Ac3MetadataControl extends js.Any
+  object Ac3MetadataControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[Ac3MetadataControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[Ac3MetadataControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -761,10 +521,12 @@ package mediaconvert {
   /**
     * Specify whether the service runs your job with accelerated transcoding. Choose DISABLED if you don't want accelerated transcoding. Choose ENABLED if you want your job to run with accelerated transcoding and to fail if your input files or your job settings aren't compatible with accelerated transcoding. Choose PREFERRED if you want your job to run with accelerated transcoding if the job is compatible with the feature and to run at standard speed if it's not.
     */
-  object AccelerationModeEnum {
-    val DISABLED  = "DISABLED"
-    val ENABLED   = "ENABLED"
-    val PREFERRED = "PREFERRED"
+  @js.native
+  sealed trait AccelerationMode extends js.Any
+  object AccelerationMode extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[AccelerationMode]
+    val ENABLED   = "ENABLED".asInstanceOf[AccelerationMode]
+    val PREFERRED = "PREFERRED".asInstanceOf[AccelerationMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED, PREFERRED))
   }
@@ -793,11 +555,13 @@ package mediaconvert {
   /**
     * Describes whether the current job is running with accelerated transcoding. For jobs that have Acceleration (AccelerationMode) set to DISABLED, AccelerationStatus is always NOT_APPLICABLE. For jobs that have Acceleration (AccelerationMode) set to ENABLED or PREFERRED, AccelerationStatus is one of the other states. AccelerationStatus is IN_PROGRESS initially, while the service determines whether the input files and job settings are compatible with accelerated transcoding. If they are, AcclerationStatus is ACCELERATED. If your input files and job settings aren't compatible with accelerated transcoding, the service either fails your job or runs it without accelerated transcoding, depending on how you set Acceleration (AccelerationMode). When the service runs your job without accelerated transcoding, AccelerationStatus is NOT_ACCELERATED.
     */
-  object AccelerationStatusEnum {
-    val NOT_APPLICABLE  = "NOT_APPLICABLE"
-    val IN_PROGRESS     = "IN_PROGRESS"
-    val ACCELERATED     = "ACCELERATED"
-    val NOT_ACCELERATED = "NOT_ACCELERATED"
+  @js.native
+  sealed trait AccelerationStatus extends js.Any
+  object AccelerationStatus extends js.Object {
+    val NOT_APPLICABLE  = "NOT_APPLICABLE".asInstanceOf[AccelerationStatus]
+    val IN_PROGRESS     = "IN_PROGRESS".asInstanceOf[AccelerationStatus]
+    val ACCELERATED     = "ACCELERATED".asInstanceOf[AccelerationStatus]
+    val NOT_ACCELERATED = "NOT_ACCELERATED".asInstanceOf[AccelerationStatus]
 
     val values = js.Object.freeze(js.Array(NOT_APPLICABLE, IN_PROGRESS, ACCELERATED, NOT_ACCELERATED))
   }
@@ -805,10 +569,12 @@ package mediaconvert {
   /**
     * This setting only applies to H.264, H.265, and MPEG2 outputs. Use Insert AFD signaling (AfdSignaling) to specify whether the service includes AFD values in the output video data and what those values are. * Choose None to remove all AFD values from this output. * Choose Fixed to ignore input AFD values and instead encode the value specified in the job. * Choose Auto to calculate output AFD values based on the input AFD scaler data.
     */
-  object AfdSignalingEnum {
-    val NONE  = "NONE"
-    val AUTO  = "AUTO"
-    val FIXED = "FIXED"
+  @js.native
+  sealed trait AfdSignaling extends js.Any
+  object AfdSignaling extends js.Object {
+    val NONE  = "NONE".asInstanceOf[AfdSignaling]
+    val AUTO  = "AUTO".asInstanceOf[AfdSignaling]
+    val FIXED = "FIXED".asInstanceOf[AfdSignaling]
 
     val values = js.Object.freeze(js.Array(NONE, AUTO, FIXED))
   }
@@ -841,9 +607,11 @@ package mediaconvert {
   /**
     * Ignore this setting unless this input is a QuickTime animation with an alpha channel. Use this setting to create separate Key and Fill outputs. In each output, specify which part of the input MediaConvert uses. Leave this setting at the default value DISCARD to delete the alpha channel and preserve the video. Set it to REMAP_TO_LUMA to delete the video and map the alpha channel to the luma channel of your outputs.
     */
-  object AlphaBehaviorEnum {
-    val DISCARD       = "DISCARD"
-    val REMAP_TO_LUMA = "REMAP_TO_LUMA"
+  @js.native
+  sealed trait AlphaBehavior extends js.Any
+  object AlphaBehavior extends js.Object {
+    val DISCARD       = "DISCARD".asInstanceOf[AlphaBehavior]
+    val REMAP_TO_LUMA = "REMAP_TO_LUMA".asInstanceOf[AlphaBehavior]
 
     val values = js.Object.freeze(js.Array(DISCARD, REMAP_TO_LUMA))
   }
@@ -851,9 +619,11 @@ package mediaconvert {
   /**
     * Specify whether this set of input captions appears in your outputs in both 608 and 708 format. If you choose Upconvert (UPCONVERT), MediaConvert includes the captions data in two ways: it passes the 608 data through using the 608 compatibility bytes fields of the 708 wrapper, and it also translates the 608 data into 708.
     */
-  object AncillaryConvert608To708Enum {
-    val UPCONVERT = "UPCONVERT"
-    val DISABLED  = "DISABLED"
+  @js.native
+  sealed trait AncillaryConvert608To708 extends js.Any
+  object AncillaryConvert608To708 extends js.Object {
+    val UPCONVERT = "UPCONVERT".asInstanceOf[AncillaryConvert608To708]
+    val DISABLED  = "DISABLED".asInstanceOf[AncillaryConvert608To708]
 
     val values = js.Object.freeze(js.Array(UPCONVERT, DISABLED))
   }
@@ -888,9 +658,11 @@ package mediaconvert {
   /**
     * By default, the service terminates any unterminated captions at the end of each input. If you want the caption to continue onto your next input, disable this setting.
     */
-  object AncillaryTerminateCaptionsEnum {
-    val END_OF_INPUT = "END_OF_INPUT"
-    val DISABLED     = "DISABLED"
+  @js.native
+  sealed trait AncillaryTerminateCaptions extends js.Any
+  object AncillaryTerminateCaptions extends js.Object {
+    val END_OF_INPUT = "END_OF_INPUT".asInstanceOf[AncillaryTerminateCaptions]
+    val DISABLED     = "DISABLED".asInstanceOf[AncillaryTerminateCaptions]
 
     val values = js.Object.freeze(js.Array(END_OF_INPUT, DISABLED))
   }
@@ -898,9 +670,11 @@ package mediaconvert {
   /**
     * The anti-alias filter is automatically applied to all outputs. The service no longer accepts the value DISABLED for AntiAlias. If you specify that in your job, the service will ignore the setting.
     */
-  object AntiAliasEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait AntiAlias extends js.Any
+  object AntiAlias extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[AntiAlias]
+    val ENABLED  = "ENABLED".asInstanceOf[AntiAlias]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -939,16 +713,18 @@ package mediaconvert {
   /**
     * Type of Audio codec.
     */
-  object AudioCodecEnum {
-    val AAC         = "AAC"
-    val MP2         = "MP2"
-    val MP3         = "MP3"
-    val WAV         = "WAV"
-    val AIFF        = "AIFF"
-    val AC3         = "AC3"
-    val EAC3        = "EAC3"
-    val EAC3_ATMOS  = "EAC3_ATMOS"
-    val PASSTHROUGH = "PASSTHROUGH"
+  @js.native
+  sealed trait AudioCodec extends js.Any
+  object AudioCodec extends js.Object {
+    val AAC         = "AAC".asInstanceOf[AudioCodec]
+    val MP2         = "MP2".asInstanceOf[AudioCodec]
+    val MP3         = "MP3".asInstanceOf[AudioCodec]
+    val WAV         = "WAV".asInstanceOf[AudioCodec]
+    val AIFF        = "AIFF".asInstanceOf[AudioCodec]
+    val AC3         = "AC3".asInstanceOf[AudioCodec]
+    val EAC3        = "EAC3".asInstanceOf[AudioCodec]
+    val EAC3_ATMOS  = "EAC3_ATMOS".asInstanceOf[AudioCodec]
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[AudioCodec]
 
     val values = js.Object.freeze(js.Array(AAC, MP2, MP3, WAV, AIFF, AC3, EAC3, EAC3_ATMOS, PASSTHROUGH))
   }
@@ -999,9 +775,11 @@ package mediaconvert {
   /**
     * Enable this setting on one audio selector to set it as the default for the job. The service uses this default for outputs where it can't find the specified input audio. If you don't set a default, those outputs have no audio.
     */
-  object AudioDefaultSelectionEnum {
-    val DEFAULT     = "DEFAULT"
-    val NOT_DEFAULT = "NOT_DEFAULT"
+  @js.native
+  sealed trait AudioDefaultSelection extends js.Any
+  object AudioDefaultSelection extends js.Object {
+    val DEFAULT     = "DEFAULT".asInstanceOf[AudioDefaultSelection]
+    val NOT_DEFAULT = "NOT_DEFAULT".asInstanceOf[AudioDefaultSelection]
 
     val values = js.Object.freeze(js.Array(DEFAULT, NOT_DEFAULT))
   }
@@ -1057,9 +835,11 @@ package mediaconvert {
   /**
     * Specify which source for language code takes precedence for this audio track. When you choose Follow input (FOLLOW_INPUT), the service uses the language code from the input track if it's present. If there's no languge code on the input track, the service uses the code that you specify in the setting Language code (languageCode or customLanguageCode). When you choose Use configured (USE_CONFIGURED), the service uses the language code that you specify.
     */
-  object AudioLanguageCodeControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait AudioLanguageCodeControl extends js.Any
+  object AudioLanguageCodeControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[AudioLanguageCodeControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[AudioLanguageCodeControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -1067,11 +847,13 @@ package mediaconvert {
   /**
     * Choose one of the following audio normalization algorithms: ITU-R BS.1770-1: Ungated loudness. A measurement of ungated average loudness for an entire piece of content, suitable for measurement of short-form content under ATSC recommendation A/85. Supports up to 5.1 audio channels. ITU-R BS.1770-2: Gated loudness. A measurement of gated average loudness compliant with the requirements of EBU-R128. Supports up to 5.1 audio channels. ITU-R BS.1770-3: Modified peak. The same loudness measurement algorithm as 1770-2, with an updated true peak measurement. ITU-R BS.1770-4: Higher channel count. Allows for more audio channels than the other algorithms, including configurations such as 7.1.
     */
-  object AudioNormalizationAlgorithmEnum {
-    val ITU_BS_1770_1 = "ITU_BS_1770_1"
-    val ITU_BS_1770_2 = "ITU_BS_1770_2"
-    val ITU_BS_1770_3 = "ITU_BS_1770_3"
-    val ITU_BS_1770_4 = "ITU_BS_1770_4"
+  @js.native
+  sealed trait AudioNormalizationAlgorithm extends js.Any
+  object AudioNormalizationAlgorithm extends js.Object {
+    val ITU_BS_1770_1 = "ITU_BS_1770_1".asInstanceOf[AudioNormalizationAlgorithm]
+    val ITU_BS_1770_2 = "ITU_BS_1770_2".asInstanceOf[AudioNormalizationAlgorithm]
+    val ITU_BS_1770_3 = "ITU_BS_1770_3".asInstanceOf[AudioNormalizationAlgorithm]
+    val ITU_BS_1770_4 = "ITU_BS_1770_4".asInstanceOf[AudioNormalizationAlgorithm]
 
     val values = js.Object.freeze(js.Array(ITU_BS_1770_1, ITU_BS_1770_2, ITU_BS_1770_3, ITU_BS_1770_4))
   }
@@ -1079,9 +861,11 @@ package mediaconvert {
   /**
     * When enabled the output audio is corrected using the chosen algorithm. If disabled, the audio will be measured but not adjusted.
     */
-  object AudioNormalizationAlgorithmControlEnum {
-    val CORRECT_AUDIO = "CORRECT_AUDIO"
-    val MEASURE_ONLY  = "MEASURE_ONLY"
+  @js.native
+  sealed trait AudioNormalizationAlgorithmControl extends js.Any
+  object AudioNormalizationAlgorithmControl extends js.Object {
+    val CORRECT_AUDIO = "CORRECT_AUDIO".asInstanceOf[AudioNormalizationAlgorithmControl]
+    val MEASURE_ONLY  = "MEASURE_ONLY".asInstanceOf[AudioNormalizationAlgorithmControl]
 
     val values = js.Object.freeze(js.Array(CORRECT_AUDIO, MEASURE_ONLY))
   }
@@ -1089,9 +873,11 @@ package mediaconvert {
   /**
     * If set to LOG, log each output's audio track loudness to a CSV file.
     */
-  object AudioNormalizationLoudnessLoggingEnum {
-    val LOG      = "LOG"
-    val DONT_LOG = "DONT_LOG"
+  @js.native
+  sealed trait AudioNormalizationLoudnessLogging extends js.Any
+  object AudioNormalizationLoudnessLogging extends js.Object {
+    val LOG      = "LOG".asInstanceOf[AudioNormalizationLoudnessLogging]
+    val DONT_LOG = "DONT_LOG".asInstanceOf[AudioNormalizationLoudnessLogging]
 
     val values = js.Object.freeze(js.Array(LOG, DONT_LOG))
   }
@@ -1099,9 +885,11 @@ package mediaconvert {
   /**
     * If set to TRUE_PEAK, calculate and log the TruePeak for each output's audio track loudness.
     */
-  object AudioNormalizationPeakCalculationEnum {
-    val TRUE_PEAK = "TRUE_PEAK"
-    val NONE      = "NONE"
+  @js.native
+  sealed trait AudioNormalizationPeakCalculation extends js.Any
+  object AudioNormalizationPeakCalculation extends js.Object {
+    val TRUE_PEAK = "TRUE_PEAK".asInstanceOf[AudioNormalizationPeakCalculation]
+    val NONE      = "NONE".asInstanceOf[AudioNormalizationPeakCalculation]
 
     val values = js.Object.freeze(js.Array(TRUE_PEAK, NONE))
   }
@@ -1212,10 +1000,12 @@ package mediaconvert {
   /**
     * Specifies the type of the audio selector.
     */
-  object AudioSelectorTypeEnum {
-    val PID           = "PID"
-    val TRACK         = "TRACK"
-    val LANGUAGE_CODE = "LANGUAGE_CODE"
+  @js.native
+  sealed trait AudioSelectorType extends js.Any
+  object AudioSelectorType extends js.Object {
+    val PID           = "PID".asInstanceOf[AudioSelectorType]
+    val TRACK         = "TRACK".asInstanceOf[AudioSelectorType]
+    val LANGUAGE_CODE = "LANGUAGE_CODE".asInstanceOf[AudioSelectorType]
 
     val values = js.Object.freeze(js.Array(PID, TRACK, LANGUAGE_CODE))
   }
@@ -1223,9 +1013,11 @@ package mediaconvert {
   /**
     * When set to FOLLOW_INPUT, if the input contains an ISO 639 audio_type, then that value is passed through to the output. If the input contains no ISO 639 audio_type, the value in Audio Type is included in the output. Otherwise the value in Audio Type is included in the output. Note that this field and audioType are both ignored if audioDescriptionBroadcasterMix is set to BROADCASTER_MIXED_AD.
     */
-  object AudioTypeControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait AudioTypeControl extends js.Any
+  object AudioTypeControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[AudioTypeControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[AudioTypeControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -1252,11 +1044,13 @@ package mediaconvert {
   /**
     * Optional. Choose a tag type that AWS Billing and Cost Management will use to sort your AWS Elemental MediaConvert costs on any billing report that you set up. Any transcoding outputs that don't have an associated tag will appear in your billing report unsorted. If you don't choose a valid value for this field, your job outputs will appear on the billing report unsorted.
     */
-  object BillingTagsSourceEnum {
-    val QUEUE        = "QUEUE"
-    val PRESET       = "PRESET"
-    val JOB_TEMPLATE = "JOB_TEMPLATE"
-    val JOB          = "JOB"
+  @js.native
+  sealed trait BillingTagsSource extends js.Any
+  object BillingTagsSource extends js.Object {
+    val QUEUE        = "QUEUE".asInstanceOf[BillingTagsSource]
+    val PRESET       = "PRESET".asInstanceOf[BillingTagsSource]
+    val JOB_TEMPLATE = "JOB_TEMPLATE".asInstanceOf[BillingTagsSource]
+    val JOB          = "JOB".asInstanceOf[BillingTagsSource]
 
     val values = js.Object.freeze(js.Array(QUEUE, PRESET, JOB_TEMPLATE, JOB))
   }
@@ -1331,9 +1125,11 @@ package mediaconvert {
   /**
     * If no explicit x_position or y_position is provided, setting alignment to centered will place the captions at the bottom center of the output. Similarly, setting a left alignment will align captions to the bottom left of the output. If x and y positions are given in conjunction with the alignment parameter, the font will be justified (either left or centered) relative to those coordinates. This option is not valid for source captions that are STL, 608/embedded or teletext. These source settings are already pre-defined by the caption stream. All burn-in and DVB-Sub font settings must match.
     */
-  object BurninSubtitleAlignmentEnum {
-    val CENTERED = "CENTERED"
-    val LEFT     = "LEFT"
+  @js.native
+  sealed trait BurninSubtitleAlignment extends js.Any
+  object BurninSubtitleAlignment extends js.Object {
+    val CENTERED = "CENTERED".asInstanceOf[BurninSubtitleAlignment]
+    val LEFT     = "LEFT".asInstanceOf[BurninSubtitleAlignment]
 
     val values = js.Object.freeze(js.Array(CENTERED, LEFT))
   }
@@ -1342,10 +1138,12 @@ package mediaconvert {
     * Specifies the color of the rectangle behind the captions.
     * All burn-in and DVB-Sub font settings must match.
     */
-  object BurninSubtitleBackgroundColorEnum {
-    val NONE  = "NONE"
-    val BLACK = "BLACK"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait BurninSubtitleBackgroundColor extends js.Any
+  object BurninSubtitleBackgroundColor extends js.Object {
+    val NONE  = "NONE".asInstanceOf[BurninSubtitleBackgroundColor]
+    val BLACK = "BLACK".asInstanceOf[BurninSubtitleBackgroundColor]
+    val WHITE = "WHITE".asInstanceOf[BurninSubtitleBackgroundColor]
 
     val values = js.Object.freeze(js.Array(NONE, BLACK, WHITE))
   }
@@ -1353,13 +1151,15 @@ package mediaconvert {
   /**
     * Specifies the color of the burned-in captions. This option is not valid for source captions that are STL, 608/embedded or teletext. These source settings are already pre-defined by the caption stream. All burn-in and DVB-Sub font settings must match.
     */
-  object BurninSubtitleFontColorEnum {
-    val WHITE  = "WHITE"
-    val BLACK  = "BLACK"
-    val YELLOW = "YELLOW"
-    val RED    = "RED"
-    val GREEN  = "GREEN"
-    val BLUE   = "BLUE"
+  @js.native
+  sealed trait BurninSubtitleFontColor extends js.Any
+  object BurninSubtitleFontColor extends js.Object {
+    val WHITE  = "WHITE".asInstanceOf[BurninSubtitleFontColor]
+    val BLACK  = "BLACK".asInstanceOf[BurninSubtitleFontColor]
+    val YELLOW = "YELLOW".asInstanceOf[BurninSubtitleFontColor]
+    val RED    = "RED".asInstanceOf[BurninSubtitleFontColor]
+    val GREEN  = "GREEN".asInstanceOf[BurninSubtitleFontColor]
+    val BLUE   = "BLUE".asInstanceOf[BurninSubtitleFontColor]
 
     val values = js.Object.freeze(js.Array(WHITE, BLACK, YELLOW, RED, GREEN, BLUE))
   }
@@ -1367,13 +1167,15 @@ package mediaconvert {
   /**
     * Specifies font outline color. This option is not valid for source captions that are either 608/embedded or teletext. These source settings are already pre-defined by the caption stream. All burn-in and DVB-Sub font settings must match.
     */
-  object BurninSubtitleOutlineColorEnum {
-    val BLACK  = "BLACK"
-    val WHITE  = "WHITE"
-    val YELLOW = "YELLOW"
-    val RED    = "RED"
-    val GREEN  = "GREEN"
-    val BLUE   = "BLUE"
+  @js.native
+  sealed trait BurninSubtitleOutlineColor extends js.Any
+  object BurninSubtitleOutlineColor extends js.Object {
+    val BLACK  = "BLACK".asInstanceOf[BurninSubtitleOutlineColor]
+    val WHITE  = "WHITE".asInstanceOf[BurninSubtitleOutlineColor]
+    val YELLOW = "YELLOW".asInstanceOf[BurninSubtitleOutlineColor]
+    val RED    = "RED".asInstanceOf[BurninSubtitleOutlineColor]
+    val GREEN  = "GREEN".asInstanceOf[BurninSubtitleOutlineColor]
+    val BLUE   = "BLUE".asInstanceOf[BurninSubtitleOutlineColor]
 
     val values = js.Object.freeze(js.Array(BLACK, WHITE, YELLOW, RED, GREEN, BLUE))
   }
@@ -1382,10 +1184,12 @@ package mediaconvert {
     * Specifies the color of the shadow cast by the captions.
     * All burn-in and DVB-Sub font settings must match.
     */
-  object BurninSubtitleShadowColorEnum {
-    val NONE  = "NONE"
-    val BLACK = "BLACK"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait BurninSubtitleShadowColor extends js.Any
+  object BurninSubtitleShadowColor extends js.Object {
+    val NONE  = "NONE".asInstanceOf[BurninSubtitleShadowColor]
+    val BLACK = "BLACK".asInstanceOf[BurninSubtitleShadowColor]
+    val WHITE = "WHITE".asInstanceOf[BurninSubtitleShadowColor]
 
     val values = js.Object.freeze(js.Array(NONE, BLACK, WHITE))
   }
@@ -1393,9 +1197,11 @@ package mediaconvert {
   /**
     * Only applies to jobs with input captions in Teletext or STL formats. Specify whether the spacing between letters in your captions is set by the captions grid or varies depending on letter width. Choose fixed grid to conform to the spacing specified in the captions file more accurately. Choose proportional to make the text easier to read if the captions are closed caption.
     */
-  object BurninSubtitleTeletextSpacingEnum {
-    val FIXED_GRID   = "FIXED_GRID"
-    val PROPORTIONAL = "PROPORTIONAL"
+  @js.native
+  sealed trait BurninSubtitleTeletextSpacing extends js.Any
+  object BurninSubtitleTeletextSpacing extends js.Object {
+    val FIXED_GRID   = "FIXED_GRID".asInstanceOf[BurninSubtitleTeletextSpacing]
+    val PROPORTIONAL = "PROPORTIONAL".asInstanceOf[BurninSubtitleTeletextSpacing]
 
     val values = js.Object.freeze(js.Array(FIXED_GRID, PROPORTIONAL))
   }
@@ -1541,19 +1347,21 @@ package mediaconvert {
   /**
     * Specify the format for this set of captions on this output. The default format is embedded without SCTE-20. Other options are embedded with SCTE-20, burn-in, DVB-sub, IMSC, SCC, SRT, teletext, TTML, and web-VTT. If you are using SCTE-20, choose SCTE-20 plus embedded (SCTE20_PLUS_EMBEDDED) to create an output that complies with the SCTE-43 spec. To create a non-compliant output where the embedded captions come first, choose Embedded plus SCTE-20 (EMBEDDED_PLUS_SCTE20).
     */
-  object CaptionDestinationTypeEnum {
-    val BURN_IN              = "BURN_IN"
-    val DVB_SUB              = "DVB_SUB"
-    val EMBEDDED             = "EMBEDDED"
-    val EMBEDDED_PLUS_SCTE20 = "EMBEDDED_PLUS_SCTE20"
-    val IMSC                 = "IMSC"
-    val SCTE20_PLUS_EMBEDDED = "SCTE20_PLUS_EMBEDDED"
-    val SCC                  = "SCC"
-    val SRT                  = "SRT"
-    val SMI                  = "SMI"
-    val TELETEXT             = "TELETEXT"
-    val TTML                 = "TTML"
-    val WEBVTT               = "WEBVTT"
+  @js.native
+  sealed trait CaptionDestinationType extends js.Any
+  object CaptionDestinationType extends js.Object {
+    val BURN_IN              = "BURN_IN".asInstanceOf[CaptionDestinationType]
+    val DVB_SUB              = "DVB_SUB".asInstanceOf[CaptionDestinationType]
+    val EMBEDDED             = "EMBEDDED".asInstanceOf[CaptionDestinationType]
+    val EMBEDDED_PLUS_SCTE20 = "EMBEDDED_PLUS_SCTE20".asInstanceOf[CaptionDestinationType]
+    val IMSC                 = "IMSC".asInstanceOf[CaptionDestinationType]
+    val SCTE20_PLUS_EMBEDDED = "SCTE20_PLUS_EMBEDDED".asInstanceOf[CaptionDestinationType]
+    val SCC                  = "SCC".asInstanceOf[CaptionDestinationType]
+    val SRT                  = "SRT".asInstanceOf[CaptionDestinationType]
+    val SMI                  = "SMI".asInstanceOf[CaptionDestinationType]
+    val TELETEXT             = "TELETEXT".asInstanceOf[CaptionDestinationType]
+    val TTML                 = "TTML".asInstanceOf[CaptionDestinationType]
+    val WEBVTT               = "WEBVTT".asInstanceOf[CaptionDestinationType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1638,19 +1446,21 @@ package mediaconvert {
   /**
     * Use Source (SourceType) to identify the format of your input captions.  The service cannot auto-detect caption format.
     */
-  object CaptionSourceTypeEnum {
-    val ANCILLARY   = "ANCILLARY"
-    val DVB_SUB     = "DVB_SUB"
-    val EMBEDDED    = "EMBEDDED"
-    val SCTE20      = "SCTE20"
-    val SCC         = "SCC"
-    val TTML        = "TTML"
-    val STL         = "STL"
-    val SRT         = "SRT"
-    val SMI         = "SMI"
-    val TELETEXT    = "TELETEXT"
-    val NULL_SOURCE = "NULL_SOURCE"
-    val IMSC        = "IMSC"
+  @js.native
+  sealed trait CaptionSourceType extends js.Any
+  object CaptionSourceType extends js.Object {
+    val ANCILLARY   = "ANCILLARY".asInstanceOf[CaptionSourceType]
+    val DVB_SUB     = "DVB_SUB".asInstanceOf[CaptionSourceType]
+    val EMBEDDED    = "EMBEDDED".asInstanceOf[CaptionSourceType]
+    val SCTE20      = "SCTE20".asInstanceOf[CaptionSourceType]
+    val SCC         = "SCC".asInstanceOf[CaptionSourceType]
+    val TTML        = "TTML".asInstanceOf[CaptionSourceType]
+    val STL         = "STL".asInstanceOf[CaptionSourceType]
+    val SRT         = "SRT".asInstanceOf[CaptionSourceType]
+    val SMI         = "SMI".asInstanceOf[CaptionSourceType]
+    val TELETEXT    = "TELETEXT".asInstanceOf[CaptionSourceType]
+    val NULL_SOURCE = "NULL_SOURCE".asInstanceOf[CaptionSourceType]
+    val IMSC        = "IMSC".asInstanceOf[CaptionSourceType]
 
     val values = js.Object.freeze(
       js.Array(ANCILLARY, DVB_SUB, EMBEDDED, SCTE20, SCC, TTML, STL, SRT, SMI, TELETEXT, NULL_SOURCE, IMSC)
@@ -1701,9 +1511,11 @@ package mediaconvert {
   /**
     * When set to ENABLED, sets #EXT-X-ALLOW-CACHE:no tag, which prevents client from saving media segments for later replay.
     */
-  object CmafClientCacheEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait CmafClientCache extends js.Any
+  object CmafClientCache extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[CmafClientCache]
+    val ENABLED  = "ENABLED".asInstanceOf[CmafClientCache]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -1711,9 +1523,11 @@ package mediaconvert {
   /**
     * Specification to use (RFC-6381 or the default RFC-4281) during m3u8 playlist generation.
     */
-  object CmafCodecSpecificationEnum {
-    val RFC_6381 = "RFC_6381"
-    val RFC_4281 = "RFC_4281"
+  @js.native
+  sealed trait CmafCodecSpecification extends js.Any
+  object CmafCodecSpecification extends js.Object {
+    val RFC_6381 = "RFC_6381".asInstanceOf[CmafCodecSpecification]
+    val RFC_4281 = "RFC_4281".asInstanceOf[CmafCodecSpecification]
 
     val values = js.Object.freeze(js.Array(RFC_6381, RFC_4281))
   }
@@ -1759,9 +1573,11 @@ package mediaconvert {
   /**
     * Specify the encryption scheme that you want the service to use when encrypting your CMAF segments. Choose AES-CBC subsample (SAMPLE-AES) or AES_CTR (AES-CTR).
     */
-  object CmafEncryptionTypeEnum {
-    val SAMPLE_AES = "SAMPLE_AES"
-    val AES_CTR    = "AES_CTR"
+  @js.native
+  sealed trait CmafEncryptionType extends js.Any
+  object CmafEncryptionType extends js.Object {
+    val SAMPLE_AES = "SAMPLE_AES".asInstanceOf[CmafEncryptionType]
+    val AES_CTR    = "AES_CTR".asInstanceOf[CmafEncryptionType]
 
     val values = js.Object.freeze(js.Array(SAMPLE_AES, AES_CTR))
   }
@@ -1844,9 +1660,11 @@ package mediaconvert {
   /**
     * When you use DRM with CMAF outputs, choose whether the service writes the 128-bit encryption initialization vector in the HLS and DASH manifests.
     */
-  object CmafInitializationVectorInManifestEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait CmafInitializationVectorInManifest extends js.Any
+  object CmafInitializationVectorInManifest extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[CmafInitializationVectorInManifest]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[CmafInitializationVectorInManifest]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -1854,9 +1672,11 @@ package mediaconvert {
   /**
     * Specify whether your DRM encryption key is static or from a key provider that follows the SPEKE standard. For more information about SPEKE, see https://docs.aws.amazon.com/speke/latest/documentation/what-is-speke.html.
     */
-  object CmafKeyProviderTypeEnum {
-    val SPEKE      = "SPEKE"
-    val STATIC_KEY = "STATIC_KEY"
+  @js.native
+  sealed trait CmafKeyProviderType extends js.Any
+  object CmafKeyProviderType extends js.Object {
+    val SPEKE      = "SPEKE".asInstanceOf[CmafKeyProviderType]
+    val STATIC_KEY = "STATIC_KEY".asInstanceOf[CmafKeyProviderType]
 
     val values = js.Object.freeze(js.Array(SPEKE, STATIC_KEY))
   }
@@ -1864,9 +1684,11 @@ package mediaconvert {
   /**
     * When set to GZIP, compresses HLS playlist.
     */
-  object CmafManifestCompressionEnum {
-    val GZIP = "GZIP"
-    val NONE = "NONE"
+  @js.native
+  sealed trait CmafManifestCompression extends js.Any
+  object CmafManifestCompression extends js.Object {
+    val GZIP = "GZIP".asInstanceOf[CmafManifestCompression]
+    val NONE = "NONE".asInstanceOf[CmafManifestCompression]
 
     val values = js.Object.freeze(js.Array(GZIP, NONE))
   }
@@ -1874,9 +1696,11 @@ package mediaconvert {
   /**
     * Indicates whether the output manifest should use floating point values for segment duration.
     */
-  object CmafManifestDurationFormatEnum {
-    val FLOATING_POINT = "FLOATING_POINT"
-    val INTEGER        = "INTEGER"
+  @js.native
+  sealed trait CmafManifestDurationFormat extends js.Any
+  object CmafManifestDurationFormat extends js.Object {
+    val FLOATING_POINT = "FLOATING_POINT".asInstanceOf[CmafManifestDurationFormat]
+    val INTEGER        = "INTEGER".asInstanceOf[CmafManifestDurationFormat]
 
     val values = js.Object.freeze(js.Array(FLOATING_POINT, INTEGER))
   }
@@ -1884,9 +1708,11 @@ package mediaconvert {
   /**
     * Specify whether your DASH profile is on-demand or main. When you choose Main profile (MAIN_PROFILE), the service signals  urn:mpeg:dash:profile:isoff-main:2011 in your .mpd DASH manifest. When you choose On-demand (ON_DEMAND_PROFILE), the service signals urn:mpeg:dash:profile:isoff-on-demand:2011 in your .mpd. When you choose On-demand, you must also set the output group setting Segment control (SegmentControl) to Single file (SINGLE_FILE).
     */
-  object CmafMpdProfileEnum {
-    val MAIN_PROFILE      = "MAIN_PROFILE"
-    val ON_DEMAND_PROFILE = "ON_DEMAND_PROFILE"
+  @js.native
+  sealed trait CmafMpdProfile extends js.Any
+  object CmafMpdProfile extends js.Object {
+    val MAIN_PROFILE      = "MAIN_PROFILE".asInstanceOf[CmafMpdProfile]
+    val ON_DEMAND_PROFILE = "ON_DEMAND_PROFILE".asInstanceOf[CmafMpdProfile]
 
     val values = js.Object.freeze(js.Array(MAIN_PROFILE, ON_DEMAND_PROFILE))
   }
@@ -1894,9 +1720,11 @@ package mediaconvert {
   /**
     * When set to SINGLE_FILE, a single output file is generated, which is internally segmented using the Fragment Length and Segment Length. When set to SEGMENTED_FILES, separate segment files will be created.
     */
-  object CmafSegmentControlEnum {
-    val SINGLE_FILE     = "SINGLE_FILE"
-    val SEGMENTED_FILES = "SEGMENTED_FILES"
+  @js.native
+  sealed trait CmafSegmentControl extends js.Any
+  object CmafSegmentControl extends js.Object {
+    val SINGLE_FILE     = "SINGLE_FILE".asInstanceOf[CmafSegmentControl]
+    val SEGMENTED_FILES = "SEGMENTED_FILES".asInstanceOf[CmafSegmentControl]
 
     val values = js.Object.freeze(js.Array(SINGLE_FILE, SEGMENTED_FILES))
   }
@@ -1904,9 +1732,11 @@ package mediaconvert {
   /**
     * Include or exclude RESOLUTION attribute for video in EXT-X-STREAM-INF tag of variant manifest.
     */
-  object CmafStreamInfResolutionEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait CmafStreamInfResolution extends js.Any
+  object CmafStreamInfResolution extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[CmafStreamInfResolution]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[CmafStreamInfResolution]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -1914,9 +1744,11 @@ package mediaconvert {
   /**
     * When set to ENABLED, a DASH MPD manifest will be generated for this output.
     */
-  object CmafWriteDASHManifestEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait CmafWriteDASHManifest extends js.Any
+  object CmafWriteDASHManifest extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[CmafWriteDASHManifest]
+    val ENABLED  = "ENABLED".asInstanceOf[CmafWriteDASHManifest]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -1924,9 +1756,11 @@ package mediaconvert {
   /**
     * When set to ENABLED, an Apple HLS manifest will be generated for this output.
     */
-  object CmafWriteHLSManifestEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait CmafWriteHLSManifest extends js.Any
+  object CmafWriteHLSManifest extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[CmafWriteHLSManifest]
+    val ENABLED  = "ENABLED".asInstanceOf[CmafWriteHLSManifest]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -1934,9 +1768,11 @@ package mediaconvert {
   /**
     * When you enable Precise segment duration in DASH manifests (writeSegmentTimelineInRepresentation), your DASH manifest shows precise segment durations. The segment duration information appears inside the SegmentTimeline element, inside SegmentTemplate at the Representation level. When this feature isn't enabled, the segment durations in your DASH manifest are approximate. The segment duration information appears in the duration attribute of the SegmentTemplate element.
     */
-  object CmafWriteSegmentTimelineInRepresentationEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait CmafWriteSegmentTimelineInRepresentation extends js.Any
+  object CmafWriteSegmentTimelineInRepresentation extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[CmafWriteSegmentTimelineInRepresentation]
+    val DISABLED = "DISABLED".asInstanceOf[CmafWriteSegmentTimelineInRepresentation]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -1944,9 +1780,11 @@ package mediaconvert {
   /**
     * Use this setting only when you specify SCTE-35 markers from ESAM. Choose INSERT to put SCTE-35 markers in this output at the insertion points that you specify in an ESAM XML document. Provide the document in the setting SCC XML (sccXml).
     */
-  object CmfcScte35EsamEnum {
-    val INSERT = "INSERT"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait CmfcScte35Esam extends js.Any
+  object CmfcScte35Esam extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[CmfcScte35Esam]
+    val NONE   = "NONE".asInstanceOf[CmfcScte35Esam]
 
     val values = js.Object.freeze(js.Array(INSERT, NONE))
   }
@@ -1954,9 +1792,11 @@ package mediaconvert {
   /**
     * Ignore this setting unless you have SCTE-35 markers in your input video file. Choose Passthrough (PASSTHROUGH) if you want SCTE-35 markers that appear in your input to also appear in this output. Choose None (NONE) if you don't want those SCTE-35 markers in this output.
     */
-  object CmfcScte35SourceEnum {
-    val PASSTHROUGH = "PASSTHROUGH"
-    val NONE        = "NONE"
+  @js.native
+  sealed trait CmfcScte35Source extends js.Any
+  object CmfcScte35Source extends js.Object {
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[CmfcScte35Source]
+    val NONE        = "NONE".asInstanceOf[CmfcScte35Source]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, NONE))
   }
@@ -2020,9 +1860,11 @@ package mediaconvert {
   /**
     * Choose Insert (INSERT) for this setting to include color metadata in this output. Choose Ignore (IGNORE) to exclude color metadata from this output. If you don't specify a value, the service sets this to Insert by default.
     */
-  object ColorMetadataEnum {
-    val IGNORE = "IGNORE"
-    val INSERT = "INSERT"
+  @js.native
+  sealed trait ColorMetadata extends js.Any
+  object ColorMetadata extends js.Object {
+    val IGNORE = "IGNORE".asInstanceOf[ColorMetadata]
+    val INSERT = "INSERT".asInstanceOf[ColorMetadata]
 
     val values = js.Object.freeze(js.Array(IGNORE, INSERT))
   }
@@ -2030,12 +1872,14 @@ package mediaconvert {
   /**
     * If your input video has accurate color space metadata, or if you don't know about color space, leave this set to the default value Follow (FOLLOW). The service will automatically detect your input color space. If your input video has metadata indicating the wrong color space, specify the accurate color space here. If your input video is HDR 10 and the SMPTE ST 2086 Mastering Display Color Volume static metadata isn't present in your video stream, or if that metadata is present but not accurate, choose Force HDR 10 (FORCE_HDR10) here and specify correct values in the input HDR 10 metadata (Hdr10Metadata) settings. For more information about MediaConvert HDR jobs, see https://docs.aws.amazon.com/console/mediaconvert/hdr.
     */
-  object ColorSpaceEnum {
-    val FOLLOW   = "FOLLOW"
-    val REC_601  = "REC_601"
-    val REC_709  = "REC_709"
-    val HDR10    = "HDR10"
-    val HLG_2020 = "HLG_2020"
+  @js.native
+  sealed trait ColorSpace extends js.Any
+  object ColorSpace extends js.Object {
+    val FOLLOW   = "FOLLOW".asInstanceOf[ColorSpace]
+    val REC_601  = "REC_601".asInstanceOf[ColorSpace]
+    val REC_709  = "REC_709".asInstanceOf[ColorSpace]
+    val HDR10    = "HDR10".asInstanceOf[ColorSpace]
+    val HLG_2020 = "HLG_2020".asInstanceOf[ColorSpace]
 
     val values = js.Object.freeze(js.Array(FOLLOW, REC_601, REC_709, HDR10, HLG_2020))
   }
@@ -2043,12 +1887,14 @@ package mediaconvert {
   /**
     * Specify the color space you want for this output. The service supports conversion between HDR formats, between SDR formats, and from SDR to HDR. The service doesn't support conversion from HDR to SDR. SDR to HDR conversion doesn't upgrade the dynamic range. The converted video has an HDR format, but visually appears the same as an unconverted output.
     */
-  object ColorSpaceConversionEnum {
-    val NONE           = "NONE"
-    val FORCE_601      = "FORCE_601"
-    val FORCE_709      = "FORCE_709"
-    val FORCE_HDR10    = "FORCE_HDR10"
-    val FORCE_HLG_2020 = "FORCE_HLG_2020"
+  @js.native
+  sealed trait ColorSpaceConversion extends js.Any
+  object ColorSpaceConversion extends js.Object {
+    val NONE           = "NONE".asInstanceOf[ColorSpaceConversion]
+    val FORCE_601      = "FORCE_601".asInstanceOf[ColorSpaceConversion]
+    val FORCE_709      = "FORCE_709".asInstanceOf[ColorSpaceConversion]
+    val FORCE_HDR10    = "FORCE_HDR10".asInstanceOf[ColorSpaceConversion]
+    val FORCE_HLG_2020 = "FORCE_HLG_2020".asInstanceOf[ColorSpaceConversion]
 
     val values = js.Object.freeze(js.Array(NONE, FORCE_601, FORCE_709, FORCE_HDR10, FORCE_HLG_2020))
   }
@@ -2056,9 +1902,11 @@ package mediaconvert {
   /**
     * There are two sources for color metadata, the input file and the job input settings Color space (ColorSpace) and HDR master display information settings(Hdr10Metadata). The Color space usage setting determines which takes precedence. Choose Force (FORCE) to use color metadata from the input job settings. If you don't specify values for those settings, the service defaults to using metadata from your input. FALLBACK - Choose Fallback (FALLBACK) to use color metadata from the source when it is present. If there's no color metadata in your input file, the service defaults to using values you specify in the input settings.
     */
-  object ColorSpaceUsageEnum {
-    val FORCE    = "FORCE"
-    val FALLBACK = "FALLBACK"
+  @js.native
+  sealed trait ColorSpaceUsage extends js.Any
+  object ColorSpaceUsage extends js.Object {
+    val FORCE    = "FORCE".asInstanceOf[ColorSpaceUsage]
+    val FALLBACK = "FALLBACK".asInstanceOf[ColorSpaceUsage]
 
     val values = js.Object.freeze(js.Array(FORCE, FALLBACK))
   }
@@ -2066,8 +1914,10 @@ package mediaconvert {
   /**
     * The length of the term of your reserved queue pricing plan commitment.
     */
-  object CommitmentEnum {
-    val ONE_YEAR = "ONE_YEAR"
+  @js.native
+  sealed trait Commitment extends js.Any
+  object Commitment extends js.Object {
+    val ONE_YEAR = "ONE_YEAR".asInstanceOf[Commitment]
 
     val values = js.Object.freeze(js.Array(ONE_YEAR))
   }
@@ -2115,17 +1965,19 @@ package mediaconvert {
   /**
     * Container for this output. Some containers require a container settings object. If not specified, the default object will be created.
     */
-  object ContainerTypeEnum {
-    val F4V  = "F4V"
-    val ISMV = "ISMV"
-    val M2TS = "M2TS"
-    val M3U8 = "M3U8"
-    val CMFC = "CMFC"
-    val MOV  = "MOV"
-    val MP4  = "MP4"
-    val MPD  = "MPD"
-    val MXF  = "MXF"
-    val RAW  = "RAW"
+  @js.native
+  sealed trait ContainerType extends js.Any
+  object ContainerType extends js.Object {
+    val F4V  = "F4V".asInstanceOf[ContainerType]
+    val ISMV = "ISMV".asInstanceOf[ContainerType]
+    val M2TS = "M2TS".asInstanceOf[ContainerType]
+    val M3U8 = "M3U8".asInstanceOf[ContainerType]
+    val CMFC = "CMFC".asInstanceOf[ContainerType]
+    val MOV  = "MOV".asInstanceOf[ContainerType]
+    val MP4  = "MP4".asInstanceOf[ContainerType]
+    val MPD  = "MPD".asInstanceOf[ContainerType]
+    val MXF  = "MXF".asInstanceOf[ContainerType]
+    val RAW  = "RAW".asInstanceOf[ContainerType]
 
     val values = js.Object.freeze(js.Array(F4V, ISMV, M2TS, M3U8, CMFC, MOV, MP4, MPD, MXF, RAW))
   }
@@ -2453,9 +2305,11 @@ package mediaconvert {
   /**
     * Supports HbbTV specification as indicated
     */
-  object DashIsoHbbtvComplianceEnum {
-    val HBBTV_1_5 = "HBBTV_1_5"
-    val NONE      = "NONE"
+  @js.native
+  sealed trait DashIsoHbbtvCompliance extends js.Any
+  object DashIsoHbbtvCompliance extends js.Object {
+    val HBBTV_1_5 = "HBBTV_1_5".asInstanceOf[DashIsoHbbtvCompliance]
+    val NONE      = "NONE".asInstanceOf[DashIsoHbbtvCompliance]
 
     val values = js.Object.freeze(js.Array(HBBTV_1_5, NONE))
   }
@@ -2463,9 +2317,11 @@ package mediaconvert {
   /**
     * Specify whether your DASH profile is on-demand or main. When you choose Main profile (MAIN_PROFILE), the service signals  urn:mpeg:dash:profile:isoff-main:2011 in your .mpd DASH manifest. When you choose On-demand (ON_DEMAND_PROFILE), the service signals urn:mpeg:dash:profile:isoff-on-demand:2011 in your .mpd. When you choose On-demand, you must also set the output group setting Segment control (SegmentControl) to Single file (SINGLE_FILE).
     */
-  object DashIsoMpdProfileEnum {
-    val MAIN_PROFILE      = "MAIN_PROFILE"
-    val ON_DEMAND_PROFILE = "ON_DEMAND_PROFILE"
+  @js.native
+  sealed trait DashIsoMpdProfile extends js.Any
+  object DashIsoMpdProfile extends js.Object {
+    val MAIN_PROFILE      = "MAIN_PROFILE".asInstanceOf[DashIsoMpdProfile]
+    val ON_DEMAND_PROFILE = "ON_DEMAND_PROFILE".asInstanceOf[DashIsoMpdProfile]
 
     val values = js.Object.freeze(js.Array(MAIN_PROFILE, ON_DEMAND_PROFILE))
   }
@@ -2473,9 +2329,11 @@ package mediaconvert {
   /**
     * This setting can improve the compatibility of your output with video players on obsolete devices. It applies only to DASH H.264 outputs with DRM encryption. Choose Unencrypted SEI (UNENCRYPTED_SEI) only to correct problems with playback on older devices. Otherwise, keep the default setting CENC v1 (CENC_V1). If you choose Unencrypted SEI, for that output, the service will exclude the access unit delimiter and will leave the SEI NAL units unencrypted.
     */
-  object DashIsoPlaybackDeviceCompatibilityEnum {
-    val CENC_V1         = "CENC_V1"
-    val UNENCRYPTED_SEI = "UNENCRYPTED_SEI"
+  @js.native
+  sealed trait DashIsoPlaybackDeviceCompatibility extends js.Any
+  object DashIsoPlaybackDeviceCompatibility extends js.Object {
+    val CENC_V1         = "CENC_V1".asInstanceOf[DashIsoPlaybackDeviceCompatibility]
+    val UNENCRYPTED_SEI = "UNENCRYPTED_SEI".asInstanceOf[DashIsoPlaybackDeviceCompatibility]
 
     val values = js.Object.freeze(js.Array(CENC_V1, UNENCRYPTED_SEI))
   }
@@ -2483,9 +2341,11 @@ package mediaconvert {
   /**
     * When set to SINGLE_FILE, a single output file is generated, which is internally segmented using the Fragment Length and Segment Length. When set to SEGMENTED_FILES, separate segment files will be created.
     */
-  object DashIsoSegmentControlEnum {
-    val SINGLE_FILE     = "SINGLE_FILE"
-    val SEGMENTED_FILES = "SEGMENTED_FILES"
+  @js.native
+  sealed trait DashIsoSegmentControl extends js.Any
+  object DashIsoSegmentControl extends js.Object {
+    val SINGLE_FILE     = "SINGLE_FILE".asInstanceOf[DashIsoSegmentControl]
+    val SEGMENTED_FILES = "SEGMENTED_FILES".asInstanceOf[DashIsoSegmentControl]
 
     val values = js.Object.freeze(js.Array(SINGLE_FILE, SEGMENTED_FILES))
   }
@@ -2493,9 +2353,11 @@ package mediaconvert {
   /**
     * When you enable Precise segment duration in manifests (writeSegmentTimelineInRepresentation), your DASH manifest shows precise segment durations. The segment duration information appears inside the SegmentTimeline element, inside SegmentTemplate at the Representation level. When this feature isn't enabled, the segment durations in your DASH manifest are approximate. The segment duration information appears in the duration attribute of the SegmentTemplate element.
     */
-  object DashIsoWriteSegmentTimelineInRepresentationEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait DashIsoWriteSegmentTimelineInRepresentation extends js.Any
+  object DashIsoWriteSegmentTimelineInRepresentation extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[DashIsoWriteSegmentTimelineInRepresentation]
+    val DISABLED = "DISABLED".asInstanceOf[DashIsoWriteSegmentTimelineInRepresentation]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -2503,10 +2365,12 @@ package mediaconvert {
   /**
     * Specify the encryption mode that you used to encrypt your input files.
     */
-  object DecryptionModeEnum {
-    val AES_CTR = "AES_CTR"
-    val AES_CBC = "AES_CBC"
-    val AES_GCM = "AES_GCM"
+  @js.native
+  sealed trait DecryptionMode extends js.Any
+  object DecryptionMode extends js.Object {
+    val AES_CTR = "AES_CTR".asInstanceOf[DecryptionMode]
+    val AES_CBC = "AES_CBC".asInstanceOf[DecryptionMode]
+    val AES_GCM = "AES_GCM".asInstanceOf[DecryptionMode]
 
     val values = js.Object.freeze(js.Array(AES_CTR, AES_CBC, AES_GCM))
   }
@@ -2514,11 +2378,13 @@ package mediaconvert {
   /**
     * Only applies when you set Deinterlacer (DeinterlaceMode) to Deinterlace (DEINTERLACE) or Adaptive (ADAPTIVE). Motion adaptive interpolate (INTERPOLATE) produces sharper pictures, while blend (BLEND) produces smoother motion. Use (INTERPOLATE_TICKER) OR (BLEND_TICKER) if your source file includes a ticker, such as a scrolling headline at the bottom of the frame.
     */
-  object DeinterlaceAlgorithmEnum {
-    val INTERPOLATE        = "INTERPOLATE"
-    val INTERPOLATE_TICKER = "INTERPOLATE_TICKER"
-    val BLEND              = "BLEND"
-    val BLEND_TICKER       = "BLEND_TICKER"
+  @js.native
+  sealed trait DeinterlaceAlgorithm extends js.Any
+  object DeinterlaceAlgorithm extends js.Object {
+    val INTERPOLATE        = "INTERPOLATE".asInstanceOf[DeinterlaceAlgorithm]
+    val INTERPOLATE_TICKER = "INTERPOLATE_TICKER".asInstanceOf[DeinterlaceAlgorithm]
+    val BLEND              = "BLEND".asInstanceOf[DeinterlaceAlgorithm]
+    val BLEND_TICKER       = "BLEND_TICKER".asInstanceOf[DeinterlaceAlgorithm]
 
     val values = js.Object.freeze(js.Array(INTERPOLATE, INTERPOLATE_TICKER, BLEND, BLEND_TICKER))
   }
@@ -2551,9 +2417,11 @@ package mediaconvert {
   /**
     * - When set to NORMAL (default), the deinterlacer does not convert frames that are tagged  in metadata as progressive. It will only convert those that are tagged as some other type. - When set to FORCE_ALL_FRAMES, the deinterlacer converts every frame to progressive - even those that are already tagged as progressive. Turn Force mode on only if there is  a good chance that the metadata has tagged frames as progressive when they are not  progressive. Do not turn on otherwise; processing frames that are already progressive  into progressive will probably result in lower quality video.
     */
-  object DeinterlacerControlEnum {
-    val FORCE_ALL_FRAMES = "FORCE_ALL_FRAMES"
-    val NORMAL           = "NORMAL"
+  @js.native
+  sealed trait DeinterlacerControl extends js.Any
+  object DeinterlacerControl extends js.Object {
+    val FORCE_ALL_FRAMES = "FORCE_ALL_FRAMES".asInstanceOf[DeinterlacerControl]
+    val NORMAL           = "NORMAL".asInstanceOf[DeinterlacerControl]
 
     val values = js.Object.freeze(js.Array(FORCE_ALL_FRAMES, NORMAL))
   }
@@ -2561,10 +2429,12 @@ package mediaconvert {
   /**
     * Use Deinterlacer (DeinterlaceMode) to choose how the service will do deinterlacing. Default is Deinterlace. - Deinterlace converts interlaced to progressive. - Inverse telecine converts Hard Telecine 29.97i to progressive 23.976p. - Adaptive auto-detects and converts to progressive.
     */
-  object DeinterlacerModeEnum {
-    val DEINTERLACE      = "DEINTERLACE"
-    val INVERSE_TELECINE = "INVERSE_TELECINE"
-    val ADAPTIVE         = "ADAPTIVE"
+  @js.native
+  sealed trait DeinterlacerMode extends js.Any
+  object DeinterlacerMode extends js.Object {
+    val DEINTERLACE      = "DEINTERLACE".asInstanceOf[DeinterlacerMode]
+    val INVERSE_TELECINE = "INVERSE_TELECINE".asInstanceOf[DeinterlacerMode]
+    val ADAPTIVE         = "ADAPTIVE".asInstanceOf[DeinterlacerMode]
 
     val values = js.Object.freeze(js.Array(DEINTERLACE, INVERSE_TELECINE, ADAPTIVE))
   }
@@ -2665,9 +2535,11 @@ package mediaconvert {
   /**
     * Optional field, defaults to DEFAULT. Specify DEFAULT for this operation to return your endpoints if any exist, or to create an endpoint for you and return it if one doesn't already exist. Specify GET_ONLY to return your endpoints if any exist, or an empty list if none exist.
     */
-  object DescribeEndpointsModeEnum {
-    val DEFAULT  = "DEFAULT"
-    val GET_ONLY = "GET_ONLY"
+  @js.native
+  sealed trait DescribeEndpointsMode extends js.Any
+  object DescribeEndpointsMode extends js.Object {
+    val DEFAULT  = "DEFAULT".asInstanceOf[DescribeEndpointsMode]
+    val GET_ONLY = "GET_ONLY".asInstanceOf[DescribeEndpointsMode]
 
     val values = js.Object.freeze(js.Array(DEFAULT, GET_ONLY))
   }
@@ -2816,10 +2688,12 @@ package mediaconvert {
   /**
     * Use Dolby Vision Mode to choose how the service will handle Dolby Vision MaxCLL and MaxFALL properies.
     */
-  object DolbyVisionLevel6ModeEnum {
-    val PASSTHROUGH = "PASSTHROUGH"
-    val RECALCULATE = "RECALCULATE"
-    val SPECIFY     = "SPECIFY"
+  @js.native
+  sealed trait DolbyVisionLevel6Mode extends js.Any
+  object DolbyVisionLevel6Mode extends js.Object {
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[DolbyVisionLevel6Mode]
+    val RECALCULATE = "RECALCULATE".asInstanceOf[DolbyVisionLevel6Mode]
+    val SPECIFY     = "SPECIFY".asInstanceOf[DolbyVisionLevel6Mode]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, RECALCULATE, SPECIFY))
   }
@@ -2827,8 +2701,10 @@ package mediaconvert {
   /**
     * In the current MediaConvert implementation, the Dolby Vision profile is always 5 (PROFILE_5). Therefore, all of your inputs must contain Dolby Vision frame interleaved data.
     */
-  object DolbyVisionProfileEnum {
-    val PROFILE_5 = "PROFILE_5"
+  @js.native
+  sealed trait DolbyVisionProfile extends js.Any
+  object DolbyVisionProfile extends js.Object {
+    val PROFILE_5 = "PROFILE_5".asInstanceOf[DolbyVisionProfile]
 
     val values = js.Object.freeze(js.Array(PROFILE_5))
   }
@@ -2836,9 +2712,11 @@ package mediaconvert {
   /**
     * Applies only to 29.97 fps outputs. When this feature is enabled, the service will use drop-frame timecode on outputs. If it is not possible to use drop-frame timecode, the system will fall back to non-drop-frame. This setting is enabled by default when Timecode insertion (TimecodeInsertion) is enabled.
     */
-  object DropFrameTimecodeEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait DropFrameTimecode extends js.Any
+  object DropFrameTimecode extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[DropFrameTimecode]
+    val ENABLED  = "ENABLED".asInstanceOf[DropFrameTimecode]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -2988,9 +2866,11 @@ package mediaconvert {
   /**
     * If no explicit x_position or y_position is provided, setting alignment to centered will place the captions at the bottom center of the output. Similarly, setting a left alignment will align captions to the bottom left of the output. If x and y positions are given in conjunction with the alignment parameter, the font will be justified (either left or centered) relative to those coordinates. This option is not valid for source captions that are STL, 608/embedded or teletext. These source settings are already pre-defined by the caption stream. All burn-in and DVB-Sub font settings must match.
     */
-  object DvbSubtitleAlignmentEnum {
-    val CENTERED = "CENTERED"
-    val LEFT     = "LEFT"
+  @js.native
+  sealed trait DvbSubtitleAlignment extends js.Any
+  object DvbSubtitleAlignment extends js.Object {
+    val CENTERED = "CENTERED".asInstanceOf[DvbSubtitleAlignment]
+    val LEFT     = "LEFT".asInstanceOf[DvbSubtitleAlignment]
 
     val values = js.Object.freeze(js.Array(CENTERED, LEFT))
   }
@@ -2999,10 +2879,12 @@ package mediaconvert {
     * Specifies the color of the rectangle behind the captions.
     * All burn-in and DVB-Sub font settings must match.
     */
-  object DvbSubtitleBackgroundColorEnum {
-    val NONE  = "NONE"
-    val BLACK = "BLACK"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait DvbSubtitleBackgroundColor extends js.Any
+  object DvbSubtitleBackgroundColor extends js.Object {
+    val NONE  = "NONE".asInstanceOf[DvbSubtitleBackgroundColor]
+    val BLACK = "BLACK".asInstanceOf[DvbSubtitleBackgroundColor]
+    val WHITE = "WHITE".asInstanceOf[DvbSubtitleBackgroundColor]
 
     val values = js.Object.freeze(js.Array(NONE, BLACK, WHITE))
   }
@@ -3010,13 +2892,15 @@ package mediaconvert {
   /**
     * Specifies the color of the burned-in captions. This option is not valid for source captions that are STL, 608/embedded or teletext. These source settings are already pre-defined by the caption stream. All burn-in and DVB-Sub font settings must match.
     */
-  object DvbSubtitleFontColorEnum {
-    val WHITE  = "WHITE"
-    val BLACK  = "BLACK"
-    val YELLOW = "YELLOW"
-    val RED    = "RED"
-    val GREEN  = "GREEN"
-    val BLUE   = "BLUE"
+  @js.native
+  sealed trait DvbSubtitleFontColor extends js.Any
+  object DvbSubtitleFontColor extends js.Object {
+    val WHITE  = "WHITE".asInstanceOf[DvbSubtitleFontColor]
+    val BLACK  = "BLACK".asInstanceOf[DvbSubtitleFontColor]
+    val YELLOW = "YELLOW".asInstanceOf[DvbSubtitleFontColor]
+    val RED    = "RED".asInstanceOf[DvbSubtitleFontColor]
+    val GREEN  = "GREEN".asInstanceOf[DvbSubtitleFontColor]
+    val BLUE   = "BLUE".asInstanceOf[DvbSubtitleFontColor]
 
     val values = js.Object.freeze(js.Array(WHITE, BLACK, YELLOW, RED, GREEN, BLUE))
   }
@@ -3024,13 +2908,15 @@ package mediaconvert {
   /**
     * Specifies font outline color. This option is not valid for source captions that are either 608/embedded or teletext. These source settings are already pre-defined by the caption stream. All burn-in and DVB-Sub font settings must match.
     */
-  object DvbSubtitleOutlineColorEnum {
-    val BLACK  = "BLACK"
-    val WHITE  = "WHITE"
-    val YELLOW = "YELLOW"
-    val RED    = "RED"
-    val GREEN  = "GREEN"
-    val BLUE   = "BLUE"
+  @js.native
+  sealed trait DvbSubtitleOutlineColor extends js.Any
+  object DvbSubtitleOutlineColor extends js.Object {
+    val BLACK  = "BLACK".asInstanceOf[DvbSubtitleOutlineColor]
+    val WHITE  = "WHITE".asInstanceOf[DvbSubtitleOutlineColor]
+    val YELLOW = "YELLOW".asInstanceOf[DvbSubtitleOutlineColor]
+    val RED    = "RED".asInstanceOf[DvbSubtitleOutlineColor]
+    val GREEN  = "GREEN".asInstanceOf[DvbSubtitleOutlineColor]
+    val BLUE   = "BLUE".asInstanceOf[DvbSubtitleOutlineColor]
 
     val values = js.Object.freeze(js.Array(BLACK, WHITE, YELLOW, RED, GREEN, BLUE))
   }
@@ -3039,10 +2925,12 @@ package mediaconvert {
     * Specifies the color of the shadow cast by the captions.
     * All burn-in and DVB-Sub font settings must match.
     */
-  object DvbSubtitleShadowColorEnum {
-    val NONE  = "NONE"
-    val BLACK = "BLACK"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait DvbSubtitleShadowColor extends js.Any
+  object DvbSubtitleShadowColor extends js.Object {
+    val NONE  = "NONE".asInstanceOf[DvbSubtitleShadowColor]
+    val BLACK = "BLACK".asInstanceOf[DvbSubtitleShadowColor]
+    val WHITE = "WHITE".asInstanceOf[DvbSubtitleShadowColor]
 
     val values = js.Object.freeze(js.Array(NONE, BLACK, WHITE))
   }
@@ -3050,9 +2938,11 @@ package mediaconvert {
   /**
     * Only applies to jobs with input captions in Teletext or STL formats. Specify whether the spacing between letters in your captions is set by the captions grid or varies depending on letter width. Choose fixed grid to conform to the spacing specified in the captions file more accurately. Choose proportional to make the text easier to read if the captions are closed caption.
     */
-  object DvbSubtitleTeletextSpacingEnum {
-    val FIXED_GRID   = "FIXED_GRID"
-    val PROPORTIONAL = "PROPORTIONAL"
+  @js.native
+  sealed trait DvbSubtitleTeletextSpacing extends js.Any
+  object DvbSubtitleTeletextSpacing extends js.Object {
+    val FIXED_GRID   = "FIXED_GRID".asInstanceOf[DvbSubtitleTeletextSpacing]
+    val PROPORTIONAL = "PROPORTIONAL".asInstanceOf[DvbSubtitleTeletextSpacing]
 
     val values = js.Object.freeze(js.Array(FIXED_GRID, PROPORTIONAL))
   }
@@ -3060,9 +2950,11 @@ package mediaconvert {
   /**
     * Specify whether your DVB subtitles are standard or for hearing impaired. Choose hearing impaired if your subtitles include audio descriptions and dialogue. Choose standard if your subtitles include only dialogue.
     */
-  object DvbSubtitlingTypeEnum {
-    val HEARING_IMPAIRED = "HEARING_IMPAIRED"
-    val STANDARD         = "STANDARD"
+  @js.native
+  sealed trait DvbSubtitlingType extends js.Any
+  object DvbSubtitlingType extends js.Object {
+    val HEARING_IMPAIRED = "HEARING_IMPAIRED".asInstanceOf[DvbSubtitlingType]
+    val STANDARD         = "STANDARD".asInstanceOf[DvbSubtitlingType]
 
     val values = js.Object.freeze(js.Array(HEARING_IMPAIRED, STANDARD))
   }
@@ -3089,8 +2981,10 @@ package mediaconvert {
   /**
     * Specify the bitstream mode for the E-AC-3 stream that the encoder emits. For more information about the EAC3 bitstream mode, see ATSC A/52-2012 (Annex E).
     */
-  object Eac3AtmosBitstreamModeEnum {
-    val COMPLETE_MAIN = "COMPLETE_MAIN"
+  @js.native
+  sealed trait Eac3AtmosBitstreamMode extends js.Any
+  object Eac3AtmosBitstreamMode extends js.Object {
+    val COMPLETE_MAIN = "COMPLETE_MAIN".asInstanceOf[Eac3AtmosBitstreamMode]
 
     val values = js.Object.freeze(js.Array(COMPLETE_MAIN))
   }
@@ -3098,8 +2992,10 @@ package mediaconvert {
   /**
     * The coding mode for Dolby Digital Plus JOC (Atmos) is always 9.1.6 (CODING_MODE_9_1_6).
     */
-  object Eac3AtmosCodingModeEnum {
-    val CODING_MODE_9_1_6 = "CODING_MODE_9_1_6"
+  @js.native
+  sealed trait Eac3AtmosCodingMode extends js.Any
+  object Eac3AtmosCodingMode extends js.Object {
+    val CODING_MODE_9_1_6 = "CODING_MODE_9_1_6".asInstanceOf[Eac3AtmosCodingMode]
 
     val values = js.Object.freeze(js.Array(CODING_MODE_9_1_6))
   }
@@ -3107,9 +3003,11 @@ package mediaconvert {
   /**
     * Enable Dolby Dialogue Intelligence to adjust loudness based on dialogue analysis.
     */
-  object Eac3AtmosDialogueIntelligenceEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait Eac3AtmosDialogueIntelligence extends js.Any
+  object Eac3AtmosDialogueIntelligence extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[Eac3AtmosDialogueIntelligence]
+    val DISABLED = "DISABLED".asInstanceOf[Eac3AtmosDialogueIntelligence]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -3117,13 +3015,15 @@ package mediaconvert {
   /**
     * Specify the absolute peak level for a signal with dynamic range compression.
     */
-  object Eac3AtmosDynamicRangeCompressionLineEnum {
-    val NONE           = "NONE"
-    val FILM_STANDARD  = "FILM_STANDARD"
-    val FILM_LIGHT     = "FILM_LIGHT"
-    val MUSIC_STANDARD = "MUSIC_STANDARD"
-    val MUSIC_LIGHT    = "MUSIC_LIGHT"
-    val SPEECH         = "SPEECH"
+  @js.native
+  sealed trait Eac3AtmosDynamicRangeCompressionLine extends js.Any
+  object Eac3AtmosDynamicRangeCompressionLine extends js.Object {
+    val NONE           = "NONE".asInstanceOf[Eac3AtmosDynamicRangeCompressionLine]
+    val FILM_STANDARD  = "FILM_STANDARD".asInstanceOf[Eac3AtmosDynamicRangeCompressionLine]
+    val FILM_LIGHT     = "FILM_LIGHT".asInstanceOf[Eac3AtmosDynamicRangeCompressionLine]
+    val MUSIC_STANDARD = "MUSIC_STANDARD".asInstanceOf[Eac3AtmosDynamicRangeCompressionLine]
+    val MUSIC_LIGHT    = "MUSIC_LIGHT".asInstanceOf[Eac3AtmosDynamicRangeCompressionLine]
+    val SPEECH         = "SPEECH".asInstanceOf[Eac3AtmosDynamicRangeCompressionLine]
 
     val values = js.Object.freeze(js.Array(NONE, FILM_STANDARD, FILM_LIGHT, MUSIC_STANDARD, MUSIC_LIGHT, SPEECH))
   }
@@ -3131,13 +3031,15 @@ package mediaconvert {
   /**
     * Specify how the service limits the audio dynamic range when compressing the audio.
     */
-  object Eac3AtmosDynamicRangeCompressionRfEnum {
-    val NONE           = "NONE"
-    val FILM_STANDARD  = "FILM_STANDARD"
-    val FILM_LIGHT     = "FILM_LIGHT"
-    val MUSIC_STANDARD = "MUSIC_STANDARD"
-    val MUSIC_LIGHT    = "MUSIC_LIGHT"
-    val SPEECH         = "SPEECH"
+  @js.native
+  sealed trait Eac3AtmosDynamicRangeCompressionRf extends js.Any
+  object Eac3AtmosDynamicRangeCompressionRf extends js.Object {
+    val NONE           = "NONE".asInstanceOf[Eac3AtmosDynamicRangeCompressionRf]
+    val FILM_STANDARD  = "FILM_STANDARD".asInstanceOf[Eac3AtmosDynamicRangeCompressionRf]
+    val FILM_LIGHT     = "FILM_LIGHT".asInstanceOf[Eac3AtmosDynamicRangeCompressionRf]
+    val MUSIC_STANDARD = "MUSIC_STANDARD".asInstanceOf[Eac3AtmosDynamicRangeCompressionRf]
+    val MUSIC_LIGHT    = "MUSIC_LIGHT".asInstanceOf[Eac3AtmosDynamicRangeCompressionRf]
+    val SPEECH         = "SPEECH".asInstanceOf[Eac3AtmosDynamicRangeCompressionRf]
 
     val values = js.Object.freeze(js.Array(NONE, FILM_STANDARD, FILM_LIGHT, MUSIC_STANDARD, MUSIC_LIGHT, SPEECH))
   }
@@ -3145,12 +3047,14 @@ package mediaconvert {
   /**
     * Choose how the service meters the loudness of your audio.
     */
-  object Eac3AtmosMeteringModeEnum {
-    val LEQ_A         = "LEQ_A"
-    val ITU_BS_1770_1 = "ITU_BS_1770_1"
-    val ITU_BS_1770_2 = "ITU_BS_1770_2"
-    val ITU_BS_1770_3 = "ITU_BS_1770_3"
-    val ITU_BS_1770_4 = "ITU_BS_1770_4"
+  @js.native
+  sealed trait Eac3AtmosMeteringMode extends js.Any
+  object Eac3AtmosMeteringMode extends js.Object {
+    val LEQ_A         = "LEQ_A".asInstanceOf[Eac3AtmosMeteringMode]
+    val ITU_BS_1770_1 = "ITU_BS_1770_1".asInstanceOf[Eac3AtmosMeteringMode]
+    val ITU_BS_1770_2 = "ITU_BS_1770_2".asInstanceOf[Eac3AtmosMeteringMode]
+    val ITU_BS_1770_3 = "ITU_BS_1770_3".asInstanceOf[Eac3AtmosMeteringMode]
+    val ITU_BS_1770_4 = "ITU_BS_1770_4".asInstanceOf[Eac3AtmosMeteringMode]
 
     val values = js.Object.freeze(js.Array(LEQ_A, ITU_BS_1770_1, ITU_BS_1770_2, ITU_BS_1770_3, ITU_BS_1770_4))
   }
@@ -3223,11 +3127,13 @@ package mediaconvert {
   /**
     * Choose how the service does stereo downmixing.
     */
-  object Eac3AtmosStereoDownmixEnum {
-    val NOT_INDICATED = "NOT_INDICATED"
-    val STEREO        = "STEREO"
-    val SURROUND      = "SURROUND"
-    val DPL2          = "DPL2"
+  @js.native
+  sealed trait Eac3AtmosStereoDownmix extends js.Any
+  object Eac3AtmosStereoDownmix extends js.Object {
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3AtmosStereoDownmix]
+    val STEREO        = "STEREO".asInstanceOf[Eac3AtmosStereoDownmix]
+    val SURROUND      = "SURROUND".asInstanceOf[Eac3AtmosStereoDownmix]
+    val DPL2          = "DPL2".asInstanceOf[Eac3AtmosStereoDownmix]
 
     val values = js.Object.freeze(js.Array(NOT_INDICATED, STEREO, SURROUND, DPL2))
   }
@@ -3235,10 +3141,12 @@ package mediaconvert {
   /**
     * Specify whether your input audio has an additional center rear surround channel matrix encoded into your left and right surround channels.
     */
-  object Eac3AtmosSurroundExModeEnum {
-    val NOT_INDICATED = "NOT_INDICATED"
-    val ENABLED       = "ENABLED"
-    val DISABLED      = "DISABLED"
+  @js.native
+  sealed trait Eac3AtmosSurroundExMode extends js.Any
+  object Eac3AtmosSurroundExMode extends js.Object {
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3AtmosSurroundExMode]
+    val ENABLED       = "ENABLED".asInstanceOf[Eac3AtmosSurroundExMode]
+    val DISABLED      = "DISABLED".asInstanceOf[Eac3AtmosSurroundExMode]
 
     val values = js.Object.freeze(js.Array(NOT_INDICATED, ENABLED, DISABLED))
   }
@@ -3246,9 +3154,11 @@ package mediaconvert {
   /**
     * If set to ATTENUATE_3_DB, applies a 3 dB attenuation to the surround channels. Only used for 3/2 coding mode.
     */
-  object Eac3AttenuationControlEnum {
-    val ATTENUATE_3_DB = "ATTENUATE_3_DB"
-    val NONE           = "NONE"
+  @js.native
+  sealed trait Eac3AttenuationControl extends js.Any
+  object Eac3AttenuationControl extends js.Object {
+    val ATTENUATE_3_DB = "ATTENUATE_3_DB".asInstanceOf[Eac3AttenuationControl]
+    val NONE           = "NONE".asInstanceOf[Eac3AttenuationControl]
 
     val values = js.Object.freeze(js.Array(ATTENUATE_3_DB, NONE))
   }
@@ -3256,12 +3166,14 @@ package mediaconvert {
   /**
     * Specify the bitstream mode for the E-AC-3 stream that the encoder emits. For more information about the EAC3 bitstream mode, see ATSC A/52-2012 (Annex E).
     */
-  object Eac3BitstreamModeEnum {
-    val COMPLETE_MAIN     = "COMPLETE_MAIN"
-    val COMMENTARY        = "COMMENTARY"
-    val EMERGENCY         = "EMERGENCY"
-    val HEARING_IMPAIRED  = "HEARING_IMPAIRED"
-    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED"
+  @js.native
+  sealed trait Eac3BitstreamMode extends js.Any
+  object Eac3BitstreamMode extends js.Object {
+    val COMPLETE_MAIN     = "COMPLETE_MAIN".asInstanceOf[Eac3BitstreamMode]
+    val COMMENTARY        = "COMMENTARY".asInstanceOf[Eac3BitstreamMode]
+    val EMERGENCY         = "EMERGENCY".asInstanceOf[Eac3BitstreamMode]
+    val HEARING_IMPAIRED  = "HEARING_IMPAIRED".asInstanceOf[Eac3BitstreamMode]
+    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED".asInstanceOf[Eac3BitstreamMode]
 
     val values = js.Object.freeze(js.Array(COMPLETE_MAIN, COMMENTARY, EMERGENCY, HEARING_IMPAIRED, VISUALLY_IMPAIRED))
   }
@@ -3269,10 +3181,12 @@ package mediaconvert {
   /**
     * Dolby Digital Plus coding mode. Determines number of channels.
     */
-  object Eac3CodingModeEnum {
-    val CODING_MODE_1_0 = "CODING_MODE_1_0"
-    val CODING_MODE_2_0 = "CODING_MODE_2_0"
-    val CODING_MODE_3_2 = "CODING_MODE_3_2"
+  @js.native
+  sealed trait Eac3CodingMode extends js.Any
+  object Eac3CodingMode extends js.Object {
+    val CODING_MODE_1_0 = "CODING_MODE_1_0".asInstanceOf[Eac3CodingMode]
+    val CODING_MODE_2_0 = "CODING_MODE_2_0".asInstanceOf[Eac3CodingMode]
+    val CODING_MODE_3_2 = "CODING_MODE_3_2".asInstanceOf[Eac3CodingMode]
 
     val values = js.Object.freeze(js.Array(CODING_MODE_1_0, CODING_MODE_2_0, CODING_MODE_3_2))
   }
@@ -3280,9 +3194,11 @@ package mediaconvert {
   /**
     * Activates a DC highpass filter for all input channels.
     */
-  object Eac3DcFilterEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait Eac3DcFilter extends js.Any
+  object Eac3DcFilter extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[Eac3DcFilter]
+    val DISABLED = "DISABLED".asInstanceOf[Eac3DcFilter]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -3290,13 +3206,15 @@ package mediaconvert {
   /**
     * Specify the absolute peak level for a signal with dynamic range compression.
     */
-  object Eac3DynamicRangeCompressionLineEnum {
-    val NONE           = "NONE"
-    val FILM_STANDARD  = "FILM_STANDARD"
-    val FILM_LIGHT     = "FILM_LIGHT"
-    val MUSIC_STANDARD = "MUSIC_STANDARD"
-    val MUSIC_LIGHT    = "MUSIC_LIGHT"
-    val SPEECH         = "SPEECH"
+  @js.native
+  sealed trait Eac3DynamicRangeCompressionLine extends js.Any
+  object Eac3DynamicRangeCompressionLine extends js.Object {
+    val NONE           = "NONE".asInstanceOf[Eac3DynamicRangeCompressionLine]
+    val FILM_STANDARD  = "FILM_STANDARD".asInstanceOf[Eac3DynamicRangeCompressionLine]
+    val FILM_LIGHT     = "FILM_LIGHT".asInstanceOf[Eac3DynamicRangeCompressionLine]
+    val MUSIC_STANDARD = "MUSIC_STANDARD".asInstanceOf[Eac3DynamicRangeCompressionLine]
+    val MUSIC_LIGHT    = "MUSIC_LIGHT".asInstanceOf[Eac3DynamicRangeCompressionLine]
+    val SPEECH         = "SPEECH".asInstanceOf[Eac3DynamicRangeCompressionLine]
 
     val values = js.Object.freeze(js.Array(NONE, FILM_STANDARD, FILM_LIGHT, MUSIC_STANDARD, MUSIC_LIGHT, SPEECH))
   }
@@ -3304,13 +3222,15 @@ package mediaconvert {
   /**
     * Specify how the service limits the audio dynamic range when compressing the audio.
     */
-  object Eac3DynamicRangeCompressionRfEnum {
-    val NONE           = "NONE"
-    val FILM_STANDARD  = "FILM_STANDARD"
-    val FILM_LIGHT     = "FILM_LIGHT"
-    val MUSIC_STANDARD = "MUSIC_STANDARD"
-    val MUSIC_LIGHT    = "MUSIC_LIGHT"
-    val SPEECH         = "SPEECH"
+  @js.native
+  sealed trait Eac3DynamicRangeCompressionRf extends js.Any
+  object Eac3DynamicRangeCompressionRf extends js.Object {
+    val NONE           = "NONE".asInstanceOf[Eac3DynamicRangeCompressionRf]
+    val FILM_STANDARD  = "FILM_STANDARD".asInstanceOf[Eac3DynamicRangeCompressionRf]
+    val FILM_LIGHT     = "FILM_LIGHT".asInstanceOf[Eac3DynamicRangeCompressionRf]
+    val MUSIC_STANDARD = "MUSIC_STANDARD".asInstanceOf[Eac3DynamicRangeCompressionRf]
+    val MUSIC_LIGHT    = "MUSIC_LIGHT".asInstanceOf[Eac3DynamicRangeCompressionRf]
+    val SPEECH         = "SPEECH".asInstanceOf[Eac3DynamicRangeCompressionRf]
 
     val values = js.Object.freeze(js.Array(NONE, FILM_STANDARD, FILM_LIGHT, MUSIC_STANDARD, MUSIC_LIGHT, SPEECH))
   }
@@ -3318,9 +3238,11 @@ package mediaconvert {
   /**
     * When encoding 3/2 audio, controls whether the LFE channel is enabled
     */
-  object Eac3LfeControlEnum {
-    val LFE    = "LFE"
-    val NO_LFE = "NO_LFE"
+  @js.native
+  sealed trait Eac3LfeControl extends js.Any
+  object Eac3LfeControl extends js.Object {
+    val LFE    = "LFE".asInstanceOf[Eac3LfeControl]
+    val NO_LFE = "NO_LFE".asInstanceOf[Eac3LfeControl]
 
     val values = js.Object.freeze(js.Array(LFE, NO_LFE))
   }
@@ -3328,9 +3250,11 @@ package mediaconvert {
   /**
     * Applies a 120Hz lowpass filter to the LFE channel prior to encoding. Only valid with 3_2_LFE coding mode.
     */
-  object Eac3LfeFilterEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait Eac3LfeFilter extends js.Any
+  object Eac3LfeFilter extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[Eac3LfeFilter]
+    val DISABLED = "DISABLED".asInstanceOf[Eac3LfeFilter]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -3338,9 +3262,11 @@ package mediaconvert {
   /**
     * When set to FOLLOW_INPUT, encoder metadata will be sourced from the DD, DD+, or DolbyE decoder that supplied this audio data. If audio was not supplied from one of these streams, then the static metadata settings will be used.
     */
-  object Eac3MetadataControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait Eac3MetadataControl extends js.Any
+  object Eac3MetadataControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[Eac3MetadataControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[Eac3MetadataControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -3348,9 +3274,11 @@ package mediaconvert {
   /**
     * When set to WHEN_POSSIBLE, input DD+ audio will be passed through if it is present on the input. this detection is dynamic over the life of the transcode. Inputs that alternate between DD+ and non-DD+ content will have a consistent DD+ output as the system alternates between passthrough and encoding.
     */
-  object Eac3PassthroughControlEnum {
-    val WHEN_POSSIBLE  = "WHEN_POSSIBLE"
-    val NO_PASSTHROUGH = "NO_PASSTHROUGH"
+  @js.native
+  sealed trait Eac3PassthroughControl extends js.Any
+  object Eac3PassthroughControl extends js.Object {
+    val WHEN_POSSIBLE  = "WHEN_POSSIBLE".asInstanceOf[Eac3PassthroughControl]
+    val NO_PASSTHROUGH = "NO_PASSTHROUGH".asInstanceOf[Eac3PassthroughControl]
 
     val values = js.Object.freeze(js.Array(WHEN_POSSIBLE, NO_PASSTHROUGH))
   }
@@ -3358,9 +3286,11 @@ package mediaconvert {
   /**
     * Controls the amount of phase-shift applied to the surround channels. Only used for 3/2 coding mode.
     */
-  object Eac3PhaseControlEnum {
-    val SHIFT_90_DEGREES = "SHIFT_90_DEGREES"
-    val NO_SHIFT         = "NO_SHIFT"
+  @js.native
+  sealed trait Eac3PhaseControl extends js.Any
+  object Eac3PhaseControl extends js.Object {
+    val SHIFT_90_DEGREES = "SHIFT_90_DEGREES".asInstanceOf[Eac3PhaseControl]
+    val NO_SHIFT         = "NO_SHIFT".asInstanceOf[Eac3PhaseControl]
 
     val values = js.Object.freeze(js.Array(SHIFT_90_DEGREES, NO_SHIFT))
   }
@@ -3451,11 +3381,13 @@ package mediaconvert {
   /**
     * Choose how the service does stereo downmixing. This setting only applies if you keep the default value of 3/2 - L, R, C, Ls, Rs (CODING_MODE_3_2) for the setting Coding mode (Eac3CodingMode). If you choose a different value for Coding mode, the service ignores Stereo downmix (Eac3StereoDownmix).
     */
-  object Eac3StereoDownmixEnum {
-    val NOT_INDICATED = "NOT_INDICATED"
-    val LO_RO         = "LO_RO"
-    val LT_RT         = "LT_RT"
-    val DPL2          = "DPL2"
+  @js.native
+  sealed trait Eac3StereoDownmix extends js.Any
+  object Eac3StereoDownmix extends js.Object {
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3StereoDownmix]
+    val LO_RO         = "LO_RO".asInstanceOf[Eac3StereoDownmix]
+    val LT_RT         = "LT_RT".asInstanceOf[Eac3StereoDownmix]
+    val DPL2          = "DPL2".asInstanceOf[Eac3StereoDownmix]
 
     val values = js.Object.freeze(js.Array(NOT_INDICATED, LO_RO, LT_RT, DPL2))
   }
@@ -3463,10 +3395,12 @@ package mediaconvert {
   /**
     * When encoding 3/2 audio, sets whether an extra center back surround channel is matrix encoded into the left and right surround channels.
     */
-  object Eac3SurroundExModeEnum {
-    val NOT_INDICATED = "NOT_INDICATED"
-    val ENABLED       = "ENABLED"
-    val DISABLED      = "DISABLED"
+  @js.native
+  sealed trait Eac3SurroundExMode extends js.Any
+  object Eac3SurroundExMode extends js.Object {
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3SurroundExMode]
+    val ENABLED       = "ENABLED".asInstanceOf[Eac3SurroundExMode]
+    val DISABLED      = "DISABLED".asInstanceOf[Eac3SurroundExMode]
 
     val values = js.Object.freeze(js.Array(NOT_INDICATED, ENABLED, DISABLED))
   }
@@ -3474,10 +3408,12 @@ package mediaconvert {
   /**
     * When encoding 2/0 audio, sets whether Dolby Surround is matrix encoded into the two channels.
     */
-  object Eac3SurroundModeEnum {
-    val NOT_INDICATED = "NOT_INDICATED"
-    val ENABLED       = "ENABLED"
-    val DISABLED      = "DISABLED"
+  @js.native
+  sealed trait Eac3SurroundMode extends js.Any
+  object Eac3SurroundMode extends js.Object {
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3SurroundMode]
+    val ENABLED       = "ENABLED".asInstanceOf[Eac3SurroundMode]
+    val DISABLED      = "DISABLED".asInstanceOf[Eac3SurroundMode]
 
     val values = js.Object.freeze(js.Array(NOT_INDICATED, ENABLED, DISABLED))
   }
@@ -3485,9 +3421,11 @@ package mediaconvert {
   /**
     * Specify whether this set of input captions appears in your outputs in both 608 and 708 format. If you choose Upconvert (UPCONVERT), MediaConvert includes the captions data in two ways: it passes the 608 data through using the 608 compatibility bytes fields of the 708 wrapper, and it also translates the 608 data into 708.
     */
-  object EmbeddedConvert608To708Enum {
-    val UPCONVERT = "UPCONVERT"
-    val DISABLED  = "DISABLED"
+  @js.native
+  sealed trait EmbeddedConvert608To708 extends js.Any
+  object EmbeddedConvert608To708 extends js.Object {
+    val UPCONVERT = "UPCONVERT".asInstanceOf[EmbeddedConvert608To708]
+    val DISABLED  = "DISABLED".asInstanceOf[EmbeddedConvert608To708]
 
     val values = js.Object.freeze(js.Array(UPCONVERT, DISABLED))
   }
@@ -3549,9 +3487,11 @@ package mediaconvert {
   /**
     * By default, the service terminates any unterminated captions at the end of each input. If you want the caption to continue onto your next input, disable this setting.
     */
-  object EmbeddedTerminateCaptionsEnum {
-    val END_OF_INPUT = "END_OF_INPUT"
-    val DISABLED     = "DISABLED"
+  @js.native
+  sealed trait EmbeddedTerminateCaptions extends js.Any
+  object EmbeddedTerminateCaptions extends js.Object {
+    val END_OF_INPUT = "END_OF_INPUT".asInstanceOf[EmbeddedTerminateCaptions]
+    val DISABLED     = "DISABLED".asInstanceOf[EmbeddedTerminateCaptions]
 
     val values = js.Object.freeze(js.Array(END_OF_INPUT, DISABLED))
   }
@@ -3645,9 +3585,11 @@ package mediaconvert {
   /**
     * If set to PROGRESSIVE_DOWNLOAD, the MOOV atom is relocated to the beginning of the archive as required for progressive downloading. Otherwise it is placed normally at the end.
     */
-  object F4vMoovPlacementEnum {
-    val PROGRESSIVE_DOWNLOAD = "PROGRESSIVE_DOWNLOAD"
-    val NORMAL               = "NORMAL"
+  @js.native
+  sealed trait F4vMoovPlacement extends js.Any
+  object F4vMoovPlacement extends js.Object {
+    val PROGRESSIVE_DOWNLOAD = "PROGRESSIVE_DOWNLOAD".asInstanceOf[F4vMoovPlacement]
+    val NORMAL               = "NORMAL".asInstanceOf[F4vMoovPlacement]
 
     val values = js.Object.freeze(js.Array(PROGRESSIVE_DOWNLOAD, NORMAL))
   }
@@ -3696,9 +3638,11 @@ package mediaconvert {
   /**
     * Specify whether this set of input captions appears in your outputs in both 608 and 708 format. If you choose Upconvert (UPCONVERT), MediaConvert includes the captions data in two ways: it passes the 608 data through using the 608 compatibility bytes fields of the 708 wrapper, and it also translates the 608 data into 708.
     */
-  object FileSourceConvert608To708Enum {
-    val UPCONVERT = "UPCONVERT"
-    val DISABLED  = "DISABLED"
+  @js.native
+  sealed trait FileSourceConvert608To708 extends js.Any
+  object FileSourceConvert608To708 extends js.Object {
+    val UPCONVERT = "UPCONVERT".asInstanceOf[FileSourceConvert608To708]
+    val DISABLED  = "DISABLED".asInstanceOf[FileSourceConvert608To708]
 
     val values = js.Object.freeze(js.Array(UPCONVERT, DISABLED))
   }
@@ -3735,10 +3679,12 @@ package mediaconvert {
   /**
     * Provide the font script, using an ISO 15924 script code, if the LanguageCode is not sufficient for determining the script type. Where LanguageCode or CustomLanguageCode is sufficient, use "AUTOMATIC" or leave unset.
     */
-  object FontScriptEnum {
-    val AUTOMATIC = "AUTOMATIC"
-    val HANS      = "HANS"
-    val HANT      = "HANT"
+  @js.native
+  sealed trait FontScript extends js.Any
+  object FontScript extends js.Object {
+    val AUTOMATIC = "AUTOMATIC".asInstanceOf[FontScript]
+    val HANS      = "HANS".asInstanceOf[FontScript]
+    val HANT      = "HANT".asInstanceOf[FontScript]
 
     val values = js.Object.freeze(js.Array(AUTOMATIC, HANS, HANT))
   }
@@ -3910,13 +3856,15 @@ package mediaconvert {
   /**
     * Adaptive quantization. Allows intra-frame quantizers to vary to improve visual quality.
     */
-  object H264AdaptiveQuantizationEnum {
-    val OFF    = "OFF"
-    val LOW    = "LOW"
-    val MEDIUM = "MEDIUM"
-    val HIGH   = "HIGH"
-    val HIGHER = "HIGHER"
-    val MAX    = "MAX"
+  @js.native
+  sealed trait H264AdaptiveQuantization extends js.Any
+  object H264AdaptiveQuantization extends js.Object {
+    val OFF    = "OFF".asInstanceOf[H264AdaptiveQuantization]
+    val LOW    = "LOW".asInstanceOf[H264AdaptiveQuantization]
+    val MEDIUM = "MEDIUM".asInstanceOf[H264AdaptiveQuantization]
+    val HIGH   = "HIGH".asInstanceOf[H264AdaptiveQuantization]
+    val HIGHER = "HIGHER".asInstanceOf[H264AdaptiveQuantization]
+    val MAX    = "MAX".asInstanceOf[H264AdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(OFF, LOW, MEDIUM, HIGH, HIGHER, MAX))
   }
@@ -3924,24 +3872,26 @@ package mediaconvert {
   /**
     * Specify an H.264 level that is consistent with your output video settings. If you aren't sure what level to specify, choose Auto (AUTO).
     */
-  object H264CodecLevelEnum {
-    val AUTO      = "AUTO"
-    val LEVEL_1   = "LEVEL_1"
-    val LEVEL_1_1 = "LEVEL_1_1"
-    val LEVEL_1_2 = "LEVEL_1_2"
-    val LEVEL_1_3 = "LEVEL_1_3"
-    val LEVEL_2   = "LEVEL_2"
-    val LEVEL_2_1 = "LEVEL_2_1"
-    val LEVEL_2_2 = "LEVEL_2_2"
-    val LEVEL_3   = "LEVEL_3"
-    val LEVEL_3_1 = "LEVEL_3_1"
-    val LEVEL_3_2 = "LEVEL_3_2"
-    val LEVEL_4   = "LEVEL_4"
-    val LEVEL_4_1 = "LEVEL_4_1"
-    val LEVEL_4_2 = "LEVEL_4_2"
-    val LEVEL_5   = "LEVEL_5"
-    val LEVEL_5_1 = "LEVEL_5_1"
-    val LEVEL_5_2 = "LEVEL_5_2"
+  @js.native
+  sealed trait H264CodecLevel extends js.Any
+  object H264CodecLevel extends js.Object {
+    val AUTO      = "AUTO".asInstanceOf[H264CodecLevel]
+    val LEVEL_1   = "LEVEL_1".asInstanceOf[H264CodecLevel]
+    val LEVEL_1_1 = "LEVEL_1_1".asInstanceOf[H264CodecLevel]
+    val LEVEL_1_2 = "LEVEL_1_2".asInstanceOf[H264CodecLevel]
+    val LEVEL_1_3 = "LEVEL_1_3".asInstanceOf[H264CodecLevel]
+    val LEVEL_2   = "LEVEL_2".asInstanceOf[H264CodecLevel]
+    val LEVEL_2_1 = "LEVEL_2_1".asInstanceOf[H264CodecLevel]
+    val LEVEL_2_2 = "LEVEL_2_2".asInstanceOf[H264CodecLevel]
+    val LEVEL_3   = "LEVEL_3".asInstanceOf[H264CodecLevel]
+    val LEVEL_3_1 = "LEVEL_3_1".asInstanceOf[H264CodecLevel]
+    val LEVEL_3_2 = "LEVEL_3_2".asInstanceOf[H264CodecLevel]
+    val LEVEL_4   = "LEVEL_4".asInstanceOf[H264CodecLevel]
+    val LEVEL_4_1 = "LEVEL_4_1".asInstanceOf[H264CodecLevel]
+    val LEVEL_4_2 = "LEVEL_4_2".asInstanceOf[H264CodecLevel]
+    val LEVEL_5   = "LEVEL_5".asInstanceOf[H264CodecLevel]
+    val LEVEL_5_1 = "LEVEL_5_1".asInstanceOf[H264CodecLevel]
+    val LEVEL_5_2 = "LEVEL_5_2".asInstanceOf[H264CodecLevel]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3969,13 +3919,15 @@ package mediaconvert {
   /**
     * H.264 Profile. High 4:2:2 and 10-bit profiles are only available with the AVC-I License.
     */
-  object H264CodecProfileEnum {
-    val BASELINE       = "BASELINE"
-    val HIGH           = "HIGH"
-    val HIGH_10BIT     = "HIGH_10BIT"
-    val HIGH_422       = "HIGH_422"
-    val HIGH_422_10BIT = "HIGH_422_10BIT"
-    val MAIN           = "MAIN"
+  @js.native
+  sealed trait H264CodecProfile extends js.Any
+  object H264CodecProfile extends js.Object {
+    val BASELINE       = "BASELINE".asInstanceOf[H264CodecProfile]
+    val HIGH           = "HIGH".asInstanceOf[H264CodecProfile]
+    val HIGH_10BIT     = "HIGH_10BIT".asInstanceOf[H264CodecProfile]
+    val HIGH_422       = "HIGH_422".asInstanceOf[H264CodecProfile]
+    val HIGH_422_10BIT = "HIGH_422_10BIT".asInstanceOf[H264CodecProfile]
+    val MAIN           = "MAIN".asInstanceOf[H264CodecProfile]
 
     val values = js.Object.freeze(js.Array(BASELINE, HIGH, HIGH_10BIT, HIGH_422, HIGH_422_10BIT, MAIN))
   }
@@ -3983,9 +3935,11 @@ package mediaconvert {
   /**
     * Choose Adaptive to improve subjective video quality for high-motion content. This will cause the service to use fewer B-frames (which infer information based on other frames) for high-motion portions of the video and more B-frames for low-motion portions. The maximum number of B-frames is limited by the value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
     */
-  object H264DynamicSubGopEnum {
-    val ADAPTIVE = "ADAPTIVE"
-    val STATIC   = "STATIC"
+  @js.native
+  sealed trait H264DynamicSubGop extends js.Any
+  object H264DynamicSubGop extends js.Object {
+    val ADAPTIVE = "ADAPTIVE".asInstanceOf[H264DynamicSubGop]
+    val STATIC   = "STATIC".asInstanceOf[H264DynamicSubGop]
 
     val values = js.Object.freeze(js.Array(ADAPTIVE, STATIC))
   }
@@ -3993,9 +3947,11 @@ package mediaconvert {
   /**
     * Entropy encoding mode. Use CABAC (must be in Main or High profile) or CAVLC.
     */
-  object H264EntropyEncodingEnum {
-    val CABAC = "CABAC"
-    val CAVLC = "CAVLC"
+  @js.native
+  sealed trait H264EntropyEncoding extends js.Any
+  object H264EntropyEncoding extends js.Object {
+    val CABAC = "CABAC".asInstanceOf[H264EntropyEncoding]
+    val CAVLC = "CAVLC".asInstanceOf[H264EntropyEncoding]
 
     val values = js.Object.freeze(js.Array(CABAC, CAVLC))
   }
@@ -4003,9 +3959,11 @@ package mediaconvert {
   /**
     * Choosing FORCE_FIELD disables PAFF encoding for interlaced outputs.
     */
-  object H264FieldEncodingEnum {
-    val PAFF        = "PAFF"
-    val FORCE_FIELD = "FORCE_FIELD"
+  @js.native
+  sealed trait H264FieldEncoding extends js.Any
+  object H264FieldEncoding extends js.Object {
+    val PAFF        = "PAFF".asInstanceOf[H264FieldEncoding]
+    val FORCE_FIELD = "FORCE_FIELD".asInstanceOf[H264FieldEncoding]
 
     val values = js.Object.freeze(js.Array(PAFF, FORCE_FIELD))
   }
@@ -4013,9 +3971,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame to reduce flicker or 'pop' on I-frames.
     */
-  object H264FlickerAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264FlickerAdaptiveQuantization extends js.Any
+  object H264FlickerAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264FlickerAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[H264FlickerAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4023,9 +3983,11 @@ package mediaconvert {
   /**
     * If you are using the console, use the Framerate setting to specify the frame rate for this output. If you want to keep the same frame rate as the input video, choose Follow source. If you want to do frame rate conversion, choose a frame rate from the dropdown list or choose Custom. The framerates shown in the dropdown list are decimal approximations of fractions. If you choose Custom, specify your frame rate as a fraction. If you are creating your transcoding job specification as a JSON file without the console, use FramerateControl to specify which value the service uses for the frame rate for this output. Choose INITIALIZE_FROM_SOURCE if you want the service to use the frame rate from the input. Choose SPECIFIED if you want the service to use the frame rate you specify in the settings FramerateNumerator and FramerateDenominator.
     */
-  object H264FramerateControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait H264FramerateControl extends js.Any
+  object H264FramerateControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[H264FramerateControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[H264FramerateControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -4033,9 +3995,11 @@ package mediaconvert {
   /**
     * When set to INTERPOLATE, produces smoother motion during frame rate conversion.
     */
-  object H264FramerateConversionAlgorithmEnum {
-    val DUPLICATE_DROP = "DUPLICATE_DROP"
-    val INTERPOLATE    = "INTERPOLATE"
+  @js.native
+  sealed trait H264FramerateConversionAlgorithm extends js.Any
+  object H264FramerateConversionAlgorithm extends js.Object {
+    val DUPLICATE_DROP = "DUPLICATE_DROP".asInstanceOf[H264FramerateConversionAlgorithm]
+    val INTERPOLATE    = "INTERPOLATE".asInstanceOf[H264FramerateConversionAlgorithm]
 
     val values = js.Object.freeze(js.Array(DUPLICATE_DROP, INTERPOLATE))
   }
@@ -4043,9 +4007,11 @@ package mediaconvert {
   /**
     * If enable, use reference B frames for GOP structures that have B frames > 1.
     */
-  object H264GopBReferenceEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264GopBReference extends js.Any
+  object H264GopBReference extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264GopBReference]
+    val ENABLED  = "ENABLED".asInstanceOf[H264GopBReference]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4053,9 +4019,11 @@ package mediaconvert {
   /**
     * Indicates if the GOP Size in H264 is specified in frames or seconds. If seconds the system will convert the GOP Size into a frame count at run time.
     */
-  object H264GopSizeUnitsEnum {
-    val FRAMES  = "FRAMES"
-    val SECONDS = "SECONDS"
+  @js.native
+  sealed trait H264GopSizeUnits extends js.Any
+  object H264GopSizeUnits extends js.Object {
+    val FRAMES  = "FRAMES".asInstanceOf[H264GopSizeUnits]
+    val SECONDS = "SECONDS".asInstanceOf[H264GopSizeUnits]
 
     val values = js.Object.freeze(js.Array(FRAMES, SECONDS))
   }
@@ -4065,12 +4033,14 @@ package mediaconvert {
     *   - If the source is interlaced, the output will be interlaced with the same polarity as the source (it will follow the source). The output could therefore be a mix of "top field first" and "bottom field first".
     *   - If the source is progressive, the output will be interlaced with "top field first" or "bottom field first" polarity, depending on which of the Follow options you chose.
     */
-  object H264InterlaceModeEnum {
-    val PROGRESSIVE         = "PROGRESSIVE"
-    val TOP_FIELD           = "TOP_FIELD"
-    val BOTTOM_FIELD        = "BOTTOM_FIELD"
-    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD"
-    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD"
+  @js.native
+  sealed trait H264InterlaceMode extends js.Any
+  object H264InterlaceMode extends js.Object {
+    val PROGRESSIVE         = "PROGRESSIVE".asInstanceOf[H264InterlaceMode]
+    val TOP_FIELD           = "TOP_FIELD".asInstanceOf[H264InterlaceMode]
+    val BOTTOM_FIELD        = "BOTTOM_FIELD".asInstanceOf[H264InterlaceMode]
+    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD".asInstanceOf[H264InterlaceMode]
+    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD".asInstanceOf[H264InterlaceMode]
 
     val values = js.Object.freeze(js.Array(PROGRESSIVE, TOP_FIELD, BOTTOM_FIELD, FOLLOW_TOP_FIELD, FOLLOW_BOTTOM_FIELD))
   }
@@ -4078,9 +4048,11 @@ package mediaconvert {
   /**
     * Using the API, enable ParFollowSource if you want the service to use the pixel aspect ratio from the input. Using the console, do this by choosing Follow source for Pixel aspect ratio.
     */
-  object H264ParControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait H264ParControl extends js.Any
+  object H264ParControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[H264ParControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[H264ParControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -4088,10 +4060,12 @@ package mediaconvert {
   /**
     * Use Quality tuning level (H264QualityTuningLevel) to specifiy whether to use fast single-pass, high-quality singlepass, or high-quality multipass video encoding.
     */
-  object H264QualityTuningLevelEnum {
-    val SINGLE_PASS    = "SINGLE_PASS"
-    val SINGLE_PASS_HQ = "SINGLE_PASS_HQ"
-    val MULTI_PASS_HQ  = "MULTI_PASS_HQ"
+  @js.native
+  sealed trait H264QualityTuningLevel extends js.Any
+  object H264QualityTuningLevel extends js.Object {
+    val SINGLE_PASS    = "SINGLE_PASS".asInstanceOf[H264QualityTuningLevel]
+    val SINGLE_PASS_HQ = "SINGLE_PASS_HQ".asInstanceOf[H264QualityTuningLevel]
+    val MULTI_PASS_HQ  = "MULTI_PASS_HQ".asInstanceOf[H264QualityTuningLevel]
 
     val values = js.Object.freeze(js.Array(SINGLE_PASS, SINGLE_PASS_HQ, MULTI_PASS_HQ))
   }
@@ -4124,10 +4098,12 @@ package mediaconvert {
   /**
     * Use this setting to specify whether this output has a variable bitrate (VBR), constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
     */
-  object H264RateControlModeEnum {
-    val VBR  = "VBR"
-    val CBR  = "CBR"
-    val QVBR = "QVBR"
+  @js.native
+  sealed trait H264RateControlMode extends js.Any
+  object H264RateControlMode extends js.Object {
+    val VBR  = "VBR".asInstanceOf[H264RateControlMode]
+    val CBR  = "CBR".asInstanceOf[H264RateControlMode]
+    val QVBR = "QVBR".asInstanceOf[H264RateControlMode]
 
     val values = js.Object.freeze(js.Array(VBR, CBR, QVBR))
   }
@@ -4135,9 +4111,11 @@ package mediaconvert {
   /**
     * Places a PPS header on each encoded picture, even if repeated.
     */
-  object H264RepeatPpsEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264RepeatPps extends js.Any
+  object H264RepeatPps extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264RepeatPps]
+    val ENABLED  = "ENABLED".asInstanceOf[H264RepeatPps]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4145,10 +4123,12 @@ package mediaconvert {
   /**
     * Enable this setting to insert I-frames at scene changes that the service automatically detects. This improves video quality and is enabled by default. If this output uses QVBR, choose Transition detection (TRANSITION_DETECTION) for further video quality improvement. For more information about QVBR, see https://docs.aws.amazon.com/console/mediaconvert/cbr-vbr-qvbr.
     */
-  object H264SceneChangeDetectEnum {
-    val DISABLED             = "DISABLED"
-    val ENABLED              = "ENABLED"
-    val TRANSITION_DETECTION = "TRANSITION_DETECTION"
+  @js.native
+  sealed trait H264SceneChangeDetect extends js.Any
+  object H264SceneChangeDetect extends js.Object {
+    val DISABLED             = "DISABLED".asInstanceOf[H264SceneChangeDetect]
+    val ENABLED              = "ENABLED".asInstanceOf[H264SceneChangeDetect]
+    val TRANSITION_DETECTION = "TRANSITION_DETECTION".asInstanceOf[H264SceneChangeDetect]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED, TRANSITION_DETECTION))
   }
@@ -4301,9 +4281,11 @@ package mediaconvert {
   /**
     * Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled as 25fps, and audio is sped up correspondingly.
     */
-  object H264SlowPalEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264SlowPal extends js.Any
+  object H264SlowPal extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264SlowPal]
+    val ENABLED  = "ENABLED".asInstanceOf[H264SlowPal]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4311,9 +4293,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame based on spatial variation of content complexity.
     */
-  object H264SpatialAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264SpatialAdaptiveQuantization extends js.Any
+  object H264SpatialAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264SpatialAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[H264SpatialAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4321,9 +4305,11 @@ package mediaconvert {
   /**
     * Produces a bitstream compliant with SMPTE RP-2027.
     */
-  object H264SyntaxEnum {
-    val DEFAULT = "DEFAULT"
-    val RP2027  = "RP2027"
+  @js.native
+  sealed trait H264Syntax extends js.Any
+  object H264Syntax extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[H264Syntax]
+    val RP2027  = "RP2027".asInstanceOf[H264Syntax]
 
     val values = js.Object.freeze(js.Array(DEFAULT, RP2027))
   }
@@ -4331,10 +4317,12 @@ package mediaconvert {
   /**
     * This field applies only if the Streams > Advanced > Framerate (framerate) field  is set to 29.970. This field works with the Streams > Advanced > Preprocessors > Deinterlacer  field (deinterlace_mode) and the Streams > Advanced > Interlaced Mode field (interlace_mode)  to identify the scan type for the output: Progressive, Interlaced, Hard Telecine or Soft Telecine. - Hard: produces 29.97i output from 23.976 input. - Soft: produces 23.976; the player converts this output to 29.97i.
     */
-  object H264TelecineEnum {
-    val NONE = "NONE"
-    val SOFT = "SOFT"
-    val HARD = "HARD"
+  @js.native
+  sealed trait H264Telecine extends js.Any
+  object H264Telecine extends js.Object {
+    val NONE = "NONE".asInstanceOf[H264Telecine]
+    val SOFT = "SOFT".asInstanceOf[H264Telecine]
+    val HARD = "HARD".asInstanceOf[H264Telecine]
 
     val values = js.Object.freeze(js.Array(NONE, SOFT, HARD))
   }
@@ -4342,9 +4330,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame based on temporal variation of content complexity.
     */
-  object H264TemporalAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264TemporalAdaptiveQuantization extends js.Any
+  object H264TemporalAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264TemporalAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[H264TemporalAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4352,9 +4342,11 @@ package mediaconvert {
   /**
     * Inserts timecode for each frame as 4 bytes of an unregistered SEI message.
     */
-  object H264UnregisteredSeiTimecodeEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264UnregisteredSeiTimecode extends js.Any
+  object H264UnregisteredSeiTimecode extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264UnregisteredSeiTimecode]
+    val ENABLED  = "ENABLED".asInstanceOf[H264UnregisteredSeiTimecode]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4362,13 +4354,15 @@ package mediaconvert {
   /**
     * Adaptive quantization. Allows intra-frame quantizers to vary to improve visual quality.
     */
-  object H265AdaptiveQuantizationEnum {
-    val OFF    = "OFF"
-    val LOW    = "LOW"
-    val MEDIUM = "MEDIUM"
-    val HIGH   = "HIGH"
-    val HIGHER = "HIGHER"
-    val MAX    = "MAX"
+  @js.native
+  sealed trait H265AdaptiveQuantization extends js.Any
+  object H265AdaptiveQuantization extends js.Object {
+    val OFF    = "OFF".asInstanceOf[H265AdaptiveQuantization]
+    val LOW    = "LOW".asInstanceOf[H265AdaptiveQuantization]
+    val MEDIUM = "MEDIUM".asInstanceOf[H265AdaptiveQuantization]
+    val HIGH   = "HIGH".asInstanceOf[H265AdaptiveQuantization]
+    val HIGHER = "HIGHER".asInstanceOf[H265AdaptiveQuantization]
+    val MAX    = "MAX".asInstanceOf[H265AdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(OFF, LOW, MEDIUM, HIGH, HIGHER, MAX))
   }
@@ -4376,9 +4370,11 @@ package mediaconvert {
   /**
     * Enables Alternate Transfer Function SEI message for outputs using Hybrid Log Gamma (HLG) Electro-Optical Transfer Function (EOTF).
     */
-  object H265AlternateTransferFunctionSeiEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265AlternateTransferFunctionSei extends js.Any
+  object H265AlternateTransferFunctionSei extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265AlternateTransferFunctionSei]
+    val ENABLED  = "ENABLED".asInstanceOf[H265AlternateTransferFunctionSei]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4386,21 +4382,23 @@ package mediaconvert {
   /**
     * H.265 Level.
     */
-  object H265CodecLevelEnum {
-    val AUTO      = "AUTO"
-    val LEVEL_1   = "LEVEL_1"
-    val LEVEL_2   = "LEVEL_2"
-    val LEVEL_2_1 = "LEVEL_2_1"
-    val LEVEL_3   = "LEVEL_3"
-    val LEVEL_3_1 = "LEVEL_3_1"
-    val LEVEL_4   = "LEVEL_4"
-    val LEVEL_4_1 = "LEVEL_4_1"
-    val LEVEL_5   = "LEVEL_5"
-    val LEVEL_5_1 = "LEVEL_5_1"
-    val LEVEL_5_2 = "LEVEL_5_2"
-    val LEVEL_6   = "LEVEL_6"
-    val LEVEL_6_1 = "LEVEL_6_1"
-    val LEVEL_6_2 = "LEVEL_6_2"
+  @js.native
+  sealed trait H265CodecLevel extends js.Any
+  object H265CodecLevel extends js.Object {
+    val AUTO      = "AUTO".asInstanceOf[H265CodecLevel]
+    val LEVEL_1   = "LEVEL_1".asInstanceOf[H265CodecLevel]
+    val LEVEL_2   = "LEVEL_2".asInstanceOf[H265CodecLevel]
+    val LEVEL_2_1 = "LEVEL_2_1".asInstanceOf[H265CodecLevel]
+    val LEVEL_3   = "LEVEL_3".asInstanceOf[H265CodecLevel]
+    val LEVEL_3_1 = "LEVEL_3_1".asInstanceOf[H265CodecLevel]
+    val LEVEL_4   = "LEVEL_4".asInstanceOf[H265CodecLevel]
+    val LEVEL_4_1 = "LEVEL_4_1".asInstanceOf[H265CodecLevel]
+    val LEVEL_5   = "LEVEL_5".asInstanceOf[H265CodecLevel]
+    val LEVEL_5_1 = "LEVEL_5_1".asInstanceOf[H265CodecLevel]
+    val LEVEL_5_2 = "LEVEL_5_2".asInstanceOf[H265CodecLevel]
+    val LEVEL_6   = "LEVEL_6".asInstanceOf[H265CodecLevel]
+    val LEVEL_6_1 = "LEVEL_6_1".asInstanceOf[H265CodecLevel]
+    val LEVEL_6_2 = "LEVEL_6_2".asInstanceOf[H265CodecLevel]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4425,15 +4423,17 @@ package mediaconvert {
   /**
     * Represents the Profile and Tier, per the HEVC (H.265) specification. Selections are grouped as [Profile] / [Tier], so "Main/High" represents Main Profile with High Tier. 4:2:2 profiles are only available with the HEVC 4:2:2 License.
     */
-  object H265CodecProfileEnum {
-    val MAIN_MAIN           = "MAIN_MAIN"
-    val MAIN_HIGH           = "MAIN_HIGH"
-    val MAIN10_MAIN         = "MAIN10_MAIN"
-    val MAIN10_HIGH         = "MAIN10_HIGH"
-    val MAIN_422_8BIT_MAIN  = "MAIN_422_8BIT_MAIN"
-    val MAIN_422_8BIT_HIGH  = "MAIN_422_8BIT_HIGH"
-    val MAIN_422_10BIT_MAIN = "MAIN_422_10BIT_MAIN"
-    val MAIN_422_10BIT_HIGH = "MAIN_422_10BIT_HIGH"
+  @js.native
+  sealed trait H265CodecProfile extends js.Any
+  object H265CodecProfile extends js.Object {
+    val MAIN_MAIN           = "MAIN_MAIN".asInstanceOf[H265CodecProfile]
+    val MAIN_HIGH           = "MAIN_HIGH".asInstanceOf[H265CodecProfile]
+    val MAIN10_MAIN         = "MAIN10_MAIN".asInstanceOf[H265CodecProfile]
+    val MAIN10_HIGH         = "MAIN10_HIGH".asInstanceOf[H265CodecProfile]
+    val MAIN_422_8BIT_MAIN  = "MAIN_422_8BIT_MAIN".asInstanceOf[H265CodecProfile]
+    val MAIN_422_8BIT_HIGH  = "MAIN_422_8BIT_HIGH".asInstanceOf[H265CodecProfile]
+    val MAIN_422_10BIT_MAIN = "MAIN_422_10BIT_MAIN".asInstanceOf[H265CodecProfile]
+    val MAIN_422_10BIT_HIGH = "MAIN_422_10BIT_HIGH".asInstanceOf[H265CodecProfile]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4452,9 +4452,11 @@ package mediaconvert {
   /**
     * Choose Adaptive to improve subjective video quality for high-motion content. This will cause the service to use fewer B-frames (which infer information based on other frames) for high-motion portions of the video and more B-frames for low-motion portions. The maximum number of B-frames is limited by the value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
     */
-  object H265DynamicSubGopEnum {
-    val ADAPTIVE = "ADAPTIVE"
-    val STATIC   = "STATIC"
+  @js.native
+  sealed trait H265DynamicSubGop extends js.Any
+  object H265DynamicSubGop extends js.Object {
+    val ADAPTIVE = "ADAPTIVE".asInstanceOf[H265DynamicSubGop]
+    val STATIC   = "STATIC".asInstanceOf[H265DynamicSubGop]
 
     val values = js.Object.freeze(js.Array(ADAPTIVE, STATIC))
   }
@@ -4462,9 +4464,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame to reduce flicker or 'pop' on I-frames.
     */
-  object H265FlickerAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265FlickerAdaptiveQuantization extends js.Any
+  object H265FlickerAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265FlickerAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[H265FlickerAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4472,9 +4476,11 @@ package mediaconvert {
   /**
     * If you are using the console, use the Framerate setting to specify the frame rate for this output. If you want to keep the same frame rate as the input video, choose Follow source. If you want to do frame rate conversion, choose a frame rate from the dropdown list or choose Custom. The framerates shown in the dropdown list are decimal approximations of fractions. If you choose Custom, specify your frame rate as a fraction. If you are creating your transcoding job sepecification as a JSON file without the console, use FramerateControl to specify which value the service uses for the frame rate for this output. Choose INITIALIZE_FROM_SOURCE if you want the service to use the frame rate from the input. Choose SPECIFIED if you want the service to use the frame rate you specify in the settings FramerateNumerator and FramerateDenominator.
     */
-  object H265FramerateControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait H265FramerateControl extends js.Any
+  object H265FramerateControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[H265FramerateControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[H265FramerateControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -4482,9 +4488,11 @@ package mediaconvert {
   /**
     * When set to INTERPOLATE, produces smoother motion during frame rate conversion.
     */
-  object H265FramerateConversionAlgorithmEnum {
-    val DUPLICATE_DROP = "DUPLICATE_DROP"
-    val INTERPOLATE    = "INTERPOLATE"
+  @js.native
+  sealed trait H265FramerateConversionAlgorithm extends js.Any
+  object H265FramerateConversionAlgorithm extends js.Object {
+    val DUPLICATE_DROP = "DUPLICATE_DROP".asInstanceOf[H265FramerateConversionAlgorithm]
+    val INTERPOLATE    = "INTERPOLATE".asInstanceOf[H265FramerateConversionAlgorithm]
 
     val values = js.Object.freeze(js.Array(DUPLICATE_DROP, INTERPOLATE))
   }
@@ -4492,9 +4500,11 @@ package mediaconvert {
   /**
     * If enable, use reference B frames for GOP structures that have B frames > 1.
     */
-  object H265GopBReferenceEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265GopBReference extends js.Any
+  object H265GopBReference extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265GopBReference]
+    val ENABLED  = "ENABLED".asInstanceOf[H265GopBReference]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4502,9 +4512,11 @@ package mediaconvert {
   /**
     * Indicates if the GOP Size in H265 is specified in frames or seconds. If seconds the system will convert the GOP Size into a frame count at run time.
     */
-  object H265GopSizeUnitsEnum {
-    val FRAMES  = "FRAMES"
-    val SECONDS = "SECONDS"
+  @js.native
+  sealed trait H265GopSizeUnits extends js.Any
+  object H265GopSizeUnits extends js.Object {
+    val FRAMES  = "FRAMES".asInstanceOf[H265GopSizeUnits]
+    val SECONDS = "SECONDS".asInstanceOf[H265GopSizeUnits]
 
     val values = js.Object.freeze(js.Array(FRAMES, SECONDS))
   }
@@ -4512,12 +4524,14 @@ package mediaconvert {
   /**
     * Choose the scan line type for the output. Choose Progressive (PROGRESSIVE) to create a progressive output, regardless of the scan type of your input. Choose Top Field First (TOP_FIELD) or Bottom Field First (BOTTOM_FIELD) to create an output that's interlaced with the same field polarity throughout. Choose Follow, Default Top (FOLLOW_TOP_FIELD) or Follow, Default Bottom (FOLLOW_BOTTOM_FIELD) to create an interlaced output with the same field polarity as the source. If the source is interlaced, the output will be interlaced with the same polarity as the source (it will follow the source). The output could therefore be a mix of "top field first" and "bottom field first". If the source is progressive, your output will be interlaced with "top field first" or "bottom field first" polarity, depending on which of the Follow options you chose. If you don't choose a value, the service will default to Progressive (PROGRESSIVE).
     */
-  object H265InterlaceModeEnum {
-    val PROGRESSIVE         = "PROGRESSIVE"
-    val TOP_FIELD           = "TOP_FIELD"
-    val BOTTOM_FIELD        = "BOTTOM_FIELD"
-    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD"
-    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD"
+  @js.native
+  sealed trait H265InterlaceMode extends js.Any
+  object H265InterlaceMode extends js.Object {
+    val PROGRESSIVE         = "PROGRESSIVE".asInstanceOf[H265InterlaceMode]
+    val TOP_FIELD           = "TOP_FIELD".asInstanceOf[H265InterlaceMode]
+    val BOTTOM_FIELD        = "BOTTOM_FIELD".asInstanceOf[H265InterlaceMode]
+    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD".asInstanceOf[H265InterlaceMode]
+    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD".asInstanceOf[H265InterlaceMode]
 
     val values = js.Object.freeze(js.Array(PROGRESSIVE, TOP_FIELD, BOTTOM_FIELD, FOLLOW_TOP_FIELD, FOLLOW_BOTTOM_FIELD))
   }
@@ -4525,9 +4539,11 @@ package mediaconvert {
   /**
     * Using the API, enable ParFollowSource if you want the service to use the pixel aspect ratio from the input. Using the console, do this by choosing Follow source for Pixel aspect ratio.
     */
-  object H265ParControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait H265ParControl extends js.Any
+  object H265ParControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[H265ParControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[H265ParControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -4535,10 +4551,12 @@ package mediaconvert {
   /**
     * Use Quality tuning level (H265QualityTuningLevel) to specifiy whether to use fast single-pass, high-quality singlepass, or high-quality multipass video encoding.
     */
-  object H265QualityTuningLevelEnum {
-    val SINGLE_PASS    = "SINGLE_PASS"
-    val SINGLE_PASS_HQ = "SINGLE_PASS_HQ"
-    val MULTI_PASS_HQ  = "MULTI_PASS_HQ"
+  @js.native
+  sealed trait H265QualityTuningLevel extends js.Any
+  object H265QualityTuningLevel extends js.Object {
+    val SINGLE_PASS    = "SINGLE_PASS".asInstanceOf[H265QualityTuningLevel]
+    val SINGLE_PASS_HQ = "SINGLE_PASS_HQ".asInstanceOf[H265QualityTuningLevel]
+    val MULTI_PASS_HQ  = "MULTI_PASS_HQ".asInstanceOf[H265QualityTuningLevel]
 
     val values = js.Object.freeze(js.Array(SINGLE_PASS, SINGLE_PASS_HQ, MULTI_PASS_HQ))
   }
@@ -4571,10 +4589,12 @@ package mediaconvert {
   /**
     * Use this setting to specify whether this output has a variable bitrate (VBR), constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
     */
-  object H265RateControlModeEnum {
-    val VBR  = "VBR"
-    val CBR  = "CBR"
-    val QVBR = "QVBR"
+  @js.native
+  sealed trait H265RateControlMode extends js.Any
+  object H265RateControlMode extends js.Object {
+    val VBR  = "VBR".asInstanceOf[H265RateControlMode]
+    val CBR  = "CBR".asInstanceOf[H265RateControlMode]
+    val QVBR = "QVBR".asInstanceOf[H265RateControlMode]
 
     val values = js.Object.freeze(js.Array(VBR, CBR, QVBR))
   }
@@ -4582,10 +4602,12 @@ package mediaconvert {
   /**
     * Specify Sample Adaptive Offset (SAO) filter strength.  Adaptive mode dynamically selects best strength based on content
     */
-  object H265SampleAdaptiveOffsetFilterModeEnum {
-    val DEFAULT  = "DEFAULT"
-    val ADAPTIVE = "ADAPTIVE"
-    val OFF      = "OFF"
+  @js.native
+  sealed trait H265SampleAdaptiveOffsetFilterMode extends js.Any
+  object H265SampleAdaptiveOffsetFilterMode extends js.Object {
+    val DEFAULT  = "DEFAULT".asInstanceOf[H265SampleAdaptiveOffsetFilterMode]
+    val ADAPTIVE = "ADAPTIVE".asInstanceOf[H265SampleAdaptiveOffsetFilterMode]
+    val OFF      = "OFF".asInstanceOf[H265SampleAdaptiveOffsetFilterMode]
 
     val values = js.Object.freeze(js.Array(DEFAULT, ADAPTIVE, OFF))
   }
@@ -4593,10 +4615,12 @@ package mediaconvert {
   /**
     * Enable this setting to insert I-frames at scene changes that the service automatically detects. This improves video quality and is enabled by default. If this output uses QVBR, choose Transition detection (TRANSITION_DETECTION) for further video quality improvement. For more information about QVBR, see https://docs.aws.amazon.com/console/mediaconvert/cbr-vbr-qvbr.
     */
-  object H265SceneChangeDetectEnum {
-    val DISABLED             = "DISABLED"
-    val ENABLED              = "ENABLED"
-    val TRANSITION_DETECTION = "TRANSITION_DETECTION"
+  @js.native
+  sealed trait H265SceneChangeDetect extends js.Any
+  object H265SceneChangeDetect extends js.Object {
+    val DISABLED             = "DISABLED".asInstanceOf[H265SceneChangeDetect]
+    val ENABLED              = "ENABLED".asInstanceOf[H265SceneChangeDetect]
+    val TRANSITION_DETECTION = "TRANSITION_DETECTION".asInstanceOf[H265SceneChangeDetect]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED, TRANSITION_DETECTION))
   }
@@ -4753,9 +4777,11 @@ package mediaconvert {
   /**
     * Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled as 25fps, and audio is sped up correspondingly.
     */
-  object H265SlowPalEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265SlowPal extends js.Any
+  object H265SlowPal extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265SlowPal]
+    val ENABLED  = "ENABLED".asInstanceOf[H265SlowPal]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4763,9 +4789,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame based on spatial variation of content complexity.
     */
-  object H265SpatialAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265SpatialAdaptiveQuantization extends js.Any
+  object H265SpatialAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265SpatialAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[H265SpatialAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4773,10 +4801,12 @@ package mediaconvert {
   /**
     * This field applies only if the Streams > Advanced > Framerate (framerate) field  is set to 29.970. This field works with the Streams > Advanced > Preprocessors > Deinterlacer  field (deinterlace_mode) and the Streams > Advanced > Interlaced Mode field (interlace_mode)  to identify the scan type for the output: Progressive, Interlaced, Hard Telecine or Soft Telecine. - Hard: produces 29.97i output from 23.976 input. - Soft: produces 23.976; the player converts this output to 29.97i.
     */
-  object H265TelecineEnum {
-    val NONE = "NONE"
-    val SOFT = "SOFT"
-    val HARD = "HARD"
+  @js.native
+  sealed trait H265Telecine extends js.Any
+  object H265Telecine extends js.Object {
+    val NONE = "NONE".asInstanceOf[H265Telecine]
+    val SOFT = "SOFT".asInstanceOf[H265Telecine]
+    val HARD = "HARD".asInstanceOf[H265Telecine]
 
     val values = js.Object.freeze(js.Array(NONE, SOFT, HARD))
   }
@@ -4784,9 +4814,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame based on temporal variation of content complexity.
     */
-  object H265TemporalAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265TemporalAdaptiveQuantization extends js.Any
+  object H265TemporalAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265TemporalAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[H265TemporalAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4794,9 +4826,11 @@ package mediaconvert {
   /**
     * Enables temporal layer identifiers in the encoded bitstream. Up to 3 layers are supported depending on GOP structure: I- and P-frames form one layer, reference B-frames can form a second layer and non-reference b-frames can form a third layer. Decoders can optionally decode only the lower temporal layers to generate a lower frame rate output. For example, given a bitstream with temporal IDs and with b-frames = 1 (i.e. IbPbPb display order), a decoder could decode all the frames for full frame rate output or only the I and P frames (lowest temporal layer) for a half frame rate output.
     */
-  object H265TemporalIdsEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265TemporalIds extends js.Any
+  object H265TemporalIds extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265TemporalIds]
+    val ENABLED  = "ENABLED".asInstanceOf[H265TemporalIds]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4804,9 +4838,11 @@ package mediaconvert {
   /**
     * Enable use of tiles, allowing horizontal as well as vertical subdivision of the encoded pictures.
     */
-  object H265TilesEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265Tiles extends js.Any
+  object H265Tiles extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265Tiles]
+    val ENABLED  = "ENABLED".asInstanceOf[H265Tiles]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4814,9 +4850,11 @@ package mediaconvert {
   /**
     * Inserts timecode for each frame as 4 bytes of an unregistered SEI message.
     */
-  object H265UnregisteredSeiTimecodeEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265UnregisteredSeiTimecode extends js.Any
+  object H265UnregisteredSeiTimecode extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265UnregisteredSeiTimecode]
+    val ENABLED  = "ENABLED".asInstanceOf[H265UnregisteredSeiTimecode]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4824,9 +4862,11 @@ package mediaconvert {
   /**
     * If the location of parameter set NAL units doesn't matter in your workflow, ignore this setting. Use this setting only with CMAF or DASH outputs, or with standalone file outputs in an MPEG-4 container (MP4 outputs). Choose HVC1 to mark your output as HVC1. This makes your output compliant with the following specification: ISO IECJTC1 SC29 N13798 Text ISO/IEC FDIS 14496-15 3rd Edition. For these outputs, the service stores parameter set NAL units in the sample headers but not in the samples directly. For MP4 outputs, when you choose HVC1, your output video might not work properly with some downstream systems and video players. The service defaults to marking your output as HEV1. For these outputs, the service writes parameter set NAL units directly into the samples.
     */
-  object H265WriteMp4PackagingTypeEnum {
-    val HVC1 = "HVC1"
-    val HEV1 = "HEV1"
+  @js.native
+  sealed trait H265WriteMp4PackagingType extends js.Any
+  object H265WriteMp4PackagingType extends js.Object {
+    val HVC1 = "HVC1".asInstanceOf[H265WriteMp4PackagingType]
+    val HEV1 = "HEV1".asInstanceOf[H265WriteMp4PackagingType]
 
     val values = js.Object.freeze(js.Array(HVC1, HEV1))
   }
@@ -4884,10 +4924,11 @@ package mediaconvert {
       __obj.asInstanceOf[Hdr10Metadata]
     }
   }
-
-  object HlsAdMarkersEnum {
-    val ELEMENTAL        = "ELEMENTAL"
-    val ELEMENTAL_SCTE35 = "ELEMENTAL_SCTE35"
+  @js.native
+  sealed trait HlsAdMarkers extends js.Any
+  object HlsAdMarkers extends js.Object {
+    val ELEMENTAL        = "ELEMENTAL".asInstanceOf[HlsAdMarkers]
+    val ELEMENTAL_SCTE35 = "ELEMENTAL_SCTE35".asInstanceOf[HlsAdMarkers]
 
     val values = js.Object.freeze(js.Array(ELEMENTAL, ELEMENTAL_SCTE35))
   }
@@ -4917,9 +4958,11 @@ package mediaconvert {
   /**
     * Use this setting only in audio-only outputs. Choose MPEG-2 Transport Stream (M2TS) to create a file in an MPEG2-TS container. Keep the default value Automatic (AUTOMATIC) to create a raw audio-only file with no container. Regardless of the value that you specify here, if this output has video, the service will place outputs into an MPEG2-TS container.
     */
-  object HlsAudioOnlyContainerEnum {
-    val AUTOMATIC = "AUTOMATIC"
-    val M2TS      = "M2TS"
+  @js.native
+  sealed trait HlsAudioOnlyContainer extends js.Any
+  object HlsAudioOnlyContainer extends js.Object {
+    val AUTOMATIC = "AUTOMATIC".asInstanceOf[HlsAudioOnlyContainer]
+    val M2TS      = "M2TS".asInstanceOf[HlsAudioOnlyContainer]
 
     val values = js.Object.freeze(js.Array(AUTOMATIC, M2TS))
   }
@@ -4927,11 +4970,13 @@ package mediaconvert {
   /**
     * Four types of audio-only tracks are supported: Audio-Only Variant Stream The client can play back this audio-only stream instead of video in low-bandwidth scenarios. Represented as an EXT-X-STREAM-INF in the HLS manifest. Alternate Audio, Auto Select, Default Alternate rendition that the client should try to play back by default. Represented as an EXT-X-MEDIA in the HLS manifest with DEFAULT=YES, AUTOSELECT=YES Alternate Audio, Auto Select, Not Default Alternate rendition that the client may try to play back by default. Represented as an EXT-X-MEDIA in the HLS manifest with DEFAULT=NO, AUTOSELECT=YES Alternate Audio, not Auto Select Alternate rendition that the client will not try to play back by default. Represented as an EXT-X-MEDIA in the HLS manifest with DEFAULT=NO, AUTOSELECT=NO
     */
-  object HlsAudioTrackTypeEnum {
-    val ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT = "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT"
-    val ALTERNATE_AUDIO_AUTO_SELECT         = "ALTERNATE_AUDIO_AUTO_SELECT"
-    val ALTERNATE_AUDIO_NOT_AUTO_SELECT     = "ALTERNATE_AUDIO_NOT_AUTO_SELECT"
-    val AUDIO_ONLY_VARIANT_STREAM           = "AUDIO_ONLY_VARIANT_STREAM"
+  @js.native
+  sealed trait HlsAudioTrackType extends js.Any
+  object HlsAudioTrackType extends js.Object {
+    val ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT = "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT".asInstanceOf[HlsAudioTrackType]
+    val ALTERNATE_AUDIO_AUTO_SELECT         = "ALTERNATE_AUDIO_AUTO_SELECT".asInstanceOf[HlsAudioTrackType]
+    val ALTERNATE_AUDIO_NOT_AUTO_SELECT     = "ALTERNATE_AUDIO_NOT_AUTO_SELECT".asInstanceOf[HlsAudioTrackType]
+    val AUDIO_ONLY_VARIANT_STREAM           = "AUDIO_ONLY_VARIANT_STREAM".asInstanceOf[HlsAudioTrackType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4974,10 +5019,12 @@ package mediaconvert {
   /**
     * Applies only to 608 Embedded output captions. Insert: Include CLOSED-CAPTIONS lines in the manifest. Specify at least one language in the CC1 Language Code field. One CLOSED-CAPTION line is added for each Language Code you specify. Make sure to specify the languages in the order in which they appear in the original source (if the source is embedded format) or the order of the caption selectors (if the source is other than embedded). Otherwise, languages in the manifest will not match up properly with the output captions. None: Include CLOSED-CAPTIONS=NONE line in the manifest. Omit: Omit any CLOSED-CAPTIONS line from the manifest.
     */
-  object HlsCaptionLanguageSettingEnum {
-    val INSERT = "INSERT"
-    val OMIT   = "OMIT"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait HlsCaptionLanguageSetting extends js.Any
+  object HlsCaptionLanguageSetting extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[HlsCaptionLanguageSetting]
+    val OMIT   = "OMIT".asInstanceOf[HlsCaptionLanguageSetting]
+    val NONE   = "NONE".asInstanceOf[HlsCaptionLanguageSetting]
 
     val values = js.Object.freeze(js.Array(INSERT, OMIT, NONE))
   }
@@ -4985,9 +5032,11 @@ package mediaconvert {
   /**
     * When set to ENABLED, sets #EXT-X-ALLOW-CACHE:no tag, which prevents client from saving media segments for later replay.
     */
-  object HlsClientCacheEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait HlsClientCache extends js.Any
+  object HlsClientCache extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[HlsClientCache]
+    val ENABLED  = "ENABLED".asInstanceOf[HlsClientCache]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4995,9 +5044,11 @@ package mediaconvert {
   /**
     * Specification to use (RFC-6381 or the default RFC-4281) during m3u8 playlist generation.
     */
-  object HlsCodecSpecificationEnum {
-    val RFC_6381 = "RFC_6381"
-    val RFC_4281 = "RFC_4281"
+  @js.native
+  sealed trait HlsCodecSpecification extends js.Any
+  object HlsCodecSpecification extends js.Object {
+    val RFC_6381 = "RFC_6381".asInstanceOf[HlsCodecSpecification]
+    val RFC_4281 = "RFC_4281".asInstanceOf[HlsCodecSpecification]
 
     val values = js.Object.freeze(js.Array(RFC_6381, RFC_4281))
   }
@@ -5005,9 +5056,11 @@ package mediaconvert {
   /**
     * Indicates whether segments should be placed in subdirectories.
     */
-  object HlsDirectoryStructureEnum {
-    val SINGLE_DIRECTORY        = "SINGLE_DIRECTORY"
-    val SUBDIRECTORY_PER_STREAM = "SUBDIRECTORY_PER_STREAM"
+  @js.native
+  sealed trait HlsDirectoryStructure extends js.Any
+  object HlsDirectoryStructure extends js.Object {
+    val SINGLE_DIRECTORY        = "SINGLE_DIRECTORY".asInstanceOf[HlsDirectoryStructure]
+    val SUBDIRECTORY_PER_STREAM = "SUBDIRECTORY_PER_STREAM".asInstanceOf[HlsDirectoryStructure]
 
     val values = js.Object.freeze(js.Array(SINGLE_DIRECTORY, SUBDIRECTORY_PER_STREAM))
   }
@@ -5056,9 +5109,11 @@ package mediaconvert {
   /**
     * Encrypts the segments with the given encryption scheme. Leave blank to disable. Selecting 'Disabled' in the web interface also disables encryption.
     */
-  object HlsEncryptionTypeEnum {
-    val AES128     = "AES128"
-    val SAMPLE_AES = "SAMPLE_AES"
+  @js.native
+  sealed trait HlsEncryptionType extends js.Any
+  object HlsEncryptionType extends js.Object {
+    val AES128     = "AES128".asInstanceOf[HlsEncryptionType]
+    val SAMPLE_AES = "SAMPLE_AES".asInstanceOf[HlsEncryptionType]
 
     val values = js.Object.freeze(js.Array(AES128, SAMPLE_AES))
   }
@@ -5159,9 +5214,11 @@ package mediaconvert {
   /**
     * When set to INCLUDE, writes I-Frame Only Manifest in addition to the HLS manifest
     */
-  object HlsIFrameOnlyManifestEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait HlsIFrameOnlyManifest extends js.Any
+  object HlsIFrameOnlyManifest extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[HlsIFrameOnlyManifest]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[HlsIFrameOnlyManifest]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -5169,9 +5226,11 @@ package mediaconvert {
   /**
     * The Initialization Vector is a 128-bit number used in conjunction with the key for encrypting blocks. If set to INCLUDE, Initialization Vector is listed in the manifest. Otherwise Initialization Vector is not in the manifest.
     */
-  object HlsInitializationVectorInManifestEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait HlsInitializationVectorInManifest extends js.Any
+  object HlsInitializationVectorInManifest extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[HlsInitializationVectorInManifest]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[HlsInitializationVectorInManifest]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -5179,9 +5238,11 @@ package mediaconvert {
   /**
     * Specify whether your DRM encryption key is static or from a key provider that follows the SPEKE standard. For more information about SPEKE, see https://docs.aws.amazon.com/speke/latest/documentation/what-is-speke.html.
     */
-  object HlsKeyProviderTypeEnum {
-    val SPEKE      = "SPEKE"
-    val STATIC_KEY = "STATIC_KEY"
+  @js.native
+  sealed trait HlsKeyProviderType extends js.Any
+  object HlsKeyProviderType extends js.Object {
+    val SPEKE      = "SPEKE".asInstanceOf[HlsKeyProviderType]
+    val STATIC_KEY = "STATIC_KEY".asInstanceOf[HlsKeyProviderType]
 
     val values = js.Object.freeze(js.Array(SPEKE, STATIC_KEY))
   }
@@ -5189,9 +5250,11 @@ package mediaconvert {
   /**
     * When set to GZIP, compresses HLS playlist.
     */
-  object HlsManifestCompressionEnum {
-    val GZIP = "GZIP"
-    val NONE = "NONE"
+  @js.native
+  sealed trait HlsManifestCompression extends js.Any
+  object HlsManifestCompression extends js.Object {
+    val GZIP = "GZIP".asInstanceOf[HlsManifestCompression]
+    val NONE = "NONE".asInstanceOf[HlsManifestCompression]
 
     val values = js.Object.freeze(js.Array(GZIP, NONE))
   }
@@ -5199,9 +5262,11 @@ package mediaconvert {
   /**
     * Indicates whether the output manifest should use floating point values for segment duration.
     */
-  object HlsManifestDurationFormatEnum {
-    val FLOATING_POINT = "FLOATING_POINT"
-    val INTEGER        = "INTEGER"
+  @js.native
+  sealed trait HlsManifestDurationFormat extends js.Any
+  object HlsManifestDurationFormat extends js.Object {
+    val FLOATING_POINT = "FLOATING_POINT".asInstanceOf[HlsManifestDurationFormat]
+    val INTEGER        = "INTEGER".asInstanceOf[HlsManifestDurationFormat]
 
     val values = js.Object.freeze(js.Array(FLOATING_POINT, INTEGER))
   }
@@ -5209,9 +5274,11 @@ package mediaconvert {
   /**
     * Enable this setting to insert the EXT-X-SESSION-KEY element into the master playlist. This allows for offline Apple HLS FairPlay content protection.
     */
-  object HlsOfflineEncryptedEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait HlsOfflineEncrypted extends js.Any
+  object HlsOfflineEncrypted extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[HlsOfflineEncrypted]
+    val DISABLED = "DISABLED".asInstanceOf[HlsOfflineEncrypted]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -5219,9 +5286,11 @@ package mediaconvert {
   /**
     * Indicates whether the .m3u8 manifest file should be generated for this HLS output group.
     */
-  object HlsOutputSelectionEnum {
-    val MANIFESTS_AND_SEGMENTS = "MANIFESTS_AND_SEGMENTS"
-    val SEGMENTS_ONLY          = "SEGMENTS_ONLY"
+  @js.native
+  sealed trait HlsOutputSelection extends js.Any
+  object HlsOutputSelection extends js.Object {
+    val MANIFESTS_AND_SEGMENTS = "MANIFESTS_AND_SEGMENTS".asInstanceOf[HlsOutputSelection]
+    val SEGMENTS_ONLY          = "SEGMENTS_ONLY".asInstanceOf[HlsOutputSelection]
 
     val values = js.Object.freeze(js.Array(MANIFESTS_AND_SEGMENTS, SEGMENTS_ONLY))
   }
@@ -5229,9 +5298,11 @@ package mediaconvert {
   /**
     * Includes or excludes EXT-X-PROGRAM-DATE-TIME tag in .m3u8 manifest files. The value is calculated as follows: either the program date and time are initialized using the input timecode source, or the time is initialized using the input timecode source and the date is initialized using the timestamp_offset.
     */
-  object HlsProgramDateTimeEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait HlsProgramDateTime extends js.Any
+  object HlsProgramDateTime extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[HlsProgramDateTime]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[HlsProgramDateTime]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -5239,9 +5310,11 @@ package mediaconvert {
   /**
     * When set to SINGLE_FILE, emits program as a single media resource (.ts) file, uses #EXT-X-BYTERANGE tags to index segment for playback.
     */
-  object HlsSegmentControlEnum {
-    val SINGLE_FILE     = "SINGLE_FILE"
-    val SEGMENTED_FILES = "SEGMENTED_FILES"
+  @js.native
+  sealed trait HlsSegmentControl extends js.Any
+  object HlsSegmentControl extends js.Object {
+    val SINGLE_FILE     = "SINGLE_FILE".asInstanceOf[HlsSegmentControl]
+    val SEGMENTED_FILES = "SEGMENTED_FILES".asInstanceOf[HlsSegmentControl]
 
     val values = js.Object.freeze(js.Array(SINGLE_FILE, SEGMENTED_FILES))
   }
@@ -5283,9 +5356,11 @@ package mediaconvert {
   /**
     * Include or exclude RESOLUTION attribute for video in EXT-X-STREAM-INF tag of variant manifest.
     */
-  object HlsStreamInfResolutionEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait HlsStreamInfResolution extends js.Any
+  object HlsStreamInfResolution extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[HlsStreamInfResolution]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[HlsStreamInfResolution]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -5293,10 +5368,12 @@ package mediaconvert {
   /**
     * Indicates ID3 frame that has the timecode.
     */
-  object HlsTimedMetadataId3FrameEnum {
-    val NONE = "NONE"
-    val PRIV = "PRIV"
-    val TDRL = "TDRL"
+  @js.native
+  sealed trait HlsTimedMetadataId3Frame extends js.Any
+  object HlsTimedMetadataId3Frame extends js.Object {
+    val NONE = "NONE".asInstanceOf[HlsTimedMetadataId3Frame]
+    val PRIV = "PRIV".asInstanceOf[HlsTimedMetadataId3Frame]
+    val TDRL = "TDRL".asInstanceOf[HlsTimedMetadataId3Frame]
 
     val values = js.Object.freeze(js.Array(NONE, PRIV, TDRL))
   }
@@ -5364,9 +5441,11 @@ package mediaconvert {
   /**
     * Keep this setting enabled to have MediaConvert use the font style and position information from the captions source in the output. This option is available only when your input captions are CFF-TT, IMSC, SMPTE-TT, or TTML. Disable this setting for simplified output captions.
     */
-  object ImscStylePassthroughEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait ImscStylePassthrough extends js.Any
+  object ImscStylePassthrough extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[ImscStylePassthrough]
+    val DISABLED = "DISABLED".asInstanceOf[ImscStylePassthrough]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -5473,9 +5552,11 @@ package mediaconvert {
   /**
     * Enable Deblock (InputDeblockFilter) to produce smoother motion in the output. Default is disabled. Only manaully controllable for MPEG2 and uncompressed video inputs.
     */
-  object InputDeblockFilterEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait InputDeblockFilter extends js.Any
+  object InputDeblockFilter extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[InputDeblockFilter]
+    val DISABLED = "DISABLED".asInstanceOf[InputDeblockFilter]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -5511,9 +5592,11 @@ package mediaconvert {
   /**
     * Enable Denoise (InputDenoiseFilter) to filter noise from the input.  Default is disabled. Only applicable to MPEG2, H.264, H.265, and uncompressed video inputs.
     */
-  object InputDenoiseFilterEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait InputDenoiseFilter extends js.Any
+  object InputDenoiseFilter extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[InputDenoiseFilter]
+    val DISABLED = "DISABLED".asInstanceOf[InputDenoiseFilter]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -5521,10 +5604,12 @@ package mediaconvert {
   /**
     * Use Filter enable (InputFilterEnable) to specify how the transcoding service applies the denoise and deblock filters. You must also enable the filters separately, with Denoise (InputDenoiseFilter) and Deblock (InputDeblockFilter). * Auto - The transcoding service determines whether to apply filtering, depending on input type and quality. * Disable - The input is not filtered. This is true even if you use the API to enable them in (InputDeblockFilter) and (InputDeblockFilter). * Force - The in put is filtered regardless of input type.
     */
-  object InputFilterEnableEnum {
-    val AUTO    = "AUTO"
-    val DISABLE = "DISABLE"
-    val FORCE   = "FORCE"
+  @js.native
+  sealed trait InputFilterEnable extends js.Any
+  object InputFilterEnable extends js.Object {
+    val AUTO    = "AUTO".asInstanceOf[InputFilterEnable]
+    val DISABLE = "DISABLE".asInstanceOf[InputFilterEnable]
+    val FORCE   = "FORCE".asInstanceOf[InputFilterEnable]
 
     val values = js.Object.freeze(js.Array(AUTO, DISABLE, FORCE))
   }
@@ -5532,9 +5617,11 @@ package mediaconvert {
   /**
     * Set PSI control (InputPsiControl) for transport stream inputs to specify which data the demux process to scans. * Ignore PSI - Scan all PIDs for audio and video. * Use PSI - Scan only PSI data.
     */
-  object InputPsiControlEnum {
-    val IGNORE_PSI = "IGNORE_PSI"
-    val USE_PSI    = "USE_PSI"
+  @js.native
+  sealed trait InputPsiControl extends js.Any
+  object InputPsiControl extends js.Object {
+    val IGNORE_PSI = "IGNORE_PSI".asInstanceOf[InputPsiControl]
+    val USE_PSI    = "USE_PSI".asInstanceOf[InputPsiControl]
 
     val values = js.Object.freeze(js.Array(IGNORE_PSI, USE_PSI))
   }
@@ -5542,12 +5629,14 @@ package mediaconvert {
   /**
     * Use Rotate (InputRotate) to specify how the service rotates your video. You can choose automatic rotation or specify a rotation. You can specify a clockwise rotation of 0, 90, 180, or 270 degrees. If your input video container is .mov or .mp4 and your input has rotation metadata, you can choose Automatic to have the service rotate your video according to the rotation specified in the metadata. The rotation must be within one degree of 90, 180, or 270 degrees. If the rotation metadata specifies any other rotation, the service will default to no rotation. By default, the service does no rotation, even if your input video has rotation metadata. The service doesn't pass through rotation metadata.
     */
-  object InputRotateEnum {
-    val DEGREE_0    = "DEGREE_0"
-    val DEGREES_90  = "DEGREES_90"
-    val DEGREES_180 = "DEGREES_180"
-    val DEGREES_270 = "DEGREES_270"
-    val AUTO        = "AUTO"
+  @js.native
+  sealed trait InputRotate extends js.Any
+  object InputRotate extends js.Object {
+    val DEGREE_0    = "DEGREE_0".asInstanceOf[InputRotate]
+    val DEGREES_90  = "DEGREES_90".asInstanceOf[InputRotate]
+    val DEGREES_180 = "DEGREES_180".asInstanceOf[InputRotate]
+    val DEGREES_270 = "DEGREES_270".asInstanceOf[InputRotate]
+    val AUTO        = "AUTO".asInstanceOf[InputRotate]
 
     val values = js.Object.freeze(js.Array(DEGREE_0, DEGREES_90, DEGREES_180, DEGREES_270, AUTO))
   }
@@ -5619,10 +5708,12 @@ package mediaconvert {
   /**
     * Use this Timecode source setting, located under the input settings (InputTimecodeSource), to specify how the service counts input video frames. This input frame count affects only the behavior of features that apply to a single input at a time, such as input clipping and synchronizing some captions formats. Choose Embedded (EMBEDDED) to use the timecodes in your input video. Choose Start at zero (ZEROBASED) to start the first frame at zero. Choose Specified start (SPECIFIEDSTART) to start the first frame at the timecode that you specify in the setting Start timecode (timecodeStart). If you don't specify a value for Timecode source, the service will use Embedded by default. For more information about timecodes, see https://docs.aws.amazon.com/console/mediaconvert/timecode.
     */
-  object InputTimecodeSourceEnum {
-    val EMBEDDED       = "EMBEDDED"
-    val ZEROBASED      = "ZEROBASED"
-    val SPECIFIEDSTART = "SPECIFIEDSTART"
+  @js.native
+  sealed trait InputTimecodeSource extends js.Any
+  object InputTimecodeSource extends js.Object {
+    val EMBEDDED       = "EMBEDDED".asInstanceOf[InputTimecodeSource]
+    val ZEROBASED      = "ZEROBASED".asInstanceOf[InputTimecodeSource]
+    val SPECIFIEDSTART = "SPECIFIEDSTART".asInstanceOf[InputTimecodeSource]
 
     val values = js.Object.freeze(js.Array(EMBEDDED, ZEROBASED, SPECIFIEDSTART))
   }
@@ -5788,10 +5879,12 @@ package mediaconvert {
   /**
     * A job's phase can be PROBING, TRANSCODING OR UPLOADING
     */
-  object JobPhaseEnum {
-    val PROBING     = "PROBING"
-    val TRANSCODING = "TRANSCODING"
-    val UPLOADING   = "UPLOADING"
+  @js.native
+  sealed trait JobPhase extends js.Any
+  object JobPhase extends js.Object {
+    val PROBING     = "PROBING".asInstanceOf[JobPhase]
+    val TRANSCODING = "TRANSCODING".asInstanceOf[JobPhase]
+    val UPLOADING   = "UPLOADING".asInstanceOf[JobPhase]
 
     val values = js.Object.freeze(js.Array(PROBING, TRANSCODING, UPLOADING))
   }
@@ -5842,12 +5935,14 @@ package mediaconvert {
   /**
     * A job's status can be SUBMITTED, PROGRESSING, COMPLETE, CANCELED, or ERROR.
     */
-  object JobStatusEnum {
-    val SUBMITTED   = "SUBMITTED"
-    val PROGRESSING = "PROGRESSING"
-    val COMPLETE    = "COMPLETE"
-    val CANCELED    = "CANCELED"
-    val ERROR       = "ERROR"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val SUBMITTED   = "SUBMITTED".asInstanceOf[JobStatus]
+    val PROGRESSING = "PROGRESSING".asInstanceOf[JobStatus]
+    val COMPLETE    = "COMPLETE".asInstanceOf[JobStatus]
+    val CANCELED    = "CANCELED".asInstanceOf[JobStatus]
+    val ERROR       = "ERROR".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(js.Array(SUBMITTED, PROGRESSING, COMPLETE, CANCELED, ERROR))
   }
@@ -5909,10 +6004,12 @@ package mediaconvert {
   /**
     * Optional. When you request a list of job templates, you can choose to list them alphabetically by NAME or chronologically by CREATION_DATE. If you don't specify, the service will list them by name.
     */
-  object JobTemplateListByEnum {
-    val NAME          = "NAME"
-    val CREATION_DATE = "CREATION_DATE"
-    val SYSTEM        = "SYSTEM"
+  @js.native
+  sealed trait JobTemplateListBy extends js.Any
+  object JobTemplateListBy extends js.Object {
+    val NAME          = "NAME".asInstanceOf[JobTemplateListBy]
+    val CREATION_DATE = "CREATION_DATE".asInstanceOf[JobTemplateListBy]
+    val SYSTEM        = "SYSTEM".asInstanceOf[JobTemplateListBy]
 
     val values = js.Object.freeze(js.Array(NAME, CREATION_DATE, SYSTEM))
   }
@@ -5963,198 +6060,200 @@ package mediaconvert {
   /**
     * Specify the language, using the ISO 639-2 three-letter code listed at https://www.loc.gov/standards/iso639-2/php/code_list.php.
     */
-  object LanguageCodeEnum {
-    val ENG = "ENG"
-    val SPA = "SPA"
-    val FRA = "FRA"
-    val DEU = "DEU"
-    val GER = "GER"
-    val ZHO = "ZHO"
-    val ARA = "ARA"
-    val HIN = "HIN"
-    val JPN = "JPN"
-    val RUS = "RUS"
-    val POR = "POR"
-    val ITA = "ITA"
-    val URD = "URD"
-    val VIE = "VIE"
-    val KOR = "KOR"
-    val PAN = "PAN"
-    val ABK = "ABK"
-    val AAR = "AAR"
-    val AFR = "AFR"
-    val AKA = "AKA"
-    val SQI = "SQI"
-    val AMH = "AMH"
-    val ARG = "ARG"
-    val HYE = "HYE"
-    val ASM = "ASM"
-    val AVA = "AVA"
-    val AVE = "AVE"
-    val AYM = "AYM"
-    val AZE = "AZE"
-    val BAM = "BAM"
-    val BAK = "BAK"
-    val EUS = "EUS"
-    val BEL = "BEL"
-    val BEN = "BEN"
-    val BIH = "BIH"
-    val BIS = "BIS"
-    val BOS = "BOS"
-    val BRE = "BRE"
-    val BUL = "BUL"
-    val MYA = "MYA"
-    val CAT = "CAT"
-    val KHM = "KHM"
-    val CHA = "CHA"
-    val CHE = "CHE"
-    val NYA = "NYA"
-    val CHU = "CHU"
-    val CHV = "CHV"
-    val COR = "COR"
-    val COS = "COS"
-    val CRE = "CRE"
-    val HRV = "HRV"
-    val CES = "CES"
-    val DAN = "DAN"
-    val DIV = "DIV"
-    val NLD = "NLD"
-    val DZO = "DZO"
-    val ENM = "ENM"
-    val EPO = "EPO"
-    val EST = "EST"
-    val EWE = "EWE"
-    val FAO = "FAO"
-    val FIJ = "FIJ"
-    val FIN = "FIN"
-    val FRM = "FRM"
-    val FUL = "FUL"
-    val GLA = "GLA"
-    val GLG = "GLG"
-    val LUG = "LUG"
-    val KAT = "KAT"
-    val ELL = "ELL"
-    val GRN = "GRN"
-    val GUJ = "GUJ"
-    val HAT = "HAT"
-    val HAU = "HAU"
-    val HEB = "HEB"
-    val HER = "HER"
-    val HMO = "HMO"
-    val HUN = "HUN"
-    val ISL = "ISL"
-    val IDO = "IDO"
-    val IBO = "IBO"
-    val IND = "IND"
-    val INA = "INA"
-    val ILE = "ILE"
-    val IKU = "IKU"
-    val IPK = "IPK"
-    val GLE = "GLE"
-    val JAV = "JAV"
-    val KAL = "KAL"
-    val KAN = "KAN"
-    val KAU = "KAU"
-    val KAS = "KAS"
-    val KAZ = "KAZ"
-    val KIK = "KIK"
-    val KIN = "KIN"
-    val KIR = "KIR"
-    val KOM = "KOM"
-    val KON = "KON"
-    val KUA = "KUA"
-    val KUR = "KUR"
-    val LAO = "LAO"
-    val LAT = "LAT"
-    val LAV = "LAV"
-    val LIM = "LIM"
-    val LIN = "LIN"
-    val LIT = "LIT"
-    val LUB = "LUB"
-    val LTZ = "LTZ"
-    val MKD = "MKD"
-    val MLG = "MLG"
-    val MSA = "MSA"
-    val MAL = "MAL"
-    val MLT = "MLT"
-    val GLV = "GLV"
-    val MRI = "MRI"
-    val MAR = "MAR"
-    val MAH = "MAH"
-    val MON = "MON"
-    val NAU = "NAU"
-    val NAV = "NAV"
-    val NDE = "NDE"
-    val NBL = "NBL"
-    val NDO = "NDO"
-    val NEP = "NEP"
-    val SME = "SME"
-    val NOR = "NOR"
-    val NOB = "NOB"
-    val NNO = "NNO"
-    val OCI = "OCI"
-    val OJI = "OJI"
-    val ORI = "ORI"
-    val ORM = "ORM"
-    val OSS = "OSS"
-    val PLI = "PLI"
-    val FAS = "FAS"
-    val POL = "POL"
-    val PUS = "PUS"
-    val QUE = "QUE"
-    val QAA = "QAA"
-    val RON = "RON"
-    val ROH = "ROH"
-    val RUN = "RUN"
-    val SMO = "SMO"
-    val SAG = "SAG"
-    val SAN = "SAN"
-    val SRD = "SRD"
-    val SRB = "SRB"
-    val SNA = "SNA"
-    val III = "III"
-    val SND = "SND"
-    val SIN = "SIN"
-    val SLK = "SLK"
-    val SLV = "SLV"
-    val SOM = "SOM"
-    val SOT = "SOT"
-    val SUN = "SUN"
-    val SWA = "SWA"
-    val SSW = "SSW"
-    val SWE = "SWE"
-    val TGL = "TGL"
-    val TAH = "TAH"
-    val TGK = "TGK"
-    val TAM = "TAM"
-    val TAT = "TAT"
-    val TEL = "TEL"
-    val THA = "THA"
-    val BOD = "BOD"
-    val TIR = "TIR"
-    val TON = "TON"
-    val TSO = "TSO"
-    val TSN = "TSN"
-    val TUR = "TUR"
-    val TUK = "TUK"
-    val TWI = "TWI"
-    val UIG = "UIG"
-    val UKR = "UKR"
-    val UZB = "UZB"
-    val VEN = "VEN"
-    val VOL = "VOL"
-    val WLN = "WLN"
-    val CYM = "CYM"
-    val FRY = "FRY"
-    val WOL = "WOL"
-    val XHO = "XHO"
-    val YID = "YID"
-    val YOR = "YOR"
-    val ZHA = "ZHA"
-    val ZUL = "ZUL"
-    val ORJ = "ORJ"
-    val QPC = "QPC"
-    val TNG = "TNG"
+  @js.native
+  sealed trait LanguageCode extends js.Any
+  object LanguageCode extends js.Object {
+    val ENG = "ENG".asInstanceOf[LanguageCode]
+    val SPA = "SPA".asInstanceOf[LanguageCode]
+    val FRA = "FRA".asInstanceOf[LanguageCode]
+    val DEU = "DEU".asInstanceOf[LanguageCode]
+    val GER = "GER".asInstanceOf[LanguageCode]
+    val ZHO = "ZHO".asInstanceOf[LanguageCode]
+    val ARA = "ARA".asInstanceOf[LanguageCode]
+    val HIN = "HIN".asInstanceOf[LanguageCode]
+    val JPN = "JPN".asInstanceOf[LanguageCode]
+    val RUS = "RUS".asInstanceOf[LanguageCode]
+    val POR = "POR".asInstanceOf[LanguageCode]
+    val ITA = "ITA".asInstanceOf[LanguageCode]
+    val URD = "URD".asInstanceOf[LanguageCode]
+    val VIE = "VIE".asInstanceOf[LanguageCode]
+    val KOR = "KOR".asInstanceOf[LanguageCode]
+    val PAN = "PAN".asInstanceOf[LanguageCode]
+    val ABK = "ABK".asInstanceOf[LanguageCode]
+    val AAR = "AAR".asInstanceOf[LanguageCode]
+    val AFR = "AFR".asInstanceOf[LanguageCode]
+    val AKA = "AKA".asInstanceOf[LanguageCode]
+    val SQI = "SQI".asInstanceOf[LanguageCode]
+    val AMH = "AMH".asInstanceOf[LanguageCode]
+    val ARG = "ARG".asInstanceOf[LanguageCode]
+    val HYE = "HYE".asInstanceOf[LanguageCode]
+    val ASM = "ASM".asInstanceOf[LanguageCode]
+    val AVA = "AVA".asInstanceOf[LanguageCode]
+    val AVE = "AVE".asInstanceOf[LanguageCode]
+    val AYM = "AYM".asInstanceOf[LanguageCode]
+    val AZE = "AZE".asInstanceOf[LanguageCode]
+    val BAM = "BAM".asInstanceOf[LanguageCode]
+    val BAK = "BAK".asInstanceOf[LanguageCode]
+    val EUS = "EUS".asInstanceOf[LanguageCode]
+    val BEL = "BEL".asInstanceOf[LanguageCode]
+    val BEN = "BEN".asInstanceOf[LanguageCode]
+    val BIH = "BIH".asInstanceOf[LanguageCode]
+    val BIS = "BIS".asInstanceOf[LanguageCode]
+    val BOS = "BOS".asInstanceOf[LanguageCode]
+    val BRE = "BRE".asInstanceOf[LanguageCode]
+    val BUL = "BUL".asInstanceOf[LanguageCode]
+    val MYA = "MYA".asInstanceOf[LanguageCode]
+    val CAT = "CAT".asInstanceOf[LanguageCode]
+    val KHM = "KHM".asInstanceOf[LanguageCode]
+    val CHA = "CHA".asInstanceOf[LanguageCode]
+    val CHE = "CHE".asInstanceOf[LanguageCode]
+    val NYA = "NYA".asInstanceOf[LanguageCode]
+    val CHU = "CHU".asInstanceOf[LanguageCode]
+    val CHV = "CHV".asInstanceOf[LanguageCode]
+    val COR = "COR".asInstanceOf[LanguageCode]
+    val COS = "COS".asInstanceOf[LanguageCode]
+    val CRE = "CRE".asInstanceOf[LanguageCode]
+    val HRV = "HRV".asInstanceOf[LanguageCode]
+    val CES = "CES".asInstanceOf[LanguageCode]
+    val DAN = "DAN".asInstanceOf[LanguageCode]
+    val DIV = "DIV".asInstanceOf[LanguageCode]
+    val NLD = "NLD".asInstanceOf[LanguageCode]
+    val DZO = "DZO".asInstanceOf[LanguageCode]
+    val ENM = "ENM".asInstanceOf[LanguageCode]
+    val EPO = "EPO".asInstanceOf[LanguageCode]
+    val EST = "EST".asInstanceOf[LanguageCode]
+    val EWE = "EWE".asInstanceOf[LanguageCode]
+    val FAO = "FAO".asInstanceOf[LanguageCode]
+    val FIJ = "FIJ".asInstanceOf[LanguageCode]
+    val FIN = "FIN".asInstanceOf[LanguageCode]
+    val FRM = "FRM".asInstanceOf[LanguageCode]
+    val FUL = "FUL".asInstanceOf[LanguageCode]
+    val GLA = "GLA".asInstanceOf[LanguageCode]
+    val GLG = "GLG".asInstanceOf[LanguageCode]
+    val LUG = "LUG".asInstanceOf[LanguageCode]
+    val KAT = "KAT".asInstanceOf[LanguageCode]
+    val ELL = "ELL".asInstanceOf[LanguageCode]
+    val GRN = "GRN".asInstanceOf[LanguageCode]
+    val GUJ = "GUJ".asInstanceOf[LanguageCode]
+    val HAT = "HAT".asInstanceOf[LanguageCode]
+    val HAU = "HAU".asInstanceOf[LanguageCode]
+    val HEB = "HEB".asInstanceOf[LanguageCode]
+    val HER = "HER".asInstanceOf[LanguageCode]
+    val HMO = "HMO".asInstanceOf[LanguageCode]
+    val HUN = "HUN".asInstanceOf[LanguageCode]
+    val ISL = "ISL".asInstanceOf[LanguageCode]
+    val IDO = "IDO".asInstanceOf[LanguageCode]
+    val IBO = "IBO".asInstanceOf[LanguageCode]
+    val IND = "IND".asInstanceOf[LanguageCode]
+    val INA = "INA".asInstanceOf[LanguageCode]
+    val ILE = "ILE".asInstanceOf[LanguageCode]
+    val IKU = "IKU".asInstanceOf[LanguageCode]
+    val IPK = "IPK".asInstanceOf[LanguageCode]
+    val GLE = "GLE".asInstanceOf[LanguageCode]
+    val JAV = "JAV".asInstanceOf[LanguageCode]
+    val KAL = "KAL".asInstanceOf[LanguageCode]
+    val KAN = "KAN".asInstanceOf[LanguageCode]
+    val KAU = "KAU".asInstanceOf[LanguageCode]
+    val KAS = "KAS".asInstanceOf[LanguageCode]
+    val KAZ = "KAZ".asInstanceOf[LanguageCode]
+    val KIK = "KIK".asInstanceOf[LanguageCode]
+    val KIN = "KIN".asInstanceOf[LanguageCode]
+    val KIR = "KIR".asInstanceOf[LanguageCode]
+    val KOM = "KOM".asInstanceOf[LanguageCode]
+    val KON = "KON".asInstanceOf[LanguageCode]
+    val KUA = "KUA".asInstanceOf[LanguageCode]
+    val KUR = "KUR".asInstanceOf[LanguageCode]
+    val LAO = "LAO".asInstanceOf[LanguageCode]
+    val LAT = "LAT".asInstanceOf[LanguageCode]
+    val LAV = "LAV".asInstanceOf[LanguageCode]
+    val LIM = "LIM".asInstanceOf[LanguageCode]
+    val LIN = "LIN".asInstanceOf[LanguageCode]
+    val LIT = "LIT".asInstanceOf[LanguageCode]
+    val LUB = "LUB".asInstanceOf[LanguageCode]
+    val LTZ = "LTZ".asInstanceOf[LanguageCode]
+    val MKD = "MKD".asInstanceOf[LanguageCode]
+    val MLG = "MLG".asInstanceOf[LanguageCode]
+    val MSA = "MSA".asInstanceOf[LanguageCode]
+    val MAL = "MAL".asInstanceOf[LanguageCode]
+    val MLT = "MLT".asInstanceOf[LanguageCode]
+    val GLV = "GLV".asInstanceOf[LanguageCode]
+    val MRI = "MRI".asInstanceOf[LanguageCode]
+    val MAR = "MAR".asInstanceOf[LanguageCode]
+    val MAH = "MAH".asInstanceOf[LanguageCode]
+    val MON = "MON".asInstanceOf[LanguageCode]
+    val NAU = "NAU".asInstanceOf[LanguageCode]
+    val NAV = "NAV".asInstanceOf[LanguageCode]
+    val NDE = "NDE".asInstanceOf[LanguageCode]
+    val NBL = "NBL".asInstanceOf[LanguageCode]
+    val NDO = "NDO".asInstanceOf[LanguageCode]
+    val NEP = "NEP".asInstanceOf[LanguageCode]
+    val SME = "SME".asInstanceOf[LanguageCode]
+    val NOR = "NOR".asInstanceOf[LanguageCode]
+    val NOB = "NOB".asInstanceOf[LanguageCode]
+    val NNO = "NNO".asInstanceOf[LanguageCode]
+    val OCI = "OCI".asInstanceOf[LanguageCode]
+    val OJI = "OJI".asInstanceOf[LanguageCode]
+    val ORI = "ORI".asInstanceOf[LanguageCode]
+    val ORM = "ORM".asInstanceOf[LanguageCode]
+    val OSS = "OSS".asInstanceOf[LanguageCode]
+    val PLI = "PLI".asInstanceOf[LanguageCode]
+    val FAS = "FAS".asInstanceOf[LanguageCode]
+    val POL = "POL".asInstanceOf[LanguageCode]
+    val PUS = "PUS".asInstanceOf[LanguageCode]
+    val QUE = "QUE".asInstanceOf[LanguageCode]
+    val QAA = "QAA".asInstanceOf[LanguageCode]
+    val RON = "RON".asInstanceOf[LanguageCode]
+    val ROH = "ROH".asInstanceOf[LanguageCode]
+    val RUN = "RUN".asInstanceOf[LanguageCode]
+    val SMO = "SMO".asInstanceOf[LanguageCode]
+    val SAG = "SAG".asInstanceOf[LanguageCode]
+    val SAN = "SAN".asInstanceOf[LanguageCode]
+    val SRD = "SRD".asInstanceOf[LanguageCode]
+    val SRB = "SRB".asInstanceOf[LanguageCode]
+    val SNA = "SNA".asInstanceOf[LanguageCode]
+    val III = "III".asInstanceOf[LanguageCode]
+    val SND = "SND".asInstanceOf[LanguageCode]
+    val SIN = "SIN".asInstanceOf[LanguageCode]
+    val SLK = "SLK".asInstanceOf[LanguageCode]
+    val SLV = "SLV".asInstanceOf[LanguageCode]
+    val SOM = "SOM".asInstanceOf[LanguageCode]
+    val SOT = "SOT".asInstanceOf[LanguageCode]
+    val SUN = "SUN".asInstanceOf[LanguageCode]
+    val SWA = "SWA".asInstanceOf[LanguageCode]
+    val SSW = "SSW".asInstanceOf[LanguageCode]
+    val SWE = "SWE".asInstanceOf[LanguageCode]
+    val TGL = "TGL".asInstanceOf[LanguageCode]
+    val TAH = "TAH".asInstanceOf[LanguageCode]
+    val TGK = "TGK".asInstanceOf[LanguageCode]
+    val TAM = "TAM".asInstanceOf[LanguageCode]
+    val TAT = "TAT".asInstanceOf[LanguageCode]
+    val TEL = "TEL".asInstanceOf[LanguageCode]
+    val THA = "THA".asInstanceOf[LanguageCode]
+    val BOD = "BOD".asInstanceOf[LanguageCode]
+    val TIR = "TIR".asInstanceOf[LanguageCode]
+    val TON = "TON".asInstanceOf[LanguageCode]
+    val TSO = "TSO".asInstanceOf[LanguageCode]
+    val TSN = "TSN".asInstanceOf[LanguageCode]
+    val TUR = "TUR".asInstanceOf[LanguageCode]
+    val TUK = "TUK".asInstanceOf[LanguageCode]
+    val TWI = "TWI".asInstanceOf[LanguageCode]
+    val UIG = "UIG".asInstanceOf[LanguageCode]
+    val UKR = "UKR".asInstanceOf[LanguageCode]
+    val UZB = "UZB".asInstanceOf[LanguageCode]
+    val VEN = "VEN".asInstanceOf[LanguageCode]
+    val VOL = "VOL".asInstanceOf[LanguageCode]
+    val WLN = "WLN".asInstanceOf[LanguageCode]
+    val CYM = "CYM".asInstanceOf[LanguageCode]
+    val FRY = "FRY".asInstanceOf[LanguageCode]
+    val WOL = "WOL".asInstanceOf[LanguageCode]
+    val XHO = "XHO".asInstanceOf[LanguageCode]
+    val YID = "YID".asInstanceOf[LanguageCode]
+    val YOR = "YOR".asInstanceOf[LanguageCode]
+    val ZHA = "ZHA".asInstanceOf[LanguageCode]
+    val ZUL = "ZUL".asInstanceOf[LanguageCode]
+    val ORJ = "ORJ".asInstanceOf[LanguageCode]
+    val QPC = "QPC".asInstanceOf[LanguageCode]
+    val TNG = "TNG".asInstanceOf[LanguageCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -6575,9 +6674,11 @@ package mediaconvert {
   /**
     * Selects between the DVB and ATSC buffer models for Dolby Digital audio.
     */
-  object M2tsAudioBufferModelEnum {
-    val DVB  = "DVB"
-    val ATSC = "ATSC"
+  @js.native
+  sealed trait M2tsAudioBufferModel extends js.Any
+  object M2tsAudioBufferModel extends js.Object {
+    val DVB  = "DVB".asInstanceOf[M2tsAudioBufferModel]
+    val ATSC = "ATSC".asInstanceOf[M2tsAudioBufferModel]
 
     val values = js.Object.freeze(js.Array(DVB, ATSC))
   }
@@ -6585,9 +6686,11 @@ package mediaconvert {
   /**
     * Controls what buffer model to use for accurate interleaving. If set to MULTIPLEX, use multiplex  buffer model. If set to NONE, this can lead to lower latency, but low-memory devices may not be able to play back the stream without interruptions.
     */
-  object M2tsBufferModelEnum {
-    val MULTIPLEX = "MULTIPLEX"
-    val NONE      = "NONE"
+  @js.native
+  sealed trait M2tsBufferModel extends js.Any
+  object M2tsBufferModel extends js.Object {
+    val MULTIPLEX = "MULTIPLEX".asInstanceOf[M2tsBufferModel]
+    val NONE      = "NONE".asInstanceOf[M2tsBufferModel]
 
     val values = js.Object.freeze(js.Array(MULTIPLEX, NONE))
   }
@@ -6595,9 +6698,11 @@ package mediaconvert {
   /**
     * When set to VIDEO_AND_FIXED_INTERVALS, audio EBP markers will be added to partitions 3 and 4. The interval between these additional markers will be fixed, and will be slightly shorter than the video EBP marker interval. When set to VIDEO_INTERVAL, these additional markers will not be inserted. Only applicable when EBP segmentation markers are is selected (segmentationMarkers is EBP or EBP_LEGACY).
     */
-  object M2tsEbpAudioIntervalEnum {
-    val VIDEO_AND_FIXED_INTERVALS = "VIDEO_AND_FIXED_INTERVALS"
-    val VIDEO_INTERVAL            = "VIDEO_INTERVAL"
+  @js.native
+  sealed trait M2tsEbpAudioInterval extends js.Any
+  object M2tsEbpAudioInterval extends js.Object {
+    val VIDEO_AND_FIXED_INTERVALS = "VIDEO_AND_FIXED_INTERVALS".asInstanceOf[M2tsEbpAudioInterval]
+    val VIDEO_INTERVAL            = "VIDEO_INTERVAL".asInstanceOf[M2tsEbpAudioInterval]
 
     val values = js.Object.freeze(js.Array(VIDEO_AND_FIXED_INTERVALS, VIDEO_INTERVAL))
   }
@@ -6605,9 +6710,11 @@ package mediaconvert {
   /**
     * Selects which PIDs to place EBP markers on. They can either be placed only on the video PID, or on both the video PID and all audio PIDs. Only applicable when EBP segmentation markers are is selected (segmentationMarkers is EBP or EBP_LEGACY).
     */
-  object M2tsEbpPlacementEnum {
-    val VIDEO_AND_AUDIO_PIDS = "VIDEO_AND_AUDIO_PIDS"
-    val VIDEO_PID            = "VIDEO_PID"
+  @js.native
+  sealed trait M2tsEbpPlacement extends js.Any
+  object M2tsEbpPlacement extends js.Object {
+    val VIDEO_AND_AUDIO_PIDS = "VIDEO_AND_AUDIO_PIDS".asInstanceOf[M2tsEbpPlacement]
+    val VIDEO_PID            = "VIDEO_PID".asInstanceOf[M2tsEbpPlacement]
 
     val values = js.Object.freeze(js.Array(VIDEO_AND_AUDIO_PIDS, VIDEO_PID))
   }
@@ -6615,9 +6722,11 @@ package mediaconvert {
   /**
     * Controls whether to include the ES Rate field in the PES header.
     */
-  object M2tsEsRateInPesEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait M2tsEsRateInPes extends js.Any
+  object M2tsEsRateInPes extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[M2tsEsRateInPes]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[M2tsEsRateInPes]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -6625,9 +6734,11 @@ package mediaconvert {
   /**
     * Keep the default value (DEFAULT) unless you know that your audio EBP markers are incorrectly appearing before your video EBP markers. To correct this problem, set this value to Force (FORCE).
     */
-  object M2tsForceTsVideoEbpOrderEnum {
-    val FORCE   = "FORCE"
-    val DEFAULT = "DEFAULT"
+  @js.native
+  sealed trait M2tsForceTsVideoEbpOrder extends js.Any
+  object M2tsForceTsVideoEbpOrder extends js.Object {
+    val FORCE   = "FORCE".asInstanceOf[M2tsForceTsVideoEbpOrder]
+    val DEFAULT = "DEFAULT".asInstanceOf[M2tsForceTsVideoEbpOrder]
 
     val values = js.Object.freeze(js.Array(FORCE, DEFAULT))
   }
@@ -6635,9 +6746,11 @@ package mediaconvert {
   /**
     * If INSERT, Nielsen inaudible tones for media tracking will be detected in the input audio and an equivalent ID3 tag will be inserted in the output.
     */
-  object M2tsNielsenId3Enum {
-    val INSERT = "INSERT"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait M2tsNielsenId3 extends js.Any
+  object M2tsNielsenId3 extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[M2tsNielsenId3]
+    val NONE   = "NONE".asInstanceOf[M2tsNielsenId3]
 
     val values = js.Object.freeze(js.Array(INSERT, NONE))
   }
@@ -6645,9 +6758,11 @@ package mediaconvert {
   /**
     * When set to PCR_EVERY_PES_PACKET, a Program Clock Reference value is inserted for every Packetized Elementary Stream (PES) header. This is effective only when the PCR PID is the same as the video or audio elementary stream.
     */
-  object M2tsPcrControlEnum {
-    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET"
-    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD"
+  @js.native
+  sealed trait M2tsPcrControl extends js.Any
+  object M2tsPcrControl extends js.Object {
+    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET".asInstanceOf[M2tsPcrControl]
+    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD".asInstanceOf[M2tsPcrControl]
 
     val values = js.Object.freeze(js.Array(PCR_EVERY_PES_PACKET, CONFIGURED_PCR_PERIOD))
   }
@@ -6655,9 +6770,11 @@ package mediaconvert {
   /**
     * When set to CBR, inserts null packets into transport stream to fill specified bitrate. When set to VBR, the bitrate setting acts as the maximum bitrate, but the output will not be padded up to that bitrate.
     */
-  object M2tsRateModeEnum {
-    val VBR = "VBR"
-    val CBR = "CBR"
+  @js.native
+  sealed trait M2tsRateMode extends js.Any
+  object M2tsRateMode extends js.Object {
+    val VBR = "VBR".asInstanceOf[M2tsRateMode]
+    val CBR = "CBR".asInstanceOf[M2tsRateMode]
 
     val values = js.Object.freeze(js.Array(VBR, CBR))
   }
@@ -6684,9 +6801,11 @@ package mediaconvert {
   /**
     * For SCTE-35 markers from your input-- Choose Passthrough (PASSTHROUGH) if you want SCTE-35 markers that appear in your input to also appear in this output. Choose None (NONE) if you don't want SCTE-35 markers in this output. For SCTE-35 markers from an ESAM XML document-- Choose None (NONE). Also provide the ESAM XML as a string in the setting Signal processing notification XML (sccXml). Also enable ESAM SCTE-35 (include the property scte35Esam).
     */
-  object M2tsScte35SourceEnum {
-    val PASSTHROUGH = "PASSTHROUGH"
-    val NONE        = "NONE"
+  @js.native
+  sealed trait M2tsScte35Source extends js.Any
+  object M2tsScte35Source extends js.Object {
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[M2tsScte35Source]
+    val NONE        = "NONE".asInstanceOf[M2tsScte35Source]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, NONE))
   }
@@ -6694,13 +6813,15 @@ package mediaconvert {
   /**
     * Inserts segmentation markers at each segmentation_time period. rai_segstart sets the Random Access Indicator bit in the adaptation field. rai_adapt sets the RAI bit and adds the current timecode in the private data bytes. psi_segstart inserts PAT and PMT tables at the start of segments. ebp adds Encoder Boundary Point information to the adaptation field as per OpenCable specification OC-SP-EBP-I01-130118. ebp_legacy adds Encoder Boundary Point information to the adaptation field using a legacy proprietary format.
     */
-  object M2tsSegmentationMarkersEnum {
-    val NONE         = "NONE"
-    val RAI_SEGSTART = "RAI_SEGSTART"
-    val RAI_ADAPT    = "RAI_ADAPT"
-    val PSI_SEGSTART = "PSI_SEGSTART"
-    val EBP          = "EBP"
-    val EBP_LEGACY   = "EBP_LEGACY"
+  @js.native
+  sealed trait M2tsSegmentationMarkers extends js.Any
+  object M2tsSegmentationMarkers extends js.Object {
+    val NONE         = "NONE".asInstanceOf[M2tsSegmentationMarkers]
+    val RAI_SEGSTART = "RAI_SEGSTART".asInstanceOf[M2tsSegmentationMarkers]
+    val RAI_ADAPT    = "RAI_ADAPT".asInstanceOf[M2tsSegmentationMarkers]
+    val PSI_SEGSTART = "PSI_SEGSTART".asInstanceOf[M2tsSegmentationMarkers]
+    val EBP          = "EBP".asInstanceOf[M2tsSegmentationMarkers]
+    val EBP_LEGACY   = "EBP_LEGACY".asInstanceOf[M2tsSegmentationMarkers]
 
     val values = js.Object.freeze(js.Array(NONE, RAI_SEGSTART, RAI_ADAPT, PSI_SEGSTART, EBP, EBP_LEGACY))
   }
@@ -6708,9 +6829,11 @@ package mediaconvert {
   /**
     * The segmentation style parameter controls how segmentation markers are inserted into the transport stream. With avails, it is possible that segments may be truncated, which can influence where future segmentation markers are inserted. When a segmentation style of "reset_cadence" is selected and a segment is truncated due to an avail, we will reset the segmentation cadence. This means the subsequent segment will have a duration of of segmentation_time seconds. When a segmentation style of "maintain_cadence" is selected and a segment is truncated due to an avail, we will not reset the segmentation cadence. This means the subsequent segment will likely be truncated as well. However, all segments after that will have a duration of segmentation_time seconds. Note that EBP lookahead is a slight exception to this rule.
     */
-  object M2tsSegmentationStyleEnum {
-    val MAINTAIN_CADENCE = "MAINTAIN_CADENCE"
-    val RESET_CADENCE    = "RESET_CADENCE"
+  @js.native
+  sealed trait M2tsSegmentationStyle extends js.Any
+  object M2tsSegmentationStyle extends js.Object {
+    val MAINTAIN_CADENCE = "MAINTAIN_CADENCE".asInstanceOf[M2tsSegmentationStyle]
+    val RESET_CADENCE    = "RESET_CADENCE".asInstanceOf[M2tsSegmentationStyle]
 
     val values = js.Object.freeze(js.Array(MAINTAIN_CADENCE, RESET_CADENCE))
   }
@@ -6842,9 +6965,11 @@ package mediaconvert {
   /**
     * If INSERT, Nielsen inaudible tones for media tracking will be detected in the input audio and an equivalent ID3 tag will be inserted in the output.
     */
-  object M3u8NielsenId3Enum {
-    val INSERT = "INSERT"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait M3u8NielsenId3 extends js.Any
+  object M3u8NielsenId3 extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[M3u8NielsenId3]
+    val NONE   = "NONE".asInstanceOf[M3u8NielsenId3]
 
     val values = js.Object.freeze(js.Array(INSERT, NONE))
   }
@@ -6852,9 +6977,11 @@ package mediaconvert {
   /**
     * When set to PCR_EVERY_PES_PACKET a Program Clock Reference value is inserted for every Packetized Elementary Stream (PES) header. This parameter is effective only when the PCR PID is the same as the video or audio elementary stream.
     */
-  object M3u8PcrControlEnum {
-    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET"
-    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD"
+  @js.native
+  sealed trait M3u8PcrControl extends js.Any
+  object M3u8PcrControl extends js.Object {
+    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET".asInstanceOf[M3u8PcrControl]
+    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD".asInstanceOf[M3u8PcrControl]
 
     val values = js.Object.freeze(js.Array(PCR_EVERY_PES_PACKET, CONFIGURED_PCR_PERIOD))
   }
@@ -6862,9 +6989,11 @@ package mediaconvert {
   /**
     * For SCTE-35 markers from your input-- Choose Passthrough (PASSTHROUGH) if you want SCTE-35 markers that appear in your input to also appear in this output. Choose None (NONE) if you don't want SCTE-35 markers in this output. For SCTE-35 markers from an ESAM XML document-- Choose None (NONE) if you don't want manifest conditioning. Choose Passthrough (PASSTHROUGH) and choose Ad markers (adMarkers) if you do want manifest conditioning. In both cases, also provide the ESAM XML as a string in the setting Signal processing notification XML (sccXml).
     */
-  object M3u8Scte35SourceEnum {
-    val PASSTHROUGH = "PASSTHROUGH"
-    val NONE        = "NONE"
+  @js.native
+  sealed trait M3u8Scte35Source extends js.Any
+  object M3u8Scte35Source extends js.Object {
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[M3u8Scte35Source]
+    val NONE        = "NONE".asInstanceOf[M3u8Scte35Source]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, NONE))
   }
@@ -6992,9 +7121,11 @@ package mediaconvert {
   /**
     * Choose the type of motion graphic asset that you are providing for your overlay. You can choose either a .mov file or a series of .png files.
     */
-  object MotionImageInsertionModeEnum {
-    val MOV = "MOV"
-    val PNG = "PNG"
+  @js.native
+  sealed trait MotionImageInsertionMode extends js.Any
+  object MotionImageInsertionMode extends js.Object {
+    val MOV = "MOV".asInstanceOf[MotionImageInsertionMode]
+    val PNG = "PNG".asInstanceOf[MotionImageInsertionMode]
 
     val values = js.Object.freeze(js.Array(MOV, PNG))
   }
@@ -7024,9 +7155,11 @@ package mediaconvert {
   /**
     * Specify whether your motion graphic overlay repeats on a loop or plays only once.
     */
-  object MotionImagePlaybackEnum {
-    val ONCE   = "ONCE"
-    val REPEAT = "REPEAT"
+  @js.native
+  sealed trait MotionImagePlayback extends js.Any
+  object MotionImagePlayback extends js.Object {
+    val ONCE   = "ONCE".asInstanceOf[MotionImagePlayback]
+    val REPEAT = "REPEAT".asInstanceOf[MotionImagePlayback]
 
     val values = js.Object.freeze(js.Array(ONCE, REPEAT))
   }
@@ -7034,9 +7167,11 @@ package mediaconvert {
   /**
     * When enabled, include 'clap' atom if appropriate for the video output settings.
     */
-  object MovClapAtomEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait MovClapAtom extends js.Any
+  object MovClapAtom extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[MovClapAtom]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[MovClapAtom]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -7044,9 +7179,11 @@ package mediaconvert {
   /**
     * When enabled, file composition times will start at zero, composition times in the 'ctts' (composition time to sample) box for B-frames will be negative, and a 'cslg' (composition shift least greatest) box will be included per 14496-1 amendment 1. This improves compatibility with Apple players and tools.
     */
-  object MovCslgAtomEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait MovCslgAtom extends js.Any
+  object MovCslgAtom extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[MovCslgAtom]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[MovCslgAtom]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -7054,9 +7191,11 @@ package mediaconvert {
   /**
     * When set to XDCAM, writes MPEG2 video streams into the QuickTime file using XDCAM fourcc codes. This increases compatibility with Apple editors and players, but may decrease compatibility with other players. Only applicable when the video codec is MPEG2.
     */
-  object MovMpeg2FourCCControlEnum {
-    val XDCAM = "XDCAM"
-    val MPEG  = "MPEG"
+  @js.native
+  sealed trait MovMpeg2FourCCControl extends js.Any
+  object MovMpeg2FourCCControl extends js.Object {
+    val XDCAM = "XDCAM".asInstanceOf[MovMpeg2FourCCControl]
+    val MPEG  = "MPEG".asInstanceOf[MovMpeg2FourCCControl]
 
     val values = js.Object.freeze(js.Array(XDCAM, MPEG))
   }
@@ -7064,9 +7203,11 @@ package mediaconvert {
   /**
     * If set to OMNEON, inserts Omneon-compatible padding
     */
-  object MovPaddingControlEnum {
-    val OMNEON = "OMNEON"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait MovPaddingControl extends js.Any
+  object MovPaddingControl extends js.Object {
+    val OMNEON = "OMNEON".asInstanceOf[MovPaddingControl]
+    val NONE   = "NONE".asInstanceOf[MovPaddingControl]
 
     val values = js.Object.freeze(js.Array(OMNEON, NONE))
   }
@@ -7074,9 +7215,11 @@ package mediaconvert {
   /**
     * Always keep the default value (SELF_CONTAINED) for this setting.
     */
-  object MovReferenceEnum {
-    val SELF_CONTAINED = "SELF_CONTAINED"
-    val EXTERNAL       = "EXTERNAL"
+  @js.native
+  sealed trait MovReference extends js.Any
+  object MovReference extends js.Object {
+    val SELF_CONTAINED = "SELF_CONTAINED".asInstanceOf[MovReference]
+    val EXTERNAL       = "EXTERNAL".asInstanceOf[MovReference]
 
     val values = js.Object.freeze(js.Array(SELF_CONTAINED, EXTERNAL))
   }
@@ -7140,9 +7283,11 @@ package mediaconvert {
   /**
     * Specify whether the service encodes this MP3 audio output with a constant bitrate (CBR) or a variable bitrate (VBR).
     */
-  object Mp3RateControlModeEnum {
-    val CBR = "CBR"
-    val VBR = "VBR"
+  @js.native
+  sealed trait Mp3RateControlMode extends js.Any
+  object Mp3RateControlMode extends js.Object {
+    val CBR = "CBR".asInstanceOf[Mp3RateControlMode]
+    val VBR = "VBR".asInstanceOf[Mp3RateControlMode]
 
     val values = js.Object.freeze(js.Array(CBR, VBR))
   }
@@ -7181,9 +7326,11 @@ package mediaconvert {
   /**
     * When enabled, file composition times will start at zero, composition times in the 'ctts' (composition time to sample) box for B-frames will be negative, and a 'cslg' (composition shift least greatest) box will be included per 14496-1 amendment 1. This improves compatibility with Apple players and tools.
     */
-  object Mp4CslgAtomEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait Mp4CslgAtom extends js.Any
+  object Mp4CslgAtom extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[Mp4CslgAtom]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[Mp4CslgAtom]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -7191,9 +7338,11 @@ package mediaconvert {
   /**
     * Inserts a free-space box immediately after the moov box.
     */
-  object Mp4FreeSpaceBoxEnum {
-    val INCLUDE = "INCLUDE"
-    val EXCLUDE = "EXCLUDE"
+  @js.native
+  sealed trait Mp4FreeSpaceBox extends js.Any
+  object Mp4FreeSpaceBox extends js.Object {
+    val INCLUDE = "INCLUDE".asInstanceOf[Mp4FreeSpaceBox]
+    val EXCLUDE = "EXCLUDE".asInstanceOf[Mp4FreeSpaceBox]
 
     val values = js.Object.freeze(js.Array(INCLUDE, EXCLUDE))
   }
@@ -7201,9 +7350,11 @@ package mediaconvert {
   /**
     * If set to PROGRESSIVE_DOWNLOAD, the MOOV atom is relocated to the beginning of the archive as required for progressive downloading. Otherwise it is placed normally at the end.
     */
-  object Mp4MoovPlacementEnum {
-    val PROGRESSIVE_DOWNLOAD = "PROGRESSIVE_DOWNLOAD"
-    val NORMAL               = "NORMAL"
+  @js.native
+  sealed trait Mp4MoovPlacement extends js.Any
+  object Mp4MoovPlacement extends js.Object {
+    val PROGRESSIVE_DOWNLOAD = "PROGRESSIVE_DOWNLOAD".asInstanceOf[Mp4MoovPlacement]
+    val NORMAL               = "NORMAL".asInstanceOf[Mp4MoovPlacement]
 
     val values = js.Object.freeze(js.Array(PROGRESSIVE_DOWNLOAD, NORMAL))
   }
@@ -7242,9 +7393,11 @@ package mediaconvert {
   /**
     * Use this setting only in DASH output groups that include sidecar TTML or IMSC captions.  You specify sidecar captions in a separate output from your audio and video. Choose Raw (RAW) for captions in a single XML file in a raw container. Choose Fragmented MPEG-4 (FRAGMENTED_MP4) for captions in XML format contained within fragmented MP4 files. This set of fragmented MP4 files is separate from your video and audio fragmented MP4 files.
     */
-  object MpdCaptionContainerTypeEnum {
-    val RAW            = "RAW"
-    val FRAGMENTED_MP4 = "FRAGMENTED_MP4"
+  @js.native
+  sealed trait MpdCaptionContainerType extends js.Any
+  object MpdCaptionContainerType extends js.Object {
+    val RAW            = "RAW".asInstanceOf[MpdCaptionContainerType]
+    val FRAGMENTED_MP4 = "FRAGMENTED_MP4".asInstanceOf[MpdCaptionContainerType]
 
     val values = js.Object.freeze(js.Array(RAW, FRAGMENTED_MP4))
   }
@@ -7252,9 +7405,11 @@ package mediaconvert {
   /**
     * Use this setting only when you specify SCTE-35 markers from ESAM. Choose INSERT to put SCTE-35 markers in this output at the insertion points that you specify in an ESAM XML document. Provide the document in the setting SCC XML (sccXml).
     */
-  object MpdScte35EsamEnum {
-    val INSERT = "INSERT"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait MpdScte35Esam extends js.Any
+  object MpdScte35Esam extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[MpdScte35Esam]
+    val NONE   = "NONE".asInstanceOf[MpdScte35Esam]
 
     val values = js.Object.freeze(js.Array(INSERT, NONE))
   }
@@ -7262,9 +7417,11 @@ package mediaconvert {
   /**
     * Ignore this setting unless you have SCTE-35 markers in your input video file. Choose Passthrough (PASSTHROUGH) if you want SCTE-35 markers that appear in your input to also appear in this output. Choose None (NONE) if you don't want those SCTE-35 markers in this output.
     */
-  object MpdScte35SourceEnum {
-    val PASSTHROUGH = "PASSTHROUGH"
-    val NONE        = "NONE"
+  @js.native
+  sealed trait MpdScte35Source extends js.Any
+  object MpdScte35Source extends js.Object {
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[MpdScte35Source]
+    val NONE        = "NONE".asInstanceOf[MpdScte35Source]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, NONE))
   }
@@ -7297,11 +7454,13 @@ package mediaconvert {
   /**
     * Adaptive quantization. Allows intra-frame quantizers to vary to improve visual quality.
     */
-  object Mpeg2AdaptiveQuantizationEnum {
-    val OFF    = "OFF"
-    val LOW    = "LOW"
-    val MEDIUM = "MEDIUM"
-    val HIGH   = "HIGH"
+  @js.native
+  sealed trait Mpeg2AdaptiveQuantization extends js.Any
+  object Mpeg2AdaptiveQuantization extends js.Object {
+    val OFF    = "OFF".asInstanceOf[Mpeg2AdaptiveQuantization]
+    val LOW    = "LOW".asInstanceOf[Mpeg2AdaptiveQuantization]
+    val MEDIUM = "MEDIUM".asInstanceOf[Mpeg2AdaptiveQuantization]
+    val HIGH   = "HIGH".asInstanceOf[Mpeg2AdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(OFF, LOW, MEDIUM, HIGH))
   }
@@ -7309,12 +7468,14 @@ package mediaconvert {
   /**
     * Use Level (Mpeg2CodecLevel) to set the MPEG-2 level for the video output.
     */
-  object Mpeg2CodecLevelEnum {
-    val AUTO     = "AUTO"
-    val LOW      = "LOW"
-    val MAIN     = "MAIN"
-    val HIGH1440 = "HIGH1440"
-    val HIGH     = "HIGH"
+  @js.native
+  sealed trait Mpeg2CodecLevel extends js.Any
+  object Mpeg2CodecLevel extends js.Object {
+    val AUTO     = "AUTO".asInstanceOf[Mpeg2CodecLevel]
+    val LOW      = "LOW".asInstanceOf[Mpeg2CodecLevel]
+    val MAIN     = "MAIN".asInstanceOf[Mpeg2CodecLevel]
+    val HIGH1440 = "HIGH1440".asInstanceOf[Mpeg2CodecLevel]
+    val HIGH     = "HIGH".asInstanceOf[Mpeg2CodecLevel]
 
     val values = js.Object.freeze(js.Array(AUTO, LOW, MAIN, HIGH1440, HIGH))
   }
@@ -7322,9 +7483,11 @@ package mediaconvert {
   /**
     * Use Profile (Mpeg2CodecProfile) to set the MPEG-2 profile for the video output.
     */
-  object Mpeg2CodecProfileEnum {
-    val MAIN        = "MAIN"
-    val PROFILE_422 = "PROFILE_422"
+  @js.native
+  sealed trait Mpeg2CodecProfile extends js.Any
+  object Mpeg2CodecProfile extends js.Object {
+    val MAIN        = "MAIN".asInstanceOf[Mpeg2CodecProfile]
+    val PROFILE_422 = "PROFILE_422".asInstanceOf[Mpeg2CodecProfile]
 
     val values = js.Object.freeze(js.Array(MAIN, PROFILE_422))
   }
@@ -7332,9 +7495,11 @@ package mediaconvert {
   /**
     * Choose Adaptive to improve subjective video quality for high-motion content. This will cause the service to use fewer B-frames (which infer information based on other frames) for high-motion portions of the video and more B-frames for low-motion portions. The maximum number of B-frames is limited by the value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
     */
-  object Mpeg2DynamicSubGopEnum {
-    val ADAPTIVE = "ADAPTIVE"
-    val STATIC   = "STATIC"
+  @js.native
+  sealed trait Mpeg2DynamicSubGop extends js.Any
+  object Mpeg2DynamicSubGop extends js.Object {
+    val ADAPTIVE = "ADAPTIVE".asInstanceOf[Mpeg2DynamicSubGop]
+    val STATIC   = "STATIC".asInstanceOf[Mpeg2DynamicSubGop]
 
     val values = js.Object.freeze(js.Array(ADAPTIVE, STATIC))
   }
@@ -7342,9 +7507,11 @@ package mediaconvert {
   /**
     * If you are using the console, use the Framerate setting to specify the frame rate for this output. If you want to keep the same frame rate as the input video, choose Follow source. If you want to do frame rate conversion, choose a frame rate from the dropdown list or choose Custom. The framerates shown in the dropdown list are decimal approximations of fractions. If you choose Custom, specify your frame rate as a fraction. If you are creating your transcoding job sepecification as a JSON file without the console, use FramerateControl to specify which value the service uses for the frame rate for this output. Choose INITIALIZE_FROM_SOURCE if you want the service to use the frame rate from the input. Choose SPECIFIED if you want the service to use the frame rate you specify in the settings FramerateNumerator and FramerateDenominator.
     */
-  object Mpeg2FramerateControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait Mpeg2FramerateControl extends js.Any
+  object Mpeg2FramerateControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[Mpeg2FramerateControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[Mpeg2FramerateControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -7352,9 +7519,11 @@ package mediaconvert {
   /**
     * When set to INTERPOLATE, produces smoother motion during frame rate conversion.
     */
-  object Mpeg2FramerateConversionAlgorithmEnum {
-    val DUPLICATE_DROP = "DUPLICATE_DROP"
-    val INTERPOLATE    = "INTERPOLATE"
+  @js.native
+  sealed trait Mpeg2FramerateConversionAlgorithm extends js.Any
+  object Mpeg2FramerateConversionAlgorithm extends js.Object {
+    val DUPLICATE_DROP = "DUPLICATE_DROP".asInstanceOf[Mpeg2FramerateConversionAlgorithm]
+    val INTERPOLATE    = "INTERPOLATE".asInstanceOf[Mpeg2FramerateConversionAlgorithm]
 
     val values = js.Object.freeze(js.Array(DUPLICATE_DROP, INTERPOLATE))
   }
@@ -7362,9 +7531,11 @@ package mediaconvert {
   /**
     * Indicates if the GOP Size in MPEG2 is specified in frames or seconds. If seconds the system will convert the GOP Size into a frame count at run time.
     */
-  object Mpeg2GopSizeUnitsEnum {
-    val FRAMES  = "FRAMES"
-    val SECONDS = "SECONDS"
+  @js.native
+  sealed trait Mpeg2GopSizeUnits extends js.Any
+  object Mpeg2GopSizeUnits extends js.Object {
+    val FRAMES  = "FRAMES".asInstanceOf[Mpeg2GopSizeUnits]
+    val SECONDS = "SECONDS".asInstanceOf[Mpeg2GopSizeUnits]
 
     val values = js.Object.freeze(js.Array(FRAMES, SECONDS))
   }
@@ -7374,12 +7545,14 @@ package mediaconvert {
     *   - If the source is interlaced, the output will be interlaced with the same polarity as the source (it will follow the source). The output could therefore be a mix of "top field first" and "bottom field first".
     *   - If the source is progressive, the output will be interlaced with "top field first" or "bottom field first" polarity, depending on which of the Follow options you chose.
     */
-  object Mpeg2InterlaceModeEnum {
-    val PROGRESSIVE         = "PROGRESSIVE"
-    val TOP_FIELD           = "TOP_FIELD"
-    val BOTTOM_FIELD        = "BOTTOM_FIELD"
-    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD"
-    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD"
+  @js.native
+  sealed trait Mpeg2InterlaceMode extends js.Any
+  object Mpeg2InterlaceMode extends js.Object {
+    val PROGRESSIVE         = "PROGRESSIVE".asInstanceOf[Mpeg2InterlaceMode]
+    val TOP_FIELD           = "TOP_FIELD".asInstanceOf[Mpeg2InterlaceMode]
+    val BOTTOM_FIELD        = "BOTTOM_FIELD".asInstanceOf[Mpeg2InterlaceMode]
+    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD".asInstanceOf[Mpeg2InterlaceMode]
+    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD".asInstanceOf[Mpeg2InterlaceMode]
 
     val values = js.Object.freeze(js.Array(PROGRESSIVE, TOP_FIELD, BOTTOM_FIELD, FOLLOW_TOP_FIELD, FOLLOW_BOTTOM_FIELD))
   }
@@ -7387,12 +7560,14 @@ package mediaconvert {
   /**
     * Use Intra DC precision (Mpeg2IntraDcPrecision) to set quantization precision for intra-block DC coefficients. If you choose the value auto, the service will automatically select the precision based on the per-frame compression ratio.
     */
-  object Mpeg2IntraDcPrecisionEnum {
-    val AUTO                  = "AUTO"
-    val INTRA_DC_PRECISION_8  = "INTRA_DC_PRECISION_8"
-    val INTRA_DC_PRECISION_9  = "INTRA_DC_PRECISION_9"
-    val INTRA_DC_PRECISION_10 = "INTRA_DC_PRECISION_10"
-    val INTRA_DC_PRECISION_11 = "INTRA_DC_PRECISION_11"
+  @js.native
+  sealed trait Mpeg2IntraDcPrecision extends js.Any
+  object Mpeg2IntraDcPrecision extends js.Object {
+    val AUTO                  = "AUTO".asInstanceOf[Mpeg2IntraDcPrecision]
+    val INTRA_DC_PRECISION_8  = "INTRA_DC_PRECISION_8".asInstanceOf[Mpeg2IntraDcPrecision]
+    val INTRA_DC_PRECISION_9  = "INTRA_DC_PRECISION_9".asInstanceOf[Mpeg2IntraDcPrecision]
+    val INTRA_DC_PRECISION_10 = "INTRA_DC_PRECISION_10".asInstanceOf[Mpeg2IntraDcPrecision]
+    val INTRA_DC_PRECISION_11 = "INTRA_DC_PRECISION_11".asInstanceOf[Mpeg2IntraDcPrecision]
 
     val values = js.Object.freeze(
       js.Array(AUTO, INTRA_DC_PRECISION_8, INTRA_DC_PRECISION_9, INTRA_DC_PRECISION_10, INTRA_DC_PRECISION_11)
@@ -7402,9 +7577,11 @@ package mediaconvert {
   /**
     * Using the API, enable ParFollowSource if you want the service to use the pixel aspect ratio from the input. Using the console, do this by choosing Follow source for Pixel aspect ratio.
     */
-  object Mpeg2ParControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait Mpeg2ParControl extends js.Any
+  object Mpeg2ParControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[Mpeg2ParControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[Mpeg2ParControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -7412,9 +7589,11 @@ package mediaconvert {
   /**
     * Use Quality tuning level (Mpeg2QualityTuningLevel) to specifiy whether to use single-pass or multipass video encoding.
     */
-  object Mpeg2QualityTuningLevelEnum {
-    val SINGLE_PASS = "SINGLE_PASS"
-    val MULTI_PASS  = "MULTI_PASS"
+  @js.native
+  sealed trait Mpeg2QualityTuningLevel extends js.Any
+  object Mpeg2QualityTuningLevel extends js.Object {
+    val SINGLE_PASS = "SINGLE_PASS".asInstanceOf[Mpeg2QualityTuningLevel]
+    val MULTI_PASS  = "MULTI_PASS".asInstanceOf[Mpeg2QualityTuningLevel]
 
     val values = js.Object.freeze(js.Array(SINGLE_PASS, MULTI_PASS))
   }
@@ -7422,9 +7601,11 @@ package mediaconvert {
   /**
     * Use Rate control mode (Mpeg2RateControlMode) to specifiy whether the bitrate is variable (vbr) or constant (cbr).
     */
-  object Mpeg2RateControlModeEnum {
-    val VBR = "VBR"
-    val CBR = "CBR"
+  @js.native
+  sealed trait Mpeg2RateControlMode extends js.Any
+  object Mpeg2RateControlMode extends js.Object {
+    val VBR = "VBR".asInstanceOf[Mpeg2RateControlMode]
+    val CBR = "CBR".asInstanceOf[Mpeg2RateControlMode]
 
     val values = js.Object.freeze(js.Array(VBR, CBR))
   }
@@ -7432,9 +7613,11 @@ package mediaconvert {
   /**
     * Enable this setting to insert I-frames at scene changes that the service automatically detects. This improves video quality and is enabled by default.
     */
-  object Mpeg2SceneChangeDetectEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait Mpeg2SceneChangeDetect extends js.Any
+  object Mpeg2SceneChangeDetect extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[Mpeg2SceneChangeDetect]
+    val ENABLED  = "ENABLED".asInstanceOf[Mpeg2SceneChangeDetect]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -7561,9 +7744,11 @@ package mediaconvert {
   /**
     * Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled as 25fps, and audio is sped up correspondingly.
     */
-  object Mpeg2SlowPalEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait Mpeg2SlowPal extends js.Any
+  object Mpeg2SlowPal extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[Mpeg2SlowPal]
+    val ENABLED  = "ENABLED".asInstanceOf[Mpeg2SlowPal]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -7571,9 +7756,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame based on spatial variation of content complexity.
     */
-  object Mpeg2SpatialAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait Mpeg2SpatialAdaptiveQuantization extends js.Any
+  object Mpeg2SpatialAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[Mpeg2SpatialAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[Mpeg2SpatialAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -7581,9 +7768,11 @@ package mediaconvert {
   /**
     * Produces a Type D-10 compatible bitstream (SMPTE 356M-2001).
     */
-  object Mpeg2SyntaxEnum {
-    val DEFAULT = "DEFAULT"
-    val D_10    = "D_10"
+  @js.native
+  sealed trait Mpeg2Syntax extends js.Any
+  object Mpeg2Syntax extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[Mpeg2Syntax]
+    val D_10    = "D_10".asInstanceOf[Mpeg2Syntax]
 
     val values = js.Object.freeze(js.Array(DEFAULT, D_10))
   }
@@ -7591,10 +7780,12 @@ package mediaconvert {
   /**
     * Only use Telecine (Mpeg2Telecine) when you set Framerate (Framerate) to 29.970. Set Telecine (Mpeg2Telecine) to Hard (hard) to produce a 29.97i output from a 23.976 input. Set it to Soft (soft) to produce 23.976 output and leave converstion to the player.
     */
-  object Mpeg2TelecineEnum {
-    val NONE = "NONE"
-    val SOFT = "SOFT"
-    val HARD = "HARD"
+  @js.native
+  sealed trait Mpeg2Telecine extends js.Any
+  object Mpeg2Telecine extends js.Object {
+    val NONE = "NONE".asInstanceOf[Mpeg2Telecine]
+    val SOFT = "SOFT".asInstanceOf[Mpeg2Telecine]
+    val HARD = "HARD".asInstanceOf[Mpeg2Telecine]
 
     val values = js.Object.freeze(js.Array(NONE, SOFT, HARD))
   }
@@ -7602,9 +7793,11 @@ package mediaconvert {
   /**
     * Adjust quantization within each frame based on temporal variation of content complexity.
     */
-  object Mpeg2TemporalAdaptiveQuantizationEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait Mpeg2TemporalAdaptiveQuantization extends js.Any
+  object Mpeg2TemporalAdaptiveQuantization extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[Mpeg2TemporalAdaptiveQuantization]
+    val ENABLED  = "ENABLED".asInstanceOf[Mpeg2TemporalAdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -7634,9 +7827,11 @@ package mediaconvert {
   /**
     * COMBINE_DUPLICATE_STREAMS combines identical audio encoding settings across a Microsoft Smooth output group into a single audio stream.
     */
-  object MsSmoothAudioDeduplicationEnum {
-    val COMBINE_DUPLICATE_STREAMS = "COMBINE_DUPLICATE_STREAMS"
-    val NONE                      = "NONE"
+  @js.native
+  sealed trait MsSmoothAudioDeduplication extends js.Any
+  object MsSmoothAudioDeduplication extends js.Object {
+    val COMBINE_DUPLICATE_STREAMS = "COMBINE_DUPLICATE_STREAMS".asInstanceOf[MsSmoothAudioDeduplication]
+    val NONE                      = "NONE".asInstanceOf[MsSmoothAudioDeduplication]
 
     val values = js.Object.freeze(js.Array(COMBINE_DUPLICATE_STREAMS, NONE))
   }
@@ -7700,9 +7895,11 @@ package mediaconvert {
   /**
     * Use Manifest encoding (MsSmoothManifestEncoding) to specify the encoding format for the server and client manifest. Valid options are utf8 and utf16.
     */
-  object MsSmoothManifestEncodingEnum {
-    val UTF8  = "UTF8"
-    val UTF16 = "UTF16"
+  @js.native
+  sealed trait MsSmoothManifestEncoding extends js.Any
+  object MsSmoothManifestEncoding extends js.Object {
+    val UTF8  = "UTF8".asInstanceOf[MsSmoothManifestEncoding]
+    val UTF16 = "UTF16".asInstanceOf[MsSmoothManifestEncoding]
 
     val values = js.Object.freeze(js.Array(UTF8, UTF16))
   }
@@ -7760,15 +7957,17 @@ package mediaconvert {
   /**
     * Use Noise reducer filter (NoiseReducerFilter) to select one of the following spatial image filtering functions. To use this setting, you must also enable Noise reducer (NoiseReducer). * Bilateral preserves edges while reducing noise. * Mean (softest), Gaussian, Lanczos, and Sharpen (sharpest) do convolution filtering. * Conserve does min/max noise reduction. * Spatial does frequency-domain filtering based on JND principles. * Temporal optimizes video quality for complex motion.
     */
-  object NoiseReducerFilterEnum {
-    val BILATERAL = "BILATERAL"
-    val MEAN      = "MEAN"
-    val GAUSSIAN  = "GAUSSIAN"
-    val LANCZOS   = "LANCZOS"
-    val SHARPEN   = "SHARPEN"
-    val CONSERVE  = "CONSERVE"
-    val SPATIAL   = "SPATIAL"
-    val TEMPORAL  = "TEMPORAL"
+  @js.native
+  sealed trait NoiseReducerFilter extends js.Any
+  object NoiseReducerFilter extends js.Object {
+    val BILATERAL = "BILATERAL".asInstanceOf[NoiseReducerFilter]
+    val MEAN      = "MEAN".asInstanceOf[NoiseReducerFilter]
+    val GAUSSIAN  = "GAUSSIAN".asInstanceOf[NoiseReducerFilter]
+    val LANCZOS   = "LANCZOS".asInstanceOf[NoiseReducerFilter]
+    val SHARPEN   = "SHARPEN".asInstanceOf[NoiseReducerFilter]
+    val CONSERVE  = "CONSERVE".asInstanceOf[NoiseReducerFilter]
+    val SPATIAL   = "SPATIAL".asInstanceOf[NoiseReducerFilter]
+    val TEMPORAL  = "TEMPORAL".asInstanceOf[NoiseReducerFilter]
 
     val values = js.Object.freeze(js.Array(BILATERAL, MEAN, GAUSSIAN, LANCZOS, SHARPEN, CONSERVE, SPATIAL, TEMPORAL))
   }
@@ -7847,9 +8046,11 @@ package mediaconvert {
   /**
     * When you request lists of resources, you can optionally specify whether they are sorted in ASCENDING or DESCENDING order. Default varies by resource.
     */
-  object OrderEnum {
-    val ASCENDING  = "ASCENDING"
-    val DESCENDING = "DESCENDING"
+  @js.native
+  sealed trait Order extends js.Any
+  object Order extends js.Object {
+    val ASCENDING  = "ASCENDING".asInstanceOf[Order]
+    val DESCENDING = "DESCENDING".asInstanceOf[Order]
 
     val values = js.Object.freeze(js.Array(ASCENDING, DESCENDING))
   }
@@ -8019,12 +8220,14 @@ package mediaconvert {
   /**
     * Type of output group (File group, Apple HLS, DASH ISO, Microsoft Smooth Streaming, CMAF)
     */
-  object OutputGroupTypeEnum {
-    val HLS_GROUP_SETTINGS       = "HLS_GROUP_SETTINGS"
-    val DASH_ISO_GROUP_SETTINGS  = "DASH_ISO_GROUP_SETTINGS"
-    val FILE_GROUP_SETTINGS      = "FILE_GROUP_SETTINGS"
-    val MS_SMOOTH_GROUP_SETTINGS = "MS_SMOOTH_GROUP_SETTINGS"
-    val CMAF_GROUP_SETTINGS      = "CMAF_GROUP_SETTINGS"
+  @js.native
+  sealed trait OutputGroupType extends js.Any
+  object OutputGroupType extends js.Object {
+    val HLS_GROUP_SETTINGS       = "HLS_GROUP_SETTINGS".asInstanceOf[OutputGroupType]
+    val DASH_ISO_GROUP_SETTINGS  = "DASH_ISO_GROUP_SETTINGS".asInstanceOf[OutputGroupType]
+    val FILE_GROUP_SETTINGS      = "FILE_GROUP_SETTINGS".asInstanceOf[OutputGroupType]
+    val MS_SMOOTH_GROUP_SETTINGS = "MS_SMOOTH_GROUP_SETTINGS".asInstanceOf[OutputGroupType]
+    val CMAF_GROUP_SETTINGS      = "CMAF_GROUP_SETTINGS".asInstanceOf[OutputGroupType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -8040,11 +8243,13 @@ package mediaconvert {
   /**
     * Selects method of inserting SDT information into output stream.  "Follow input SDT" copies SDT information from input stream to  output stream. "Follow input SDT if present" copies SDT information from  input stream to output stream if SDT information is present in the input, otherwise it will fall back on the user-defined values. Enter "SDT  Manually" means user will enter the SDT information. "No SDT" means output  stream will not contain SDT information.
     */
-  object OutputSdtEnum {
-    val SDT_FOLLOW            = "SDT_FOLLOW"
-    val SDT_FOLLOW_IF_PRESENT = "SDT_FOLLOW_IF_PRESENT"
-    val SDT_MANUAL            = "SDT_MANUAL"
-    val SDT_NONE              = "SDT_NONE"
+  @js.native
+  sealed trait OutputSdt extends js.Any
+  object OutputSdt extends js.Object {
+    val SDT_FOLLOW            = "SDT_FOLLOW".asInstanceOf[OutputSdt]
+    val SDT_FOLLOW_IF_PRESENT = "SDT_FOLLOW_IF_PRESENT".asInstanceOf[OutputSdt]
+    val SDT_MANUAL            = "SDT_MANUAL".asInstanceOf[OutputSdt]
+    val SDT_NONE              = "SDT_NONE".asInstanceOf[OutputSdt]
 
     val values = js.Object.freeze(js.Array(SDT_FOLLOW, SDT_FOLLOW_IF_PRESENT, SDT_MANUAL, SDT_NONE))
   }
@@ -8113,10 +8318,12 @@ package mediaconvert {
   /**
     * Optional. When you request a list of presets, you can choose to list them alphabetically by NAME or chronologically by CREATION_DATE. If you don't specify, the service will list them by name.
     */
-  object PresetListByEnum {
-    val NAME          = "NAME"
-    val CREATION_DATE = "CREATION_DATE"
-    val SYSTEM        = "SYSTEM"
+  @js.native
+  sealed trait PresetListBy extends js.Any
+  object PresetListBy extends js.Object {
+    val NAME          = "NAME".asInstanceOf[PresetListBy]
+    val CREATION_DATE = "CREATION_DATE".asInstanceOf[PresetListBy]
+    val SYSTEM        = "SYSTEM".asInstanceOf[PresetListBy]
 
     val values = js.Object.freeze(js.Array(NAME, CREATION_DATE, SYSTEM))
   }
@@ -8152,9 +8359,11 @@ package mediaconvert {
   /**
     * Specifies whether the pricing plan for the queue is on-demand or reserved. For on-demand, you pay per minute, billed in increments of .01 minute. For reserved, you pay for the transcoding capacity of the entire queue, regardless of how much or how little you use it. Reserved pricing requires a 12-month commitment.
     */
-  object PricingPlanEnum {
-    val ON_DEMAND = "ON_DEMAND"
-    val RESERVED  = "RESERVED"
+  @js.native
+  sealed trait PricingPlan extends js.Any
+  object PricingPlan extends js.Object {
+    val ON_DEMAND = "ON_DEMAND".asInstanceOf[PricingPlan]
+    val RESERVED  = "RESERVED".asInstanceOf[PricingPlan]
 
     val values = js.Object.freeze(js.Array(ON_DEMAND, RESERVED))
   }
@@ -8162,11 +8371,13 @@ package mediaconvert {
   /**
     * Use Profile (ProResCodecProfile) to specifiy the type of Apple ProRes codec to use for this output.
     */
-  object ProresCodecProfileEnum {
-    val APPLE_PRORES_422       = "APPLE_PRORES_422"
-    val APPLE_PRORES_422_HQ    = "APPLE_PRORES_422_HQ"
-    val APPLE_PRORES_422_LT    = "APPLE_PRORES_422_LT"
-    val APPLE_PRORES_422_PROXY = "APPLE_PRORES_422_PROXY"
+  @js.native
+  sealed trait ProresCodecProfile extends js.Any
+  object ProresCodecProfile extends js.Object {
+    val APPLE_PRORES_422       = "APPLE_PRORES_422".asInstanceOf[ProresCodecProfile]
+    val APPLE_PRORES_422_HQ    = "APPLE_PRORES_422_HQ".asInstanceOf[ProresCodecProfile]
+    val APPLE_PRORES_422_LT    = "APPLE_PRORES_422_LT".asInstanceOf[ProresCodecProfile]
+    val APPLE_PRORES_422_PROXY = "APPLE_PRORES_422_PROXY".asInstanceOf[ProresCodecProfile]
 
     val values =
       js.Object.freeze(js.Array(APPLE_PRORES_422, APPLE_PRORES_422_HQ, APPLE_PRORES_422_LT, APPLE_PRORES_422_PROXY))
@@ -8175,9 +8386,11 @@ package mediaconvert {
   /**
     * If you are using the console, use the Framerate setting to specify the frame rate for this output. If you want to keep the same frame rate as the input video, choose Follow source. If you want to do frame rate conversion, choose a frame rate from the dropdown list or choose Custom. The framerates shown in the dropdown list are decimal approximations of fractions. If you choose Custom, specify your frame rate as a fraction. If you are creating your transcoding job sepecification as a JSON file without the console, use FramerateControl to specify which value the service uses for the frame rate for this output. Choose INITIALIZE_FROM_SOURCE if you want the service to use the frame rate from the input. Choose SPECIFIED if you want the service to use the frame rate you specify in the settings FramerateNumerator and FramerateDenominator.
     */
-  object ProresFramerateControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait ProresFramerateControl extends js.Any
+  object ProresFramerateControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[ProresFramerateControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[ProresFramerateControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -8185,9 +8398,11 @@ package mediaconvert {
   /**
     * When set to INTERPOLATE, produces smoother motion during frame rate conversion.
     */
-  object ProresFramerateConversionAlgorithmEnum {
-    val DUPLICATE_DROP = "DUPLICATE_DROP"
-    val INTERPOLATE    = "INTERPOLATE"
+  @js.native
+  sealed trait ProresFramerateConversionAlgorithm extends js.Any
+  object ProresFramerateConversionAlgorithm extends js.Object {
+    val DUPLICATE_DROP = "DUPLICATE_DROP".asInstanceOf[ProresFramerateConversionAlgorithm]
+    val INTERPOLATE    = "INTERPOLATE".asInstanceOf[ProresFramerateConversionAlgorithm]
 
     val values = js.Object.freeze(js.Array(DUPLICATE_DROP, INTERPOLATE))
   }
@@ -8197,12 +8412,14 @@ package mediaconvert {
     *   - If the source is interlaced, the output will be interlaced with the same polarity as the source (it will follow the source). The output could therefore be a mix of "top field first" and "bottom field first".
     *   - If the source is progressive, the output will be interlaced with "top field first" or "bottom field first" polarity, depending on which of the Follow options you chose.
     */
-  object ProresInterlaceModeEnum {
-    val PROGRESSIVE         = "PROGRESSIVE"
-    val TOP_FIELD           = "TOP_FIELD"
-    val BOTTOM_FIELD        = "BOTTOM_FIELD"
-    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD"
-    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD"
+  @js.native
+  sealed trait ProresInterlaceMode extends js.Any
+  object ProresInterlaceMode extends js.Object {
+    val PROGRESSIVE         = "PROGRESSIVE".asInstanceOf[ProresInterlaceMode]
+    val TOP_FIELD           = "TOP_FIELD".asInstanceOf[ProresInterlaceMode]
+    val BOTTOM_FIELD        = "BOTTOM_FIELD".asInstanceOf[ProresInterlaceMode]
+    val FOLLOW_TOP_FIELD    = "FOLLOW_TOP_FIELD".asInstanceOf[ProresInterlaceMode]
+    val FOLLOW_BOTTOM_FIELD = "FOLLOW_BOTTOM_FIELD".asInstanceOf[ProresInterlaceMode]
 
     val values = js.Object.freeze(js.Array(PROGRESSIVE, TOP_FIELD, BOTTOM_FIELD, FOLLOW_TOP_FIELD, FOLLOW_BOTTOM_FIELD))
   }
@@ -8210,9 +8427,11 @@ package mediaconvert {
   /**
     * Use (ProresParControl) to specify how the service determines the pixel aspect ratio. Set to Follow source (INITIALIZE_FROM_SOURCE) to use the pixel aspect ratio from the input.  To specify a different pixel aspect ratio: Using the console, choose it from the dropdown menu. Using the API, set ProresParControl to (SPECIFIED) and provide  for (ParNumerator) and (ParDenominator).
     */
-  object ProresParControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait ProresParControl extends js.Any
+  object ProresParControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[ProresParControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[ProresParControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -8271,9 +8490,11 @@ package mediaconvert {
   /**
     * Enables Slow PAL rate conversion. 23.976fps and 24fps input is relabeled as 25fps, and audio is sped up correspondingly.
     */
-  object ProresSlowPalEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait ProresSlowPal extends js.Any
+  object ProresSlowPal extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[ProresSlowPal]
+    val ENABLED  = "ENABLED".asInstanceOf[ProresSlowPal]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -8281,9 +8502,11 @@ package mediaconvert {
   /**
     * Only use Telecine (ProresTelecine) when you set Framerate (Framerate) to 29.970. Set Telecine (ProresTelecine) to Hard (hard) to produce a 29.97i output from a 23.976 input. Set it to Soft (soft) to produce 23.976 output and leave converstion to the player.
     */
-  object ProresTelecineEnum {
-    val NONE = "NONE"
-    val HARD = "HARD"
+  @js.native
+  sealed trait ProresTelecine extends js.Any
+  object ProresTelecine extends js.Object {
+    val NONE = "NONE".asInstanceOf[ProresTelecine]
+    val HARD = "HARD".asInstanceOf[ProresTelecine]
 
     val values = js.Object.freeze(js.Array(NONE, HARD))
   }
@@ -8342,9 +8565,11 @@ package mediaconvert {
   /**
     * Optional. When you request a list of queues, you can choose to list them alphabetically by NAME or chronologically by CREATION_DATE. If you don't specify, the service will list them by creation date.
     */
-  object QueueListByEnum {
-    val NAME          = "NAME"
-    val CREATION_DATE = "CREATION_DATE"
+  @js.native
+  sealed trait QueueListBy extends js.Any
+  object QueueListBy extends js.Object {
+    val NAME          = "NAME".asInstanceOf[QueueListBy]
+    val CREATION_DATE = "CREATION_DATE".asInstanceOf[QueueListBy]
 
     val values = js.Object.freeze(js.Array(NAME, CREATION_DATE))
   }
@@ -8352,9 +8577,11 @@ package mediaconvert {
   /**
     * Queues can be ACTIVE or PAUSED. If you pause a queue, jobs in that queue won't begin. Jobs that are running when you pause a queue continue to run until they finish or result in an error.
     */
-  object QueueStatusEnum {
-    val ACTIVE = "ACTIVE"
-    val PAUSED = "PAUSED"
+  @js.native
+  sealed trait QueueStatus extends js.Any
+  object QueueStatus extends js.Object {
+    val ACTIVE = "ACTIVE".asInstanceOf[QueueStatus]
+    val PAUSED = "PAUSED".asInstanceOf[QueueStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, PAUSED))
   }
@@ -8415,9 +8642,11 @@ package mediaconvert {
   /**
     * Specifies whether the term of your reserved queue pricing plan is automatically extended (AUTO_RENEW) or expires (EXPIRE) at the end of the term.
     */
-  object RenewalTypeEnum {
-    val AUTO_RENEW = "AUTO_RENEW"
-    val EXPIRE     = "EXPIRE"
+  @js.native
+  sealed trait RenewalType extends js.Any
+  object RenewalType extends js.Object {
+    val AUTO_RENEW = "AUTO_RENEW".asInstanceOf[RenewalType]
+    val EXPIRE     = "EXPIRE".asInstanceOf[RenewalType]
 
     val values = js.Object.freeze(js.Array(AUTO_RENEW, EXPIRE))
   }
@@ -8486,9 +8715,11 @@ package mediaconvert {
   /**
     * Specifies whether the pricing plan for your reserved queue is ACTIVE or EXPIRED.
     */
-  object ReservationPlanStatusEnum {
-    val ACTIVE  = "ACTIVE"
-    val EXPIRED = "EXPIRED"
+  @js.native
+  sealed trait ReservationPlanStatus extends js.Any
+  object ReservationPlanStatus extends js.Object {
+    val ACTIVE  = "ACTIVE".asInstanceOf[ReservationPlanStatus]
+    val EXPIRED = "EXPIRED".asInstanceOf[ReservationPlanStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, EXPIRED))
   }
@@ -8518,10 +8749,12 @@ package mediaconvert {
   /**
     * Use Respond to AFD (RespondToAfd) to specify how the service changes the video itself in response to AFD values in the input. * Choose Respond to clip the input video frame according to the AFD value, input display aspect ratio, and output display aspect ratio. * Choose Passthrough to include the input AFD values. Do not choose this when AfdSignaling is set to (NONE). A preferred implementation of this workflow is to set RespondToAfd to (NONE) and set AfdSignaling to (AUTO). * Choose None to remove all input AFD values from this output.
     */
-  object RespondToAfdEnum {
-    val NONE        = "NONE"
-    val RESPOND     = "RESPOND"
-    val PASSTHROUGH = "PASSTHROUGH"
+  @js.native
+  sealed trait RespondToAfd extends js.Any
+  object RespondToAfd extends js.Object {
+    val NONE        = "NONE".asInstanceOf[RespondToAfd]
+    val RESPOND     = "RESPOND".asInstanceOf[RespondToAfd]
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[RespondToAfd]
 
     val values = js.Object.freeze(js.Array(NONE, RESPOND, PASSTHROUGH))
   }
@@ -8596,11 +8829,13 @@ package mediaconvert {
   /**
     * Choose an Amazon S3 canned ACL for MediaConvert to apply to this output.
     */
-  object S3ObjectCannedAclEnum {
-    val PUBLIC_READ               = "PUBLIC_READ"
-    val AUTHENTICATED_READ        = "AUTHENTICATED_READ"
-    val BUCKET_OWNER_READ         = "BUCKET_OWNER_READ"
-    val BUCKET_OWNER_FULL_CONTROL = "BUCKET_OWNER_FULL_CONTROL"
+  @js.native
+  sealed trait S3ObjectCannedAcl extends js.Any
+  object S3ObjectCannedAcl extends js.Object {
+    val PUBLIC_READ               = "PUBLIC_READ".asInstanceOf[S3ObjectCannedAcl]
+    val AUTHENTICATED_READ        = "AUTHENTICATED_READ".asInstanceOf[S3ObjectCannedAcl]
+    val BUCKET_OWNER_READ         = "BUCKET_OWNER_READ".asInstanceOf[S3ObjectCannedAcl]
+    val BUCKET_OWNER_FULL_CONTROL = "BUCKET_OWNER_FULL_CONTROL".asInstanceOf[S3ObjectCannedAcl]
 
     val values =
       js.Object.freeze(js.Array(PUBLIC_READ, AUTHENTICATED_READ, BUCKET_OWNER_READ, BUCKET_OWNER_FULL_CONTROL))
@@ -8609,9 +8844,11 @@ package mediaconvert {
   /**
     * Specify how you want your data keys managed. AWS uses data keys to encrypt your content. AWS also encrypts the data keys themselves, using a customer master key (CMK), and then stores the encrypted data keys alongside your encrypted content. Use this setting to specify which AWS service manages the CMK. For simplest set up, choose Amazon S3 (SERVER_SIDE_ENCRYPTION_S3). If you want your master key to be managed by AWS Key Management Service (KMS), choose AWS KMS (SERVER_SIDE_ENCRYPTION_KMS). By default, when you choose AWS KMS, KMS uses the AWS managed customer master key (CMK) associated with Amazon S3 to encrypt your data keys. You can optionally choose to specify a different, customer managed CMK. Do so by specifying the Amazon Resource Name (ARN) of the key for the setting  KMS ARN (kmsKeyArn).
     */
-  object S3ServerSideEncryptionTypeEnum {
-    val SERVER_SIDE_ENCRYPTION_S3  = "SERVER_SIDE_ENCRYPTION_S3"
-    val SERVER_SIDE_ENCRYPTION_KMS = "SERVER_SIDE_ENCRYPTION_KMS"
+  @js.native
+  sealed trait S3ServerSideEncryptionType extends js.Any
+  object S3ServerSideEncryptionType extends js.Object {
+    val SERVER_SIDE_ENCRYPTION_S3  = "SERVER_SIDE_ENCRYPTION_S3".asInstanceOf[S3ServerSideEncryptionType]
+    val SERVER_SIDE_ENCRYPTION_KMS = "SERVER_SIDE_ENCRYPTION_KMS".asInstanceOf[S3ServerSideEncryptionType]
 
     val values = js.Object.freeze(js.Array(SERVER_SIDE_ENCRYPTION_S3, SERVER_SIDE_ENCRYPTION_KMS))
   }
@@ -8619,9 +8856,11 @@ package mediaconvert {
   /**
     * Specify how the service handles outputs that have a different aspect ratio from the input aspect ratio. Choose Stretch to output (STRETCH_TO_OUTPUT) to have the service stretch your video image to fit. Keep the setting Default (DEFAULT) to have the service letterbox your video instead. This setting overrides any value that you specify for the setting Selection placement (position) in this output.
     */
-  object ScalingBehaviorEnum {
-    val DEFAULT           = "DEFAULT"
-    val STRETCH_TO_OUTPUT = "STRETCH_TO_OUTPUT"
+  @js.native
+  sealed trait ScalingBehavior extends js.Any
+  object ScalingBehavior extends js.Object {
+    val DEFAULT           = "DEFAULT".asInstanceOf[ScalingBehavior]
+    val STRETCH_TO_OUTPUT = "STRETCH_TO_OUTPUT".asInstanceOf[ScalingBehavior]
 
     val values = js.Object.freeze(js.Array(DEFAULT, STRETCH_TO_OUTPUT))
   }
@@ -8629,12 +8868,14 @@ package mediaconvert {
   /**
     * Set Framerate (SccDestinationFramerate) to make sure that the captions and the video are synchronized in the output. Specify a frame rate that matches the frame rate of the associated video. If the video frame rate is 29.97, choose 29.97 dropframe (FRAMERATE_29_97_DROPFRAME) only if the video has video_insertion=true and drop_frame_timecode=true; otherwise, choose 29.97 non-dropframe (FRAMERATE_29_97_NON_DROPFRAME).
     */
-  object SccDestinationFramerateEnum {
-    val FRAMERATE_23_97               = "FRAMERATE_23_97"
-    val FRAMERATE_24                  = "FRAMERATE_24"
-    val FRAMERATE_25                  = "FRAMERATE_25"
-    val FRAMERATE_29_97_DROPFRAME     = "FRAMERATE_29_97_DROPFRAME"
-    val FRAMERATE_29_97_NON_DROPFRAME = "FRAMERATE_29_97_NON_DROPFRAME"
+  @js.native
+  sealed trait SccDestinationFramerate extends js.Any
+  object SccDestinationFramerate extends js.Object {
+    val FRAMERATE_23_97               = "FRAMERATE_23_97".asInstanceOf[SccDestinationFramerate]
+    val FRAMERATE_24                  = "FRAMERATE_24".asInstanceOf[SccDestinationFramerate]
+    val FRAMERATE_25                  = "FRAMERATE_25".asInstanceOf[SccDestinationFramerate]
+    val FRAMERATE_29_97_DROPFRAME     = "FRAMERATE_29_97_DROPFRAME".asInstanceOf[SccDestinationFramerate]
+    val FRAMERATE_29_97_NON_DROPFRAME = "FRAMERATE_29_97_NON_DROPFRAME".asInstanceOf[SccDestinationFramerate]
 
     val values = js.Object.freeze(
       js.Array(FRAMERATE_23_97, FRAMERATE_24, FRAMERATE_25, FRAMERATE_29_97_DROPFRAME, FRAMERATE_29_97_NON_DROPFRAME)
@@ -8663,9 +8904,11 @@ package mediaconvert {
   /**
     * Enable this setting when you run a test job to estimate how many reserved transcoding slots (RTS) you need. When this is enabled, MediaConvert runs your job from an on-demand queue with similar performance to what you will see with one RTS in a reserved queue. This setting is disabled by default.
     */
-  object SimulateReservedQueueEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait SimulateReservedQueue extends js.Any
+  object SimulateReservedQueue extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[SimulateReservedQueue]
+    val ENABLED  = "ENABLED".asInstanceOf[SimulateReservedQueue]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -8762,22 +9005,24 @@ package mediaconvert {
   /**
     * Specify how often MediaConvert sends STATUS_UPDATE events to Amazon CloudWatch Events. Set the interval, in seconds, between status updates. MediaConvert sends an update at this interval from the time the service begins processing your job to the time it completes the transcode or encounters an error.
     */
-  object StatusUpdateIntervalEnum {
-    val SECONDS_10  = "SECONDS_10"
-    val SECONDS_12  = "SECONDS_12"
-    val SECONDS_15  = "SECONDS_15"
-    val SECONDS_20  = "SECONDS_20"
-    val SECONDS_30  = "SECONDS_30"
-    val SECONDS_60  = "SECONDS_60"
-    val SECONDS_120 = "SECONDS_120"
-    val SECONDS_180 = "SECONDS_180"
-    val SECONDS_240 = "SECONDS_240"
-    val SECONDS_300 = "SECONDS_300"
-    val SECONDS_360 = "SECONDS_360"
-    val SECONDS_420 = "SECONDS_420"
-    val SECONDS_480 = "SECONDS_480"
-    val SECONDS_540 = "SECONDS_540"
-    val SECONDS_600 = "SECONDS_600"
+  @js.native
+  sealed trait StatusUpdateInterval extends js.Any
+  object StatusUpdateInterval extends js.Object {
+    val SECONDS_10  = "SECONDS_10".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_12  = "SECONDS_12".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_15  = "SECONDS_15".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_20  = "SECONDS_20".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_30  = "SECONDS_30".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_60  = "SECONDS_60".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_120 = "SECONDS_120".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_180 = "SECONDS_180".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_240 = "SECONDS_240".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_300 = "SECONDS_300".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_360 = "SECONDS_360".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_420 = "SECONDS_420".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_480 = "SECONDS_480".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_540 = "SECONDS_540".asInstanceOf[StatusUpdateInterval]
+    val SECONDS_600 = "SECONDS_600".asInstanceOf[StatusUpdateInterval]
 
     val values = js.Object.freeze(
       js.Array(
@@ -8859,12 +9104,14 @@ package mediaconvert {
   /**
     * A page type as defined in the standard ETSI EN 300 468, Table 94
     */
-  object TeletextPageTypeEnum {
-    val PAGE_TYPE_INITIAL                   = "PAGE_TYPE_INITIAL"
-    val PAGE_TYPE_SUBTITLE                  = "PAGE_TYPE_SUBTITLE"
-    val PAGE_TYPE_ADDL_INFO                 = "PAGE_TYPE_ADDL_INFO"
-    val PAGE_TYPE_PROGRAM_SCHEDULE          = "PAGE_TYPE_PROGRAM_SCHEDULE"
-    val PAGE_TYPE_HEARING_IMPAIRED_SUBTITLE = "PAGE_TYPE_HEARING_IMPAIRED_SUBTITLE"
+  @js.native
+  sealed trait TeletextPageType extends js.Any
+  object TeletextPageType extends js.Object {
+    val PAGE_TYPE_INITIAL                   = "PAGE_TYPE_INITIAL".asInstanceOf[TeletextPageType]
+    val PAGE_TYPE_SUBTITLE                  = "PAGE_TYPE_SUBTITLE".asInstanceOf[TeletextPageType]
+    val PAGE_TYPE_ADDL_INFO                 = "PAGE_TYPE_ADDL_INFO".asInstanceOf[TeletextPageType]
+    val PAGE_TYPE_PROGRAM_SCHEDULE          = "PAGE_TYPE_PROGRAM_SCHEDULE".asInstanceOf[TeletextPageType]
+    val PAGE_TYPE_HEARING_IMPAIRED_SUBTITLE = "PAGE_TYPE_HEARING_IMPAIRED_SUBTITLE".asInstanceOf[TeletextPageType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -8924,16 +9171,18 @@ package mediaconvert {
   /**
     * Use Position (Position) under under Timecode burn-in (TimecodeBurnIn) to specify the location the burned-in timecode on output video.
     */
-  object TimecodeBurninPositionEnum {
-    val TOP_CENTER    = "TOP_CENTER"
-    val TOP_LEFT      = "TOP_LEFT"
-    val TOP_RIGHT     = "TOP_RIGHT"
-    val MIDDLE_LEFT   = "MIDDLE_LEFT"
-    val MIDDLE_CENTER = "MIDDLE_CENTER"
-    val MIDDLE_RIGHT  = "MIDDLE_RIGHT"
-    val BOTTOM_LEFT   = "BOTTOM_LEFT"
-    val BOTTOM_CENTER = "BOTTOM_CENTER"
-    val BOTTOM_RIGHT  = "BOTTOM_RIGHT"
+  @js.native
+  sealed trait TimecodeBurninPosition extends js.Any
+  object TimecodeBurninPosition extends js.Object {
+    val TOP_CENTER    = "TOP_CENTER".asInstanceOf[TimecodeBurninPosition]
+    val TOP_LEFT      = "TOP_LEFT".asInstanceOf[TimecodeBurninPosition]
+    val TOP_RIGHT     = "TOP_RIGHT".asInstanceOf[TimecodeBurninPosition]
+    val MIDDLE_LEFT   = "MIDDLE_LEFT".asInstanceOf[TimecodeBurninPosition]
+    val MIDDLE_CENTER = "MIDDLE_CENTER".asInstanceOf[TimecodeBurninPosition]
+    val MIDDLE_RIGHT  = "MIDDLE_RIGHT".asInstanceOf[TimecodeBurninPosition]
+    val BOTTOM_LEFT   = "BOTTOM_LEFT".asInstanceOf[TimecodeBurninPosition]
+    val BOTTOM_CENTER = "BOTTOM_CENTER".asInstanceOf[TimecodeBurninPosition]
+    val BOTTOM_RIGHT  = "BOTTOM_RIGHT".asInstanceOf[TimecodeBurninPosition]
 
     val values = js.Object.freeze(
       js.Array(
@@ -8981,10 +9230,12 @@ package mediaconvert {
   /**
     * Use Source (TimecodeSource) to set how timecodes are handled within this job. To make sure that your video, audio, captions, and markers are synchronized and that time-based features, such as image inserter, work correctly, choose the Timecode source option that matches your assets. All timecodes are in a 24-hour format with frame number (HH:MM:SS:FF). * Embedded (EMBEDDED) - Use the timecode that is in the input video. If no embedded timecode is in the source, the service will use Start at 0 (ZEROBASED) instead. * Start at 0 (ZEROBASED) - Set the timecode of the initial frame to 00:00:00:00. * Specified Start (SPECIFIEDSTART) - Set the timecode of the initial frame to a value other than zero. You use Start timecode (Start) to provide this value.
     */
-  object TimecodeSourceEnum {
-    val EMBEDDED       = "EMBEDDED"
-    val ZEROBASED      = "ZEROBASED"
-    val SPECIFIEDSTART = "SPECIFIEDSTART"
+  @js.native
+  sealed trait TimecodeSource extends js.Any
+  object TimecodeSource extends js.Object {
+    val EMBEDDED       = "EMBEDDED".asInstanceOf[TimecodeSource]
+    val ZEROBASED      = "ZEROBASED".asInstanceOf[TimecodeSource]
+    val SPECIFIEDSTART = "SPECIFIEDSTART".asInstanceOf[TimecodeSource]
 
     val values = js.Object.freeze(js.Array(EMBEDDED, ZEROBASED, SPECIFIEDSTART))
   }
@@ -8992,9 +9243,11 @@ package mediaconvert {
   /**
     * Applies only to HLS outputs. Use this setting to specify whether the service inserts the ID3 timed metadata from the input in this output.
     */
-  object TimedMetadataEnum {
-    val PASSTHROUGH = "PASSTHROUGH"
-    val NONE        = "NONE"
+  @js.native
+  sealed trait TimedMetadata extends js.Any
+  object TimedMetadata extends js.Object {
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[TimedMetadata]
+    val NONE        = "NONE".asInstanceOf[TimedMetadata]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, NONE))
   }
@@ -9084,16 +9337,19 @@ package mediaconvert {
   /**
     * Pass through style and position information from a TTML-like input source (TTML, SMPTE-TT, CFF-TT) to the CFF-TT output or TTML output.
     */
-  object TtmlStylePassthroughEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait TtmlStylePassthrough extends js.Any
+  object TtmlStylePassthrough extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[TtmlStylePassthrough]
+    val DISABLED = "DISABLED".asInstanceOf[TtmlStylePassthrough]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
-
-  object TypeEnum {
-    val SYSTEM = "SYSTEM"
-    val CUSTOM = "CUSTOM"
+  @js.native
+  sealed trait Type extends js.Any
+  object Type extends js.Object {
+    val SYSTEM = "SYSTEM".asInstanceOf[Type]
+    val CUSTOM = "CUSTOM".asInstanceOf[Type]
 
     val values = js.Object.freeze(js.Array(SYSTEM, CUSTOM))
   }
@@ -9276,12 +9532,14 @@ package mediaconvert {
   /**
     * Type of video codec
     */
-  object VideoCodecEnum {
-    val FRAME_CAPTURE = "FRAME_CAPTURE"
-    val H_264         = "H_264"
-    val H_265         = "H_265"
-    val MPEG2         = "MPEG2"
-    val PRORES        = "PRORES"
+  @js.native
+  sealed trait VideoCodec extends js.Any
+  object VideoCodec extends js.Object {
+    val FRAME_CAPTURE = "FRAME_CAPTURE".asInstanceOf[VideoCodec]
+    val H_264         = "H_264".asInstanceOf[VideoCodec]
+    val H_265         = "H_265".asInstanceOf[VideoCodec]
+    val MPEG2         = "MPEG2".asInstanceOf[VideoCodec]
+    val PRORES        = "PRORES".asInstanceOf[VideoCodec]
 
     val values = js.Object.freeze(js.Array(FRAME_CAPTURE, H_264, H_265, MPEG2, PRORES))
   }
@@ -9477,9 +9735,11 @@ package mediaconvert {
   /**
     * Applies only to H.264, H.265, MPEG2, and ProRes outputs. Only enable Timecode insertion when the input frame rate is identical to the output frame rate. To include timecodes in this output, set Timecode insertion (VideoTimecodeInsertion) to PIC_TIMING_SEI. To leave them out, set it to DISABLED. Default is DISABLED. When the service inserts timecodes in an output, by default, it uses any embedded timecodes from the input. If none are present, the service will set the timecode for the first output frame to zero. To change this default behavior, adjust the settings under Timecode configuration (TimecodeConfig). In the console, these settings are located under Job > Job settings > Timecode configuration. Note - Timecode source under input settings (InputTimecodeSource) does not affect the timecodes that are inserted in the output. Source under Job settings > Timecode configuration (TimecodeSource) does.
     */
-  object VideoTimecodeInsertionEnum {
-    val DISABLED       = "DISABLED"
-    val PIC_TIMING_SEI = "PIC_TIMING_SEI"
+  @js.native
+  sealed trait VideoTimecodeInsertion extends js.Any
+  object VideoTimecodeInsertion extends js.Object {
+    val DISABLED       = "DISABLED".asInstanceOf[VideoTimecodeInsertion]
+    val PIC_TIMING_SEI = "PIC_TIMING_SEI".asInstanceOf[VideoTimecodeInsertion]
 
     val values = js.Object.freeze(js.Array(DISABLED, PIC_TIMING_SEI))
   }
@@ -9487,9 +9747,11 @@ package mediaconvert {
   /**
     * The service defaults to using RIFF for WAV outputs. If your output audio is likely to exceed 4 GB in file size, or if you otherwise need the extended support of the RF64 format, set your output WAV file format to RF64.
     */
-  object WavFormatEnum {
-    val RIFF = "RIFF"
-    val RF64 = "RF64"
+  @js.native
+  sealed trait WavFormat extends js.Any
+  object WavFormat extends js.Object {
+    val RIFF = "RIFF".asInstanceOf[WavFormat]
+    val RF64 = "RF64".asInstanceOf[WavFormat]
 
     val values = js.Object.freeze(js.Array(RIFF, RF64))
   }

--- a/services/medialive/src/main/scala/facade/amazonaws/services/MediaLive.scala
+++ b/services/medialive/src/main/scala/facade/amazonaws/services/MediaLive.scala
@@ -7,215 +7,8 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object medialive {
-  type AacCodingMode                                 = String
-  type AacInputType                                  = String
-  type AacProfile                                    = String
-  type AacRateControlMode                            = String
-  type AacRawFormat                                  = String
-  type AacSpec                                       = String
-  type AacVbrQuality                                 = String
-  type Ac3BitstreamMode                              = String
-  type Ac3CodingMode                                 = String
-  type Ac3DrcProfile                                 = String
-  type Ac3LfeFilter                                  = String
-  type Ac3MetadataControl                            = String
-  type AfdSignaling                                  = String
-  type AudioDescriptionAudioTypeControl              = String
-  type AudioDescriptionLanguageCodeControl           = String
-  type AudioLanguageSelectionPolicy                  = String
-  type AudioNormalizationAlgorithm                   = String
-  type AudioNormalizationAlgorithmControl            = String
-  type AudioOnlyHlsSegmentType                       = String
-  type AudioOnlyHlsTrackType                         = String
-  type AudioType                                     = String
-  type AuthenticationScheme                          = String
-  type AvailBlankingState                            = String
-  type BlackoutSlateNetworkEndBlackout               = String
-  type BlackoutSlateState                            = String
-  type BurnInAlignment                               = String
-  type BurnInBackgroundColor                         = String
-  type BurnInFontColor                               = String
-  type BurnInOutlineColor                            = String
-  type BurnInShadowColor                             = String
-  type BurnInTeletextGridControl                     = String
-  type ChannelClass                                  = String
-  type ChannelState                                  = String
-  type DvbSdtOutputSdt                               = String
-  type DvbSubDestinationAlignment                    = String
-  type DvbSubDestinationBackgroundColor              = String
-  type DvbSubDestinationFontColor                    = String
-  type DvbSubDestinationOutlineColor                 = String
-  type DvbSubDestinationShadowColor                  = String
-  type DvbSubDestinationTeletextGridControl          = String
-  type Eac3AttenuationControl                        = String
-  type Eac3BitstreamMode                             = String
-  type Eac3CodingMode                                = String
-  type Eac3DcFilter                                  = String
-  type Eac3DrcLine                                   = String
-  type Eac3DrcRf                                     = String
-  type Eac3LfeControl                                = String
-  type Eac3LfeFilter                                 = String
-  type Eac3MetadataControl                           = String
-  type Eac3PassthroughControl                        = String
-  type Eac3PhaseControl                              = String
-  type Eac3StereoDownmix                             = String
-  type Eac3SurroundExMode                            = String
-  type Eac3SurroundMode                              = String
-  type EmbeddedConvert608To708                       = String
-  type EmbeddedScte20Detection                       = String
-  type FecOutputIncludeFec                           = String
-  type FixedAfd                                      = String
-  type FollowPoint                                   = String
-  type FrameCaptureIntervalUnit                      = String
-  type GlobalConfigurationInputEndAction             = String
-  type GlobalConfigurationLowFramerateInputs         = String
-  type GlobalConfigurationOutputLockingMode          = String
-  type GlobalConfigurationOutputTimingSource         = String
-  type H264AdaptiveQuantization                      = String
-  type H264ColorMetadata                             = String
-  type H264EntropyEncoding                           = String
-  type H264FlickerAq                                 = String
-  type H264FramerateControl                          = String
-  type H264GopBReference                             = String
-  type H264GopSizeUnits                              = String
-  type H264Level                                     = String
-  type H264LookAheadRateControl                      = String
-  type H264ParControl                                = String
-  type H264Profile                                   = String
-  type H264RateControlMode                           = String
-  type H264ScanType                                  = String
-  type H264SceneChangeDetect                         = String
-  type H264SpatialAq                                 = String
-  type H264SubGopLength                              = String
-  type H264Syntax                                    = String
-  type H264TemporalAq                                = String
-  type H264TimecodeInsertionBehavior                 = String
-  type H265AdaptiveQuantization                      = String
-  type H265AlternativeTransferFunction               = String
-  type H265ColorMetadata                             = String
-  type H265FlickerAq                                 = String
-  type H265GopSizeUnits                              = String
-  type H265Level                                     = String
-  type H265LookAheadRateControl                      = String
-  type H265Profile                                   = String
-  type H265RateControlMode                           = String
-  type H265ScanType                                  = String
-  type H265SceneChangeDetect                         = String
-  type H265Tier                                      = String
-  type H265TimecodeInsertionBehavior                 = String
-  type HlsAdMarkers                                  = String
-  type HlsAkamaiHttpTransferMode                     = String
-  type HlsCaptionLanguageSetting                     = String
-  type HlsClientCache                                = String
-  type HlsCodecSpecification                         = String
-  type HlsDirectoryStructure                         = String
-  type HlsEncryptionType                             = String
-  type HlsH265PackagingType                          = String
-  type HlsId3SegmentTaggingState                     = String
-  type HlsIvInManifest                               = String
-  type HlsIvSource                                   = String
-  type HlsManifestCompression                        = String
-  type HlsManifestDurationFormat                     = String
-  type HlsMediaStoreStorageClass                     = String
-  type HlsMode                                       = String
-  type HlsOutputSelection                            = String
-  type HlsProgramDateTime                            = String
-  type HlsRedundantManifest                          = String
-  type HlsSegmentationMode                           = String
-  type HlsStreamInfResolution                        = String
-  type HlsTimedMetadataId3Frame                      = String
-  type HlsTsFileMode                                 = String
-  type HlsWebdavHttpTransferMode                     = String
-  type IFrameOnlyPlaylistType                        = String
-  type InputClass                                    = String
-  type InputCodec                                    = String
-  type InputDeblockFilter                            = String
-  type InputDenoiseFilter                            = String
-  type InputFilter                                   = String
-  type InputLossActionForHlsOut                      = String
-  type InputLossActionForMsSmoothOut                 = String
-  type InputLossActionForRtmpOut                     = String
-  type InputLossActionForUdpOut                      = String
-  type InputLossImageType                            = String
-  type InputMaximumBitrate                           = String
-  type InputResolution                               = String
-  type InputSecurityGroupState                       = String
-  type InputSourceEndBehavior                        = String
-  type InputSourceType                               = String
-  type InputState                                    = String
-  type InputTimecodeSource                           = String
-  type InputType                                     = String
-  type LastFrameClippingBehavior                     = String
-  type LogLevel                                      = String
-  type M2tsAbsentInputAudioBehavior                  = String
-  type M2tsArib                                      = String
-  type M2tsAribCaptionsPidControl                    = String
-  type M2tsAudioBufferModel                          = String
-  type M2tsAudioInterval                             = String
-  type M2tsAudioStreamType                           = String
-  type M2tsBufferModel                               = String
-  type M2tsCcDescriptor                              = String
-  type M2tsEbifControl                               = String
-  type M2tsEbpPlacement                              = String
-  type M2tsEsRateInPes                               = String
-  type M2tsKlv                                       = String
-  type M2tsNielsenId3Behavior                        = String
-  type M2tsPcrControl                                = String
-  type M2tsRateMode                                  = String
-  type M2tsScte35Control                             = String
-  type M2tsSegmentationMarkers                       = String
-  type M2tsSegmentationStyle                         = String
-  type M2tsTimedMetadataBehavior                     = String
-  type M3u8NielsenId3Behavior                        = String
-  type M3u8PcrControl                                = String
-  type M3u8Scte35Behavior                            = String
-  type M3u8TimedMetadataBehavior                     = String
   type MaxResults                                    = Int
-  type Mp2CodingMode                                 = String
-  type MsSmoothH265PackagingType                     = String
-  type MultiplexState                                = String
-  type NetworkInputServerValidation                  = String
-  type NielsenPcmToId3TaggingState                   = String
-  type OfferingDurationUnits                         = String
-  type OfferingType                                  = String
-  type PipelineId                                    = String
-  type ReservationCodec                              = String
-  type ReservationMaximumBitrate                     = String
-  type ReservationMaximumFramerate                   = String
-  type ReservationResolution                         = String
-  type ReservationResourceType                       = String
-  type ReservationSpecialFeature                     = String
-  type ReservationState                              = String
-  type ReservationVideoQuality                       = String
-  type RtmpCacheFullBehavior                         = String
-  type RtmpCaptionData                               = String
-  type RtmpOutputCertificateMode                     = String
-  type Scte20Convert608To708                         = String
-  type Scte35AposNoRegionalBlackoutBehavior          = String
-  type Scte35AposWebDeliveryAllowedBehavior          = String
-  type Scte35ArchiveAllowedFlag                      = String
-  type Scte35DeviceRestrictions                      = String
-  type Scte35NoRegionalBlackoutFlag                  = String
-  type Scte35SegmentationCancelIndicator             = String
-  type Scte35SpliceInsertNoRegionalBlackoutBehavior  = String
-  type Scte35SpliceInsertWebDeliveryAllowedBehavior  = String
-  type Scte35WebDeliveryAllowedFlag                  = String
-  type SmoothGroupAudioOnlyTimecodeControl           = String
-  type SmoothGroupCertificateMode                    = String
-  type SmoothGroupEventIdMode                        = String
-  type SmoothGroupEventStopBehavior                  = String
-  type SmoothGroupSegmentationMode                   = String
-  type SmoothGroupSparseTrackType                    = String
-  type SmoothGroupStreamManifestBehavior             = String
-  type SmoothGroupTimestampOffsetMode                = String
   type Tags                                          = js.Dictionary[__string]
-  type TimecodeConfigSource                          = String
-  type TtmlDestinationStyleControl                   = String
-  type UdpTimedMetadataId3Frame                      = String
-  type VideoDescriptionRespondToAfd                  = String
-  type VideoDescriptionScalingBehavior               = String
-  type VideoSelectorColorSpace                       = String
-  type VideoSelectorColorSpaceUsage                  = String
   type __double                                      = Double
   type __doubleMin0                                  = Double
   type __doubleMin1                                  = Double
@@ -486,12 +279,14 @@ package medialive {
   /**
     * Aac Coding Mode
     */
-  object AacCodingModeEnum {
-    val AD_RECEIVER_MIX = "AD_RECEIVER_MIX"
-    val CODING_MODE_1_0 = "CODING_MODE_1_0"
-    val CODING_MODE_1_1 = "CODING_MODE_1_1"
-    val CODING_MODE_2_0 = "CODING_MODE_2_0"
-    val CODING_MODE_5_1 = "CODING_MODE_5_1"
+  @js.native
+  sealed trait AacCodingMode extends js.Any
+  object AacCodingMode extends js.Object {
+    val AD_RECEIVER_MIX = "AD_RECEIVER_MIX".asInstanceOf[AacCodingMode]
+    val CODING_MODE_1_0 = "CODING_MODE_1_0".asInstanceOf[AacCodingMode]
+    val CODING_MODE_1_1 = "CODING_MODE_1_1".asInstanceOf[AacCodingMode]
+    val CODING_MODE_2_0 = "CODING_MODE_2_0".asInstanceOf[AacCodingMode]
+    val CODING_MODE_5_1 = "CODING_MODE_5_1".asInstanceOf[AacCodingMode]
 
     val values =
       js.Object.freeze(js.Array(AD_RECEIVER_MIX, CODING_MODE_1_0, CODING_MODE_1_1, CODING_MODE_2_0, CODING_MODE_5_1))
@@ -500,9 +295,11 @@ package medialive {
   /**
     * Aac Input Type
     */
-  object AacInputTypeEnum {
-    val BROADCASTER_MIXED_AD = "BROADCASTER_MIXED_AD"
-    val NORMAL               = "NORMAL"
+  @js.native
+  sealed trait AacInputType extends js.Any
+  object AacInputType extends js.Object {
+    val BROADCASTER_MIXED_AD = "BROADCASTER_MIXED_AD".asInstanceOf[AacInputType]
+    val NORMAL               = "NORMAL".asInstanceOf[AacInputType]
 
     val values = js.Object.freeze(js.Array(BROADCASTER_MIXED_AD, NORMAL))
   }
@@ -510,10 +307,12 @@ package medialive {
   /**
     * Aac Profile
     */
-  object AacProfileEnum {
-    val HEV1 = "HEV1"
-    val HEV2 = "HEV2"
-    val LC   = "LC"
+  @js.native
+  sealed trait AacProfile extends js.Any
+  object AacProfile extends js.Object {
+    val HEV1 = "HEV1".asInstanceOf[AacProfile]
+    val HEV2 = "HEV2".asInstanceOf[AacProfile]
+    val LC   = "LC".asInstanceOf[AacProfile]
 
     val values = js.Object.freeze(js.Array(HEV1, HEV2, LC))
   }
@@ -521,9 +320,11 @@ package medialive {
   /**
     * Aac Rate Control Mode
     */
-  object AacRateControlModeEnum {
-    val CBR = "CBR"
-    val VBR = "VBR"
+  @js.native
+  sealed trait AacRateControlMode extends js.Any
+  object AacRateControlMode extends js.Object {
+    val CBR = "CBR".asInstanceOf[AacRateControlMode]
+    val VBR = "VBR".asInstanceOf[AacRateControlMode]
 
     val values = js.Object.freeze(js.Array(CBR, VBR))
   }
@@ -531,9 +332,11 @@ package medialive {
   /**
     * Aac Raw Format
     */
-  object AacRawFormatEnum {
-    val LATM_LOAS = "LATM_LOAS"
-    val NONE      = "NONE"
+  @js.native
+  sealed trait AacRawFormat extends js.Any
+  object AacRawFormat extends js.Object {
+    val LATM_LOAS = "LATM_LOAS".asInstanceOf[AacRawFormat]
+    val NONE      = "NONE".asInstanceOf[AacRawFormat]
 
     val values = js.Object.freeze(js.Array(LATM_LOAS, NONE))
   }
@@ -584,9 +387,11 @@ package medialive {
   /**
     * Aac Spec
     */
-  object AacSpecEnum {
-    val MPEG2 = "MPEG2"
-    val MPEG4 = "MPEG4"
+  @js.native
+  sealed trait AacSpec extends js.Any
+  object AacSpec extends js.Object {
+    val MPEG2 = "MPEG2".asInstanceOf[AacSpec]
+    val MPEG4 = "MPEG4".asInstanceOf[AacSpec]
 
     val values = js.Object.freeze(js.Array(MPEG2, MPEG4))
   }
@@ -594,11 +399,13 @@ package medialive {
   /**
     * Aac Vbr Quality
     */
-  object AacVbrQualityEnum {
-    val HIGH        = "HIGH"
-    val LOW         = "LOW"
-    val MEDIUM_HIGH = "MEDIUM_HIGH"
-    val MEDIUM_LOW  = "MEDIUM_LOW"
+  @js.native
+  sealed trait AacVbrQuality extends js.Any
+  object AacVbrQuality extends js.Object {
+    val HIGH        = "HIGH".asInstanceOf[AacVbrQuality]
+    val LOW         = "LOW".asInstanceOf[AacVbrQuality]
+    val MEDIUM_HIGH = "MEDIUM_HIGH".asInstanceOf[AacVbrQuality]
+    val MEDIUM_LOW  = "MEDIUM_LOW".asInstanceOf[AacVbrQuality]
 
     val values = js.Object.freeze(js.Array(HIGH, LOW, MEDIUM_HIGH, MEDIUM_LOW))
   }
@@ -606,15 +413,17 @@ package medialive {
   /**
     * Ac3 Bitstream Mode
     */
-  object Ac3BitstreamModeEnum {
-    val COMMENTARY        = "COMMENTARY"
-    val COMPLETE_MAIN     = "COMPLETE_MAIN"
-    val DIALOGUE          = "DIALOGUE"
-    val EMERGENCY         = "EMERGENCY"
-    val HEARING_IMPAIRED  = "HEARING_IMPAIRED"
-    val MUSIC_AND_EFFECTS = "MUSIC_AND_EFFECTS"
-    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED"
-    val VOICE_OVER        = "VOICE_OVER"
+  @js.native
+  sealed trait Ac3BitstreamMode extends js.Any
+  object Ac3BitstreamMode extends js.Object {
+    val COMMENTARY        = "COMMENTARY".asInstanceOf[Ac3BitstreamMode]
+    val COMPLETE_MAIN     = "COMPLETE_MAIN".asInstanceOf[Ac3BitstreamMode]
+    val DIALOGUE          = "DIALOGUE".asInstanceOf[Ac3BitstreamMode]
+    val EMERGENCY         = "EMERGENCY".asInstanceOf[Ac3BitstreamMode]
+    val HEARING_IMPAIRED  = "HEARING_IMPAIRED".asInstanceOf[Ac3BitstreamMode]
+    val MUSIC_AND_EFFECTS = "MUSIC_AND_EFFECTS".asInstanceOf[Ac3BitstreamMode]
+    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED".asInstanceOf[Ac3BitstreamMode]
+    val VOICE_OVER        = "VOICE_OVER".asInstanceOf[Ac3BitstreamMode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -633,11 +442,13 @@ package medialive {
   /**
     * Ac3 Coding Mode
     */
-  object Ac3CodingModeEnum {
-    val CODING_MODE_1_0     = "CODING_MODE_1_0"
-    val CODING_MODE_1_1     = "CODING_MODE_1_1"
-    val CODING_MODE_2_0     = "CODING_MODE_2_0"
-    val CODING_MODE_3_2_LFE = "CODING_MODE_3_2_LFE"
+  @js.native
+  sealed trait Ac3CodingMode extends js.Any
+  object Ac3CodingMode extends js.Object {
+    val CODING_MODE_1_0     = "CODING_MODE_1_0".asInstanceOf[Ac3CodingMode]
+    val CODING_MODE_1_1     = "CODING_MODE_1_1".asInstanceOf[Ac3CodingMode]
+    val CODING_MODE_2_0     = "CODING_MODE_2_0".asInstanceOf[Ac3CodingMode]
+    val CODING_MODE_3_2_LFE = "CODING_MODE_3_2_LFE".asInstanceOf[Ac3CodingMode]
 
     val values = js.Object.freeze(js.Array(CODING_MODE_1_0, CODING_MODE_1_1, CODING_MODE_2_0, CODING_MODE_3_2_LFE))
   }
@@ -645,9 +456,11 @@ package medialive {
   /**
     * Ac3 Drc Profile
     */
-  object Ac3DrcProfileEnum {
-    val FILM_STANDARD = "FILM_STANDARD"
-    val NONE          = "NONE"
+  @js.native
+  sealed trait Ac3DrcProfile extends js.Any
+  object Ac3DrcProfile extends js.Object {
+    val FILM_STANDARD = "FILM_STANDARD".asInstanceOf[Ac3DrcProfile]
+    val NONE          = "NONE".asInstanceOf[Ac3DrcProfile]
 
     val values = js.Object.freeze(js.Array(FILM_STANDARD, NONE))
   }
@@ -655,9 +468,11 @@ package medialive {
   /**
     * Ac3 Lfe Filter
     */
-  object Ac3LfeFilterEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait Ac3LfeFilter extends js.Any
+  object Ac3LfeFilter extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[Ac3LfeFilter]
+    val ENABLED  = "ENABLED".asInstanceOf[Ac3LfeFilter]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -665,9 +480,11 @@ package medialive {
   /**
     * Ac3 Metadata Control
     */
-  object Ac3MetadataControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait Ac3MetadataControl extends js.Any
+  object Ac3MetadataControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[Ac3MetadataControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[Ac3MetadataControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -712,10 +529,12 @@ package medialive {
   /**
     * Afd Signaling
     */
-  object AfdSignalingEnum {
-    val AUTO  = "AUTO"
-    val FIXED = "FIXED"
-    val NONE  = "NONE"
+  @js.native
+  sealed trait AfdSignaling extends js.Any
+  object AfdSignaling extends js.Object {
+    val AUTO  = "AUTO".asInstanceOf[AfdSignaling]
+    val FIXED = "FIXED".asInstanceOf[AfdSignaling]
+    val NONE  = "NONE".asInstanceOf[AfdSignaling]
 
     val values = js.Object.freeze(js.Array(AUTO, FIXED, NONE))
   }
@@ -930,9 +749,11 @@ package medialive {
   /**
     * Audio Description Audio Type Control
     */
-  object AudioDescriptionAudioTypeControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait AudioDescriptionAudioTypeControl extends js.Any
+  object AudioDescriptionAudioTypeControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[AudioDescriptionAudioTypeControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[AudioDescriptionAudioTypeControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -940,9 +761,11 @@ package medialive {
   /**
     * Audio Description Language Code Control
     */
-  object AudioDescriptionLanguageCodeControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait AudioDescriptionLanguageCodeControl extends js.Any
+  object AudioDescriptionLanguageCodeControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[AudioDescriptionLanguageCodeControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[AudioDescriptionLanguageCodeControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -974,9 +797,11 @@ package medialive {
   /**
     * Audio Language Selection Policy
     */
-  object AudioLanguageSelectionPolicyEnum {
-    val LOOSE  = "LOOSE"
-    val STRICT = "STRICT"
+  @js.native
+  sealed trait AudioLanguageSelectionPolicy extends js.Any
+  object AudioLanguageSelectionPolicy extends js.Object {
+    val LOOSE  = "LOOSE".asInstanceOf[AudioLanguageSelectionPolicy]
+    val STRICT = "STRICT".asInstanceOf[AudioLanguageSelectionPolicy]
 
     val values = js.Object.freeze(js.Array(LOOSE, STRICT))
   }
@@ -984,9 +809,11 @@ package medialive {
   /**
     * Audio Normalization Algorithm
     */
-  object AudioNormalizationAlgorithmEnum {
-    val ITU_1770_1 = "ITU_1770_1"
-    val ITU_1770_2 = "ITU_1770_2"
+  @js.native
+  sealed trait AudioNormalizationAlgorithm extends js.Any
+  object AudioNormalizationAlgorithm extends js.Object {
+    val ITU_1770_1 = "ITU_1770_1".asInstanceOf[AudioNormalizationAlgorithm]
+    val ITU_1770_2 = "ITU_1770_2".asInstanceOf[AudioNormalizationAlgorithm]
 
     val values = js.Object.freeze(js.Array(ITU_1770_1, ITU_1770_2))
   }
@@ -994,8 +821,10 @@ package medialive {
   /**
     * Audio Normalization Algorithm Control
     */
-  object AudioNormalizationAlgorithmControlEnum {
-    val CORRECT_AUDIO = "CORRECT_AUDIO"
+  @js.native
+  sealed trait AudioNormalizationAlgorithmControl extends js.Any
+  object AudioNormalizationAlgorithmControl extends js.Object {
+    val CORRECT_AUDIO = "CORRECT_AUDIO".asInstanceOf[AudioNormalizationAlgorithmControl]
 
     val values = js.Object.freeze(js.Array(CORRECT_AUDIO))
   }
@@ -1028,9 +857,11 @@ package medialive {
   /**
     * Audio Only Hls Segment Type
     */
-  object AudioOnlyHlsSegmentTypeEnum {
-    val AAC  = "AAC"
-    val FMP4 = "FMP4"
+  @js.native
+  sealed trait AudioOnlyHlsSegmentType extends js.Any
+  object AudioOnlyHlsSegmentType extends js.Object {
+    val AAC  = "AAC".asInstanceOf[AudioOnlyHlsSegmentType]
+    val FMP4 = "FMP4".asInstanceOf[AudioOnlyHlsSegmentType]
 
     val values = js.Object.freeze(js.Array(AAC, FMP4))
   }
@@ -1066,11 +897,13 @@ package medialive {
   /**
     * Audio Only Hls Track Type
     */
-  object AudioOnlyHlsTrackTypeEnum {
-    val ALTERNATE_AUDIO_AUTO_SELECT         = "ALTERNATE_AUDIO_AUTO_SELECT"
-    val ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT = "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT"
-    val ALTERNATE_AUDIO_NOT_AUTO_SELECT     = "ALTERNATE_AUDIO_NOT_AUTO_SELECT"
-    val AUDIO_ONLY_VARIANT_STREAM           = "AUDIO_ONLY_VARIANT_STREAM"
+  @js.native
+  sealed trait AudioOnlyHlsTrackType extends js.Any
+  object AudioOnlyHlsTrackType extends js.Object {
+    val ALTERNATE_AUDIO_AUTO_SELECT         = "ALTERNATE_AUDIO_AUTO_SELECT".asInstanceOf[AudioOnlyHlsTrackType]
+    val ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT = "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT".asInstanceOf[AudioOnlyHlsTrackType]
+    val ALTERNATE_AUDIO_NOT_AUTO_SELECT     = "ALTERNATE_AUDIO_NOT_AUTO_SELECT".asInstanceOf[AudioOnlyHlsTrackType]
+    val AUDIO_ONLY_VARIANT_STREAM           = "AUDIO_ONLY_VARIANT_STREAM".asInstanceOf[AudioOnlyHlsTrackType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1152,11 +985,13 @@ package medialive {
   /**
     * Audio Type
     */
-  object AudioTypeEnum {
-    val CLEAN_EFFECTS              = "CLEAN_EFFECTS"
-    val HEARING_IMPAIRED           = "HEARING_IMPAIRED"
-    val UNDEFINED                  = "UNDEFINED"
-    val VISUAL_IMPAIRED_COMMENTARY = "VISUAL_IMPAIRED_COMMENTARY"
+  @js.native
+  sealed trait AudioType extends js.Any
+  object AudioType extends js.Object {
+    val CLEAN_EFFECTS              = "CLEAN_EFFECTS".asInstanceOf[AudioType]
+    val HEARING_IMPAIRED           = "HEARING_IMPAIRED".asInstanceOf[AudioType]
+    val UNDEFINED                  = "UNDEFINED".asInstanceOf[AudioType]
+    val VISUAL_IMPAIRED_COMMENTARY = "VISUAL_IMPAIRED_COMMENTARY".asInstanceOf[AudioType]
 
     val values = js.Object.freeze(js.Array(CLEAN_EFFECTS, HEARING_IMPAIRED, UNDEFINED, VISUAL_IMPAIRED_COMMENTARY))
   }
@@ -1164,9 +999,11 @@ package medialive {
   /**
     * Authentication Scheme
     */
-  object AuthenticationSchemeEnum {
-    val AKAMAI = "AKAMAI"
-    val COMMON = "COMMON"
+  @js.native
+  sealed trait AuthenticationScheme extends js.Any
+  object AuthenticationScheme extends js.Object {
+    val AKAMAI = "AKAMAI".asInstanceOf[AuthenticationScheme]
+    val COMMON = "COMMON".asInstanceOf[AuthenticationScheme]
 
     val values = js.Object.freeze(js.Array(AKAMAI, COMMON))
   }
@@ -1196,9 +1033,11 @@ package medialive {
   /**
     * Avail Blanking State
     */
-  object AvailBlankingStateEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait AvailBlankingState extends js.Any
+  object AvailBlankingState extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[AvailBlankingState]
+    val ENABLED  = "ENABLED".asInstanceOf[AvailBlankingState]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -1411,9 +1250,11 @@ package medialive {
   /**
     * Blackout Slate Network End Blackout
     */
-  object BlackoutSlateNetworkEndBlackoutEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait BlackoutSlateNetworkEndBlackout extends js.Any
+  object BlackoutSlateNetworkEndBlackout extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[BlackoutSlateNetworkEndBlackout]
+    val ENABLED  = "ENABLED".asInstanceOf[BlackoutSlateNetworkEndBlackout]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -1421,9 +1262,11 @@ package medialive {
   /**
     * Blackout Slate State
     */
-  object BlackoutSlateStateEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait BlackoutSlateState extends js.Any
+  object BlackoutSlateState extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[BlackoutSlateState]
+    val ENABLED  = "ENABLED".asInstanceOf[BlackoutSlateState]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -1431,10 +1274,12 @@ package medialive {
   /**
     * Burn In Alignment
     */
-  object BurnInAlignmentEnum {
-    val CENTERED = "CENTERED"
-    val LEFT     = "LEFT"
-    val SMART    = "SMART"
+  @js.native
+  sealed trait BurnInAlignment extends js.Any
+  object BurnInAlignment extends js.Object {
+    val CENTERED = "CENTERED".asInstanceOf[BurnInAlignment]
+    val LEFT     = "LEFT".asInstanceOf[BurnInAlignment]
+    val SMART    = "SMART".asInstanceOf[BurnInAlignment]
 
     val values = js.Object.freeze(js.Array(CENTERED, LEFT, SMART))
   }
@@ -1442,10 +1287,12 @@ package medialive {
   /**
     * Burn In Background Color
     */
-  object BurnInBackgroundColorEnum {
-    val BLACK = "BLACK"
-    val NONE  = "NONE"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait BurnInBackgroundColor extends js.Any
+  object BurnInBackgroundColor extends js.Object {
+    val BLACK = "BLACK".asInstanceOf[BurnInBackgroundColor]
+    val NONE  = "NONE".asInstanceOf[BurnInBackgroundColor]
+    val WHITE = "WHITE".asInstanceOf[BurnInBackgroundColor]
 
     val values = js.Object.freeze(js.Array(BLACK, NONE, WHITE))
   }
@@ -1520,13 +1367,15 @@ package medialive {
   /**
     * Burn In Font Color
     */
-  object BurnInFontColorEnum {
-    val BLACK  = "BLACK"
-    val BLUE   = "BLUE"
-    val GREEN  = "GREEN"
-    val RED    = "RED"
-    val WHITE  = "WHITE"
-    val YELLOW = "YELLOW"
+  @js.native
+  sealed trait BurnInFontColor extends js.Any
+  object BurnInFontColor extends js.Object {
+    val BLACK  = "BLACK".asInstanceOf[BurnInFontColor]
+    val BLUE   = "BLUE".asInstanceOf[BurnInFontColor]
+    val GREEN  = "GREEN".asInstanceOf[BurnInFontColor]
+    val RED    = "RED".asInstanceOf[BurnInFontColor]
+    val WHITE  = "WHITE".asInstanceOf[BurnInFontColor]
+    val YELLOW = "YELLOW".asInstanceOf[BurnInFontColor]
 
     val values = js.Object.freeze(js.Array(BLACK, BLUE, GREEN, RED, WHITE, YELLOW))
   }
@@ -1534,13 +1383,15 @@ package medialive {
   /**
     * Burn In Outline Color
     */
-  object BurnInOutlineColorEnum {
-    val BLACK  = "BLACK"
-    val BLUE   = "BLUE"
-    val GREEN  = "GREEN"
-    val RED    = "RED"
-    val WHITE  = "WHITE"
-    val YELLOW = "YELLOW"
+  @js.native
+  sealed trait BurnInOutlineColor extends js.Any
+  object BurnInOutlineColor extends js.Object {
+    val BLACK  = "BLACK".asInstanceOf[BurnInOutlineColor]
+    val BLUE   = "BLUE".asInstanceOf[BurnInOutlineColor]
+    val GREEN  = "GREEN".asInstanceOf[BurnInOutlineColor]
+    val RED    = "RED".asInstanceOf[BurnInOutlineColor]
+    val WHITE  = "WHITE".asInstanceOf[BurnInOutlineColor]
+    val YELLOW = "YELLOW".asInstanceOf[BurnInOutlineColor]
 
     val values = js.Object.freeze(js.Array(BLACK, BLUE, GREEN, RED, WHITE, YELLOW))
   }
@@ -1548,10 +1399,12 @@ package medialive {
   /**
     * Burn In Shadow Color
     */
-  object BurnInShadowColorEnum {
-    val BLACK = "BLACK"
-    val NONE  = "NONE"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait BurnInShadowColor extends js.Any
+  object BurnInShadowColor extends js.Object {
+    val BLACK = "BLACK".asInstanceOf[BurnInShadowColor]
+    val NONE  = "NONE".asInstanceOf[BurnInShadowColor]
+    val WHITE = "WHITE".asInstanceOf[BurnInShadowColor]
 
     val values = js.Object.freeze(js.Array(BLACK, NONE, WHITE))
   }
@@ -1559,9 +1412,11 @@ package medialive {
   /**
     * Burn In Teletext Grid Control
     */
-  object BurnInTeletextGridControlEnum {
-    val FIXED  = "FIXED"
-    val SCALED = "SCALED"
+  @js.native
+  sealed trait BurnInTeletextGridControl extends js.Any
+  object BurnInTeletextGridControl extends js.Object {
+    val FIXED  = "FIXED".asInstanceOf[BurnInTeletextGridControl]
+    val SCALED = "SCALED".asInstanceOf[BurnInTeletextGridControl]
 
     val values = js.Object.freeze(js.Array(FIXED, SCALED))
   }
@@ -1823,9 +1678,11 @@ package medialive {
   /**
     * A standard channel has two encoding pipelines and a single pipeline channel only has one.
     */
-  object ChannelClassEnum {
-    val STANDARD        = "STANDARD"
-    val SINGLE_PIPELINE = "SINGLE_PIPELINE"
+  @js.native
+  sealed trait ChannelClass extends js.Any
+  object ChannelClass extends js.Object {
+    val STANDARD        = "STANDARD".asInstanceOf[ChannelClass]
+    val SINGLE_PIPELINE = "SINGLE_PIPELINE".asInstanceOf[ChannelClass]
 
     val values = js.Object.freeze(js.Array(STANDARD, SINGLE_PIPELINE))
   }
@@ -1852,18 +1709,20 @@ package medialive {
   /**
     * Placeholder documentation for ChannelState
     */
-  object ChannelStateEnum {
-    val CREATING      = "CREATING"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val IDLE          = "IDLE"
-    val STARTING      = "STARTING"
-    val RUNNING       = "RUNNING"
-    val RECOVERING    = "RECOVERING"
-    val STOPPING      = "STOPPING"
-    val DELETING      = "DELETING"
-    val DELETED       = "DELETED"
-    val UPDATING      = "UPDATING"
-    val UPDATE_FAILED = "UPDATE_FAILED"
+  @js.native
+  sealed trait ChannelState extends js.Any
+  object ChannelState extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[ChannelState]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[ChannelState]
+    val IDLE          = "IDLE".asInstanceOf[ChannelState]
+    val STARTING      = "STARTING".asInstanceOf[ChannelState]
+    val RUNNING       = "RUNNING".asInstanceOf[ChannelState]
+    val RECOVERING    = "RECOVERING".asInstanceOf[ChannelState]
+    val STOPPING      = "STOPPING".asInstanceOf[ChannelState]
+    val DELETING      = "DELETING".asInstanceOf[ChannelState]
+    val DELETED       = "DELETED".asInstanceOf[ChannelState]
+    val UPDATING      = "UPDATING".asInstanceOf[ChannelState]
+    val UPDATE_FAILED = "UPDATE_FAILED".asInstanceOf[ChannelState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3254,11 +3113,13 @@ package medialive {
   /**
     * Dvb Sdt Output Sdt
     */
-  object DvbSdtOutputSdtEnum {
-    val SDT_FOLLOW            = "SDT_FOLLOW"
-    val SDT_FOLLOW_IF_PRESENT = "SDT_FOLLOW_IF_PRESENT"
-    val SDT_MANUAL            = "SDT_MANUAL"
-    val SDT_NONE              = "SDT_NONE"
+  @js.native
+  sealed trait DvbSdtOutputSdt extends js.Any
+  object DvbSdtOutputSdt extends js.Object {
+    val SDT_FOLLOW            = "SDT_FOLLOW".asInstanceOf[DvbSdtOutputSdt]
+    val SDT_FOLLOW_IF_PRESENT = "SDT_FOLLOW_IF_PRESENT".asInstanceOf[DvbSdtOutputSdt]
+    val SDT_MANUAL            = "SDT_MANUAL".asInstanceOf[DvbSdtOutputSdt]
+    val SDT_NONE              = "SDT_NONE".asInstanceOf[DvbSdtOutputSdt]
 
     val values = js.Object.freeze(js.Array(SDT_FOLLOW, SDT_FOLLOW_IF_PRESENT, SDT_MANUAL, SDT_NONE))
   }
@@ -3294,10 +3155,12 @@ package medialive {
   /**
     * Dvb Sub Destination Alignment
     */
-  object DvbSubDestinationAlignmentEnum {
-    val CENTERED = "CENTERED"
-    val LEFT     = "LEFT"
-    val SMART    = "SMART"
+  @js.native
+  sealed trait DvbSubDestinationAlignment extends js.Any
+  object DvbSubDestinationAlignment extends js.Object {
+    val CENTERED = "CENTERED".asInstanceOf[DvbSubDestinationAlignment]
+    val LEFT     = "LEFT".asInstanceOf[DvbSubDestinationAlignment]
+    val SMART    = "SMART".asInstanceOf[DvbSubDestinationAlignment]
 
     val values = js.Object.freeze(js.Array(CENTERED, LEFT, SMART))
   }
@@ -3305,10 +3168,12 @@ package medialive {
   /**
     * Dvb Sub Destination Background Color
     */
-  object DvbSubDestinationBackgroundColorEnum {
-    val BLACK = "BLACK"
-    val NONE  = "NONE"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait DvbSubDestinationBackgroundColor extends js.Any
+  object DvbSubDestinationBackgroundColor extends js.Object {
+    val BLACK = "BLACK".asInstanceOf[DvbSubDestinationBackgroundColor]
+    val NONE  = "NONE".asInstanceOf[DvbSubDestinationBackgroundColor]
+    val WHITE = "WHITE".asInstanceOf[DvbSubDestinationBackgroundColor]
 
     val values = js.Object.freeze(js.Array(BLACK, NONE, WHITE))
   }
@@ -3316,13 +3181,15 @@ package medialive {
   /**
     * Dvb Sub Destination Font Color
     */
-  object DvbSubDestinationFontColorEnum {
-    val BLACK  = "BLACK"
-    val BLUE   = "BLUE"
-    val GREEN  = "GREEN"
-    val RED    = "RED"
-    val WHITE  = "WHITE"
-    val YELLOW = "YELLOW"
+  @js.native
+  sealed trait DvbSubDestinationFontColor extends js.Any
+  object DvbSubDestinationFontColor extends js.Object {
+    val BLACK  = "BLACK".asInstanceOf[DvbSubDestinationFontColor]
+    val BLUE   = "BLUE".asInstanceOf[DvbSubDestinationFontColor]
+    val GREEN  = "GREEN".asInstanceOf[DvbSubDestinationFontColor]
+    val RED    = "RED".asInstanceOf[DvbSubDestinationFontColor]
+    val WHITE  = "WHITE".asInstanceOf[DvbSubDestinationFontColor]
+    val YELLOW = "YELLOW".asInstanceOf[DvbSubDestinationFontColor]
 
     val values = js.Object.freeze(js.Array(BLACK, BLUE, GREEN, RED, WHITE, YELLOW))
   }
@@ -3330,13 +3197,15 @@ package medialive {
   /**
     * Dvb Sub Destination Outline Color
     */
-  object DvbSubDestinationOutlineColorEnum {
-    val BLACK  = "BLACK"
-    val BLUE   = "BLUE"
-    val GREEN  = "GREEN"
-    val RED    = "RED"
-    val WHITE  = "WHITE"
-    val YELLOW = "YELLOW"
+  @js.native
+  sealed trait DvbSubDestinationOutlineColor extends js.Any
+  object DvbSubDestinationOutlineColor extends js.Object {
+    val BLACK  = "BLACK".asInstanceOf[DvbSubDestinationOutlineColor]
+    val BLUE   = "BLUE".asInstanceOf[DvbSubDestinationOutlineColor]
+    val GREEN  = "GREEN".asInstanceOf[DvbSubDestinationOutlineColor]
+    val RED    = "RED".asInstanceOf[DvbSubDestinationOutlineColor]
+    val WHITE  = "WHITE".asInstanceOf[DvbSubDestinationOutlineColor]
+    val YELLOW = "YELLOW".asInstanceOf[DvbSubDestinationOutlineColor]
 
     val values = js.Object.freeze(js.Array(BLACK, BLUE, GREEN, RED, WHITE, YELLOW))
   }
@@ -3411,10 +3280,12 @@ package medialive {
   /**
     * Dvb Sub Destination Shadow Color
     */
-  object DvbSubDestinationShadowColorEnum {
-    val BLACK = "BLACK"
-    val NONE  = "NONE"
-    val WHITE = "WHITE"
+  @js.native
+  sealed trait DvbSubDestinationShadowColor extends js.Any
+  object DvbSubDestinationShadowColor extends js.Object {
+    val BLACK = "BLACK".asInstanceOf[DvbSubDestinationShadowColor]
+    val NONE  = "NONE".asInstanceOf[DvbSubDestinationShadowColor]
+    val WHITE = "WHITE".asInstanceOf[DvbSubDestinationShadowColor]
 
     val values = js.Object.freeze(js.Array(BLACK, NONE, WHITE))
   }
@@ -3422,9 +3293,11 @@ package medialive {
   /**
     * Dvb Sub Destination Teletext Grid Control
     */
-  object DvbSubDestinationTeletextGridControlEnum {
-    val FIXED  = "FIXED"
-    val SCALED = "SCALED"
+  @js.native
+  sealed trait DvbSubDestinationTeletextGridControl extends js.Any
+  object DvbSubDestinationTeletextGridControl extends js.Object {
+    val FIXED  = "FIXED".asInstanceOf[DvbSubDestinationTeletextGridControl]
+    val SCALED = "SCALED".asInstanceOf[DvbSubDestinationTeletextGridControl]
 
     val values = js.Object.freeze(js.Array(FIXED, SCALED))
   }
@@ -3470,9 +3343,11 @@ package medialive {
   /**
     * Eac3 Attenuation Control
     */
-  object Eac3AttenuationControlEnum {
-    val ATTENUATE_3_DB = "ATTENUATE_3_DB"
-    val NONE           = "NONE"
+  @js.native
+  sealed trait Eac3AttenuationControl extends js.Any
+  object Eac3AttenuationControl extends js.Object {
+    val ATTENUATE_3_DB = "ATTENUATE_3_DB".asInstanceOf[Eac3AttenuationControl]
+    val NONE           = "NONE".asInstanceOf[Eac3AttenuationControl]
 
     val values = js.Object.freeze(js.Array(ATTENUATE_3_DB, NONE))
   }
@@ -3480,12 +3355,14 @@ package medialive {
   /**
     * Eac3 Bitstream Mode
     */
-  object Eac3BitstreamModeEnum {
-    val COMMENTARY        = "COMMENTARY"
-    val COMPLETE_MAIN     = "COMPLETE_MAIN"
-    val EMERGENCY         = "EMERGENCY"
-    val HEARING_IMPAIRED  = "HEARING_IMPAIRED"
-    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED"
+  @js.native
+  sealed trait Eac3BitstreamMode extends js.Any
+  object Eac3BitstreamMode extends js.Object {
+    val COMMENTARY        = "COMMENTARY".asInstanceOf[Eac3BitstreamMode]
+    val COMPLETE_MAIN     = "COMPLETE_MAIN".asInstanceOf[Eac3BitstreamMode]
+    val EMERGENCY         = "EMERGENCY".asInstanceOf[Eac3BitstreamMode]
+    val HEARING_IMPAIRED  = "HEARING_IMPAIRED".asInstanceOf[Eac3BitstreamMode]
+    val VISUALLY_IMPAIRED = "VISUALLY_IMPAIRED".asInstanceOf[Eac3BitstreamMode]
 
     val values = js.Object.freeze(js.Array(COMMENTARY, COMPLETE_MAIN, EMERGENCY, HEARING_IMPAIRED, VISUALLY_IMPAIRED))
   }
@@ -3493,10 +3370,12 @@ package medialive {
   /**
     * Eac3 Coding Mode
     */
-  object Eac3CodingModeEnum {
-    val CODING_MODE_1_0 = "CODING_MODE_1_0"
-    val CODING_MODE_2_0 = "CODING_MODE_2_0"
-    val CODING_MODE_3_2 = "CODING_MODE_3_2"
+  @js.native
+  sealed trait Eac3CodingMode extends js.Any
+  object Eac3CodingMode extends js.Object {
+    val CODING_MODE_1_0 = "CODING_MODE_1_0".asInstanceOf[Eac3CodingMode]
+    val CODING_MODE_2_0 = "CODING_MODE_2_0".asInstanceOf[Eac3CodingMode]
+    val CODING_MODE_3_2 = "CODING_MODE_3_2".asInstanceOf[Eac3CodingMode]
 
     val values = js.Object.freeze(js.Array(CODING_MODE_1_0, CODING_MODE_2_0, CODING_MODE_3_2))
   }
@@ -3504,9 +3383,11 @@ package medialive {
   /**
     * Eac3 Dc Filter
     */
-  object Eac3DcFilterEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait Eac3DcFilter extends js.Any
+  object Eac3DcFilter extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[Eac3DcFilter]
+    val ENABLED  = "ENABLED".asInstanceOf[Eac3DcFilter]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -3514,13 +3395,15 @@ package medialive {
   /**
     * Eac3 Drc Line
     */
-  object Eac3DrcLineEnum {
-    val FILM_LIGHT     = "FILM_LIGHT"
-    val FILM_STANDARD  = "FILM_STANDARD"
-    val MUSIC_LIGHT    = "MUSIC_LIGHT"
-    val MUSIC_STANDARD = "MUSIC_STANDARD"
-    val NONE           = "NONE"
-    val SPEECH         = "SPEECH"
+  @js.native
+  sealed trait Eac3DrcLine extends js.Any
+  object Eac3DrcLine extends js.Object {
+    val FILM_LIGHT     = "FILM_LIGHT".asInstanceOf[Eac3DrcLine]
+    val FILM_STANDARD  = "FILM_STANDARD".asInstanceOf[Eac3DrcLine]
+    val MUSIC_LIGHT    = "MUSIC_LIGHT".asInstanceOf[Eac3DrcLine]
+    val MUSIC_STANDARD = "MUSIC_STANDARD".asInstanceOf[Eac3DrcLine]
+    val NONE           = "NONE".asInstanceOf[Eac3DrcLine]
+    val SPEECH         = "SPEECH".asInstanceOf[Eac3DrcLine]
 
     val values = js.Object.freeze(js.Array(FILM_LIGHT, FILM_STANDARD, MUSIC_LIGHT, MUSIC_STANDARD, NONE, SPEECH))
   }
@@ -3528,13 +3411,15 @@ package medialive {
   /**
     * Eac3 Drc Rf
     */
-  object Eac3DrcRfEnum {
-    val FILM_LIGHT     = "FILM_LIGHT"
-    val FILM_STANDARD  = "FILM_STANDARD"
-    val MUSIC_LIGHT    = "MUSIC_LIGHT"
-    val MUSIC_STANDARD = "MUSIC_STANDARD"
-    val NONE           = "NONE"
-    val SPEECH         = "SPEECH"
+  @js.native
+  sealed trait Eac3DrcRf extends js.Any
+  object Eac3DrcRf extends js.Object {
+    val FILM_LIGHT     = "FILM_LIGHT".asInstanceOf[Eac3DrcRf]
+    val FILM_STANDARD  = "FILM_STANDARD".asInstanceOf[Eac3DrcRf]
+    val MUSIC_LIGHT    = "MUSIC_LIGHT".asInstanceOf[Eac3DrcRf]
+    val MUSIC_STANDARD = "MUSIC_STANDARD".asInstanceOf[Eac3DrcRf]
+    val NONE           = "NONE".asInstanceOf[Eac3DrcRf]
+    val SPEECH         = "SPEECH".asInstanceOf[Eac3DrcRf]
 
     val values = js.Object.freeze(js.Array(FILM_LIGHT, FILM_STANDARD, MUSIC_LIGHT, MUSIC_STANDARD, NONE, SPEECH))
   }
@@ -3542,9 +3427,11 @@ package medialive {
   /**
     * Eac3 Lfe Control
     */
-  object Eac3LfeControlEnum {
-    val LFE    = "LFE"
-    val NO_LFE = "NO_LFE"
+  @js.native
+  sealed trait Eac3LfeControl extends js.Any
+  object Eac3LfeControl extends js.Object {
+    val LFE    = "LFE".asInstanceOf[Eac3LfeControl]
+    val NO_LFE = "NO_LFE".asInstanceOf[Eac3LfeControl]
 
     val values = js.Object.freeze(js.Array(LFE, NO_LFE))
   }
@@ -3552,9 +3439,11 @@ package medialive {
   /**
     * Eac3 Lfe Filter
     */
-  object Eac3LfeFilterEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait Eac3LfeFilter extends js.Any
+  object Eac3LfeFilter extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[Eac3LfeFilter]
+    val ENABLED  = "ENABLED".asInstanceOf[Eac3LfeFilter]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -3562,9 +3451,11 @@ package medialive {
   /**
     * Eac3 Metadata Control
     */
-  object Eac3MetadataControlEnum {
-    val FOLLOW_INPUT   = "FOLLOW_INPUT"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait Eac3MetadataControl extends js.Any
+  object Eac3MetadataControl extends js.Object {
+    val FOLLOW_INPUT   = "FOLLOW_INPUT".asInstanceOf[Eac3MetadataControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[Eac3MetadataControl]
 
     val values = js.Object.freeze(js.Array(FOLLOW_INPUT, USE_CONFIGURED))
   }
@@ -3572,9 +3463,11 @@ package medialive {
   /**
     * Eac3 Passthrough Control
     */
-  object Eac3PassthroughControlEnum {
-    val NO_PASSTHROUGH = "NO_PASSTHROUGH"
-    val WHEN_POSSIBLE  = "WHEN_POSSIBLE"
+  @js.native
+  sealed trait Eac3PassthroughControl extends js.Any
+  object Eac3PassthroughControl extends js.Object {
+    val NO_PASSTHROUGH = "NO_PASSTHROUGH".asInstanceOf[Eac3PassthroughControl]
+    val WHEN_POSSIBLE  = "WHEN_POSSIBLE".asInstanceOf[Eac3PassthroughControl]
 
     val values = js.Object.freeze(js.Array(NO_PASSTHROUGH, WHEN_POSSIBLE))
   }
@@ -3582,9 +3475,11 @@ package medialive {
   /**
     * Eac3 Phase Control
     */
-  object Eac3PhaseControlEnum {
-    val NO_SHIFT         = "NO_SHIFT"
-    val SHIFT_90_DEGREES = "SHIFT_90_DEGREES"
+  @js.native
+  sealed trait Eac3PhaseControl extends js.Any
+  object Eac3PhaseControl extends js.Object {
+    val NO_SHIFT         = "NO_SHIFT".asInstanceOf[Eac3PhaseControl]
+    val SHIFT_90_DEGREES = "SHIFT_90_DEGREES".asInstanceOf[Eac3PhaseControl]
 
     val values = js.Object.freeze(js.Array(NO_SHIFT, SHIFT_90_DEGREES))
   }
@@ -3668,11 +3563,13 @@ package medialive {
   /**
     * Eac3 Stereo Downmix
     */
-  object Eac3StereoDownmixEnum {
-    val DPL2          = "DPL2"
-    val LO_RO         = "LO_RO"
-    val LT_RT         = "LT_RT"
-    val NOT_INDICATED = "NOT_INDICATED"
+  @js.native
+  sealed trait Eac3StereoDownmix extends js.Any
+  object Eac3StereoDownmix extends js.Object {
+    val DPL2          = "DPL2".asInstanceOf[Eac3StereoDownmix]
+    val LO_RO         = "LO_RO".asInstanceOf[Eac3StereoDownmix]
+    val LT_RT         = "LT_RT".asInstanceOf[Eac3StereoDownmix]
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3StereoDownmix]
 
     val values = js.Object.freeze(js.Array(DPL2, LO_RO, LT_RT, NOT_INDICATED))
   }
@@ -3680,10 +3577,12 @@ package medialive {
   /**
     * Eac3 Surround Ex Mode
     */
-  object Eac3SurroundExModeEnum {
-    val DISABLED      = "DISABLED"
-    val ENABLED       = "ENABLED"
-    val NOT_INDICATED = "NOT_INDICATED"
+  @js.native
+  sealed trait Eac3SurroundExMode extends js.Any
+  object Eac3SurroundExMode extends js.Object {
+    val DISABLED      = "DISABLED".asInstanceOf[Eac3SurroundExMode]
+    val ENABLED       = "ENABLED".asInstanceOf[Eac3SurroundExMode]
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3SurroundExMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED, NOT_INDICATED))
   }
@@ -3691,10 +3590,12 @@ package medialive {
   /**
     * Eac3 Surround Mode
     */
-  object Eac3SurroundModeEnum {
-    val DISABLED      = "DISABLED"
-    val ENABLED       = "ENABLED"
-    val NOT_INDICATED = "NOT_INDICATED"
+  @js.native
+  sealed trait Eac3SurroundMode extends js.Any
+  object Eac3SurroundMode extends js.Object {
+    val DISABLED      = "DISABLED".asInstanceOf[Eac3SurroundMode]
+    val ENABLED       = "ENABLED".asInstanceOf[Eac3SurroundMode]
+    val NOT_INDICATED = "NOT_INDICATED".asInstanceOf[Eac3SurroundMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED, NOT_INDICATED))
   }
@@ -3702,9 +3603,11 @@ package medialive {
   /**
     * Embedded Convert608 To708
     */
-  object EmbeddedConvert608To708Enum {
-    val DISABLED  = "DISABLED"
-    val UPCONVERT = "UPCONVERT"
+  @js.native
+  sealed trait EmbeddedConvert608To708 extends js.Any
+  object EmbeddedConvert608To708 extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[EmbeddedConvert608To708]
+    val UPCONVERT = "UPCONVERT".asInstanceOf[EmbeddedConvert608To708]
 
     val values = js.Object.freeze(js.Array(DISABLED, UPCONVERT))
   }
@@ -3744,9 +3647,11 @@ package medialive {
   /**
     * Embedded Scte20 Detection
     */
-  object EmbeddedScte20DetectionEnum {
-    val AUTO = "AUTO"
-    val OFF  = "OFF"
+  @js.native
+  sealed trait EmbeddedScte20Detection extends js.Any
+  object EmbeddedScte20Detection extends js.Object {
+    val AUTO = "AUTO".asInstanceOf[EmbeddedScte20Detection]
+    val OFF  = "OFF".asInstanceOf[EmbeddedScte20Detection]
 
     val values = js.Object.freeze(js.Array(AUTO, OFF))
   }
@@ -3830,9 +3735,11 @@ package medialive {
   /**
     * Fec Output Include Fec
     */
-  object FecOutputIncludeFecEnum {
-    val COLUMN         = "COLUMN"
-    val COLUMN_AND_ROW = "COLUMN_AND_ROW"
+  @js.native
+  sealed trait FecOutputIncludeFec extends js.Any
+  object FecOutputIncludeFec extends js.Object {
+    val COLUMN         = "COLUMN".asInstanceOf[FecOutputIncludeFec]
+    val COLUMN_AND_ROW = "COLUMN_AND_ROW".asInstanceOf[FecOutputIncludeFec]
 
     val values = js.Object.freeze(js.Array(COLUMN, COLUMN_AND_ROW))
   }
@@ -3865,18 +3772,20 @@ package medialive {
   /**
     * Fixed Afd
     */
-  object FixedAfdEnum {
-    val AFD_0000 = "AFD_0000"
-    val AFD_0010 = "AFD_0010"
-    val AFD_0011 = "AFD_0011"
-    val AFD_0100 = "AFD_0100"
-    val AFD_1000 = "AFD_1000"
-    val AFD_1001 = "AFD_1001"
-    val AFD_1010 = "AFD_1010"
-    val AFD_1011 = "AFD_1011"
-    val AFD_1101 = "AFD_1101"
-    val AFD_1110 = "AFD_1110"
-    val AFD_1111 = "AFD_1111"
+  @js.native
+  sealed trait FixedAfd extends js.Any
+  object FixedAfd extends js.Object {
+    val AFD_0000 = "AFD_0000".asInstanceOf[FixedAfd]
+    val AFD_0010 = "AFD_0010".asInstanceOf[FixedAfd]
+    val AFD_0011 = "AFD_0011".asInstanceOf[FixedAfd]
+    val AFD_0100 = "AFD_0100".asInstanceOf[FixedAfd]
+    val AFD_1000 = "AFD_1000".asInstanceOf[FixedAfd]
+    val AFD_1001 = "AFD_1001".asInstanceOf[FixedAfd]
+    val AFD_1010 = "AFD_1010".asInstanceOf[FixedAfd]
+    val AFD_1011 = "AFD_1011".asInstanceOf[FixedAfd]
+    val AFD_1101 = "AFD_1101".asInstanceOf[FixedAfd]
+    val AFD_1110 = "AFD_1110".asInstanceOf[FixedAfd]
+    val AFD_1111 = "AFD_1111".asInstanceOf[FixedAfd]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3962,9 +3871,11 @@ package medialive {
   /**
     * Follow reference point.
     */
-  object FollowPointEnum {
-    val END   = "END"
-    val START = "START"
+  @js.native
+  sealed trait FollowPoint extends js.Any
+  object FollowPoint extends js.Object {
+    val END   = "END".asInstanceOf[FollowPoint]
+    val START = "START".asInstanceOf[FollowPoint]
 
     val values = js.Object.freeze(js.Array(END, START))
   }
@@ -3993,9 +3904,11 @@ package medialive {
   /**
     * Frame Capture Interval Unit
     */
-  object FrameCaptureIntervalUnitEnum {
-    val MILLISECONDS = "MILLISECONDS"
-    val SECONDS      = "SECONDS"
+  @js.native
+  sealed trait FrameCaptureIntervalUnit extends js.Any
+  object FrameCaptureIntervalUnit extends js.Object {
+    val MILLISECONDS = "MILLISECONDS".asInstanceOf[FrameCaptureIntervalUnit]
+    val SECONDS      = "SECONDS".asInstanceOf[FrameCaptureIntervalUnit]
 
     val values = js.Object.freeze(js.Array(MILLISECONDS, SECONDS))
   }
@@ -4082,9 +3995,11 @@ package medialive {
   /**
     * Global Configuration Input End Action
     */
-  object GlobalConfigurationInputEndActionEnum {
-    val NONE                   = "NONE"
-    val SWITCH_AND_LOOP_INPUTS = "SWITCH_AND_LOOP_INPUTS"
+  @js.native
+  sealed trait GlobalConfigurationInputEndAction extends js.Any
+  object GlobalConfigurationInputEndAction extends js.Object {
+    val NONE                   = "NONE".asInstanceOf[GlobalConfigurationInputEndAction]
+    val SWITCH_AND_LOOP_INPUTS = "SWITCH_AND_LOOP_INPUTS".asInstanceOf[GlobalConfigurationInputEndAction]
 
     val values = js.Object.freeze(js.Array(NONE, SWITCH_AND_LOOP_INPUTS))
   }
@@ -4092,9 +4007,11 @@ package medialive {
   /**
     * Global Configuration Low Framerate Inputs
     */
-  object GlobalConfigurationLowFramerateInputsEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait GlobalConfigurationLowFramerateInputs extends js.Any
+  object GlobalConfigurationLowFramerateInputs extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[GlobalConfigurationLowFramerateInputs]
+    val ENABLED  = "ENABLED".asInstanceOf[GlobalConfigurationLowFramerateInputs]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4102,9 +4019,11 @@ package medialive {
   /**
     * Global Configuration Output Locking Mode
     */
-  object GlobalConfigurationOutputLockingModeEnum {
-    val EPOCH_LOCKING    = "EPOCH_LOCKING"
-    val PIPELINE_LOCKING = "PIPELINE_LOCKING"
+  @js.native
+  sealed trait GlobalConfigurationOutputLockingMode extends js.Any
+  object GlobalConfigurationOutputLockingMode extends js.Object {
+    val EPOCH_LOCKING    = "EPOCH_LOCKING".asInstanceOf[GlobalConfigurationOutputLockingMode]
+    val PIPELINE_LOCKING = "PIPELINE_LOCKING".asInstanceOf[GlobalConfigurationOutputLockingMode]
 
     val values = js.Object.freeze(js.Array(EPOCH_LOCKING, PIPELINE_LOCKING))
   }
@@ -4112,9 +4031,11 @@ package medialive {
   /**
     * Global Configuration Output Timing Source
     */
-  object GlobalConfigurationOutputTimingSourceEnum {
-    val INPUT_CLOCK  = "INPUT_CLOCK"
-    val SYSTEM_CLOCK = "SYSTEM_CLOCK"
+  @js.native
+  sealed trait GlobalConfigurationOutputTimingSource extends js.Any
+  object GlobalConfigurationOutputTimingSource extends js.Object {
+    val INPUT_CLOCK  = "INPUT_CLOCK".asInstanceOf[GlobalConfigurationOutputTimingSource]
+    val SYSTEM_CLOCK = "SYSTEM_CLOCK".asInstanceOf[GlobalConfigurationOutputTimingSource]
 
     val values = js.Object.freeze(js.Array(INPUT_CLOCK, SYSTEM_CLOCK))
   }
@@ -4122,13 +4043,15 @@ package medialive {
   /**
     * H264 Adaptive Quantization
     */
-  object H264AdaptiveQuantizationEnum {
-    val HIGH   = "HIGH"
-    val HIGHER = "HIGHER"
-    val LOW    = "LOW"
-    val MAX    = "MAX"
-    val MEDIUM = "MEDIUM"
-    val OFF    = "OFF"
+  @js.native
+  sealed trait H264AdaptiveQuantization extends js.Any
+  object H264AdaptiveQuantization extends js.Object {
+    val HIGH   = "HIGH".asInstanceOf[H264AdaptiveQuantization]
+    val HIGHER = "HIGHER".asInstanceOf[H264AdaptiveQuantization]
+    val LOW    = "LOW".asInstanceOf[H264AdaptiveQuantization]
+    val MAX    = "MAX".asInstanceOf[H264AdaptiveQuantization]
+    val MEDIUM = "MEDIUM".asInstanceOf[H264AdaptiveQuantization]
+    val OFF    = "OFF".asInstanceOf[H264AdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(HIGH, HIGHER, LOW, MAX, MEDIUM, OFF))
   }
@@ -4136,9 +4059,11 @@ package medialive {
   /**
     * H264 Color Metadata
     */
-  object H264ColorMetadataEnum {
-    val IGNORE = "IGNORE"
-    val INSERT = "INSERT"
+  @js.native
+  sealed trait H264ColorMetadata extends js.Any
+  object H264ColorMetadata extends js.Object {
+    val IGNORE = "IGNORE".asInstanceOf[H264ColorMetadata]
+    val INSERT = "INSERT".asInstanceOf[H264ColorMetadata]
 
     val values = js.Object.freeze(js.Array(IGNORE, INSERT))
   }
@@ -4173,9 +4098,11 @@ package medialive {
   /**
     * H264 Entropy Encoding
     */
-  object H264EntropyEncodingEnum {
-    val CABAC = "CABAC"
-    val CAVLC = "CAVLC"
+  @js.native
+  sealed trait H264EntropyEncoding extends js.Any
+  object H264EntropyEncoding extends js.Object {
+    val CABAC = "CABAC".asInstanceOf[H264EntropyEncoding]
+    val CAVLC = "CAVLC".asInstanceOf[H264EntropyEncoding]
 
     val values = js.Object.freeze(js.Array(CABAC, CAVLC))
   }
@@ -4183,9 +4110,11 @@ package medialive {
   /**
     * H264 Flicker Aq
     */
-  object H264FlickerAqEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264FlickerAq extends js.Any
+  object H264FlickerAq extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264FlickerAq]
+    val ENABLED  = "ENABLED".asInstanceOf[H264FlickerAq]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4193,9 +4122,11 @@ package medialive {
   /**
     * H264 Framerate Control
     */
-  object H264FramerateControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait H264FramerateControl extends js.Any
+  object H264FramerateControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[H264FramerateControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[H264FramerateControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -4203,9 +4134,11 @@ package medialive {
   /**
     * H264 Gop BReference
     */
-  object H264GopBReferenceEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264GopBReference extends js.Any
+  object H264GopBReference extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264GopBReference]
+    val ENABLED  = "ENABLED".asInstanceOf[H264GopBReference]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4213,9 +4146,11 @@ package medialive {
   /**
     * H264 Gop Size Units
     */
-  object H264GopSizeUnitsEnum {
-    val FRAMES  = "FRAMES"
-    val SECONDS = "SECONDS"
+  @js.native
+  sealed trait H264GopSizeUnits extends js.Any
+  object H264GopSizeUnits extends js.Object {
+    val FRAMES  = "FRAMES".asInstanceOf[H264GopSizeUnits]
+    val SECONDS = "SECONDS".asInstanceOf[H264GopSizeUnits]
 
     val values = js.Object.freeze(js.Array(FRAMES, SECONDS))
   }
@@ -4223,24 +4158,26 @@ package medialive {
   /**
     * H264 Level
     */
-  object H264LevelEnum {
-    val H264_LEVEL_1    = "H264_LEVEL_1"
-    val H264_LEVEL_1_1  = "H264_LEVEL_1_1"
-    val H264_LEVEL_1_2  = "H264_LEVEL_1_2"
-    val H264_LEVEL_1_3  = "H264_LEVEL_1_3"
-    val H264_LEVEL_2    = "H264_LEVEL_2"
-    val H264_LEVEL_2_1  = "H264_LEVEL_2_1"
-    val H264_LEVEL_2_2  = "H264_LEVEL_2_2"
-    val H264_LEVEL_3    = "H264_LEVEL_3"
-    val H264_LEVEL_3_1  = "H264_LEVEL_3_1"
-    val H264_LEVEL_3_2  = "H264_LEVEL_3_2"
-    val H264_LEVEL_4    = "H264_LEVEL_4"
-    val H264_LEVEL_4_1  = "H264_LEVEL_4_1"
-    val H264_LEVEL_4_2  = "H264_LEVEL_4_2"
-    val H264_LEVEL_5    = "H264_LEVEL_5"
-    val H264_LEVEL_5_1  = "H264_LEVEL_5_1"
-    val H264_LEVEL_5_2  = "H264_LEVEL_5_2"
-    val H264_LEVEL_AUTO = "H264_LEVEL_AUTO"
+  @js.native
+  sealed trait H264Level extends js.Any
+  object H264Level extends js.Object {
+    val H264_LEVEL_1    = "H264_LEVEL_1".asInstanceOf[H264Level]
+    val H264_LEVEL_1_1  = "H264_LEVEL_1_1".asInstanceOf[H264Level]
+    val H264_LEVEL_1_2  = "H264_LEVEL_1_2".asInstanceOf[H264Level]
+    val H264_LEVEL_1_3  = "H264_LEVEL_1_3".asInstanceOf[H264Level]
+    val H264_LEVEL_2    = "H264_LEVEL_2".asInstanceOf[H264Level]
+    val H264_LEVEL_2_1  = "H264_LEVEL_2_1".asInstanceOf[H264Level]
+    val H264_LEVEL_2_2  = "H264_LEVEL_2_2".asInstanceOf[H264Level]
+    val H264_LEVEL_3    = "H264_LEVEL_3".asInstanceOf[H264Level]
+    val H264_LEVEL_3_1  = "H264_LEVEL_3_1".asInstanceOf[H264Level]
+    val H264_LEVEL_3_2  = "H264_LEVEL_3_2".asInstanceOf[H264Level]
+    val H264_LEVEL_4    = "H264_LEVEL_4".asInstanceOf[H264Level]
+    val H264_LEVEL_4_1  = "H264_LEVEL_4_1".asInstanceOf[H264Level]
+    val H264_LEVEL_4_2  = "H264_LEVEL_4_2".asInstanceOf[H264Level]
+    val H264_LEVEL_5    = "H264_LEVEL_5".asInstanceOf[H264Level]
+    val H264_LEVEL_5_1  = "H264_LEVEL_5_1".asInstanceOf[H264Level]
+    val H264_LEVEL_5_2  = "H264_LEVEL_5_2".asInstanceOf[H264Level]
+    val H264_LEVEL_AUTO = "H264_LEVEL_AUTO".asInstanceOf[H264Level]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4268,10 +4205,12 @@ package medialive {
   /**
     * H264 Look Ahead Rate Control
     */
-  object H264LookAheadRateControlEnum {
-    val HIGH   = "HIGH"
-    val LOW    = "LOW"
-    val MEDIUM = "MEDIUM"
+  @js.native
+  sealed trait H264LookAheadRateControl extends js.Any
+  object H264LookAheadRateControl extends js.Object {
+    val HIGH   = "HIGH".asInstanceOf[H264LookAheadRateControl]
+    val LOW    = "LOW".asInstanceOf[H264LookAheadRateControl]
+    val MEDIUM = "MEDIUM".asInstanceOf[H264LookAheadRateControl]
 
     val values = js.Object.freeze(js.Array(HIGH, LOW, MEDIUM))
   }
@@ -4279,9 +4218,11 @@ package medialive {
   /**
     * H264 Par Control
     */
-  object H264ParControlEnum {
-    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE"
-    val SPECIFIED              = "SPECIFIED"
+  @js.native
+  sealed trait H264ParControl extends js.Any
+  object H264ParControl extends js.Object {
+    val INITIALIZE_FROM_SOURCE = "INITIALIZE_FROM_SOURCE".asInstanceOf[H264ParControl]
+    val SPECIFIED              = "SPECIFIED".asInstanceOf[H264ParControl]
 
     val values = js.Object.freeze(js.Array(INITIALIZE_FROM_SOURCE, SPECIFIED))
   }
@@ -4289,13 +4230,15 @@ package medialive {
   /**
     * H264 Profile
     */
-  object H264ProfileEnum {
-    val BASELINE       = "BASELINE"
-    val HIGH           = "HIGH"
-    val HIGH_10BIT     = "HIGH_10BIT"
-    val HIGH_422       = "HIGH_422"
-    val HIGH_422_10BIT = "HIGH_422_10BIT"
-    val MAIN           = "MAIN"
+  @js.native
+  sealed trait H264Profile extends js.Any
+  object H264Profile extends js.Object {
+    val BASELINE       = "BASELINE".asInstanceOf[H264Profile]
+    val HIGH           = "HIGH".asInstanceOf[H264Profile]
+    val HIGH_10BIT     = "HIGH_10BIT".asInstanceOf[H264Profile]
+    val HIGH_422       = "HIGH_422".asInstanceOf[H264Profile]
+    val HIGH_422_10BIT = "HIGH_422_10BIT".asInstanceOf[H264Profile]
+    val MAIN           = "MAIN".asInstanceOf[H264Profile]
 
     val values = js.Object.freeze(js.Array(BASELINE, HIGH, HIGH_10BIT, HIGH_422, HIGH_422_10BIT, MAIN))
   }
@@ -4303,11 +4246,13 @@ package medialive {
   /**
     * H264 Rate Control Mode
     */
-  object H264RateControlModeEnum {
-    val CBR       = "CBR"
-    val MULTIPLEX = "MULTIPLEX"
-    val QVBR      = "QVBR"
-    val VBR       = "VBR"
+  @js.native
+  sealed trait H264RateControlMode extends js.Any
+  object H264RateControlMode extends js.Object {
+    val CBR       = "CBR".asInstanceOf[H264RateControlMode]
+    val MULTIPLEX = "MULTIPLEX".asInstanceOf[H264RateControlMode]
+    val QVBR      = "QVBR".asInstanceOf[H264RateControlMode]
+    val VBR       = "VBR".asInstanceOf[H264RateControlMode]
 
     val values = js.Object.freeze(js.Array(CBR, MULTIPLEX, QVBR, VBR))
   }
@@ -4315,9 +4260,11 @@ package medialive {
   /**
     * H264 Scan Type
     */
-  object H264ScanTypeEnum {
-    val INTERLACED  = "INTERLACED"
-    val PROGRESSIVE = "PROGRESSIVE"
+  @js.native
+  sealed trait H264ScanType extends js.Any
+  object H264ScanType extends js.Object {
+    val INTERLACED  = "INTERLACED".asInstanceOf[H264ScanType]
+    val PROGRESSIVE = "PROGRESSIVE".asInstanceOf[H264ScanType]
 
     val values = js.Object.freeze(js.Array(INTERLACED, PROGRESSIVE))
   }
@@ -4325,9 +4272,11 @@ package medialive {
   /**
     * H264 Scene Change Detect
     */
-  object H264SceneChangeDetectEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264SceneChangeDetect extends js.Any
+  object H264SceneChangeDetect extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264SceneChangeDetect]
+    val ENABLED  = "ENABLED".asInstanceOf[H264SceneChangeDetect]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4465,9 +4414,11 @@ package medialive {
   /**
     * H264 Spatial Aq
     */
-  object H264SpatialAqEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264SpatialAq extends js.Any
+  object H264SpatialAq extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264SpatialAq]
+    val ENABLED  = "ENABLED".asInstanceOf[H264SpatialAq]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4475,9 +4426,11 @@ package medialive {
   /**
     * H264 Sub Gop Length
     */
-  object H264SubGopLengthEnum {
-    val DYNAMIC = "DYNAMIC"
-    val FIXED   = "FIXED"
+  @js.native
+  sealed trait H264SubGopLength extends js.Any
+  object H264SubGopLength extends js.Object {
+    val DYNAMIC = "DYNAMIC".asInstanceOf[H264SubGopLength]
+    val FIXED   = "FIXED".asInstanceOf[H264SubGopLength]
 
     val values = js.Object.freeze(js.Array(DYNAMIC, FIXED))
   }
@@ -4485,9 +4438,11 @@ package medialive {
   /**
     * H264 Syntax
     */
-  object H264SyntaxEnum {
-    val DEFAULT = "DEFAULT"
-    val RP2027  = "RP2027"
+  @js.native
+  sealed trait H264Syntax extends js.Any
+  object H264Syntax extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[H264Syntax]
+    val RP2027  = "RP2027".asInstanceOf[H264Syntax]
 
     val values = js.Object.freeze(js.Array(DEFAULT, RP2027))
   }
@@ -4495,9 +4450,11 @@ package medialive {
   /**
     * H264 Temporal Aq
     */
-  object H264TemporalAqEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H264TemporalAq extends js.Any
+  object H264TemporalAq extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H264TemporalAq]
+    val ENABLED  = "ENABLED".asInstanceOf[H264TemporalAq]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4505,9 +4462,11 @@ package medialive {
   /**
     * H264 Timecode Insertion Behavior
     */
-  object H264TimecodeInsertionBehaviorEnum {
-    val DISABLED       = "DISABLED"
-    val PIC_TIMING_SEI = "PIC_TIMING_SEI"
+  @js.native
+  sealed trait H264TimecodeInsertionBehavior extends js.Any
+  object H264TimecodeInsertionBehavior extends js.Object {
+    val DISABLED       = "DISABLED".asInstanceOf[H264TimecodeInsertionBehavior]
+    val PIC_TIMING_SEI = "PIC_TIMING_SEI".asInstanceOf[H264TimecodeInsertionBehavior]
 
     val values = js.Object.freeze(js.Array(DISABLED, PIC_TIMING_SEI))
   }
@@ -4515,13 +4474,15 @@ package medialive {
   /**
     * H265 Adaptive Quantization
     */
-  object H265AdaptiveQuantizationEnum {
-    val HIGH   = "HIGH"
-    val HIGHER = "HIGHER"
-    val LOW    = "LOW"
-    val MAX    = "MAX"
-    val MEDIUM = "MEDIUM"
-    val OFF    = "OFF"
+  @js.native
+  sealed trait H265AdaptiveQuantization extends js.Any
+  object H265AdaptiveQuantization extends js.Object {
+    val HIGH   = "HIGH".asInstanceOf[H265AdaptiveQuantization]
+    val HIGHER = "HIGHER".asInstanceOf[H265AdaptiveQuantization]
+    val LOW    = "LOW".asInstanceOf[H265AdaptiveQuantization]
+    val MAX    = "MAX".asInstanceOf[H265AdaptiveQuantization]
+    val MEDIUM = "MEDIUM".asInstanceOf[H265AdaptiveQuantization]
+    val OFF    = "OFF".asInstanceOf[H265AdaptiveQuantization]
 
     val values = js.Object.freeze(js.Array(HIGH, HIGHER, LOW, MAX, MEDIUM, OFF))
   }
@@ -4529,9 +4490,11 @@ package medialive {
   /**
     * H265 Alternative Transfer Function
     */
-  object H265AlternativeTransferFunctionEnum {
-    val INSERT = "INSERT"
-    val OMIT   = "OMIT"
+  @js.native
+  sealed trait H265AlternativeTransferFunction extends js.Any
+  object H265AlternativeTransferFunction extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[H265AlternativeTransferFunction]
+    val OMIT   = "OMIT".asInstanceOf[H265AlternativeTransferFunction]
 
     val values = js.Object.freeze(js.Array(INSERT, OMIT))
   }
@@ -4539,9 +4502,11 @@ package medialive {
   /**
     * H265 Color Metadata
     */
-  object H265ColorMetadataEnum {
-    val IGNORE = "IGNORE"
-    val INSERT = "INSERT"
+  @js.native
+  sealed trait H265ColorMetadata extends js.Any
+  object H265ColorMetadata extends js.Object {
+    val IGNORE = "IGNORE".asInstanceOf[H265ColorMetadata]
+    val INSERT = "INSERT".asInstanceOf[H265ColorMetadata]
 
     val values = js.Object.freeze(js.Array(IGNORE, INSERT))
   }
@@ -4579,9 +4544,11 @@ package medialive {
   /**
     * H265 Flicker Aq
     */
-  object H265FlickerAqEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265FlickerAq extends js.Any
+  object H265FlickerAq extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265FlickerAq]
+    val ENABLED  = "ENABLED".asInstanceOf[H265FlickerAq]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4589,9 +4556,11 @@ package medialive {
   /**
     * H265 Gop Size Units
     */
-  object H265GopSizeUnitsEnum {
-    val FRAMES  = "FRAMES"
-    val SECONDS = "SECONDS"
+  @js.native
+  sealed trait H265GopSizeUnits extends js.Any
+  object H265GopSizeUnits extends js.Object {
+    val FRAMES  = "FRAMES".asInstanceOf[H265GopSizeUnits]
+    val SECONDS = "SECONDS".asInstanceOf[H265GopSizeUnits]
 
     val values = js.Object.freeze(js.Array(FRAMES, SECONDS))
   }
@@ -4599,21 +4568,23 @@ package medialive {
   /**
     * H265 Level
     */
-  object H265LevelEnum {
-    val H265_LEVEL_1    = "H265_LEVEL_1"
-    val H265_LEVEL_2    = "H265_LEVEL_2"
-    val H265_LEVEL_2_1  = "H265_LEVEL_2_1"
-    val H265_LEVEL_3    = "H265_LEVEL_3"
-    val H265_LEVEL_3_1  = "H265_LEVEL_3_1"
-    val H265_LEVEL_4    = "H265_LEVEL_4"
-    val H265_LEVEL_4_1  = "H265_LEVEL_4_1"
-    val H265_LEVEL_5    = "H265_LEVEL_5"
-    val H265_LEVEL_5_1  = "H265_LEVEL_5_1"
-    val H265_LEVEL_5_2  = "H265_LEVEL_5_2"
-    val H265_LEVEL_6    = "H265_LEVEL_6"
-    val H265_LEVEL_6_1  = "H265_LEVEL_6_1"
-    val H265_LEVEL_6_2  = "H265_LEVEL_6_2"
-    val H265_LEVEL_AUTO = "H265_LEVEL_AUTO"
+  @js.native
+  sealed trait H265Level extends js.Any
+  object H265Level extends js.Object {
+    val H265_LEVEL_1    = "H265_LEVEL_1".asInstanceOf[H265Level]
+    val H265_LEVEL_2    = "H265_LEVEL_2".asInstanceOf[H265Level]
+    val H265_LEVEL_2_1  = "H265_LEVEL_2_1".asInstanceOf[H265Level]
+    val H265_LEVEL_3    = "H265_LEVEL_3".asInstanceOf[H265Level]
+    val H265_LEVEL_3_1  = "H265_LEVEL_3_1".asInstanceOf[H265Level]
+    val H265_LEVEL_4    = "H265_LEVEL_4".asInstanceOf[H265Level]
+    val H265_LEVEL_4_1  = "H265_LEVEL_4_1".asInstanceOf[H265Level]
+    val H265_LEVEL_5    = "H265_LEVEL_5".asInstanceOf[H265Level]
+    val H265_LEVEL_5_1  = "H265_LEVEL_5_1".asInstanceOf[H265Level]
+    val H265_LEVEL_5_2  = "H265_LEVEL_5_2".asInstanceOf[H265Level]
+    val H265_LEVEL_6    = "H265_LEVEL_6".asInstanceOf[H265Level]
+    val H265_LEVEL_6_1  = "H265_LEVEL_6_1".asInstanceOf[H265Level]
+    val H265_LEVEL_6_2  = "H265_LEVEL_6_2".asInstanceOf[H265Level]
+    val H265_LEVEL_AUTO = "H265_LEVEL_AUTO".asInstanceOf[H265Level]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4638,10 +4609,12 @@ package medialive {
   /**
     * H265 Look Ahead Rate Control
     */
-  object H265LookAheadRateControlEnum {
-    val HIGH   = "HIGH"
-    val LOW    = "LOW"
-    val MEDIUM = "MEDIUM"
+  @js.native
+  sealed trait H265LookAheadRateControl extends js.Any
+  object H265LookAheadRateControl extends js.Object {
+    val HIGH   = "HIGH".asInstanceOf[H265LookAheadRateControl]
+    val LOW    = "LOW".asInstanceOf[H265LookAheadRateControl]
+    val MEDIUM = "MEDIUM".asInstanceOf[H265LookAheadRateControl]
 
     val values = js.Object.freeze(js.Array(HIGH, LOW, MEDIUM))
   }
@@ -4649,9 +4622,11 @@ package medialive {
   /**
     * H265 Profile
     */
-  object H265ProfileEnum {
-    val MAIN       = "MAIN"
-    val MAIN_10BIT = "MAIN_10BIT"
+  @js.native
+  sealed trait H265Profile extends js.Any
+  object H265Profile extends js.Object {
+    val MAIN       = "MAIN".asInstanceOf[H265Profile]
+    val MAIN_10BIT = "MAIN_10BIT".asInstanceOf[H265Profile]
 
     val values = js.Object.freeze(js.Array(MAIN, MAIN_10BIT))
   }
@@ -4659,10 +4634,12 @@ package medialive {
   /**
     * H265 Rate Control Mode
     */
-  object H265RateControlModeEnum {
-    val CBR       = "CBR"
-    val MULTIPLEX = "MULTIPLEX"
-    val QVBR      = "QVBR"
+  @js.native
+  sealed trait H265RateControlMode extends js.Any
+  object H265RateControlMode extends js.Object {
+    val CBR       = "CBR".asInstanceOf[H265RateControlMode]
+    val MULTIPLEX = "MULTIPLEX".asInstanceOf[H265RateControlMode]
+    val QVBR      = "QVBR".asInstanceOf[H265RateControlMode]
 
     val values = js.Object.freeze(js.Array(CBR, MULTIPLEX, QVBR))
   }
@@ -4670,8 +4647,10 @@ package medialive {
   /**
     * H265 Scan Type
     */
-  object H265ScanTypeEnum {
-    val PROGRESSIVE = "PROGRESSIVE"
+  @js.native
+  sealed trait H265ScanType extends js.Any
+  object H265ScanType extends js.Object {
+    val PROGRESSIVE = "PROGRESSIVE".asInstanceOf[H265ScanType]
 
     val values = js.Object.freeze(js.Array(PROGRESSIVE))
   }
@@ -4679,9 +4658,11 @@ package medialive {
   /**
     * H265 Scene Change Detect
     */
-  object H265SceneChangeDetectEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait H265SceneChangeDetect extends js.Any
+  object H265SceneChangeDetect extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[H265SceneChangeDetect]
+    val ENABLED  = "ENABLED".asInstanceOf[H265SceneChangeDetect]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4793,9 +4774,11 @@ package medialive {
   /**
     * H265 Tier
     */
-  object H265TierEnum {
-    val HIGH = "HIGH"
-    val MAIN = "MAIN"
+  @js.native
+  sealed trait H265Tier extends js.Any
+  object H265Tier extends js.Object {
+    val HIGH = "HIGH".asInstanceOf[H265Tier]
+    val MAIN = "MAIN".asInstanceOf[H265Tier]
 
     val values = js.Object.freeze(js.Array(HIGH, MAIN))
   }
@@ -4803,9 +4786,11 @@ package medialive {
   /**
     * H265 Timecode Insertion Behavior
     */
-  object H265TimecodeInsertionBehaviorEnum {
-    val DISABLED       = "DISABLED"
-    val PIC_TIMING_SEI = "PIC_TIMING_SEI"
+  @js.native
+  sealed trait H265TimecodeInsertionBehavior extends js.Any
+  object H265TimecodeInsertionBehavior extends js.Object {
+    val DISABLED       = "DISABLED".asInstanceOf[H265TimecodeInsertionBehavior]
+    val PIC_TIMING_SEI = "PIC_TIMING_SEI".asInstanceOf[H265TimecodeInsertionBehavior]
 
     val values = js.Object.freeze(js.Array(DISABLED, PIC_TIMING_SEI))
   }
@@ -4835,10 +4820,12 @@ package medialive {
   /**
     * Hls Ad Markers
     */
-  object HlsAdMarkersEnum {
-    val ADOBE            = "ADOBE"
-    val ELEMENTAL        = "ELEMENTAL"
-    val ELEMENTAL_SCTE35 = "ELEMENTAL_SCTE35"
+  @js.native
+  sealed trait HlsAdMarkers extends js.Any
+  object HlsAdMarkers extends js.Object {
+    val ADOBE            = "ADOBE".asInstanceOf[HlsAdMarkers]
+    val ELEMENTAL        = "ELEMENTAL".asInstanceOf[HlsAdMarkers]
+    val ELEMENTAL_SCTE35 = "ELEMENTAL_SCTE35".asInstanceOf[HlsAdMarkers]
 
     val values = js.Object.freeze(js.Array(ADOBE, ELEMENTAL, ELEMENTAL_SCTE35))
   }
@@ -4846,9 +4833,11 @@ package medialive {
   /**
     * Hls Akamai Http Transfer Mode
     */
-  object HlsAkamaiHttpTransferModeEnum {
-    val CHUNKED     = "CHUNKED"
-    val NON_CHUNKED = "NON_CHUNKED"
+  @js.native
+  sealed trait HlsAkamaiHttpTransferMode extends js.Any
+  object HlsAkamaiHttpTransferMode extends js.Object {
+    val CHUNKED     = "CHUNKED".asInstanceOf[HlsAkamaiHttpTransferMode]
+    val NON_CHUNKED = "NON_CHUNKED".asInstanceOf[HlsAkamaiHttpTransferMode]
 
     val values = js.Object.freeze(js.Array(CHUNKED, NON_CHUNKED))
   }
@@ -4921,10 +4910,12 @@ package medialive {
   /**
     * Hls Caption Language Setting
     */
-  object HlsCaptionLanguageSettingEnum {
-    val INSERT = "INSERT"
-    val NONE   = "NONE"
-    val OMIT   = "OMIT"
+  @js.native
+  sealed trait HlsCaptionLanguageSetting extends js.Any
+  object HlsCaptionLanguageSetting extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[HlsCaptionLanguageSetting]
+    val NONE   = "NONE".asInstanceOf[HlsCaptionLanguageSetting]
+    val OMIT   = "OMIT".asInstanceOf[HlsCaptionLanguageSetting]
 
     val values = js.Object.freeze(js.Array(INSERT, NONE, OMIT))
   }
@@ -4960,9 +4951,11 @@ package medialive {
   /**
     * Hls Client Cache
     */
-  object HlsClientCacheEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait HlsClientCache extends js.Any
+  object HlsClientCache extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[HlsClientCache]
+    val ENABLED  = "ENABLED".asInstanceOf[HlsClientCache]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -4970,9 +4963,11 @@ package medialive {
   /**
     * Hls Codec Specification
     */
-  object HlsCodecSpecificationEnum {
-    val RFC_4281 = "RFC_4281"
-    val RFC_6381 = "RFC_6381"
+  @js.native
+  sealed trait HlsCodecSpecification extends js.Any
+  object HlsCodecSpecification extends js.Object {
+    val RFC_4281 = "RFC_4281".asInstanceOf[HlsCodecSpecification]
+    val RFC_6381 = "RFC_6381".asInstanceOf[HlsCodecSpecification]
 
     val values = js.Object.freeze(js.Array(RFC_4281, RFC_6381))
   }
@@ -4980,9 +4975,11 @@ package medialive {
   /**
     * Hls Directory Structure
     */
-  object HlsDirectoryStructureEnum {
-    val SINGLE_DIRECTORY        = "SINGLE_DIRECTORY"
-    val SUBDIRECTORY_PER_STREAM = "SUBDIRECTORY_PER_STREAM"
+  @js.native
+  sealed trait HlsDirectoryStructure extends js.Any
+  object HlsDirectoryStructure extends js.Object {
+    val SINGLE_DIRECTORY        = "SINGLE_DIRECTORY".asInstanceOf[HlsDirectoryStructure]
+    val SUBDIRECTORY_PER_STREAM = "SUBDIRECTORY_PER_STREAM".asInstanceOf[HlsDirectoryStructure]
 
     val values = js.Object.freeze(js.Array(SINGLE_DIRECTORY, SUBDIRECTORY_PER_STREAM))
   }
@@ -4990,9 +4987,11 @@ package medialive {
   /**
     * Hls Encryption Type
     */
-  object HlsEncryptionTypeEnum {
-    val AES128     = "AES128"
-    val SAMPLE_AES = "SAMPLE_AES"
+  @js.native
+  sealed trait HlsEncryptionType extends js.Any
+  object HlsEncryptionType extends js.Object {
+    val AES128     = "AES128".asInstanceOf[HlsEncryptionType]
+    val SAMPLE_AES = "SAMPLE_AES".asInstanceOf[HlsEncryptionType]
 
     val values = js.Object.freeze(js.Array(AES128, SAMPLE_AES))
   }
@@ -5140,9 +5139,11 @@ package medialive {
   /**
     * Hls H265 Packaging Type
     */
-  object HlsH265PackagingTypeEnum {
-    val HEV1 = "HEV1"
-    val HVC1 = "HVC1"
+  @js.native
+  sealed trait HlsH265PackagingType extends js.Any
+  object HlsH265PackagingType extends js.Object {
+    val HEV1 = "HEV1".asInstanceOf[HlsH265PackagingType]
+    val HVC1 = "HVC1".asInstanceOf[HlsH265PackagingType]
 
     val values = js.Object.freeze(js.Array(HEV1, HVC1))
   }
@@ -5171,9 +5172,11 @@ package medialive {
   /**
     * State of HLS ID3 Segment Tagging
     */
-  object HlsId3SegmentTaggingStateEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait HlsId3SegmentTaggingState extends js.Any
+  object HlsId3SegmentTaggingState extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[HlsId3SegmentTaggingState]
+    val ENABLED  = "ENABLED".asInstanceOf[HlsId3SegmentTaggingState]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -5209,9 +5212,11 @@ package medialive {
   /**
     * Hls Iv In Manifest
     */
-  object HlsIvInManifestEnum {
-    val EXCLUDE = "EXCLUDE"
-    val INCLUDE = "INCLUDE"
+  @js.native
+  sealed trait HlsIvInManifest extends js.Any
+  object HlsIvInManifest extends js.Object {
+    val EXCLUDE = "EXCLUDE".asInstanceOf[HlsIvInManifest]
+    val INCLUDE = "INCLUDE".asInstanceOf[HlsIvInManifest]
 
     val values = js.Object.freeze(js.Array(EXCLUDE, INCLUDE))
   }
@@ -5219,9 +5224,11 @@ package medialive {
   /**
     * Hls Iv Source
     */
-  object HlsIvSourceEnum {
-    val EXPLICIT               = "EXPLICIT"
-    val FOLLOWS_SEGMENT_NUMBER = "FOLLOWS_SEGMENT_NUMBER"
+  @js.native
+  sealed trait HlsIvSource extends js.Any
+  object HlsIvSource extends js.Object {
+    val EXPLICIT               = "EXPLICIT".asInstanceOf[HlsIvSource]
+    val FOLLOWS_SEGMENT_NUMBER = "FOLLOWS_SEGMENT_NUMBER".asInstanceOf[HlsIvSource]
 
     val values = js.Object.freeze(js.Array(EXPLICIT, FOLLOWS_SEGMENT_NUMBER))
   }
@@ -5229,9 +5236,11 @@ package medialive {
   /**
     * Hls Manifest Compression
     */
-  object HlsManifestCompressionEnum {
-    val GZIP = "GZIP"
-    val NONE = "NONE"
+  @js.native
+  sealed trait HlsManifestCompression extends js.Any
+  object HlsManifestCompression extends js.Object {
+    val GZIP = "GZIP".asInstanceOf[HlsManifestCompression]
+    val NONE = "NONE".asInstanceOf[HlsManifestCompression]
 
     val values = js.Object.freeze(js.Array(GZIP, NONE))
   }
@@ -5239,9 +5248,11 @@ package medialive {
   /**
     * Hls Manifest Duration Format
     */
-  object HlsManifestDurationFormatEnum {
-    val FLOATING_POINT = "FLOATING_POINT"
-    val INTEGER        = "INTEGER"
+  @js.native
+  sealed trait HlsManifestDurationFormat extends js.Any
+  object HlsManifestDurationFormat extends js.Object {
+    val FLOATING_POINT = "FLOATING_POINT".asInstanceOf[HlsManifestDurationFormat]
+    val INTEGER        = "INTEGER".asInstanceOf[HlsManifestDurationFormat]
 
     val values = js.Object.freeze(js.Array(FLOATING_POINT, INTEGER))
   }
@@ -5280,8 +5291,10 @@ package medialive {
   /**
     * Hls Media Store Storage Class
     */
-  object HlsMediaStoreStorageClassEnum {
-    val TEMPORAL = "TEMPORAL"
+  @js.native
+  sealed trait HlsMediaStoreStorageClass extends js.Any
+  object HlsMediaStoreStorageClass extends js.Object {
+    val TEMPORAL = "TEMPORAL".asInstanceOf[HlsMediaStoreStorageClass]
 
     val values = js.Object.freeze(js.Array(TEMPORAL))
   }
@@ -5289,9 +5302,11 @@ package medialive {
   /**
     * Hls Mode
     */
-  object HlsModeEnum {
-    val LIVE = "LIVE"
-    val VOD  = "VOD"
+  @js.native
+  sealed trait HlsMode extends js.Any
+  object HlsMode extends js.Object {
+    val LIVE = "LIVE".asInstanceOf[HlsMode]
+    val VOD  = "VOD".asInstanceOf[HlsMode]
 
     val values = js.Object.freeze(js.Array(LIVE, VOD))
   }
@@ -5299,9 +5314,11 @@ package medialive {
   /**
     * Hls Output Selection
     */
-  object HlsOutputSelectionEnum {
-    val MANIFESTS_AND_SEGMENTS = "MANIFESTS_AND_SEGMENTS"
-    val SEGMENTS_ONLY          = "SEGMENTS_ONLY"
+  @js.native
+  sealed trait HlsOutputSelection extends js.Any
+  object HlsOutputSelection extends js.Object {
+    val MANIFESTS_AND_SEGMENTS = "MANIFESTS_AND_SEGMENTS".asInstanceOf[HlsOutputSelection]
+    val SEGMENTS_ONLY          = "SEGMENTS_ONLY".asInstanceOf[HlsOutputSelection]
 
     val values = js.Object.freeze(js.Array(MANIFESTS_AND_SEGMENTS, SEGMENTS_ONLY))
   }
@@ -5339,9 +5356,11 @@ package medialive {
   /**
     * Hls Program Date Time
     */
-  object HlsProgramDateTimeEnum {
-    val EXCLUDE = "EXCLUDE"
-    val INCLUDE = "INCLUDE"
+  @js.native
+  sealed trait HlsProgramDateTime extends js.Any
+  object HlsProgramDateTime extends js.Object {
+    val EXCLUDE = "EXCLUDE".asInstanceOf[HlsProgramDateTime]
+    val INCLUDE = "INCLUDE".asInstanceOf[HlsProgramDateTime]
 
     val values = js.Object.freeze(js.Array(EXCLUDE, INCLUDE))
   }
@@ -5349,9 +5368,11 @@ package medialive {
   /**
     * Hls Redundant Manifest
     */
-  object HlsRedundantManifestEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait HlsRedundantManifest extends js.Any
+  object HlsRedundantManifest extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[HlsRedundantManifest]
+    val ENABLED  = "ENABLED".asInstanceOf[HlsRedundantManifest]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -5359,9 +5380,11 @@ package medialive {
   /**
     * Hls Segmentation Mode
     */
-  object HlsSegmentationModeEnum {
-    val USE_INPUT_SEGMENTATION = "USE_INPUT_SEGMENTATION"
-    val USE_SEGMENT_DURATION   = "USE_SEGMENT_DURATION"
+  @js.native
+  sealed trait HlsSegmentationMode extends js.Any
+  object HlsSegmentationMode extends js.Object {
+    val USE_INPUT_SEGMENTATION = "USE_INPUT_SEGMENTATION".asInstanceOf[HlsSegmentationMode]
+    val USE_SEGMENT_DURATION   = "USE_SEGMENT_DURATION".asInstanceOf[HlsSegmentationMode]
 
     val values = js.Object.freeze(js.Array(USE_INPUT_SEGMENTATION, USE_SEGMENT_DURATION))
   }
@@ -5394,9 +5417,11 @@ package medialive {
   /**
     * Hls Stream Inf Resolution
     */
-  object HlsStreamInfResolutionEnum {
-    val EXCLUDE = "EXCLUDE"
-    val INCLUDE = "INCLUDE"
+  @js.native
+  sealed trait HlsStreamInfResolution extends js.Any
+  object HlsStreamInfResolution extends js.Object {
+    val EXCLUDE = "EXCLUDE".asInstanceOf[HlsStreamInfResolution]
+    val INCLUDE = "INCLUDE".asInstanceOf[HlsStreamInfResolution]
 
     val values = js.Object.freeze(js.Array(EXCLUDE, INCLUDE))
   }
@@ -5404,10 +5429,12 @@ package medialive {
   /**
     * Hls Timed Metadata Id3 Frame
     */
-  object HlsTimedMetadataId3FrameEnum {
-    val NONE = "NONE"
-    val PRIV = "PRIV"
-    val TDRL = "TDRL"
+  @js.native
+  sealed trait HlsTimedMetadataId3Frame extends js.Any
+  object HlsTimedMetadataId3Frame extends js.Object {
+    val NONE = "NONE".asInstanceOf[HlsTimedMetadataId3Frame]
+    val PRIV = "PRIV".asInstanceOf[HlsTimedMetadataId3Frame]
+    val TDRL = "TDRL".asInstanceOf[HlsTimedMetadataId3Frame]
 
     val values = js.Object.freeze(js.Array(NONE, PRIV, TDRL))
   }
@@ -5436,9 +5463,11 @@ package medialive {
   /**
     * Hls Ts File Mode
     */
-  object HlsTsFileModeEnum {
-    val SEGMENTED_FILES = "SEGMENTED_FILES"
-    val SINGLE_FILE     = "SINGLE_FILE"
+  @js.native
+  sealed trait HlsTsFileMode extends js.Any
+  object HlsTsFileMode extends js.Object {
+    val SEGMENTED_FILES = "SEGMENTED_FILES".asInstanceOf[HlsTsFileMode]
+    val SINGLE_FILE     = "SINGLE_FILE".asInstanceOf[HlsTsFileMode]
 
     val values = js.Object.freeze(js.Array(SEGMENTED_FILES, SINGLE_FILE))
   }
@@ -5446,9 +5475,11 @@ package medialive {
   /**
     * Hls Webdav Http Transfer Mode
     */
-  object HlsWebdavHttpTransferModeEnum {
-    val CHUNKED     = "CHUNKED"
-    val NON_CHUNKED = "NON_CHUNKED"
+  @js.native
+  sealed trait HlsWebdavHttpTransferMode extends js.Any
+  object HlsWebdavHttpTransferMode extends js.Object {
+    val CHUNKED     = "CHUNKED".asInstanceOf[HlsWebdavHttpTransferMode]
+    val NON_CHUNKED = "NON_CHUNKED".asInstanceOf[HlsWebdavHttpTransferMode]
 
     val values = js.Object.freeze(js.Array(CHUNKED, NON_CHUNKED))
   }
@@ -5487,9 +5518,11 @@ package medialive {
   /**
     * When set to "standard", an I-Frame only playlist will be written out for each video output in the output group. This I-Frame only playlist will contain byte range offsets pointing to the I-frame(s) in each segment.
     */
-  object IFrameOnlyPlaylistTypeEnum {
-    val DISABLED = "DISABLED"
-    val STANDARD = "STANDARD"
+  @js.native
+  sealed trait IFrameOnlyPlaylistType extends js.Any
+  object IFrameOnlyPlaylistType extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[IFrameOnlyPlaylistType]
+    val STANDARD = "STANDARD".asInstanceOf[IFrameOnlyPlaylistType]
 
     val values = js.Object.freeze(js.Array(DISABLED, STANDARD))
   }
@@ -5620,9 +5653,11 @@ package medialive {
   /**
     * A standard input has two sources and a single pipeline input only has one.
     */
-  object InputClassEnum {
-    val STANDARD        = "STANDARD"
-    val SINGLE_PIPELINE = "SINGLE_PIPELINE"
+  @js.native
+  sealed trait InputClass extends js.Any
+  object InputClass extends js.Object {
+    val STANDARD        = "STANDARD".asInstanceOf[InputClass]
+    val SINGLE_PIPELINE = "SINGLE_PIPELINE".asInstanceOf[InputClass]
 
     val values = js.Object.freeze(js.Array(STANDARD, SINGLE_PIPELINE))
   }
@@ -5657,10 +5692,12 @@ package medialive {
   /**
     * codec in increasing order of complexity
     */
-  object InputCodecEnum {
-    val MPEG2 = "MPEG2"
-    val AVC   = "AVC"
-    val HEVC  = "HEVC"
+  @js.native
+  sealed trait InputCodec extends js.Any
+  object InputCodec extends js.Object {
+    val MPEG2 = "MPEG2".asInstanceOf[InputCodec]
+    val AVC   = "AVC".asInstanceOf[InputCodec]
+    val HEVC  = "HEVC".asInstanceOf[InputCodec]
 
     val values = js.Object.freeze(js.Array(MPEG2, AVC, HEVC))
   }
@@ -5668,9 +5705,11 @@ package medialive {
   /**
     * Input Deblock Filter
     */
-  object InputDeblockFilterEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait InputDeblockFilter extends js.Any
+  object InputDeblockFilter extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[InputDeblockFilter]
+    val ENABLED  = "ENABLED".asInstanceOf[InputDeblockFilter]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -5678,9 +5717,11 @@ package medialive {
   /**
     * Input Denoise Filter
     */
-  object InputDenoiseFilterEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait InputDenoiseFilter extends js.Any
+  object InputDenoiseFilter extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[InputDenoiseFilter]
+    val ENABLED  = "ENABLED".asInstanceOf[InputDenoiseFilter]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -5757,10 +5798,12 @@ package medialive {
   /**
     * Input Filter
     */
-  object InputFilterEnum {
-    val AUTO     = "AUTO"
-    val DISABLED = "DISABLED"
-    val FORCED   = "FORCED"
+  @js.native
+  sealed trait InputFilter extends js.Any
+  object InputFilter extends js.Object {
+    val AUTO     = "AUTO".asInstanceOf[InputFilter]
+    val DISABLED = "DISABLED".asInstanceOf[InputFilter]
+    val FORCED   = "FORCED".asInstanceOf[InputFilter]
 
     val values = js.Object.freeze(js.Array(AUTO, DISABLED, FORCED))
   }
@@ -5795,9 +5838,11 @@ package medialive {
   /**
     * Input Loss Action For Hls Out
     */
-  object InputLossActionForHlsOutEnum {
-    val EMIT_OUTPUT  = "EMIT_OUTPUT"
-    val PAUSE_OUTPUT = "PAUSE_OUTPUT"
+  @js.native
+  sealed trait InputLossActionForHlsOut extends js.Any
+  object InputLossActionForHlsOut extends js.Object {
+    val EMIT_OUTPUT  = "EMIT_OUTPUT".asInstanceOf[InputLossActionForHlsOut]
+    val PAUSE_OUTPUT = "PAUSE_OUTPUT".asInstanceOf[InputLossActionForHlsOut]
 
     val values = js.Object.freeze(js.Array(EMIT_OUTPUT, PAUSE_OUTPUT))
   }
@@ -5805,9 +5850,11 @@ package medialive {
   /**
     * Input Loss Action For Ms Smooth Out
     */
-  object InputLossActionForMsSmoothOutEnum {
-    val EMIT_OUTPUT  = "EMIT_OUTPUT"
-    val PAUSE_OUTPUT = "PAUSE_OUTPUT"
+  @js.native
+  sealed trait InputLossActionForMsSmoothOut extends js.Any
+  object InputLossActionForMsSmoothOut extends js.Object {
+    val EMIT_OUTPUT  = "EMIT_OUTPUT".asInstanceOf[InputLossActionForMsSmoothOut]
+    val PAUSE_OUTPUT = "PAUSE_OUTPUT".asInstanceOf[InputLossActionForMsSmoothOut]
 
     val values = js.Object.freeze(js.Array(EMIT_OUTPUT, PAUSE_OUTPUT))
   }
@@ -5815,9 +5862,11 @@ package medialive {
   /**
     * Input Loss Action For Rtmp Out
     */
-  object InputLossActionForRtmpOutEnum {
-    val EMIT_OUTPUT  = "EMIT_OUTPUT"
-    val PAUSE_OUTPUT = "PAUSE_OUTPUT"
+  @js.native
+  sealed trait InputLossActionForRtmpOut extends js.Any
+  object InputLossActionForRtmpOut extends js.Object {
+    val EMIT_OUTPUT  = "EMIT_OUTPUT".asInstanceOf[InputLossActionForRtmpOut]
+    val PAUSE_OUTPUT = "PAUSE_OUTPUT".asInstanceOf[InputLossActionForRtmpOut]
 
     val values = js.Object.freeze(js.Array(EMIT_OUTPUT, PAUSE_OUTPUT))
   }
@@ -5825,10 +5874,12 @@ package medialive {
   /**
     * Input Loss Action For Udp Out
     */
-  object InputLossActionForUdpOutEnum {
-    val DROP_PROGRAM = "DROP_PROGRAM"
-    val DROP_TS      = "DROP_TS"
-    val EMIT_PROGRAM = "EMIT_PROGRAM"
+  @js.native
+  sealed trait InputLossActionForUdpOut extends js.Any
+  object InputLossActionForUdpOut extends js.Object {
+    val DROP_PROGRAM = "DROP_PROGRAM".asInstanceOf[InputLossActionForUdpOut]
+    val DROP_TS      = "DROP_TS".asInstanceOf[InputLossActionForUdpOut]
+    val EMIT_PROGRAM = "EMIT_PROGRAM".asInstanceOf[InputLossActionForUdpOut]
 
     val values = js.Object.freeze(js.Array(DROP_PROGRAM, DROP_TS, EMIT_PROGRAM))
   }
@@ -5867,9 +5918,11 @@ package medialive {
   /**
     * Input Loss Image Type
     */
-  object InputLossImageTypeEnum {
-    val COLOR = "COLOR"
-    val SLATE = "SLATE"
+  @js.native
+  sealed trait InputLossImageType extends js.Any
+  object InputLossImageType extends js.Object {
+    val COLOR = "COLOR".asInstanceOf[InputLossImageType]
+    val SLATE = "SLATE".asInstanceOf[InputLossImageType]
 
     val values = js.Object.freeze(js.Array(COLOR, SLATE))
   }
@@ -5877,10 +5930,12 @@ package medialive {
   /**
     * Maximum input bitrate in megabits per second. Bitrates up to 50 Mbps are supported currently.
     */
-  object InputMaximumBitrateEnum {
-    val MAX_10_MBPS = "MAX_10_MBPS"
-    val MAX_20_MBPS = "MAX_20_MBPS"
-    val MAX_50_MBPS = "MAX_50_MBPS"
+  @js.native
+  sealed trait InputMaximumBitrate extends js.Any
+  object InputMaximumBitrate extends js.Object {
+    val MAX_10_MBPS = "MAX_10_MBPS".asInstanceOf[InputMaximumBitrate]
+    val MAX_20_MBPS = "MAX_20_MBPS".asInstanceOf[InputMaximumBitrate]
+    val MAX_50_MBPS = "MAX_50_MBPS".asInstanceOf[InputMaximumBitrate]
 
     val values = js.Object.freeze(js.Array(MAX_10_MBPS, MAX_20_MBPS, MAX_50_MBPS))
   }
@@ -5888,10 +5943,12 @@ package medialive {
   /**
     * Input resolution based on lines of vertical resolution in the input; SD is less than 720 lines, HD is 720 to 1080 lines, UHD is greater than 1080 lines
     */
-  object InputResolutionEnum {
-    val SD  = "SD"
-    val HD  = "HD"
-    val UHD = "UHD"
+  @js.native
+  sealed trait InputResolution extends js.Any
+  object InputResolution extends js.Object {
+    val SD  = "SD".asInstanceOf[InputResolution]
+    val HD  = "HD".asInstanceOf[InputResolution]
+    val UHD = "UHD".asInstanceOf[InputResolution]
 
     val values = js.Object.freeze(js.Array(SD, HD, UHD))
   }
@@ -5933,11 +5990,13 @@ package medialive {
   /**
     * Placeholder documentation for InputSecurityGroupState
     */
-  object InputSecurityGroupStateEnum {
-    val IDLE     = "IDLE"
-    val IN_USE   = "IN_USE"
-    val UPDATING = "UPDATING"
-    val DELETED  = "DELETED"
+  @js.native
+  sealed trait InputSecurityGroupState extends js.Any
+  object InputSecurityGroupState extends js.Object {
+    val IDLE     = "IDLE".asInstanceOf[InputSecurityGroupState]
+    val IN_USE   = "IN_USE".asInstanceOf[InputSecurityGroupState]
+    val UPDATING = "UPDATING".asInstanceOf[InputSecurityGroupState]
+    val DELETED  = "DELETED".asInstanceOf[InputSecurityGroupState]
 
     val values = js.Object.freeze(js.Array(IDLE, IN_USE, UPDATING, DELETED))
   }
@@ -6013,9 +6072,11 @@ package medialive {
   /**
     * Input Source End Behavior
     */
-  object InputSourceEndBehaviorEnum {
-    val CONTINUE = "CONTINUE"
-    val LOOP     = "LOOP"
+  @js.native
+  sealed trait InputSourceEndBehavior extends js.Any
+  object InputSourceEndBehavior extends js.Object {
+    val CONTINUE = "CONTINUE".asInstanceOf[InputSourceEndBehavior]
+    val LOOP     = "LOOP".asInstanceOf[InputSourceEndBehavior]
 
     val values = js.Object.freeze(js.Array(CONTINUE, LOOP))
   }
@@ -6050,9 +6111,11 @@ package medialive {
     * change the source url of the input dynamically using an input switch action. However, the only input type
     * to support a dynamic url at this time is MP4_FILE. By default all input sources are static.
     */
-  object InputSourceTypeEnum {
-    val STATIC  = "STATIC"
-    val DYNAMIC = "DYNAMIC"
+  @js.native
+  sealed trait InputSourceType extends js.Any
+  object InputSourceType extends js.Object {
+    val STATIC  = "STATIC".asInstanceOf[InputSourceType]
+    val DYNAMIC = "DYNAMIC".asInstanceOf[InputSourceType]
 
     val values = js.Object.freeze(js.Array(STATIC, DYNAMIC))
   }
@@ -6085,12 +6148,14 @@ package medialive {
   /**
     * Placeholder documentation for InputState
     */
-  object InputStateEnum {
-    val CREATING = "CREATING"
-    val DETACHED = "DETACHED"
-    val ATTACHED = "ATTACHED"
-    val DELETING = "DELETING"
-    val DELETED  = "DELETED"
+  @js.native
+  sealed trait InputState extends js.Any
+  object InputState extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[InputState]
+    val DETACHED = "DETACHED".asInstanceOf[InputState]
+    val ATTACHED = "ATTACHED".asInstanceOf[InputState]
+    val DELETING = "DELETING".asInstanceOf[InputState]
+    val DELETED  = "DELETED".asInstanceOf[InputState]
 
     val values = js.Object.freeze(js.Array(CREATING, DETACHED, ATTACHED, DELETING, DELETED))
   }
@@ -6125,9 +6190,11 @@ package medialive {
   /**
     * Documentation update needed
     */
-  object InputTimecodeSourceEnum {
-    val ZEROBASED = "ZEROBASED"
-    val EMBEDDED  = "EMBEDDED"
+  @js.native
+  sealed trait InputTimecodeSource extends js.Any
+  object InputTimecodeSource extends js.Object {
+    val ZEROBASED = "ZEROBASED".asInstanceOf[InputTimecodeSource]
+    val EMBEDDED  = "EMBEDDED".asInstanceOf[InputTimecodeSource]
 
     val values = js.Object.freeze(js.Array(ZEROBASED, EMBEDDED))
   }
@@ -6135,14 +6202,16 @@ package medialive {
   /**
     * Placeholder documentation for InputType
     */
-  object InputTypeEnum {
-    val UDP_PUSH     = "UDP_PUSH"
-    val RTP_PUSH     = "RTP_PUSH"
-    val RTMP_PUSH    = "RTMP_PUSH"
-    val RTMP_PULL    = "RTMP_PULL"
-    val URL_PULL     = "URL_PULL"
-    val MP4_FILE     = "MP4_FILE"
-    val MEDIACONNECT = "MEDIACONNECT"
+  @js.native
+  sealed trait InputType extends js.Any
+  object InputType extends js.Object {
+    val UDP_PUSH     = "UDP_PUSH".asInstanceOf[InputType]
+    val RTP_PUSH     = "RTP_PUSH".asInstanceOf[InputType]
+    val RTMP_PUSH    = "RTMP_PUSH".asInstanceOf[InputType]
+    val RTMP_PULL    = "RTMP_PULL".asInstanceOf[InputType]
+    val URL_PULL     = "URL_PULL".asInstanceOf[InputType]
+    val MP4_FILE     = "MP4_FILE".asInstanceOf[InputType]
+    val MEDIACONNECT = "MEDIACONNECT".asInstanceOf[InputType]
 
     val values = js.Object.freeze(js.Array(UDP_PUSH, RTP_PUSH, RTMP_PUSH, RTMP_PULL, URL_PULL, MP4_FILE, MEDIACONNECT))
   }
@@ -6234,9 +6303,11 @@ package medialive {
   /**
     * If you specify a StopTimecode in an input (in order to clip the file), you can specify if you want the clip to exclude (the default) or include the frame specified by the timecode.
     */
-  object LastFrameClippingBehaviorEnum {
-    val EXCLUDE_LAST_FRAME = "EXCLUDE_LAST_FRAME"
-    val INCLUDE_LAST_FRAME = "INCLUDE_LAST_FRAME"
+  @js.native
+  sealed trait LastFrameClippingBehavior extends js.Any
+  object LastFrameClippingBehavior extends js.Object {
+    val EXCLUDE_LAST_FRAME = "EXCLUDE_LAST_FRAME".asInstanceOf[LastFrameClippingBehavior]
+    val INCLUDE_LAST_FRAME = "INCLUDE_LAST_FRAME".asInstanceOf[LastFrameClippingBehavior]
 
     val values = js.Object.freeze(js.Array(EXCLUDE_LAST_FRAME, INCLUDE_LAST_FRAME))
   }
@@ -6651,12 +6722,14 @@ package medialive {
   /**
     * The log level the user wants for their channel.
     */
-  object LogLevelEnum {
-    val ERROR    = "ERROR"
-    val WARNING  = "WARNING"
-    val INFO     = "INFO"
-    val DEBUG    = "DEBUG"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait LogLevel extends js.Any
+  object LogLevel extends js.Object {
+    val ERROR    = "ERROR".asInstanceOf[LogLevel]
+    val WARNING  = "WARNING".asInstanceOf[LogLevel]
+    val INFO     = "INFO".asInstanceOf[LogLevel]
+    val DEBUG    = "DEBUG".asInstanceOf[LogLevel]
+    val DISABLED = "DISABLED".asInstanceOf[LogLevel]
 
     val values = js.Object.freeze(js.Array(ERROR, WARNING, INFO, DEBUG, DISABLED))
   }
@@ -6664,9 +6737,11 @@ package medialive {
   /**
     * M2ts Absent Input Audio Behavior
     */
-  object M2tsAbsentInputAudioBehaviorEnum {
-    val DROP           = "DROP"
-    val ENCODE_SILENCE = "ENCODE_SILENCE"
+  @js.native
+  sealed trait M2tsAbsentInputAudioBehavior extends js.Any
+  object M2tsAbsentInputAudioBehavior extends js.Object {
+    val DROP           = "DROP".asInstanceOf[M2tsAbsentInputAudioBehavior]
+    val ENCODE_SILENCE = "ENCODE_SILENCE".asInstanceOf[M2tsAbsentInputAudioBehavior]
 
     val values = js.Object.freeze(js.Array(DROP, ENCODE_SILENCE))
   }
@@ -6674,9 +6749,11 @@ package medialive {
   /**
     * M2ts Arib
     */
-  object M2tsAribEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait M2tsArib extends js.Any
+  object M2tsArib extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[M2tsArib]
+    val ENABLED  = "ENABLED".asInstanceOf[M2tsArib]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -6684,9 +6761,11 @@ package medialive {
   /**
     * M2ts Arib Captions Pid Control
     */
-  object M2tsAribCaptionsPidControlEnum {
-    val AUTO           = "AUTO"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait M2tsAribCaptionsPidControl extends js.Any
+  object M2tsAribCaptionsPidControl extends js.Object {
+    val AUTO           = "AUTO".asInstanceOf[M2tsAribCaptionsPidControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[M2tsAribCaptionsPidControl]
 
     val values = js.Object.freeze(js.Array(AUTO, USE_CONFIGURED))
   }
@@ -6694,9 +6773,11 @@ package medialive {
   /**
     * M2ts Audio Buffer Model
     */
-  object M2tsAudioBufferModelEnum {
-    val ATSC = "ATSC"
-    val DVB  = "DVB"
+  @js.native
+  sealed trait M2tsAudioBufferModel extends js.Any
+  object M2tsAudioBufferModel extends js.Object {
+    val ATSC = "ATSC".asInstanceOf[M2tsAudioBufferModel]
+    val DVB  = "DVB".asInstanceOf[M2tsAudioBufferModel]
 
     val values = js.Object.freeze(js.Array(ATSC, DVB))
   }
@@ -6704,9 +6785,11 @@ package medialive {
   /**
     * M2ts Audio Interval
     */
-  object M2tsAudioIntervalEnum {
-    val VIDEO_AND_FIXED_INTERVALS = "VIDEO_AND_FIXED_INTERVALS"
-    val VIDEO_INTERVAL            = "VIDEO_INTERVAL"
+  @js.native
+  sealed trait M2tsAudioInterval extends js.Any
+  object M2tsAudioInterval extends js.Object {
+    val VIDEO_AND_FIXED_INTERVALS = "VIDEO_AND_FIXED_INTERVALS".asInstanceOf[M2tsAudioInterval]
+    val VIDEO_INTERVAL            = "VIDEO_INTERVAL".asInstanceOf[M2tsAudioInterval]
 
     val values = js.Object.freeze(js.Array(VIDEO_AND_FIXED_INTERVALS, VIDEO_INTERVAL))
   }
@@ -6714,9 +6797,11 @@ package medialive {
   /**
     * M2ts Audio Stream Type
     */
-  object M2tsAudioStreamTypeEnum {
-    val ATSC = "ATSC"
-    val DVB  = "DVB"
+  @js.native
+  sealed trait M2tsAudioStreamType extends js.Any
+  object M2tsAudioStreamType extends js.Object {
+    val ATSC = "ATSC".asInstanceOf[M2tsAudioStreamType]
+    val DVB  = "DVB".asInstanceOf[M2tsAudioStreamType]
 
     val values = js.Object.freeze(js.Array(ATSC, DVB))
   }
@@ -6724,9 +6809,11 @@ package medialive {
   /**
     * M2ts Buffer Model
     */
-  object M2tsBufferModelEnum {
-    val MULTIPLEX = "MULTIPLEX"
-    val NONE      = "NONE"
+  @js.native
+  sealed trait M2tsBufferModel extends js.Any
+  object M2tsBufferModel extends js.Object {
+    val MULTIPLEX = "MULTIPLEX".asInstanceOf[M2tsBufferModel]
+    val NONE      = "NONE".asInstanceOf[M2tsBufferModel]
 
     val values = js.Object.freeze(js.Array(MULTIPLEX, NONE))
   }
@@ -6734,9 +6821,11 @@ package medialive {
   /**
     * M2ts Cc Descriptor
     */
-  object M2tsCcDescriptorEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait M2tsCcDescriptor extends js.Any
+  object M2tsCcDescriptor extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[M2tsCcDescriptor]
+    val ENABLED  = "ENABLED".asInstanceOf[M2tsCcDescriptor]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -6744,9 +6833,11 @@ package medialive {
   /**
     * M2ts Ebif Control
     */
-  object M2tsEbifControlEnum {
-    val NONE        = "NONE"
-    val PASSTHROUGH = "PASSTHROUGH"
+  @js.native
+  sealed trait M2tsEbifControl extends js.Any
+  object M2tsEbifControl extends js.Object {
+    val NONE        = "NONE".asInstanceOf[M2tsEbifControl]
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[M2tsEbifControl]
 
     val values = js.Object.freeze(js.Array(NONE, PASSTHROUGH))
   }
@@ -6754,9 +6845,11 @@ package medialive {
   /**
     * M2ts Ebp Placement
     */
-  object M2tsEbpPlacementEnum {
-    val VIDEO_AND_AUDIO_PIDS = "VIDEO_AND_AUDIO_PIDS"
-    val VIDEO_PID            = "VIDEO_PID"
+  @js.native
+  sealed trait M2tsEbpPlacement extends js.Any
+  object M2tsEbpPlacement extends js.Object {
+    val VIDEO_AND_AUDIO_PIDS = "VIDEO_AND_AUDIO_PIDS".asInstanceOf[M2tsEbpPlacement]
+    val VIDEO_PID            = "VIDEO_PID".asInstanceOf[M2tsEbpPlacement]
 
     val values = js.Object.freeze(js.Array(VIDEO_AND_AUDIO_PIDS, VIDEO_PID))
   }
@@ -6764,9 +6857,11 @@ package medialive {
   /**
     * M2ts Es Rate In Pes
     */
-  object M2tsEsRateInPesEnum {
-    val EXCLUDE = "EXCLUDE"
-    val INCLUDE = "INCLUDE"
+  @js.native
+  sealed trait M2tsEsRateInPes extends js.Any
+  object M2tsEsRateInPes extends js.Object {
+    val EXCLUDE = "EXCLUDE".asInstanceOf[M2tsEsRateInPes]
+    val INCLUDE = "INCLUDE".asInstanceOf[M2tsEsRateInPes]
 
     val values = js.Object.freeze(js.Array(EXCLUDE, INCLUDE))
   }
@@ -6774,9 +6869,11 @@ package medialive {
   /**
     * M2ts Klv
     */
-  object M2tsKlvEnum {
-    val NONE        = "NONE"
-    val PASSTHROUGH = "PASSTHROUGH"
+  @js.native
+  sealed trait M2tsKlv extends js.Any
+  object M2tsKlv extends js.Object {
+    val NONE        = "NONE".asInstanceOf[M2tsKlv]
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[M2tsKlv]
 
     val values = js.Object.freeze(js.Array(NONE, PASSTHROUGH))
   }
@@ -6784,9 +6881,11 @@ package medialive {
   /**
     * M2ts Nielsen Id3 Behavior
     */
-  object M2tsNielsenId3BehaviorEnum {
-    val NO_PASSTHROUGH = "NO_PASSTHROUGH"
-    val PASSTHROUGH    = "PASSTHROUGH"
+  @js.native
+  sealed trait M2tsNielsenId3Behavior extends js.Any
+  object M2tsNielsenId3Behavior extends js.Object {
+    val NO_PASSTHROUGH = "NO_PASSTHROUGH".asInstanceOf[M2tsNielsenId3Behavior]
+    val PASSTHROUGH    = "PASSTHROUGH".asInstanceOf[M2tsNielsenId3Behavior]
 
     val values = js.Object.freeze(js.Array(NO_PASSTHROUGH, PASSTHROUGH))
   }
@@ -6794,9 +6893,11 @@ package medialive {
   /**
     * M2ts Pcr Control
     */
-  object M2tsPcrControlEnum {
-    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD"
-    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET"
+  @js.native
+  sealed trait M2tsPcrControl extends js.Any
+  object M2tsPcrControl extends js.Object {
+    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD".asInstanceOf[M2tsPcrControl]
+    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET".asInstanceOf[M2tsPcrControl]
 
     val values = js.Object.freeze(js.Array(CONFIGURED_PCR_PERIOD, PCR_EVERY_PES_PACKET))
   }
@@ -6804,9 +6905,11 @@ package medialive {
   /**
     * M2ts Rate Mode
     */
-  object M2tsRateModeEnum {
-    val CBR = "CBR"
-    val VBR = "VBR"
+  @js.native
+  sealed trait M2tsRateMode extends js.Any
+  object M2tsRateMode extends js.Object {
+    val CBR = "CBR".asInstanceOf[M2tsRateMode]
+    val VBR = "VBR".asInstanceOf[M2tsRateMode]
 
     val values = js.Object.freeze(js.Array(CBR, VBR))
   }
@@ -6814,9 +6917,11 @@ package medialive {
   /**
     * M2ts Scte35 Control
     */
-  object M2tsScte35ControlEnum {
-    val NONE        = "NONE"
-    val PASSTHROUGH = "PASSTHROUGH"
+  @js.native
+  sealed trait M2tsScte35Control extends js.Any
+  object M2tsScte35Control extends js.Object {
+    val NONE        = "NONE".asInstanceOf[M2tsScte35Control]
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[M2tsScte35Control]
 
     val values = js.Object.freeze(js.Array(NONE, PASSTHROUGH))
   }
@@ -6824,13 +6929,15 @@ package medialive {
   /**
     * M2ts Segmentation Markers
     */
-  object M2tsSegmentationMarkersEnum {
-    val EBP          = "EBP"
-    val EBP_LEGACY   = "EBP_LEGACY"
-    val NONE         = "NONE"
-    val PSI_SEGSTART = "PSI_SEGSTART"
-    val RAI_ADAPT    = "RAI_ADAPT"
-    val RAI_SEGSTART = "RAI_SEGSTART"
+  @js.native
+  sealed trait M2tsSegmentationMarkers extends js.Any
+  object M2tsSegmentationMarkers extends js.Object {
+    val EBP          = "EBP".asInstanceOf[M2tsSegmentationMarkers]
+    val EBP_LEGACY   = "EBP_LEGACY".asInstanceOf[M2tsSegmentationMarkers]
+    val NONE         = "NONE".asInstanceOf[M2tsSegmentationMarkers]
+    val PSI_SEGSTART = "PSI_SEGSTART".asInstanceOf[M2tsSegmentationMarkers]
+    val RAI_ADAPT    = "RAI_ADAPT".asInstanceOf[M2tsSegmentationMarkers]
+    val RAI_SEGSTART = "RAI_SEGSTART".asInstanceOf[M2tsSegmentationMarkers]
 
     val values = js.Object.freeze(js.Array(EBP, EBP_LEGACY, NONE, PSI_SEGSTART, RAI_ADAPT, RAI_SEGSTART))
   }
@@ -6838,9 +6945,11 @@ package medialive {
   /**
     * M2ts Segmentation Style
     */
-  object M2tsSegmentationStyleEnum {
-    val MAINTAIN_CADENCE = "MAINTAIN_CADENCE"
-    val RESET_CADENCE    = "RESET_CADENCE"
+  @js.native
+  sealed trait M2tsSegmentationStyle extends js.Any
+  object M2tsSegmentationStyle extends js.Object {
+    val MAINTAIN_CADENCE = "MAINTAIN_CADENCE".asInstanceOf[M2tsSegmentationStyle]
+    val RESET_CADENCE    = "RESET_CADENCE".asInstanceOf[M2tsSegmentationStyle]
 
     val values = js.Object.freeze(js.Array(MAINTAIN_CADENCE, RESET_CADENCE))
   }
@@ -7005,9 +7114,11 @@ package medialive {
   /**
     * M2ts Timed Metadata Behavior
     */
-  object M2tsTimedMetadataBehaviorEnum {
-    val NO_PASSTHROUGH = "NO_PASSTHROUGH"
-    val PASSTHROUGH    = "PASSTHROUGH"
+  @js.native
+  sealed trait M2tsTimedMetadataBehavior extends js.Any
+  object M2tsTimedMetadataBehavior extends js.Object {
+    val NO_PASSTHROUGH = "NO_PASSTHROUGH".asInstanceOf[M2tsTimedMetadataBehavior]
+    val PASSTHROUGH    = "PASSTHROUGH".asInstanceOf[M2tsTimedMetadataBehavior]
 
     val values = js.Object.freeze(js.Array(NO_PASSTHROUGH, PASSTHROUGH))
   }
@@ -7015,9 +7126,11 @@ package medialive {
   /**
     * M3u8 Nielsen Id3 Behavior
     */
-  object M3u8NielsenId3BehaviorEnum {
-    val NO_PASSTHROUGH = "NO_PASSTHROUGH"
-    val PASSTHROUGH    = "PASSTHROUGH"
+  @js.native
+  sealed trait M3u8NielsenId3Behavior extends js.Any
+  object M3u8NielsenId3Behavior extends js.Object {
+    val NO_PASSTHROUGH = "NO_PASSTHROUGH".asInstanceOf[M3u8NielsenId3Behavior]
+    val PASSTHROUGH    = "PASSTHROUGH".asInstanceOf[M3u8NielsenId3Behavior]
 
     val values = js.Object.freeze(js.Array(NO_PASSTHROUGH, PASSTHROUGH))
   }
@@ -7025,9 +7138,11 @@ package medialive {
   /**
     * M3u8 Pcr Control
     */
-  object M3u8PcrControlEnum {
-    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD"
-    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET"
+  @js.native
+  sealed trait M3u8PcrControl extends js.Any
+  object M3u8PcrControl extends js.Object {
+    val CONFIGURED_PCR_PERIOD = "CONFIGURED_PCR_PERIOD".asInstanceOf[M3u8PcrControl]
+    val PCR_EVERY_PES_PACKET  = "PCR_EVERY_PES_PACKET".asInstanceOf[M3u8PcrControl]
 
     val values = js.Object.freeze(js.Array(CONFIGURED_PCR_PERIOD, PCR_EVERY_PES_PACKET))
   }
@@ -7035,9 +7150,11 @@ package medialive {
   /**
     * M3u8 Scte35 Behavior
     */
-  object M3u8Scte35BehaviorEnum {
-    val NO_PASSTHROUGH = "NO_PASSTHROUGH"
-    val PASSTHROUGH    = "PASSTHROUGH"
+  @js.native
+  sealed trait M3u8Scte35Behavior extends js.Any
+  object M3u8Scte35Behavior extends js.Object {
+    val NO_PASSTHROUGH = "NO_PASSTHROUGH".asInstanceOf[M3u8Scte35Behavior]
+    val PASSTHROUGH    = "PASSTHROUGH".asInstanceOf[M3u8Scte35Behavior]
 
     val values = js.Object.freeze(js.Array(NO_PASSTHROUGH, PASSTHROUGH))
   }
@@ -7112,9 +7229,11 @@ package medialive {
   /**
     * M3u8 Timed Metadata Behavior
     */
-  object M3u8TimedMetadataBehaviorEnum {
-    val NO_PASSTHROUGH = "NO_PASSTHROUGH"
-    val PASSTHROUGH    = "PASSTHROUGH"
+  @js.native
+  sealed trait M3u8TimedMetadataBehavior extends js.Any
+  object M3u8TimedMetadataBehavior extends js.Object {
+    val NO_PASSTHROUGH = "NO_PASSTHROUGH".asInstanceOf[M3u8TimedMetadataBehavior]
+    val PASSTHROUGH    = "PASSTHROUGH".asInstanceOf[M3u8TimedMetadataBehavior]
 
     val values = js.Object.freeze(js.Array(NO_PASSTHROUGH, PASSTHROUGH))
   }
@@ -7216,9 +7335,11 @@ package medialive {
   /**
     * Mp2 Coding Mode
     */
-  object Mp2CodingModeEnum {
-    val CODING_MODE_1_0 = "CODING_MODE_1_0"
-    val CODING_MODE_2_0 = "CODING_MODE_2_0"
+  @js.native
+  sealed trait Mp2CodingMode extends js.Any
+  object Mp2CodingMode extends js.Object {
+    val CODING_MODE_1_0 = "CODING_MODE_1_0".asInstanceOf[Mp2CodingMode]
+    val CODING_MODE_2_0 = "CODING_MODE_2_0".asInstanceOf[Mp2CodingMode]
 
     val values = js.Object.freeze(js.Array(CODING_MODE_1_0, CODING_MODE_2_0))
   }
@@ -7326,9 +7447,11 @@ package medialive {
   /**
     * Ms Smooth H265 Packaging Type
     */
-  object MsSmoothH265PackagingTypeEnum {
-    val HEV1 = "HEV1"
-    val HVC1 = "HVC1"
+  @js.native
+  sealed trait MsSmoothH265PackagingType extends js.Any
+  object MsSmoothH265PackagingType extends js.Object {
+    val HEV1 = "HEV1".asInstanceOf[MsSmoothH265PackagingType]
+    val HVC1 = "HVC1".asInstanceOf[MsSmoothH265PackagingType]
 
     val values = js.Object.freeze(js.Array(HEV1, HVC1))
   }
@@ -7710,16 +7833,18 @@ package medialive {
   /**
     * The current state of the multiplex.
     */
-  object MultiplexStateEnum {
-    val CREATING      = "CREATING"
-    val CREATE_FAILED = "CREATE_FAILED"
-    val IDLE          = "IDLE"
-    val STARTING      = "STARTING"
-    val RUNNING       = "RUNNING"
-    val RECOVERING    = "RECOVERING"
-    val STOPPING      = "STOPPING"
-    val DELETING      = "DELETING"
-    val DELETED       = "DELETED"
+  @js.native
+  sealed trait MultiplexState extends js.Any
+  object MultiplexState extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[MultiplexState]
+    val CREATE_FAILED = "CREATE_FAILED".asInstanceOf[MultiplexState]
+    val IDLE          = "IDLE".asInstanceOf[MultiplexState]
+    val STARTING      = "STARTING".asInstanceOf[MultiplexState]
+    val RUNNING       = "RUNNING".asInstanceOf[MultiplexState]
+    val RECOVERING    = "RECOVERING".asInstanceOf[MultiplexState]
+    val STOPPING      = "STOPPING".asInstanceOf[MultiplexState]
+    val DELETING      = "DELETING".asInstanceOf[MultiplexState]
+    val DELETED       = "DELETED".asInstanceOf[MultiplexState]
 
     val values = js.Object.freeze(
       js.Array(CREATING, CREATE_FAILED, IDLE, STARTING, RUNNING, RECOVERING, STOPPING, DELETING, DELETED)
@@ -7816,9 +7941,12 @@ package medialive {
   /**
     * Network Input Server Validation
     */
-  object NetworkInputServerValidationEnum {
-    val CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME = "CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME"
-    val CHECK_CRYPTOGRAPHY_ONLY              = "CHECK_CRYPTOGRAPHY_ONLY"
+  @js.native
+  sealed trait NetworkInputServerValidation extends js.Any
+  object NetworkInputServerValidation extends js.Object {
+    val CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME =
+      "CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME".asInstanceOf[NetworkInputServerValidation]
+    val CHECK_CRYPTOGRAPHY_ONLY = "CHECK_CRYPTOGRAPHY_ONLY".asInstanceOf[NetworkInputServerValidation]
 
     val values = js.Object.freeze(js.Array(CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME, CHECK_CRYPTOGRAPHY_ONLY))
   }
@@ -7870,9 +7998,11 @@ package medialive {
   /**
     * State of Nielsen PCM to ID3 tagging
     */
-  object NielsenPcmToId3TaggingStateEnum {
-    val DISABLED = "DISABLED"
-    val ENABLED  = "ENABLED"
+  @js.native
+  sealed trait NielsenPcmToId3TaggingState extends js.Any
+  object NielsenPcmToId3TaggingState extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[NielsenPcmToId3TaggingState]
+    val ENABLED  = "ENABLED".asInstanceOf[NielsenPcmToId3TaggingState]
 
     val values = js.Object.freeze(js.Array(DISABLED, ENABLED))
   }
@@ -7929,8 +8059,10 @@ package medialive {
   /**
     * Units for duration, e.g. 'MONTHS'
     */
-  object OfferingDurationUnitsEnum {
-    val MONTHS = "MONTHS"
+  @js.native
+  sealed trait OfferingDurationUnits extends js.Any
+  object OfferingDurationUnits extends js.Object {
+    val MONTHS = "MONTHS".asInstanceOf[OfferingDurationUnits]
 
     val values = js.Object.freeze(js.Array(MONTHS))
   }
@@ -7938,8 +8070,10 @@ package medialive {
   /**
     * Offering type, e.g. 'NO_UPFRONT'
     */
-  object OfferingTypeEnum {
-    val NO_UPFRONT = "NO_UPFRONT"
+  @js.native
+  sealed trait OfferingType extends js.Any
+  object OfferingType extends js.Object {
+    val NO_UPFRONT = "NO_UPFRONT".asInstanceOf[OfferingType]
 
     val values = js.Object.freeze(js.Array(NO_UPFRONT))
   }
@@ -8234,9 +8368,11 @@ package medialive {
   /**
     * Pipeline ID
     */
-  object PipelineIdEnum {
-    val PIPELINE_0 = "PIPELINE_0"
-    val PIPELINE_1 = "PIPELINE_1"
+  @js.native
+  sealed trait PipelineId extends js.Any
+  object PipelineId extends js.Object {
+    val PIPELINE_0 = "PIPELINE_0".asInstanceOf[PipelineId]
+    val PIPELINE_1 = "PIPELINE_1".asInstanceOf[PipelineId]
 
     val values = js.Object.freeze(js.Array(PIPELINE_0, PIPELINE_1))
   }
@@ -8449,11 +8585,13 @@ package medialive {
   /**
     * Codec, 'MPEG2', 'AVC', 'HEVC', or 'AUDIO'
     */
-  object ReservationCodecEnum {
-    val MPEG2 = "MPEG2"
-    val AVC   = "AVC"
-    val HEVC  = "HEVC"
-    val AUDIO = "AUDIO"
+  @js.native
+  sealed trait ReservationCodec extends js.Any
+  object ReservationCodec extends js.Object {
+    val MPEG2 = "MPEG2".asInstanceOf[ReservationCodec]
+    val AVC   = "AVC".asInstanceOf[ReservationCodec]
+    val HEVC  = "HEVC".asInstanceOf[ReservationCodec]
+    val AUDIO = "AUDIO".asInstanceOf[ReservationCodec]
 
     val values = js.Object.freeze(js.Array(MPEG2, AVC, HEVC, AUDIO))
   }
@@ -8461,10 +8599,12 @@ package medialive {
   /**
     * Maximum bitrate in megabits per second
     */
-  object ReservationMaximumBitrateEnum {
-    val MAX_10_MBPS = "MAX_10_MBPS"
-    val MAX_20_MBPS = "MAX_20_MBPS"
-    val MAX_50_MBPS = "MAX_50_MBPS"
+  @js.native
+  sealed trait ReservationMaximumBitrate extends js.Any
+  object ReservationMaximumBitrate extends js.Object {
+    val MAX_10_MBPS = "MAX_10_MBPS".asInstanceOf[ReservationMaximumBitrate]
+    val MAX_20_MBPS = "MAX_20_MBPS".asInstanceOf[ReservationMaximumBitrate]
+    val MAX_50_MBPS = "MAX_50_MBPS".asInstanceOf[ReservationMaximumBitrate]
 
     val values = js.Object.freeze(js.Array(MAX_10_MBPS, MAX_20_MBPS, MAX_50_MBPS))
   }
@@ -8472,9 +8612,11 @@ package medialive {
   /**
     * Maximum framerate in frames per second (Outputs only)
     */
-  object ReservationMaximumFramerateEnum {
-    val MAX_30_FPS = "MAX_30_FPS"
-    val MAX_60_FPS = "MAX_60_FPS"
+  @js.native
+  sealed trait ReservationMaximumFramerate extends js.Any
+  object ReservationMaximumFramerate extends js.Object {
+    val MAX_30_FPS = "MAX_30_FPS".asInstanceOf[ReservationMaximumFramerate]
+    val MAX_60_FPS = "MAX_60_FPS".asInstanceOf[ReservationMaximumFramerate]
 
     val values = js.Object.freeze(js.Array(MAX_30_FPS, MAX_60_FPS))
   }
@@ -8482,11 +8624,13 @@ package medialive {
   /**
     * Resolution based on lines of vertical resolution; SD is less than 720 lines, HD is 720 to 1080 lines, FHD is 1080 lines, UHD is greater than 1080 lines
     */
-  object ReservationResolutionEnum {
-    val SD  = "SD"
-    val HD  = "HD"
-    val FHD = "FHD"
-    val UHD = "UHD"
+  @js.native
+  sealed trait ReservationResolution extends js.Any
+  object ReservationResolution extends js.Object {
+    val SD  = "SD".asInstanceOf[ReservationResolution]
+    val HD  = "HD".asInstanceOf[ReservationResolution]
+    val FHD = "FHD".asInstanceOf[ReservationResolution]
+    val UHD = "UHD".asInstanceOf[ReservationResolution]
 
     val values = js.Object.freeze(js.Array(SD, HD, FHD, UHD))
   }
@@ -8534,11 +8678,13 @@ package medialive {
   /**
     * Resource type, 'INPUT', 'OUTPUT', 'MULTIPLEX', or 'CHANNEL'
     */
-  object ReservationResourceTypeEnum {
-    val INPUT     = "INPUT"
-    val OUTPUT    = "OUTPUT"
-    val MULTIPLEX = "MULTIPLEX"
-    val CHANNEL   = "CHANNEL"
+  @js.native
+  sealed trait ReservationResourceType extends js.Any
+  object ReservationResourceType extends js.Object {
+    val INPUT     = "INPUT".asInstanceOf[ReservationResourceType]
+    val OUTPUT    = "OUTPUT".asInstanceOf[ReservationResourceType]
+    val MULTIPLEX = "MULTIPLEX".asInstanceOf[ReservationResourceType]
+    val CHANNEL   = "CHANNEL".asInstanceOf[ReservationResourceType]
 
     val values = js.Object.freeze(js.Array(INPUT, OUTPUT, MULTIPLEX, CHANNEL))
   }
@@ -8546,9 +8692,11 @@ package medialive {
   /**
     * Special features, 'ADVANCED_AUDIO' or 'AUDIO_NORMALIZATION'
     */
-  object ReservationSpecialFeatureEnum {
-    val ADVANCED_AUDIO      = "ADVANCED_AUDIO"
-    val AUDIO_NORMALIZATION = "AUDIO_NORMALIZATION"
+  @js.native
+  sealed trait ReservationSpecialFeature extends js.Any
+  object ReservationSpecialFeature extends js.Object {
+    val ADVANCED_AUDIO      = "ADVANCED_AUDIO".asInstanceOf[ReservationSpecialFeature]
+    val AUDIO_NORMALIZATION = "AUDIO_NORMALIZATION".asInstanceOf[ReservationSpecialFeature]
 
     val values = js.Object.freeze(js.Array(ADVANCED_AUDIO, AUDIO_NORMALIZATION))
   }
@@ -8556,11 +8704,13 @@ package medialive {
   /**
     * Current reservation state
     */
-  object ReservationStateEnum {
-    val ACTIVE   = "ACTIVE"
-    val EXPIRED  = "EXPIRED"
-    val CANCELED = "CANCELED"
-    val DELETED  = "DELETED"
+  @js.native
+  sealed trait ReservationState extends js.Any
+  object ReservationState extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[ReservationState]
+    val EXPIRED  = "EXPIRED".asInstanceOf[ReservationState]
+    val CANCELED = "CANCELED".asInstanceOf[ReservationState]
+    val DELETED  = "DELETED".asInstanceOf[ReservationState]
 
     val values = js.Object.freeze(js.Array(ACTIVE, EXPIRED, CANCELED, DELETED))
   }
@@ -8568,10 +8718,12 @@ package medialive {
   /**
     * Video quality, e.g. 'STANDARD' (Outputs only)
     */
-  object ReservationVideoQualityEnum {
-    val STANDARD = "STANDARD"
-    val ENHANCED = "ENHANCED"
-    val PREMIUM  = "PREMIUM"
+  @js.native
+  sealed trait ReservationVideoQuality extends js.Any
+  object ReservationVideoQuality extends js.Object {
+    val STANDARD = "STANDARD".asInstanceOf[ReservationVideoQuality]
+    val ENHANCED = "ENHANCED".asInstanceOf[ReservationVideoQuality]
+    val PREMIUM  = "PREMIUM".asInstanceOf[ReservationVideoQuality]
 
     val values = js.Object.freeze(js.Array(STANDARD, ENHANCED, PREMIUM))
   }
@@ -8579,9 +8731,11 @@ package medialive {
   /**
     * Rtmp Cache Full Behavior
     */
-  object RtmpCacheFullBehaviorEnum {
-    val DISCONNECT_IMMEDIATELY = "DISCONNECT_IMMEDIATELY"
-    val WAIT_FOR_SERVER        = "WAIT_FOR_SERVER"
+  @js.native
+  sealed trait RtmpCacheFullBehavior extends js.Any
+  object RtmpCacheFullBehavior extends js.Object {
+    val DISCONNECT_IMMEDIATELY = "DISCONNECT_IMMEDIATELY".asInstanceOf[RtmpCacheFullBehavior]
+    val WAIT_FOR_SERVER        = "WAIT_FOR_SERVER".asInstanceOf[RtmpCacheFullBehavior]
 
     val values = js.Object.freeze(js.Array(DISCONNECT_IMMEDIATELY, WAIT_FOR_SERVER))
   }
@@ -8589,10 +8743,12 @@ package medialive {
   /**
     * Rtmp Caption Data
     */
-  object RtmpCaptionDataEnum {
-    val ALL                   = "ALL"
-    val FIELD1_608            = "FIELD1_608"
-    val FIELD1_AND_FIELD2_608 = "FIELD1_AND_FIELD2_608"
+  @js.native
+  sealed trait RtmpCaptionData extends js.Any
+  object RtmpCaptionData extends js.Object {
+    val ALL                   = "ALL".asInstanceOf[RtmpCaptionData]
+    val FIELD1_608            = "FIELD1_608".asInstanceOf[RtmpCaptionData]
+    val FIELD1_AND_FIELD2_608 = "FIELD1_AND_FIELD2_608".asInstanceOf[RtmpCaptionData]
 
     val values = js.Object.freeze(js.Array(ALL, FIELD1_608, FIELD1_AND_FIELD2_608))
   }
@@ -8650,9 +8806,11 @@ package medialive {
   /**
     * Rtmp Output Certificate Mode
     */
-  object RtmpOutputCertificateModeEnum {
-    val SELF_SIGNED         = "SELF_SIGNED"
-    val VERIFY_AUTHENTICITY = "VERIFY_AUTHENTICITY"
+  @js.native
+  sealed trait RtmpOutputCertificateMode extends js.Any
+  object RtmpOutputCertificateMode extends js.Object {
+    val SELF_SIGNED         = "SELF_SIGNED".asInstanceOf[RtmpOutputCertificateMode]
+    val VERIFY_AUTHENTICITY = "VERIFY_AUTHENTICITY".asInstanceOf[RtmpOutputCertificateMode]
 
     val values = js.Object.freeze(js.Array(SELF_SIGNED, VERIFY_AUTHENTICITY))
   }
@@ -8801,9 +8959,11 @@ package medialive {
   /**
     * Scte20 Convert608 To708
     */
-  object Scte20Convert608To708Enum {
-    val DISABLED  = "DISABLED"
-    val UPCONVERT = "UPCONVERT"
+  @js.native
+  sealed trait Scte20Convert608To708 extends js.Any
+  object Scte20Convert608To708 extends js.Object {
+    val DISABLED  = "DISABLED".asInstanceOf[Scte20Convert608To708]
+    val UPCONVERT = "UPCONVERT".asInstanceOf[Scte20Convert608To708]
 
     val values = js.Object.freeze(js.Array(DISABLED, UPCONVERT))
   }
@@ -8884,9 +9044,11 @@ package medialive {
   /**
     * Scte35 Apos No Regional Blackout Behavior
     */
-  object Scte35AposNoRegionalBlackoutBehaviorEnum {
-    val FOLLOW = "FOLLOW"
-    val IGNORE = "IGNORE"
+  @js.native
+  sealed trait Scte35AposNoRegionalBlackoutBehavior extends js.Any
+  object Scte35AposNoRegionalBlackoutBehavior extends js.Object {
+    val FOLLOW = "FOLLOW".asInstanceOf[Scte35AposNoRegionalBlackoutBehavior]
+    val IGNORE = "IGNORE".asInstanceOf[Scte35AposNoRegionalBlackoutBehavior]
 
     val values = js.Object.freeze(js.Array(FOLLOW, IGNORE))
   }
@@ -8894,9 +9056,11 @@ package medialive {
   /**
     * Scte35 Apos Web Delivery Allowed Behavior
     */
-  object Scte35AposWebDeliveryAllowedBehaviorEnum {
-    val FOLLOW = "FOLLOW"
-    val IGNORE = "IGNORE"
+  @js.native
+  sealed trait Scte35AposWebDeliveryAllowedBehavior extends js.Any
+  object Scte35AposWebDeliveryAllowedBehavior extends js.Object {
+    val FOLLOW = "FOLLOW".asInstanceOf[Scte35AposWebDeliveryAllowedBehavior]
+    val IGNORE = "IGNORE".asInstanceOf[Scte35AposWebDeliveryAllowedBehavior]
 
     val values = js.Object.freeze(js.Array(FOLLOW, IGNORE))
   }
@@ -8904,9 +9068,11 @@ package medialive {
   /**
     * Corresponds to the archive_allowed parameter. A value of ARCHIVE_NOT_ALLOWED corresponds to 0 (false) in the SCTE-35 specification. If you include one of the "restriction" flags then you must include all four of them.
     */
-  object Scte35ArchiveAllowedFlagEnum {
-    val ARCHIVE_NOT_ALLOWED = "ARCHIVE_NOT_ALLOWED"
-    val ARCHIVE_ALLOWED     = "ARCHIVE_ALLOWED"
+  @js.native
+  sealed trait Scte35ArchiveAllowedFlag extends js.Any
+  object Scte35ArchiveAllowedFlag extends js.Object {
+    val ARCHIVE_NOT_ALLOWED = "ARCHIVE_NOT_ALLOWED".asInstanceOf[Scte35ArchiveAllowedFlag]
+    val ARCHIVE_ALLOWED     = "ARCHIVE_ALLOWED".asInstanceOf[Scte35ArchiveAllowedFlag]
 
     val values = js.Object.freeze(js.Array(ARCHIVE_NOT_ALLOWED, ARCHIVE_ALLOWED))
   }
@@ -8987,11 +9153,13 @@ package medialive {
   /**
     * Corresponds to the device_restrictions parameter in a segmentation_descriptor. If you include one of the "restriction" flags then you must include all four of them.
     */
-  object Scte35DeviceRestrictionsEnum {
-    val NONE            = "NONE"
-    val RESTRICT_GROUP0 = "RESTRICT_GROUP0"
-    val RESTRICT_GROUP1 = "RESTRICT_GROUP1"
-    val RESTRICT_GROUP2 = "RESTRICT_GROUP2"
+  @js.native
+  sealed trait Scte35DeviceRestrictions extends js.Any
+  object Scte35DeviceRestrictions extends js.Object {
+    val NONE            = "NONE".asInstanceOf[Scte35DeviceRestrictions]
+    val RESTRICT_GROUP0 = "RESTRICT_GROUP0".asInstanceOf[Scte35DeviceRestrictions]
+    val RESTRICT_GROUP1 = "RESTRICT_GROUP1".asInstanceOf[Scte35DeviceRestrictions]
+    val RESTRICT_GROUP2 = "RESTRICT_GROUP2".asInstanceOf[Scte35DeviceRestrictions]
 
     val values = js.Object.freeze(js.Array(NONE, RESTRICT_GROUP0, RESTRICT_GROUP1, RESTRICT_GROUP2))
   }
@@ -8999,9 +9167,11 @@ package medialive {
   /**
     * Corresponds to the no_regional_blackout_flag parameter. A value of REGIONAL_BLACKOUT corresponds to 0 (false) in the SCTE-35 specification. If you include one of the "restriction" flags then you must include all four of them.
     */
-  object Scte35NoRegionalBlackoutFlagEnum {
-    val REGIONAL_BLACKOUT    = "REGIONAL_BLACKOUT"
-    val NO_REGIONAL_BLACKOUT = "NO_REGIONAL_BLACKOUT"
+  @js.native
+  sealed trait Scte35NoRegionalBlackoutFlag extends js.Any
+  object Scte35NoRegionalBlackoutFlag extends js.Object {
+    val REGIONAL_BLACKOUT    = "REGIONAL_BLACKOUT".asInstanceOf[Scte35NoRegionalBlackoutFlag]
+    val NO_REGIONAL_BLACKOUT = "NO_REGIONAL_BLACKOUT".asInstanceOf[Scte35NoRegionalBlackoutFlag]
 
     val values = js.Object.freeze(js.Array(REGIONAL_BLACKOUT, NO_REGIONAL_BLACKOUT))
   }
@@ -9030,9 +9200,12 @@ package medialive {
   /**
     * Corresponds to SCTE-35 segmentation_event_cancel_indicator. SEGMENTATION_EVENT_NOT_CANCELED corresponds to 0 in the SCTE-35 specification and indicates that this is an insertion request. SEGMENTATION_EVENT_CANCELED corresponds to 1 in the SCTE-35 specification and indicates that this is a cancelation request, in which case complete this field and the existing event ID to cancel.
     */
-  object Scte35SegmentationCancelIndicatorEnum {
-    val SEGMENTATION_EVENT_NOT_CANCELED = "SEGMENTATION_EVENT_NOT_CANCELED"
-    val SEGMENTATION_EVENT_CANCELED     = "SEGMENTATION_EVENT_CANCELED"
+  @js.native
+  sealed trait Scte35SegmentationCancelIndicator extends js.Any
+  object Scte35SegmentationCancelIndicator extends js.Object {
+    val SEGMENTATION_EVENT_NOT_CANCELED =
+      "SEGMENTATION_EVENT_NOT_CANCELED".asInstanceOf[Scte35SegmentationCancelIndicator]
+    val SEGMENTATION_EVENT_CANCELED = "SEGMENTATION_EVENT_CANCELED".asInstanceOf[Scte35SegmentationCancelIndicator]
 
     val values = js.Object.freeze(js.Array(SEGMENTATION_EVENT_NOT_CANCELED, SEGMENTATION_EVENT_CANCELED))
   }
@@ -9116,9 +9289,11 @@ package medialive {
   /**
     * Scte35 Splice Insert No Regional Blackout Behavior
     */
-  object Scte35SpliceInsertNoRegionalBlackoutBehaviorEnum {
-    val FOLLOW = "FOLLOW"
-    val IGNORE = "IGNORE"
+  @js.native
+  sealed trait Scte35SpliceInsertNoRegionalBlackoutBehavior extends js.Any
+  object Scte35SpliceInsertNoRegionalBlackoutBehavior extends js.Object {
+    val FOLLOW = "FOLLOW".asInstanceOf[Scte35SpliceInsertNoRegionalBlackoutBehavior]
+    val IGNORE = "IGNORE".asInstanceOf[Scte35SpliceInsertNoRegionalBlackoutBehavior]
 
     val values = js.Object.freeze(js.Array(FOLLOW, IGNORE))
   }
@@ -9150,9 +9325,11 @@ package medialive {
   /**
     * Scte35 Splice Insert Web Delivery Allowed Behavior
     */
-  object Scte35SpliceInsertWebDeliveryAllowedBehaviorEnum {
-    val FOLLOW = "FOLLOW"
-    val IGNORE = "IGNORE"
+  @js.native
+  sealed trait Scte35SpliceInsertWebDeliveryAllowedBehavior extends js.Any
+  object Scte35SpliceInsertWebDeliveryAllowedBehavior extends js.Object {
+    val FOLLOW = "FOLLOW".asInstanceOf[Scte35SpliceInsertWebDeliveryAllowedBehavior]
+    val IGNORE = "IGNORE".asInstanceOf[Scte35SpliceInsertWebDeliveryAllowedBehavior]
 
     val values = js.Object.freeze(js.Array(FOLLOW, IGNORE))
   }
@@ -9206,9 +9383,11 @@ package medialive {
   /**
     * Corresponds to the web_delivery_allowed_flag parameter. A value of WEB_DELIVERY_NOT_ALLOWED corresponds to 0 (false) in the SCTE-35 specification. If you include one of the "restriction" flags then you must include all four of them.
     */
-  object Scte35WebDeliveryAllowedFlagEnum {
-    val WEB_DELIVERY_NOT_ALLOWED = "WEB_DELIVERY_NOT_ALLOWED"
-    val WEB_DELIVERY_ALLOWED     = "WEB_DELIVERY_ALLOWED"
+  @js.native
+  sealed trait Scte35WebDeliveryAllowedFlag extends js.Any
+  object Scte35WebDeliveryAllowedFlag extends js.Object {
+    val WEB_DELIVERY_NOT_ALLOWED = "WEB_DELIVERY_NOT_ALLOWED".asInstanceOf[Scte35WebDeliveryAllowedFlag]
+    val WEB_DELIVERY_ALLOWED     = "WEB_DELIVERY_ALLOWED".asInstanceOf[Scte35WebDeliveryAllowedFlag]
 
     val values = js.Object.freeze(js.Array(WEB_DELIVERY_NOT_ALLOWED, WEB_DELIVERY_ALLOWED))
   }
@@ -9216,9 +9395,11 @@ package medialive {
   /**
     * Smooth Group Audio Only Timecode Control
     */
-  object SmoothGroupAudioOnlyTimecodeControlEnum {
-    val PASSTHROUGH          = "PASSTHROUGH"
-    val USE_CONFIGURED_CLOCK = "USE_CONFIGURED_CLOCK"
+  @js.native
+  sealed trait SmoothGroupAudioOnlyTimecodeControl extends js.Any
+  object SmoothGroupAudioOnlyTimecodeControl extends js.Object {
+    val PASSTHROUGH          = "PASSTHROUGH".asInstanceOf[SmoothGroupAudioOnlyTimecodeControl]
+    val USE_CONFIGURED_CLOCK = "USE_CONFIGURED_CLOCK".asInstanceOf[SmoothGroupAudioOnlyTimecodeControl]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, USE_CONFIGURED_CLOCK))
   }
@@ -9226,9 +9407,11 @@ package medialive {
   /**
     * Smooth Group Certificate Mode
     */
-  object SmoothGroupCertificateModeEnum {
-    val SELF_SIGNED         = "SELF_SIGNED"
-    val VERIFY_AUTHENTICITY = "VERIFY_AUTHENTICITY"
+  @js.native
+  sealed trait SmoothGroupCertificateMode extends js.Any
+  object SmoothGroupCertificateMode extends js.Object {
+    val SELF_SIGNED         = "SELF_SIGNED".asInstanceOf[SmoothGroupCertificateMode]
+    val VERIFY_AUTHENTICITY = "VERIFY_AUTHENTICITY".asInstanceOf[SmoothGroupCertificateMode]
 
     val values = js.Object.freeze(js.Array(SELF_SIGNED, VERIFY_AUTHENTICITY))
   }
@@ -9236,10 +9419,12 @@ package medialive {
   /**
     * Smooth Group Event Id Mode
     */
-  object SmoothGroupEventIdModeEnum {
-    val NO_EVENT_ID    = "NO_EVENT_ID"
-    val USE_CONFIGURED = "USE_CONFIGURED"
-    val USE_TIMESTAMP  = "USE_TIMESTAMP"
+  @js.native
+  sealed trait SmoothGroupEventIdMode extends js.Any
+  object SmoothGroupEventIdMode extends js.Object {
+    val NO_EVENT_ID    = "NO_EVENT_ID".asInstanceOf[SmoothGroupEventIdMode]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[SmoothGroupEventIdMode]
+    val USE_TIMESTAMP  = "USE_TIMESTAMP".asInstanceOf[SmoothGroupEventIdMode]
 
     val values = js.Object.freeze(js.Array(NO_EVENT_ID, USE_CONFIGURED, USE_TIMESTAMP))
   }
@@ -9247,9 +9432,11 @@ package medialive {
   /**
     * Smooth Group Event Stop Behavior
     */
-  object SmoothGroupEventStopBehaviorEnum {
-    val NONE     = "NONE"
-    val SEND_EOS = "SEND_EOS"
+  @js.native
+  sealed trait SmoothGroupEventStopBehavior extends js.Any
+  object SmoothGroupEventStopBehavior extends js.Object {
+    val NONE     = "NONE".asInstanceOf[SmoothGroupEventStopBehavior]
+    val SEND_EOS = "SEND_EOS".asInstanceOf[SmoothGroupEventStopBehavior]
 
     val values = js.Object.freeze(js.Array(NONE, SEND_EOS))
   }
@@ -9257,9 +9444,11 @@ package medialive {
   /**
     * Smooth Group Segmentation Mode
     */
-  object SmoothGroupSegmentationModeEnum {
-    val USE_INPUT_SEGMENTATION = "USE_INPUT_SEGMENTATION"
-    val USE_SEGMENT_DURATION   = "USE_SEGMENT_DURATION"
+  @js.native
+  sealed trait SmoothGroupSegmentationMode extends js.Any
+  object SmoothGroupSegmentationMode extends js.Object {
+    val USE_INPUT_SEGMENTATION = "USE_INPUT_SEGMENTATION".asInstanceOf[SmoothGroupSegmentationMode]
+    val USE_SEGMENT_DURATION   = "USE_SEGMENT_DURATION".asInstanceOf[SmoothGroupSegmentationMode]
 
     val values = js.Object.freeze(js.Array(USE_INPUT_SEGMENTATION, USE_SEGMENT_DURATION))
   }
@@ -9267,9 +9456,11 @@ package medialive {
   /**
     * Smooth Group Sparse Track Type
     */
-  object SmoothGroupSparseTrackTypeEnum {
-    val NONE    = "NONE"
-    val SCTE_35 = "SCTE_35"
+  @js.native
+  sealed trait SmoothGroupSparseTrackType extends js.Any
+  object SmoothGroupSparseTrackType extends js.Object {
+    val NONE    = "NONE".asInstanceOf[SmoothGroupSparseTrackType]
+    val SCTE_35 = "SCTE_35".asInstanceOf[SmoothGroupSparseTrackType]
 
     val values = js.Object.freeze(js.Array(NONE, SCTE_35))
   }
@@ -9277,9 +9468,11 @@ package medialive {
   /**
     * Smooth Group Stream Manifest Behavior
     */
-  object SmoothGroupStreamManifestBehaviorEnum {
-    val DO_NOT_SEND = "DO_NOT_SEND"
-    val SEND        = "SEND"
+  @js.native
+  sealed trait SmoothGroupStreamManifestBehavior extends js.Any
+  object SmoothGroupStreamManifestBehavior extends js.Object {
+    val DO_NOT_SEND = "DO_NOT_SEND".asInstanceOf[SmoothGroupStreamManifestBehavior]
+    val SEND        = "SEND".asInstanceOf[SmoothGroupStreamManifestBehavior]
 
     val values = js.Object.freeze(js.Array(DO_NOT_SEND, SEND))
   }
@@ -9287,9 +9480,11 @@ package medialive {
   /**
     * Smooth Group Timestamp Offset Mode
     */
-  object SmoothGroupTimestampOffsetModeEnum {
-    val USE_CONFIGURED_OFFSET = "USE_CONFIGURED_OFFSET"
-    val USE_EVENT_START_DATE  = "USE_EVENT_START_DATE"
+  @js.native
+  sealed trait SmoothGroupTimestampOffsetMode extends js.Any
+  object SmoothGroupTimestampOffsetMode extends js.Object {
+    val USE_CONFIGURED_OFFSET = "USE_CONFIGURED_OFFSET".asInstanceOf[SmoothGroupTimestampOffsetMode]
+    val USE_EVENT_START_DATE  = "USE_EVENT_START_DATE".asInstanceOf[SmoothGroupTimestampOffsetMode]
 
     val values = js.Object.freeze(js.Array(USE_CONFIGURED_OFFSET, USE_EVENT_START_DATE))
   }
@@ -9831,10 +10026,12 @@ package medialive {
   /**
     * Timecode Config Source
     */
-  object TimecodeConfigSourceEnum {
-    val EMBEDDED    = "EMBEDDED"
-    val SYSTEMCLOCK = "SYSTEMCLOCK"
-    val ZEROBASED   = "ZEROBASED"
+  @js.native
+  sealed trait TimecodeConfigSource extends js.Any
+  object TimecodeConfigSource extends js.Object {
+    val EMBEDDED    = "EMBEDDED".asInstanceOf[TimecodeConfigSource]
+    val SYSTEMCLOCK = "SYSTEMCLOCK".asInstanceOf[TimecodeConfigSource]
+    val ZEROBASED   = "ZEROBASED".asInstanceOf[TimecodeConfigSource]
 
     val values = js.Object.freeze(js.Array(EMBEDDED, SYSTEMCLOCK, ZEROBASED))
   }
@@ -9861,9 +10058,11 @@ package medialive {
   /**
     * Ttml Destination Style Control
     */
-  object TtmlDestinationStyleControlEnum {
-    val PASSTHROUGH    = "PASSTHROUGH"
-    val USE_CONFIGURED = "USE_CONFIGURED"
+  @js.native
+  sealed trait TtmlDestinationStyleControl extends js.Any
+  object TtmlDestinationStyleControl extends js.Object {
+    val PASSTHROUGH    = "PASSTHROUGH".asInstanceOf[TtmlDestinationStyleControl]
+    val USE_CONFIGURED = "USE_CONFIGURED".asInstanceOf[TtmlDestinationStyleControl]
 
     val values = js.Object.freeze(js.Array(PASSTHROUGH, USE_CONFIGURED))
   }
@@ -9945,10 +10144,12 @@ package medialive {
   /**
     * Udp Timed Metadata Id3 Frame
     */
-  object UdpTimedMetadataId3FrameEnum {
-    val NONE = "NONE"
-    val PRIV = "PRIV"
-    val TDRL = "TDRL"
+  @js.native
+  sealed trait UdpTimedMetadataId3Frame extends js.Any
+  object UdpTimedMetadataId3Frame extends js.Object {
+    val NONE = "NONE".asInstanceOf[UdpTimedMetadataId3Frame]
+    val PRIV = "PRIV".asInstanceOf[UdpTimedMetadataId3Frame]
+    val TDRL = "TDRL".asInstanceOf[UdpTimedMetadataId3Frame]
 
     val values = js.Object.freeze(js.Array(NONE, PRIV, TDRL))
   }
@@ -10366,10 +10567,12 @@ package medialive {
   /**
     * Video Description Respond To Afd
     */
-  object VideoDescriptionRespondToAfdEnum {
-    val NONE        = "NONE"
-    val PASSTHROUGH = "PASSTHROUGH"
-    val RESPOND     = "RESPOND"
+  @js.native
+  sealed trait VideoDescriptionRespondToAfd extends js.Any
+  object VideoDescriptionRespondToAfd extends js.Object {
+    val NONE        = "NONE".asInstanceOf[VideoDescriptionRespondToAfd]
+    val PASSTHROUGH = "PASSTHROUGH".asInstanceOf[VideoDescriptionRespondToAfd]
+    val RESPOND     = "RESPOND".asInstanceOf[VideoDescriptionRespondToAfd]
 
     val values = js.Object.freeze(js.Array(NONE, PASSTHROUGH, RESPOND))
   }
@@ -10377,9 +10580,11 @@ package medialive {
   /**
     * Video Description Scaling Behavior
     */
-  object VideoDescriptionScalingBehaviorEnum {
-    val DEFAULT           = "DEFAULT"
-    val STRETCH_TO_OUTPUT = "STRETCH_TO_OUTPUT"
+  @js.native
+  sealed trait VideoDescriptionScalingBehavior extends js.Any
+  object VideoDescriptionScalingBehavior extends js.Object {
+    val DEFAULT           = "DEFAULT".asInstanceOf[VideoDescriptionScalingBehavior]
+    val STRETCH_TO_OUTPUT = "STRETCH_TO_OUTPUT".asInstanceOf[VideoDescriptionScalingBehavior]
 
     val values = js.Object.freeze(js.Array(DEFAULT, STRETCH_TO_OUTPUT))
   }
@@ -10412,10 +10617,12 @@ package medialive {
   /**
     * Video Selector Color Space
     */
-  object VideoSelectorColorSpaceEnum {
-    val FOLLOW  = "FOLLOW"
-    val REC_601 = "REC_601"
-    val REC_709 = "REC_709"
+  @js.native
+  sealed trait VideoSelectorColorSpace extends js.Any
+  object VideoSelectorColorSpace extends js.Object {
+    val FOLLOW  = "FOLLOW".asInstanceOf[VideoSelectorColorSpace]
+    val REC_601 = "REC_601".asInstanceOf[VideoSelectorColorSpace]
+    val REC_709 = "REC_709".asInstanceOf[VideoSelectorColorSpace]
 
     val values = js.Object.freeze(js.Array(FOLLOW, REC_601, REC_709))
   }
@@ -10423,9 +10630,11 @@ package medialive {
   /**
     * Video Selector Color Space Usage
     */
-  object VideoSelectorColorSpaceUsageEnum {
-    val FALLBACK = "FALLBACK"
-    val FORCE    = "FORCE"
+  @js.native
+  sealed trait VideoSelectorColorSpaceUsage extends js.Any
+  object VideoSelectorColorSpaceUsage extends js.Object {
+    val FALLBACK = "FALLBACK".asInstanceOf[VideoSelectorColorSpaceUsage]
+    val FORCE    = "FORCE".asInstanceOf[VideoSelectorColorSpaceUsage]
 
     val values = js.Object.freeze(js.Array(FALLBACK, FORCE))
   }

--- a/services/mediapackage/src/main/scala/facade/amazonaws/services/MediaPackage.scala
+++ b/services/mediapackage/src/main/scala/facade/amazonaws/services/MediaPackage.scala
@@ -7,21 +7,9 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object mediapackage {
-  type AdMarkers                                   = String
   type AdTriggers                                  = js.Array[__AdTriggersElement]
-  type AdsOnDeliveryRestrictions                   = String
-  type EncryptionMethod                            = String
-  type ManifestLayout                              = String
   type MaxResults                                  = Int
-  type Origination                                 = String
-  type PlaylistType                                = String
-  type Profile                                     = String
-  type SegmentTemplateFormat                       = String
-  type Status                                      = String
-  type StreamOrder                                 = String
   type Tags                                        = js.Dictionary[__string]
-  type __AdTriggersElement                         = String
-  type __PeriodTriggersElement                     = String
   type __boolean                                   = Boolean
   type __integer                                   = Int
   type __listOfChannel                             = js.Array[Channel]
@@ -107,11 +95,12 @@ package mediapackage {
         params: RotateChannelCredentialsRequest
     ): Request[RotateChannelCredentialsResponse] = js.native
   }
-
-  object AdMarkersEnum {
-    val NONE            = "NONE"
-    val SCTE35_ENHANCED = "SCTE35_ENHANCED"
-    val PASSTHROUGH     = "PASSTHROUGH"
+  @js.native
+  sealed trait AdMarkers extends js.Any
+  object AdMarkers extends js.Object {
+    val NONE            = "NONE".asInstanceOf[AdMarkers]
+    val SCTE35_ENHANCED = "SCTE35_ENHANCED".asInstanceOf[AdMarkers]
+    val PASSTHROUGH     = "PASSTHROUGH".asInstanceOf[AdMarkers]
 
     val values = js.Object.freeze(js.Array(NONE, SCTE35_ENHANCED, PASSTHROUGH))
   }
@@ -126,11 +115,13 @@ package mediapackage {
     * AdTriggers will be treated as ads.  Note that Splice Insert messages do not have these flags
     * and are always treated as ads if specified in AdTriggers.
     */
-  object AdsOnDeliveryRestrictionsEnum {
-    val NONE         = "NONE"
-    val RESTRICTED   = "RESTRICTED"
-    val UNRESTRICTED = "UNRESTRICTED"
-    val BOTH         = "BOTH"
+  @js.native
+  sealed trait AdsOnDeliveryRestrictions extends js.Any
+  object AdsOnDeliveryRestrictions extends js.Object {
+    val NONE         = "NONE".asInstanceOf[AdsOnDeliveryRestrictions]
+    val RESTRICTED   = "RESTRICTED".asInstanceOf[AdsOnDeliveryRestrictions]
+    val UNRESTRICTED = "UNRESTRICTED".asInstanceOf[AdsOnDeliveryRestrictions]
+    val BOTH         = "BOTH".asInstanceOf[AdsOnDeliveryRestrictions]
 
     val values = js.Object.freeze(js.Array(NONE, RESTRICTED, UNRESTRICTED, BOTH))
   }
@@ -856,10 +847,11 @@ package mediapackage {
       __obj.asInstanceOf[DescribeOriginEndpointResponse]
     }
   }
-
-  object EncryptionMethodEnum {
-    val AES_128    = "AES_128"
-    val SAMPLE_AES = "SAMPLE_AES"
+  @js.native
+  sealed trait EncryptionMethod extends js.Any
+  object EncryptionMethod extends js.Object {
+    val AES_128    = "AES_128".asInstanceOf[EncryptionMethod]
+    val SAMPLE_AES = "SAMPLE_AES".asInstanceOf[EncryptionMethod]
 
     val values = js.Object.freeze(js.Array(AES_128, SAMPLE_AES))
   }
@@ -1293,10 +1285,11 @@ package mediapackage {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object ManifestLayoutEnum {
-    val FULL    = "FULL"
-    val COMPACT = "COMPACT"
+  @js.native
+  sealed trait ManifestLayout extends js.Any
+  object ManifestLayout extends js.Object {
+    val FULL    = "FULL".asInstanceOf[ManifestLayout]
+    val COMPACT = "COMPACT".asInstanceOf[ManifestLayout]
 
     val values = js.Object.freeze(js.Array(FULL, COMPACT))
   }
@@ -1413,25 +1406,28 @@ package mediapackage {
       __obj.asInstanceOf[OriginEndpoint]
     }
   }
-
-  object OriginationEnum {
-    val ALLOW = "ALLOW"
-    val DENY  = "DENY"
+  @js.native
+  sealed trait Origination extends js.Any
+  object Origination extends js.Object {
+    val ALLOW = "ALLOW".asInstanceOf[Origination]
+    val DENY  = "DENY".asInstanceOf[Origination]
 
     val values = js.Object.freeze(js.Array(ALLOW, DENY))
   }
-
-  object PlaylistTypeEnum {
-    val NONE  = "NONE"
-    val EVENT = "EVENT"
-    val VOD   = "VOD"
+  @js.native
+  sealed trait PlaylistType extends js.Any
+  object PlaylistType extends js.Object {
+    val NONE  = "NONE".asInstanceOf[PlaylistType]
+    val EVENT = "EVENT".asInstanceOf[PlaylistType]
+    val VOD   = "VOD".asInstanceOf[PlaylistType]
 
     val values = js.Object.freeze(js.Array(NONE, EVENT, VOD))
   }
-
-  object ProfileEnum {
-    val NONE      = "NONE"
-    val HBBTV_1_5 = "HBBTV_1_5"
+  @js.native
+  sealed trait Profile extends js.Any
+  object Profile extends js.Object {
+    val NONE      = "NONE".asInstanceOf[Profile]
+    val HBBTV_1_5 = "HBBTV_1_5".asInstanceOf[Profile]
 
     val values = js.Object.freeze(js.Array(NONE, HBBTV_1_5))
   }
@@ -1559,11 +1555,12 @@ package mediapackage {
       __obj.asInstanceOf[S3Destination]
     }
   }
-
-  object SegmentTemplateFormatEnum {
-    val NUMBER_WITH_TIMELINE = "NUMBER_WITH_TIMELINE"
-    val TIME_WITH_TIMELINE   = "TIME_WITH_TIMELINE"
-    val NUMBER_WITH_DURATION = "NUMBER_WITH_DURATION"
+  @js.native
+  sealed trait SegmentTemplateFormat extends js.Any
+  object SegmentTemplateFormat extends js.Object {
+    val NUMBER_WITH_TIMELINE = "NUMBER_WITH_TIMELINE".asInstanceOf[SegmentTemplateFormat]
+    val TIME_WITH_TIMELINE   = "TIME_WITH_TIMELINE".asInstanceOf[SegmentTemplateFormat]
+    val NUMBER_WITH_DURATION = "NUMBER_WITH_DURATION".asInstanceOf[SegmentTemplateFormat]
 
     val values = js.Object.freeze(js.Array(NUMBER_WITH_TIMELINE, TIME_WITH_TIMELINE, NUMBER_WITH_DURATION))
   }
@@ -1600,19 +1597,21 @@ package mediapackage {
       __obj.asInstanceOf[SpekeKeyProvider]
     }
   }
-
-  object StatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[Status]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[Status]
+    val FAILED      = "FAILED".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, SUCCEEDED, FAILED))
   }
-
-  object StreamOrderEnum {
-    val ORIGINAL                 = "ORIGINAL"
-    val VIDEO_BITRATE_ASCENDING  = "VIDEO_BITRATE_ASCENDING"
-    val VIDEO_BITRATE_DESCENDING = "VIDEO_BITRATE_DESCENDING"
+  @js.native
+  sealed trait StreamOrder extends js.Any
+  object StreamOrder extends js.Object {
+    val ORIGINAL                 = "ORIGINAL".asInstanceOf[StreamOrder]
+    val VIDEO_BITRATE_ASCENDING  = "VIDEO_BITRATE_ASCENDING".asInstanceOf[StreamOrder]
+    val VIDEO_BITRATE_DESCENDING = "VIDEO_BITRATE_DESCENDING".asInstanceOf[StreamOrder]
 
     val values = js.Object.freeze(js.Array(ORIGINAL, VIDEO_BITRATE_ASCENDING, VIDEO_BITRATE_DESCENDING))
   }
@@ -1850,16 +1849,19 @@ package mediapackage {
       __obj.asInstanceOf[UpdateOriginEndpointResponse]
     }
   }
-
-  object __AdTriggersElementEnum {
-    val SPLICE_INSERT                             = "SPLICE_INSERT"
-    val BREAK                                     = "BREAK"
-    val PROVIDER_ADVERTISEMENT                    = "PROVIDER_ADVERTISEMENT"
-    val DISTRIBUTOR_ADVERTISEMENT                 = "DISTRIBUTOR_ADVERTISEMENT"
-    val PROVIDER_PLACEMENT_OPPORTUNITY            = "PROVIDER_PLACEMENT_OPPORTUNITY"
-    val DISTRIBUTOR_PLACEMENT_OPPORTUNITY         = "DISTRIBUTOR_PLACEMENT_OPPORTUNITY"
-    val PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY    = "PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY"
-    val DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY = "DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY"
+  @js.native
+  sealed trait __AdTriggersElement extends js.Any
+  object __AdTriggersElement extends js.Object {
+    val SPLICE_INSERT                     = "SPLICE_INSERT".asInstanceOf[__AdTriggersElement]
+    val BREAK                             = "BREAK".asInstanceOf[__AdTriggersElement]
+    val PROVIDER_ADVERTISEMENT            = "PROVIDER_ADVERTISEMENT".asInstanceOf[__AdTriggersElement]
+    val DISTRIBUTOR_ADVERTISEMENT         = "DISTRIBUTOR_ADVERTISEMENT".asInstanceOf[__AdTriggersElement]
+    val PROVIDER_PLACEMENT_OPPORTUNITY    = "PROVIDER_PLACEMENT_OPPORTUNITY".asInstanceOf[__AdTriggersElement]
+    val DISTRIBUTOR_PLACEMENT_OPPORTUNITY = "DISTRIBUTOR_PLACEMENT_OPPORTUNITY".asInstanceOf[__AdTriggersElement]
+    val PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY =
+      "PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY".asInstanceOf[__AdTriggersElement]
+    val DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY =
+      "DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY".asInstanceOf[__AdTriggersElement]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1874,9 +1876,10 @@ package mediapackage {
       )
     )
   }
-
-  object __PeriodTriggersElementEnum {
-    val ADS = "ADS"
+  @js.native
+  sealed trait __PeriodTriggersElement extends js.Any
+  object __PeriodTriggersElement extends js.Object {
+    val ADS = "ADS".asInstanceOf[__PeriodTriggersElement]
 
     val values = js.Object.freeze(js.Array(ADS))
   }

--- a/services/mediapackagevod/src/main/scala/facade/amazonaws/services/MediaPackageVod.scala
+++ b/services/mediapackagevod/src/main/scala/facade/amazonaws/services/MediaPackageVod.scala
@@ -7,14 +7,7 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object mediapackagevod {
-  type AdMarkers                       = String
-  type EncryptionMethod                = String
-  type ManifestLayout                  = String
   type MaxResults                      = Int
-  type Profile                         = String
-  type SegmentTemplateFormat           = String
-  type StreamOrder                     = String
-  type __PeriodTriggersElement         = String
   type __boolean                       = Boolean
   type __integer                       = Int
   type __listOfAssetShallow            = js.Array[AssetShallow]
@@ -90,11 +83,12 @@ package mediapackagevod {
     ): Request[ListPackagingConfigurationsResponse]                                                   = js.native
     def listPackagingGroups(params: ListPackagingGroupsRequest): Request[ListPackagingGroupsResponse] = js.native
   }
-
-  object AdMarkersEnum {
-    val NONE            = "NONE"
-    val SCTE35_ENHANCED = "SCTE35_ENHANCED"
-    val PASSTHROUGH     = "PASSTHROUGH"
+  @js.native
+  sealed trait AdMarkers extends js.Any
+  object AdMarkers extends js.Object {
+    val NONE            = "NONE".asInstanceOf[AdMarkers]
+    val SCTE35_ENHANCED = "SCTE35_ENHANCED".asInstanceOf[AdMarkers]
+    val PASSTHROUGH     = "PASSTHROUGH".asInstanceOf[AdMarkers]
 
     val values = js.Object.freeze(js.Array(NONE, SCTE35_ENHANCED, PASSTHROUGH))
   }
@@ -713,10 +707,11 @@ package mediapackagevod {
       __obj.asInstanceOf[EgressEndpoint]
     }
   }
-
-  object EncryptionMethodEnum {
-    val AES_128    = "AES_128"
-    val SAMPLE_AES = "SAMPLE_AES"
+  @js.native
+  sealed trait EncryptionMethod extends js.Any
+  object EncryptionMethod extends js.Object {
+    val AES_128    = "AES_128".asInstanceOf[EncryptionMethod]
+    val SAMPLE_AES = "SAMPLE_AES".asInstanceOf[EncryptionMethod]
 
     val values = js.Object.freeze(js.Array(AES_128, SAMPLE_AES))
   }
@@ -935,10 +930,11 @@ package mediapackagevod {
       __obj.asInstanceOf[ListPackagingGroupsResponse]
     }
   }
-
-  object ManifestLayoutEnum {
-    val FULL    = "FULL"
-    val COMPACT = "COMPACT"
+  @js.native
+  sealed trait ManifestLayout extends js.Any
+  object ManifestLayout extends js.Object {
+    val FULL    = "FULL".asInstanceOf[ManifestLayout]
+    val COMPACT = "COMPACT".asInstanceOf[ManifestLayout]
 
     val values = js.Object.freeze(js.Array(FULL, COMPACT))
   }
@@ -1074,18 +1070,20 @@ package mediapackagevod {
       __obj.asInstanceOf[PackagingGroup]
     }
   }
-
-  object ProfileEnum {
-    val NONE      = "NONE"
-    val HBBTV_1_5 = "HBBTV_1_5"
+  @js.native
+  sealed trait Profile extends js.Any
+  object Profile extends js.Object {
+    val NONE      = "NONE".asInstanceOf[Profile]
+    val HBBTV_1_5 = "HBBTV_1_5".asInstanceOf[Profile]
 
     val values = js.Object.freeze(js.Array(NONE, HBBTV_1_5))
   }
-
-  object SegmentTemplateFormatEnum {
-    val NUMBER_WITH_TIMELINE = "NUMBER_WITH_TIMELINE"
-    val TIME_WITH_TIMELINE   = "TIME_WITH_TIMELINE"
-    val NUMBER_WITH_DURATION = "NUMBER_WITH_DURATION"
+  @js.native
+  sealed trait SegmentTemplateFormat extends js.Any
+  object SegmentTemplateFormat extends js.Object {
+    val NUMBER_WITH_TIMELINE = "NUMBER_WITH_TIMELINE".asInstanceOf[SegmentTemplateFormat]
+    val TIME_WITH_TIMELINE   = "TIME_WITH_TIMELINE".asInstanceOf[SegmentTemplateFormat]
+    val NUMBER_WITH_DURATION = "NUMBER_WITH_DURATION".asInstanceOf[SegmentTemplateFormat]
 
     val values = js.Object.freeze(js.Array(NUMBER_WITH_TIMELINE, TIME_WITH_TIMELINE, NUMBER_WITH_DURATION))
   }
@@ -1116,11 +1114,12 @@ package mediapackagevod {
       __obj.asInstanceOf[SpekeKeyProvider]
     }
   }
-
-  object StreamOrderEnum {
-    val ORIGINAL                 = "ORIGINAL"
-    val VIDEO_BITRATE_ASCENDING  = "VIDEO_BITRATE_ASCENDING"
-    val VIDEO_BITRATE_DESCENDING = "VIDEO_BITRATE_DESCENDING"
+  @js.native
+  sealed trait StreamOrder extends js.Any
+  object StreamOrder extends js.Object {
+    val ORIGINAL                 = "ORIGINAL".asInstanceOf[StreamOrder]
+    val VIDEO_BITRATE_ASCENDING  = "VIDEO_BITRATE_ASCENDING".asInstanceOf[StreamOrder]
+    val VIDEO_BITRATE_DESCENDING = "VIDEO_BITRATE_DESCENDING".asInstanceOf[StreamOrder]
 
     val values = js.Object.freeze(js.Array(ORIGINAL, VIDEO_BITRATE_ASCENDING, VIDEO_BITRATE_DESCENDING))
   }
@@ -1149,9 +1148,10 @@ package mediapackagevod {
       __obj.asInstanceOf[StreamSelection]
     }
   }
-
-  object __PeriodTriggersElementEnum {
-    val ADS = "ADS"
+  @js.native
+  sealed trait __PeriodTriggersElement extends js.Any
+  object __PeriodTriggersElement extends js.Object {
+    val ADS = "ADS".asInstanceOf[__PeriodTriggersElement]
 
     val values = js.Object.freeze(js.Array(ADS))
   }

--- a/services/mediastore/src/main/scala/facade/amazonaws/services/MediaStore.scala
+++ b/services/mediastore/src/main/scala/facade/amazonaws/services/MediaStore.scala
@@ -16,14 +16,12 @@ package object mediastore {
   type ContainerListLimit            = Int
   type ContainerName                 = String
   type ContainerPolicy               = String
-  type ContainerStatus               = String
   type CorsPolicy                    = js.Array[CorsRule]
   type Endpoint                      = String
   type ExposeHeaders                 = js.Array[Header]
   type Header                        = String
   type LifecyclePolicy               = String
   type MaxAgeSeconds                 = Int
-  type MethodName                    = String
   type Origin                        = String
   type PaginationToken               = String
   type TagKey                        = String
@@ -132,11 +130,12 @@ package mediastore {
       __obj.asInstanceOf[Container]
     }
   }
-
-  object ContainerStatusEnum {
-    val ACTIVE   = "ACTIVE"
-    val CREATING = "CREATING"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait ContainerStatus extends js.Any
+  object ContainerStatus extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[ContainerStatus]
+    val CREATING = "CREATING".asInstanceOf[ContainerStatus]
+    val DELETING = "DELETING".asInstanceOf[ContainerStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, CREATING, DELETING))
   }
@@ -550,12 +549,13 @@ package mediastore {
       __obj.asInstanceOf[ListTagsForResourceOutput]
     }
   }
-
-  object MethodNameEnum {
-    val PUT    = "PUT"
-    val GET    = "GET"
-    val DELETE = "DELETE"
-    val HEAD   = "HEAD"
+  @js.native
+  sealed trait MethodName extends js.Any
+  object MethodName extends js.Object {
+    val PUT    = "PUT".asInstanceOf[MethodName]
+    val GET    = "GET".asInstanceOf[MethodName]
+    val DELETE = "DELETE".asInstanceOf[MethodName]
+    val HEAD   = "HEAD".asInstanceOf[MethodName]
 
     val values = js.Object.freeze(js.Array(PUT, GET, DELETE, HEAD))
   }

--- a/services/mediastoredata/src/main/scala/facade/amazonaws/services/MediaStoreData.scala
+++ b/services/mediastoredata/src/main/scala/facade/amazonaws/services/MediaStoreData.scala
@@ -12,7 +12,6 @@ package object mediastoredata {
   type ETag                = String
   type ItemList            = js.Array[Item]
   type ItemName            = String
-  type ItemType            = String
   type ListLimit           = Int
   type ListPathNaming      = String
   type NonNegativeLong     = Double
@@ -21,10 +20,8 @@ package object mediastoredata {
   type PayloadBlob         = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type RangePattern        = String
   type SHA256Hash          = String
-  type StorageClass        = String
   type StringPrimitive     = String
   type TimeStamp           = js.Date
-  type UploadAvailability  = String
   type statusCode          = Int
 
   implicit final class MediaStoreDataOps(private val service: MediaStoreData) extends AnyVal {
@@ -225,10 +222,11 @@ package mediastoredata {
       __obj.asInstanceOf[Item]
     }
   }
-
-  object ItemTypeEnum {
-    val OBJECT = "OBJECT"
-    val FOLDER = "FOLDER"
+  @js.native
+  sealed trait ItemType extends js.Any
+  object ItemType extends js.Object {
+    val OBJECT = "OBJECT".asInstanceOf[ItemType]
+    val FOLDER = "FOLDER".asInstanceOf[ItemType]
 
     val values = js.Object.freeze(js.Array(OBJECT, FOLDER))
   }
@@ -328,16 +326,18 @@ package mediastoredata {
       __obj.asInstanceOf[PutObjectResponse]
     }
   }
-
-  object StorageClassEnum {
-    val TEMPORAL = "TEMPORAL"
+  @js.native
+  sealed trait StorageClass extends js.Any
+  object StorageClass extends js.Object {
+    val TEMPORAL = "TEMPORAL".asInstanceOf[StorageClass]
 
     val values = js.Object.freeze(js.Array(TEMPORAL))
   }
-
-  object UploadAvailabilityEnum {
-    val STANDARD  = "STANDARD"
-    val STREAMING = "STREAMING"
+  @js.native
+  sealed trait UploadAvailability extends js.Any
+  object UploadAvailability extends js.Object {
+    val STANDARD  = "STANDARD".asInstanceOf[UploadAvailability]
+    val STREAMING = "STREAMING".asInstanceOf[UploadAvailability]
 
     val values = js.Object.freeze(js.Array(STANDARD, STREAMING))
   }

--- a/services/mediatailor/src/main/scala/facade/amazonaws/services/MediaTailor.scala
+++ b/services/mediatailor/src/main/scala/facade/amazonaws/services/MediaTailor.scala
@@ -7,7 +7,6 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object mediatailor {
-  type OriginManifestType             = String
   type __integer                      = Int
   type __integerMin1                  = Int
   type __integerMin1Max100            = Int
@@ -349,10 +348,11 @@ package mediatailor {
       __obj.asInstanceOf[LivePreRollConfiguration]
     }
   }
-
-  object OriginManifestTypeEnum {
-    val SINGLE_PERIOD = "SINGLE_PERIOD"
-    val MULTI_PERIOD  = "MULTI_PERIOD"
+  @js.native
+  sealed trait OriginManifestType extends js.Any
+  object OriginManifestType extends js.Object {
+    val SINGLE_PERIOD = "SINGLE_PERIOD".asInstanceOf[OriginManifestType]
+    val MULTI_PERIOD  = "MULTI_PERIOD".asInstanceOf[OriginManifestType]
 
     val values = js.Object.freeze(js.Array(SINGLE_PERIOD, MULTI_PERIOD))
   }

--- a/services/migrationhub/src/main/scala/facade/amazonaws/services/MigrationHub.scala
+++ b/services/migrationhub/src/main/scala/facade/amazonaws/services/MigrationHub.scala
@@ -10,7 +10,6 @@ package object migrationhub {
   type ApplicationId                   = String
   type ApplicationIds                  = js.Array[ApplicationId]
   type ApplicationStateList            = js.Array[ApplicationState]
-  type ApplicationStatus               = String
   type ConfigurationId                 = String
   type CreatedArtifactDescription      = String
   type CreatedArtifactList             = js.Array[CreatedArtifact]
@@ -29,10 +28,8 @@ package object migrationhub {
   type ProgressUpdateStream            = String
   type ProgressUpdateStreamSummaryList = js.Array[ProgressUpdateStreamSummary]
   type ResourceAttributeList           = js.Array[ResourceAttribute]
-  type ResourceAttributeType           = String
   type ResourceAttributeValue          = String
   type ResourceName                    = String
-  type Status                          = String
   type StatusDetail                    = String
   type Token                           = String
   type UpdateDateTime                  = js.Date
@@ -151,11 +148,12 @@ package migrationhub {
       __obj.asInstanceOf[ApplicationState]
     }
   }
-
-  object ApplicationStatusEnum {
-    val NOT_STARTED = "NOT_STARTED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
+  @js.native
+  sealed trait ApplicationStatus extends js.Any
+  object ApplicationStatus extends js.Object {
+    val NOT_STARTED = "NOT_STARTED".asInstanceOf[ApplicationStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ApplicationStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[ApplicationStatus]
 
     val values = js.Object.freeze(js.Array(NOT_STARTED, IN_PROGRESS, COMPLETED))
   }
@@ -1002,18 +1000,19 @@ package migrationhub {
       __obj.asInstanceOf[ResourceAttribute]
     }
   }
-
-  object ResourceAttributeTypeEnum {
-    val IPV4_ADDRESS                = "IPV4_ADDRESS"
-    val IPV6_ADDRESS                = "IPV6_ADDRESS"
-    val MAC_ADDRESS                 = "MAC_ADDRESS"
-    val FQDN                        = "FQDN"
-    val VM_MANAGER_ID               = "VM_MANAGER_ID"
-    val VM_MANAGED_OBJECT_REFERENCE = "VM_MANAGED_OBJECT_REFERENCE"
-    val VM_NAME                     = "VM_NAME"
-    val VM_PATH                     = "VM_PATH"
-    val BIOS_ID                     = "BIOS_ID"
-    val MOTHERBOARD_SERIAL_NUMBER   = "MOTHERBOARD_SERIAL_NUMBER"
+  @js.native
+  sealed trait ResourceAttributeType extends js.Any
+  object ResourceAttributeType extends js.Object {
+    val IPV4_ADDRESS                = "IPV4_ADDRESS".asInstanceOf[ResourceAttributeType]
+    val IPV6_ADDRESS                = "IPV6_ADDRESS".asInstanceOf[ResourceAttributeType]
+    val MAC_ADDRESS                 = "MAC_ADDRESS".asInstanceOf[ResourceAttributeType]
+    val FQDN                        = "FQDN".asInstanceOf[ResourceAttributeType]
+    val VM_MANAGER_ID               = "VM_MANAGER_ID".asInstanceOf[ResourceAttributeType]
+    val VM_MANAGED_OBJECT_REFERENCE = "VM_MANAGED_OBJECT_REFERENCE".asInstanceOf[ResourceAttributeType]
+    val VM_NAME                     = "VM_NAME".asInstanceOf[ResourceAttributeType]
+    val VM_PATH                     = "VM_PATH".asInstanceOf[ResourceAttributeType]
+    val BIOS_ID                     = "BIOS_ID".asInstanceOf[ResourceAttributeType]
+    val MOTHERBOARD_SERIAL_NUMBER   = "MOTHERBOARD_SERIAL_NUMBER".asInstanceOf[ResourceAttributeType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1030,12 +1029,13 @@ package migrationhub {
       )
     )
   }
-
-  object StatusEnum {
-    val NOT_STARTED = "NOT_STARTED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val FAILED      = "FAILED"
-    val COMPLETED   = "COMPLETED"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val NOT_STARTED = "NOT_STARTED".asInstanceOf[Status]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[Status]
+    val FAILED      = "FAILED".asInstanceOf[Status]
+    val COMPLETED   = "COMPLETED".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(NOT_STARTED, IN_PROGRESS, FAILED, COMPLETED))
   }

--- a/services/migrationhubconfig/src/main/scala/facade/amazonaws/services/MigrationHubConfig.scala
+++ b/services/migrationhubconfig/src/main/scala/facade/amazonaws/services/MigrationHubConfig.scala
@@ -14,7 +14,6 @@ package object migrationhubconfig {
   type HomeRegionControls                   = js.Array[HomeRegionControl]
   type RequestedTime                        = js.Date
   type TargetId                             = String
-  type TargetType                           = String
   type Token                                = String
 
   implicit final class MigrationHubConfigOps(private val service: MigrationHubConfig) extends AnyVal {
@@ -211,9 +210,10 @@ package migrationhubconfig {
       __obj.asInstanceOf[Target]
     }
   }
-
-  object TargetTypeEnum {
-    val ACCOUNT = "ACCOUNT"
+  @js.native
+  sealed trait TargetType extends js.Any
+  object TargetType extends js.Object {
+    val ACCOUNT = "ACCOUNT".asInstanceOf[TargetType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT))
   }

--- a/services/mobile/src/main/scala/facade/amazonaws/services/Mobile.scala
+++ b/services/mobile/src/main/scala/facade/amazonaws/services/Mobile.scala
@@ -24,12 +24,10 @@ package object mobile {
   type IconUrl           = String
   type MaxResults        = Int
   type NextToken         = String
-  type Platform          = String
   type Platforms         = js.Array[Platform]
   type ProjectId         = String
   type ProjectName       = String
   type ProjectRegion     = String
-  type ProjectState      = String
   type ProjectSummaries  = js.Array[ProjectSummary]
   type ResourceArn       = String
   type ResourceName      = String
@@ -509,14 +507,16 @@ package mobile {
   /**
     * Developer desktop or target mobile app or website platform.
     */
-  object PlatformEnum {
-    val OSX        = "OSX"
-    val WINDOWS    = "WINDOWS"
-    val LINUX      = "LINUX"
-    val OBJC       = "OBJC"
-    val SWIFT      = "SWIFT"
-    val ANDROID    = "ANDROID"
-    val JAVASCRIPT = "JAVASCRIPT"
+  @js.native
+  sealed trait Platform extends js.Any
+  object Platform extends js.Object {
+    val OSX        = "OSX".asInstanceOf[Platform]
+    val WINDOWS    = "WINDOWS".asInstanceOf[Platform]
+    val LINUX      = "LINUX".asInstanceOf[Platform]
+    val OBJC       = "OBJC".asInstanceOf[Platform]
+    val SWIFT      = "SWIFT".asInstanceOf[Platform]
+    val ANDROID    = "ANDROID".asInstanceOf[Platform]
+    val JAVASCRIPT = "JAVASCRIPT".asInstanceOf[Platform]
 
     val values = js.Object.freeze(js.Array(OSX, WINDOWS, LINUX, OBJC, SWIFT, ANDROID, JAVASCRIPT))
   }
@@ -564,10 +564,12 @@ package mobile {
   /**
     * Synchronization state for a project.
     */
-  object ProjectStateEnum {
-    val NORMAL    = "NORMAL"
-    val SYNCING   = "SYNCING"
-    val IMPORTING = "IMPORTING"
+  @js.native
+  sealed trait ProjectState extends js.Any
+  object ProjectState extends js.Object {
+    val NORMAL    = "NORMAL".asInstanceOf[ProjectState]
+    val SYNCING   = "SYNCING".asInstanceOf[ProjectState]
+    val IMPORTING = "IMPORTING".asInstanceOf[ProjectState]
 
     val values = js.Object.freeze(js.Array(NORMAL, SYNCING, IMPORTING))
   }

--- a/services/mq/src/main/scala/facade/amazonaws/services/MQ.scala
+++ b/services/mq/src/main/scala/facade/amazonaws/services/MQ.scala
@@ -7,14 +7,7 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object mq {
-  type BrokerState                   = String
-  type BrokerStorageType             = String
-  type ChangeType                    = String
-  type DayOfWeek                     = String
-  type DeploymentMode                = String
-  type EngineType                    = String
   type MaxResults                    = Int
-  type SanitizationWarningReason     = String
   type __boolean                     = Boolean
   type __integer                     = Int
   type __integerMin5Max100           = Int
@@ -231,12 +224,14 @@ package mq {
   /**
     * The status of the broker.
     */
-  object BrokerStateEnum {
-    val CREATION_IN_PROGRESS = "CREATION_IN_PROGRESS"
-    val CREATION_FAILED      = "CREATION_FAILED"
-    val DELETION_IN_PROGRESS = "DELETION_IN_PROGRESS"
-    val RUNNING              = "RUNNING"
-    val REBOOT_IN_PROGRESS   = "REBOOT_IN_PROGRESS"
+  @js.native
+  sealed trait BrokerState extends js.Any
+  object BrokerState extends js.Object {
+    val CREATION_IN_PROGRESS = "CREATION_IN_PROGRESS".asInstanceOf[BrokerState]
+    val CREATION_FAILED      = "CREATION_FAILED".asInstanceOf[BrokerState]
+    val DELETION_IN_PROGRESS = "DELETION_IN_PROGRESS".asInstanceOf[BrokerState]
+    val RUNNING              = "RUNNING".asInstanceOf[BrokerState]
+    val REBOOT_IN_PROGRESS   = "REBOOT_IN_PROGRESS".asInstanceOf[BrokerState]
 
     val values = js.Object.freeze(
       js.Array(CREATION_IN_PROGRESS, CREATION_FAILED, DELETION_IN_PROGRESS, RUNNING, REBOOT_IN_PROGRESS)
@@ -246,9 +241,11 @@ package mq {
   /**
     * The storage type of the broker.
     */
-  object BrokerStorageTypeEnum {
-    val EBS = "EBS"
-    val EFS = "EFS"
+  @js.native
+  sealed trait BrokerStorageType extends js.Any
+  object BrokerStorageType extends js.Object {
+    val EBS = "EBS".asInstanceOf[BrokerStorageType]
+    val EFS = "EFS".asInstanceOf[BrokerStorageType]
 
     val values = js.Object.freeze(js.Array(EBS, EFS))
   }
@@ -293,10 +290,12 @@ package mq {
   /**
     * The type of change pending for the ActiveMQ user.
     */
-  object ChangeTypeEnum {
-    val CREATE = "CREATE"
-    val UPDATE = "UPDATE"
-    val DELETE = "DELETE"
+  @js.native
+  sealed trait ChangeType extends js.Any
+  object ChangeType extends js.Object {
+    val CREATE = "CREATE".asInstanceOf[ChangeType]
+    val UPDATE = "UPDATE".asInstanceOf[ChangeType]
+    val DELETE = "DELETE".asInstanceOf[ChangeType]
 
     val values = js.Object.freeze(js.Array(CREATE, UPDATE, DELETE))
   }
@@ -629,15 +628,16 @@ package mq {
       __obj.asInstanceOf[CreateUserResponse]
     }
   }
-
-  object DayOfWeekEnum {
-    val MONDAY    = "MONDAY"
-    val TUESDAY   = "TUESDAY"
-    val WEDNESDAY = "WEDNESDAY"
-    val THURSDAY  = "THURSDAY"
-    val FRIDAY    = "FRIDAY"
-    val SATURDAY  = "SATURDAY"
-    val SUNDAY    = "SUNDAY"
+  @js.native
+  sealed trait DayOfWeek extends js.Any
+  object DayOfWeek extends js.Object {
+    val MONDAY    = "MONDAY".asInstanceOf[DayOfWeek]
+    val TUESDAY   = "TUESDAY".asInstanceOf[DayOfWeek]
+    val WEDNESDAY = "WEDNESDAY".asInstanceOf[DayOfWeek]
+    val THURSDAY  = "THURSDAY".asInstanceOf[DayOfWeek]
+    val FRIDAY    = "FRIDAY".asInstanceOf[DayOfWeek]
+    val SATURDAY  = "SATURDAY".asInstanceOf[DayOfWeek]
+    val SUNDAY    = "SUNDAY".asInstanceOf[DayOfWeek]
 
     val values = js.Object.freeze(js.Array(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY))
   }
@@ -734,9 +734,11 @@ package mq {
   /**
     * The deployment mode of the broker.
     */
-  object DeploymentModeEnum {
-    val SINGLE_INSTANCE         = "SINGLE_INSTANCE"
-    val ACTIVE_STANDBY_MULTI_AZ = "ACTIVE_STANDBY_MULTI_AZ"
+  @js.native
+  sealed trait DeploymentMode extends js.Any
+  object DeploymentMode extends js.Object {
+    val SINGLE_INSTANCE         = "SINGLE_INSTANCE".asInstanceOf[DeploymentMode]
+    val ACTIVE_STANDBY_MULTI_AZ = "ACTIVE_STANDBY_MULTI_AZ".asInstanceOf[DeploymentMode]
 
     val values = js.Object.freeze(js.Array(SINGLE_INSTANCE, ACTIVE_STANDBY_MULTI_AZ))
   }
@@ -1120,8 +1122,10 @@ package mq {
   /**
     * The type of broker engine. Note: Currently, Amazon MQ supports only ActiveMQ.
     */
-  object EngineTypeEnum {
-    val ACTIVEMQ = "ACTIVEMQ"
+  @js.native
+  sealed trait EngineType extends js.Any
+  object EngineType extends js.Object {
+    val ACTIVEMQ = "ACTIVEMQ".asInstanceOf[EngineType]
 
     val values = js.Object.freeze(js.Array(ACTIVEMQ))
   }
@@ -1490,10 +1494,12 @@ package mq {
   /**
     * The reason for which the XML elements or attributes were sanitized.
     */
-  object SanitizationWarningReasonEnum {
-    val DISALLOWED_ELEMENT_REMOVED      = "DISALLOWED_ELEMENT_REMOVED"
-    val DISALLOWED_ATTRIBUTE_REMOVED    = "DISALLOWED_ATTRIBUTE_REMOVED"
-    val INVALID_ATTRIBUTE_VALUE_REMOVED = "INVALID_ATTRIBUTE_VALUE_REMOVED"
+  @js.native
+  sealed trait SanitizationWarningReason extends js.Any
+  object SanitizationWarningReason extends js.Object {
+    val DISALLOWED_ELEMENT_REMOVED      = "DISALLOWED_ELEMENT_REMOVED".asInstanceOf[SanitizationWarningReason]
+    val DISALLOWED_ATTRIBUTE_REMOVED    = "DISALLOWED_ATTRIBUTE_REMOVED".asInstanceOf[SanitizationWarningReason]
+    val INVALID_ATTRIBUTE_VALUE_REMOVED = "INVALID_ATTRIBUTE_VALUE_REMOVED".asInstanceOf[SanitizationWarningReason]
 
     val values = js.Object.freeze(
       js.Array(DISALLOWED_ELEMENT_REMOVED, DISALLOWED_ATTRIBUTE_REMOVED, INVALID_ATTRIBUTE_VALUE_REMOVED)

--- a/services/mturk/src/main/scala/facade/amazonaws/services/MTurk.scala
+++ b/services/mturk/src/main/scala/facade/amazonaws/services/MTurk.scala
@@ -8,28 +8,20 @@ import facade.amazonaws._
 
 package object mturk {
   type AssignmentList                 = js.Array[Assignment]
-  type AssignmentStatus               = String
   type AssignmentStatusList           = js.Array[AssignmentStatus]
   type BonusPaymentList               = js.Array[BonusPayment]
-  type Comparator                     = String
   type CountryParameters              = String
   type CurrencyAmount                 = String
   type CustomerId                     = String
   type CustomerIdList                 = js.Array[CustomerId]
   type EntityId                       = String
-  type EventType                      = String
   type EventTypeList                  = js.Array[EventType]
   type ExceptionMessage               = String
-  type HITAccessActions               = String
   type HITLayoutParameterList         = js.Array[HITLayoutParameter]
   type HITList                        = js.Array[HIT]
-  type HITReviewStatus                = String
-  type HITStatus                      = String
   type IdempotencyToken               = String
   type IntegerList                    = js.Array[Int]
   type LocaleList                     = js.Array[Locale]
-  type NotificationTransport          = String
-  type NotifyWorkersFailureCode       = String
   type NotifyWorkersFailureStatusList = js.Array[NotifyWorkersFailureStatus]
   type PaginationToken                = String
   type ParameterMapEntryList          = js.Array[ParameterMapEntry]
@@ -37,16 +29,11 @@ package object mturk {
   type QualificationList              = js.Array[Qualification]
   type QualificationRequestList       = js.Array[QualificationRequest]
   type QualificationRequirementList   = js.Array[QualificationRequirement]
-  type QualificationStatus            = String
   type QualificationTypeList          = js.Array[QualificationType]
-  type QualificationTypeStatus        = String
   type ResultSize                     = Int
   type ReviewActionDetailList         = js.Array[ReviewActionDetail]
-  type ReviewActionStatus             = String
-  type ReviewPolicyLevel              = String
   type ReviewPolicyLevelList          = js.Array[ReviewPolicyLevel]
   type ReviewResultDetailList         = js.Array[ReviewResultDetail]
-  type ReviewableHITStatus            = String
   type StringList                     = js.Array[String]
   type Timestamp                      = js.Date
   type TurkErrorCode                  = String
@@ -353,11 +340,12 @@ package mturk {
       __obj.asInstanceOf[Assignment]
     }
   }
-
-  object AssignmentStatusEnum {
-    val Submitted = "Submitted"
-    val Approved  = "Approved"
-    val Rejected  = "Rejected"
+  @js.native
+  sealed trait AssignmentStatus extends js.Any
+  object AssignmentStatus extends js.Object {
+    val Submitted = "Submitted".asInstanceOf[AssignmentStatus]
+    val Approved  = "Approved".asInstanceOf[AssignmentStatus]
+    val Rejected  = "Rejected".asInstanceOf[AssignmentStatus]
 
     val values = js.Object.freeze(js.Array(Submitted, Approved, Rejected))
   }
@@ -432,18 +420,19 @@ package mturk {
       __obj.asInstanceOf[BonusPayment]
     }
   }
-
-  object ComparatorEnum {
-    val LessThan             = "LessThan"
-    val LessThanOrEqualTo    = "LessThanOrEqualTo"
-    val GreaterThan          = "GreaterThan"
-    val GreaterThanOrEqualTo = "GreaterThanOrEqualTo"
-    val EqualTo              = "EqualTo"
-    val NotEqualTo           = "NotEqualTo"
-    val Exists               = "Exists"
-    val DoesNotExist         = "DoesNotExist"
-    val In                   = "In"
-    val NotIn                = "NotIn"
+  @js.native
+  sealed trait Comparator extends js.Any
+  object Comparator extends js.Object {
+    val LessThan             = "LessThan".asInstanceOf[Comparator]
+    val LessThanOrEqualTo    = "LessThanOrEqualTo".asInstanceOf[Comparator]
+    val GreaterThan          = "GreaterThan".asInstanceOf[Comparator]
+    val GreaterThanOrEqualTo = "GreaterThanOrEqualTo".asInstanceOf[Comparator]
+    val EqualTo              = "EqualTo".asInstanceOf[Comparator]
+    val NotEqualTo           = "NotEqualTo".asInstanceOf[Comparator]
+    val Exists               = "Exists".asInstanceOf[Comparator]
+    val DoesNotExist         = "DoesNotExist".asInstanceOf[Comparator]
+    val In                   = "In".asInstanceOf[Comparator]
+    val NotIn                = "NotIn".asInstanceOf[Comparator]
 
     val values = js.Object.freeze(
       js.Array(
@@ -925,20 +914,21 @@ package mturk {
       __obj.asInstanceOf[DisassociateQualificationFromWorkerResponse]
     }
   }
-
-  object EventTypeEnum {
-    val AssignmentAccepted  = "AssignmentAccepted"
-    val AssignmentAbandoned = "AssignmentAbandoned"
-    val AssignmentReturned  = "AssignmentReturned"
-    val AssignmentSubmitted = "AssignmentSubmitted"
-    val AssignmentRejected  = "AssignmentRejected"
-    val AssignmentApproved  = "AssignmentApproved"
-    val HITCreated          = "HITCreated"
-    val HITExpired          = "HITExpired"
-    val HITReviewable       = "HITReviewable"
-    val HITExtended         = "HITExtended"
-    val HITDisposed         = "HITDisposed"
-    val Ping                = "Ping"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val AssignmentAccepted  = "AssignmentAccepted".asInstanceOf[EventType]
+    val AssignmentAbandoned = "AssignmentAbandoned".asInstanceOf[EventType]
+    val AssignmentReturned  = "AssignmentReturned".asInstanceOf[EventType]
+    val AssignmentSubmitted = "AssignmentSubmitted".asInstanceOf[EventType]
+    val AssignmentRejected  = "AssignmentRejected".asInstanceOf[EventType]
+    val AssignmentApproved  = "AssignmentApproved".asInstanceOf[EventType]
+    val HITCreated          = "HITCreated".asInstanceOf[EventType]
+    val HITExpired          = "HITExpired".asInstanceOf[EventType]
+    val HITReviewable       = "HITReviewable".asInstanceOf[EventType]
+    val HITExtended         = "HITExtended".asInstanceOf[EventType]
+    val HITDisposed         = "HITDisposed".asInstanceOf[EventType]
+    val Ping                = "Ping".asInstanceOf[EventType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1259,11 +1249,12 @@ package mturk {
       __obj.asInstanceOf[HIT]
     }
   }
-
-  object HITAccessActionsEnum {
-    val Accept                   = "Accept"
-    val PreviewAndAccept         = "PreviewAndAccept"
-    val DiscoverPreviewAndAccept = "DiscoverPreviewAndAccept"
+  @js.native
+  sealed trait HITAccessActions extends js.Any
+  object HITAccessActions extends js.Object {
+    val Accept                   = "Accept".asInstanceOf[HITAccessActions]
+    val PreviewAndAccept         = "PreviewAndAccept".asInstanceOf[HITAccessActions]
+    val DiscoverPreviewAndAccept = "DiscoverPreviewAndAccept".asInstanceOf[HITAccessActions]
 
     val values = js.Object.freeze(js.Array(Accept, PreviewAndAccept, DiscoverPreviewAndAccept))
   }
@@ -1291,22 +1282,24 @@ package mturk {
       __obj.asInstanceOf[HITLayoutParameter]
     }
   }
-
-  object HITReviewStatusEnum {
-    val NotReviewed           = "NotReviewed"
-    val MarkedForReview       = "MarkedForReview"
-    val ReviewedAppropriate   = "ReviewedAppropriate"
-    val ReviewedInappropriate = "ReviewedInappropriate"
+  @js.native
+  sealed trait HITReviewStatus extends js.Any
+  object HITReviewStatus extends js.Object {
+    val NotReviewed           = "NotReviewed".asInstanceOf[HITReviewStatus]
+    val MarkedForReview       = "MarkedForReview".asInstanceOf[HITReviewStatus]
+    val ReviewedAppropriate   = "ReviewedAppropriate".asInstanceOf[HITReviewStatus]
+    val ReviewedInappropriate = "ReviewedInappropriate".asInstanceOf[HITReviewStatus]
 
     val values = js.Object.freeze(js.Array(NotReviewed, MarkedForReview, ReviewedAppropriate, ReviewedInappropriate))
   }
-
-  object HITStatusEnum {
-    val Assignable   = "Assignable"
-    val Unassignable = "Unassignable"
-    val Reviewable   = "Reviewable"
-    val Reviewing    = "Reviewing"
-    val Disposed     = "Disposed"
+  @js.native
+  sealed trait HITStatus extends js.Any
+  object HITStatus extends js.Object {
+    val Assignable   = "Assignable".asInstanceOf[HITStatus]
+    val Unassignable = "Unassignable".asInstanceOf[HITStatus]
+    val Reviewable   = "Reviewable".asInstanceOf[HITStatus]
+    val Reviewing    = "Reviewing".asInstanceOf[HITStatus]
+    val Disposed     = "Disposed".asInstanceOf[HITStatus]
 
     val values = js.Object.freeze(js.Array(Assignable, Unassignable, Reviewable, Reviewing, Disposed))
   }
@@ -1844,18 +1837,20 @@ package mturk {
       __obj.asInstanceOf[NotificationSpecification]
     }
   }
-
-  object NotificationTransportEnum {
-    val Email = "Email"
-    val SQS   = "SQS"
-    val SNS   = "SNS"
+  @js.native
+  sealed trait NotificationTransport extends js.Any
+  object NotificationTransport extends js.Object {
+    val Email = "Email".asInstanceOf[NotificationTransport]
+    val SQS   = "SQS".asInstanceOf[NotificationTransport]
+    val SNS   = "SNS".asInstanceOf[NotificationTransport]
 
     val values = js.Object.freeze(js.Array(Email, SQS, SNS))
   }
-
-  object NotifyWorkersFailureCodeEnum {
-    val SoftFailure = "SoftFailure"
-    val HardFailure = "HardFailure"
+  @js.native
+  sealed trait NotifyWorkersFailureCode extends js.Any
+  object NotifyWorkersFailureCode extends js.Object {
+    val SoftFailure = "SoftFailure".asInstanceOf[NotifyWorkersFailureCode]
+    val HardFailure = "HardFailure".asInstanceOf[NotifyWorkersFailureCode]
 
     val values = js.Object.freeze(js.Array(SoftFailure, HardFailure))
   }
@@ -2079,10 +2074,11 @@ package mturk {
       __obj.asInstanceOf[QualificationRequirement]
     }
   }
-
-  object QualificationStatusEnum {
-    val Granted = "Granted"
-    val Revoked = "Revoked"
+  @js.native
+  sealed trait QualificationStatus extends js.Any
+  object QualificationStatus extends js.Object {
+    val Granted = "Granted".asInstanceOf[QualificationStatus]
+    val Revoked = "Revoked".asInstanceOf[QualificationStatus]
 
     val values = js.Object.freeze(js.Array(Granted, Revoked))
   }
@@ -2141,10 +2137,11 @@ package mturk {
       __obj.asInstanceOf[QualificationType]
     }
   }
-
-  object QualificationTypeStatusEnum {
-    val Active   = "Active"
-    val Inactive = "Inactive"
+  @js.native
+  sealed trait QualificationTypeStatus extends js.Any
+  object QualificationTypeStatus extends js.Object {
+    val Active   = "Active".asInstanceOf[QualificationTypeStatus]
+    val Inactive = "Inactive".asInstanceOf[QualificationTypeStatus]
 
     val values = js.Object.freeze(js.Array(Active, Inactive))
   }
@@ -2265,12 +2262,13 @@ package mturk {
       __obj.asInstanceOf[ReviewActionDetail]
     }
   }
-
-  object ReviewActionStatusEnum {
-    val Intended  = "Intended"
-    val Succeeded = "Succeeded"
-    val Failed    = "Failed"
-    val Cancelled = "Cancelled"
+  @js.native
+  sealed trait ReviewActionStatus extends js.Any
+  object ReviewActionStatus extends js.Object {
+    val Intended  = "Intended".asInstanceOf[ReviewActionStatus]
+    val Succeeded = "Succeeded".asInstanceOf[ReviewActionStatus]
+    val Failed    = "Failed".asInstanceOf[ReviewActionStatus]
+    val Cancelled = "Cancelled".asInstanceOf[ReviewActionStatus]
 
     val values = js.Object.freeze(js.Array(Intended, Succeeded, Failed, Cancelled))
   }
@@ -2298,10 +2296,11 @@ package mturk {
       __obj.asInstanceOf[ReviewPolicy]
     }
   }
-
-  object ReviewPolicyLevelEnum {
-    val Assignment = "Assignment"
-    val HIT        = "HIT"
+  @js.native
+  sealed trait ReviewPolicyLevel extends js.Any
+  object ReviewPolicyLevel extends js.Object {
+    val Assignment = "Assignment".asInstanceOf[ReviewPolicyLevel]
+    val HIT        = "HIT".asInstanceOf[ReviewPolicyLevel]
 
     val values = js.Object.freeze(js.Array(Assignment, HIT))
   }
@@ -2361,10 +2360,11 @@ package mturk {
       __obj.asInstanceOf[ReviewResultDetail]
     }
   }
-
-  object ReviewableHITStatusEnum {
-    val Reviewable = "Reviewable"
-    val Reviewing  = "Reviewing"
+  @js.native
+  sealed trait ReviewableHITStatus extends js.Any
+  object ReviewableHITStatus extends js.Object {
+    val Reviewable = "Reviewable".asInstanceOf[ReviewableHITStatus]
+    val Reviewing  = "Reviewing".asInstanceOf[ReviewableHITStatus]
 
     val values = js.Object.freeze(js.Array(Reviewable, Reviewing))
   }

--- a/services/neptune/src/main/scala/facade/amazonaws/services/Neptune.scala
+++ b/services/neptune/src/main/scala/facade/amazonaws/services/Neptune.scala
@@ -7,7 +7,6 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object neptune {
-  type ApplyMethod                         = String
   type AttributeValueList                  = js.Array[String]
   type AvailabilityZoneList                = js.Array[AvailabilityZone]
   type AvailabilityZones                   = js.Array[String]
@@ -49,7 +48,6 @@ package object neptune {
   type ReadReplicaDBInstanceIdentifierList = js.Array[String]
   type ReadReplicaIdentifierList           = js.Array[String]
   type SourceIdsList                       = js.Array[String]
-  type SourceType                          = String
   type SubnetIdentifierList                = js.Array[String]
   type SubnetList                          = js.Array[Subnet]
   type SupportedCharacterSetsList          = js.Array[CharacterSet]
@@ -411,10 +409,11 @@ package neptune {
       __obj.asInstanceOf[AddTagsToResourceMessage]
     }
   }
-
-  object ApplyMethodEnum {
-    val immediate        = "immediate"
-    val `pending-reboot` = "pending-reboot"
+  @js.native
+  sealed trait ApplyMethod extends js.Any
+  object ApplyMethod extends js.Object {
+    val immediate        = "immediate".asInstanceOf[ApplyMethod]
+    val `pending-reboot` = "pending-reboot".asInstanceOf[ApplyMethod]
 
     val values = js.Object.freeze(js.Array(immediate, `pending-reboot`))
   }
@@ -4391,14 +4390,15 @@ package neptune {
       __obj.asInstanceOf[RestoreDBClusterToPointInTimeResult]
     }
   }
-
-  object SourceTypeEnum {
-    val `db-instance`         = "db-instance"
-    val `db-parameter-group`  = "db-parameter-group"
-    val `db-security-group`   = "db-security-group"
-    val `db-snapshot`         = "db-snapshot"
-    val `db-cluster`          = "db-cluster"
-    val `db-cluster-snapshot` = "db-cluster-snapshot"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val `db-instance`         = "db-instance".asInstanceOf[SourceType]
+    val `db-parameter-group`  = "db-parameter-group".asInstanceOf[SourceType]
+    val `db-security-group`   = "db-security-group".asInstanceOf[SourceType]
+    val `db-snapshot`         = "db-snapshot".asInstanceOf[SourceType]
+    val `db-cluster`          = "db-cluster".asInstanceOf[SourceType]
+    val `db-cluster-snapshot` = "db-cluster-snapshot".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/networkmanager/src/main/scala/facade/amazonaws/services/NetworkManager.scala
+++ b/services/networkmanager/src/main/scala/facade/amazonaws/services/NetworkManager.scala
@@ -7,28 +7,21 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object networkmanager {
-  type CustomerGatewayAssociationList  = js.Array[CustomerGatewayAssociation]
-  type CustomerGatewayAssociationState = String
-  type DateTime                        = js.Date
-  type DeviceList                      = js.Array[Device]
-  type DeviceState                     = String
-  type GlobalNetworkList               = js.Array[GlobalNetwork]
-  type GlobalNetworkState              = String
-  type LinkAssociationList             = js.Array[LinkAssociation]
-  type LinkAssociationState            = String
-  type LinkList                        = js.Array[Link]
-  type LinkState                       = String
-  type MaxResults                      = Int
-  type ResourceARN                     = String
-  type SiteList                        = js.Array[Site]
-  type SiteState                       = String
-  type StringList                      = js.Array[String]
-  type TagKey                          = String
-  type TagKeyList                      = js.Array[TagKey]
-  type TagList                         = js.Array[Tag]
-  type TagValue                        = String
-  type TransitGatewayRegistrationList  = js.Array[TransitGatewayRegistration]
-  type TransitGatewayRegistrationState = String
+  type CustomerGatewayAssociationList = js.Array[CustomerGatewayAssociation]
+  type DateTime                       = js.Date
+  type DeviceList                     = js.Array[Device]
+  type GlobalNetworkList              = js.Array[GlobalNetwork]
+  type LinkAssociationList            = js.Array[LinkAssociation]
+  type LinkList                       = js.Array[Link]
+  type MaxResults                     = Int
+  type ResourceARN                    = String
+  type SiteList                       = js.Array[Site]
+  type StringList                     = js.Array[String]
+  type TagKey                         = String
+  type TagKeyList                     = js.Array[TagKey]
+  type TagList                        = js.Array[Tag]
+  type TagValue                       = String
+  type TransitGatewayRegistrationList = js.Array[TransitGatewayRegistration]
 
   implicit final class NetworkManagerOps(private val service: NetworkManager) extends AnyVal {
 
@@ -469,12 +462,13 @@ package networkmanager {
       __obj.asInstanceOf[CustomerGatewayAssociation]
     }
   }
-
-  object CustomerGatewayAssociationStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val DELETING  = "DELETING"
-    val DELETED   = "DELETED"
+  @js.native
+  sealed trait CustomerGatewayAssociationState extends js.Any
+  object CustomerGatewayAssociationState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[CustomerGatewayAssociationState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[CustomerGatewayAssociationState]
+    val DELETING  = "DELETING".asInstanceOf[CustomerGatewayAssociationState]
+    val DELETED   = "DELETED".asInstanceOf[CustomerGatewayAssociationState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, DELETING, DELETED))
   }
@@ -758,12 +752,13 @@ package networkmanager {
       __obj.asInstanceOf[Device]
     }
   }
-
-  object DeviceStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val DELETING  = "DELETING"
-    val UPDATING  = "UPDATING"
+  @js.native
+  sealed trait DeviceState extends js.Any
+  object DeviceState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[DeviceState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[DeviceState]
+    val DELETING  = "DELETING".asInstanceOf[DeviceState]
+    val UPDATING  = "UPDATING".asInstanceOf[DeviceState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, DELETING, UPDATING))
   }
@@ -1175,12 +1170,13 @@ package networkmanager {
       __obj.asInstanceOf[GlobalNetwork]
     }
   }
-
-  object GlobalNetworkStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val DELETING  = "DELETING"
-    val UPDATING  = "UPDATING"
+  @js.native
+  sealed trait GlobalNetworkState extends js.Any
+  object GlobalNetworkState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[GlobalNetworkState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[GlobalNetworkState]
+    val DELETING  = "DELETING".asInstanceOf[GlobalNetworkState]
+    val UPDATING  = "UPDATING".asInstanceOf[GlobalNetworkState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, DELETING, UPDATING))
   }
@@ -1261,21 +1257,23 @@ package networkmanager {
       __obj.asInstanceOf[LinkAssociation]
     }
   }
-
-  object LinkAssociationStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val DELETING  = "DELETING"
-    val DELETED   = "DELETED"
+  @js.native
+  sealed trait LinkAssociationState extends js.Any
+  object LinkAssociationState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[LinkAssociationState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[LinkAssociationState]
+    val DELETING  = "DELETING".asInstanceOf[LinkAssociationState]
+    val DELETED   = "DELETED".asInstanceOf[LinkAssociationState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, DELETING, DELETED))
   }
-
-  object LinkStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val DELETING  = "DELETING"
-    val UPDATING  = "UPDATING"
+  @js.native
+  sealed trait LinkState extends js.Any
+  object LinkState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[LinkState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[LinkState]
+    val DELETING  = "DELETING".asInstanceOf[LinkState]
+    val UPDATING  = "UPDATING".asInstanceOf[LinkState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, DELETING, UPDATING))
   }
@@ -1417,12 +1415,13 @@ package networkmanager {
       __obj.asInstanceOf[Site]
     }
   }
-
-  object SiteStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val DELETING  = "DELETING"
-    val UPDATING  = "UPDATING"
+  @js.native
+  sealed trait SiteState extends js.Any
+  object SiteState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[SiteState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[SiteState]
+    val DELETING  = "DELETING".asInstanceOf[SiteState]
+    val UPDATING  = "UPDATING".asInstanceOf[SiteState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, DELETING, UPDATING))
   }
@@ -1507,13 +1506,14 @@ package networkmanager {
       __obj.asInstanceOf[TransitGatewayRegistration]
     }
   }
-
-  object TransitGatewayRegistrationStateEnum {
-    val PENDING   = "PENDING"
-    val AVAILABLE = "AVAILABLE"
-    val DELETING  = "DELETING"
-    val DELETED   = "DELETED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait TransitGatewayRegistrationState extends js.Any
+  object TransitGatewayRegistrationState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[TransitGatewayRegistrationState]
+    val AVAILABLE = "AVAILABLE".asInstanceOf[TransitGatewayRegistrationState]
+    val DELETING  = "DELETING".asInstanceOf[TransitGatewayRegistrationState]
+    val DELETED   = "DELETED".asInstanceOf[TransitGatewayRegistrationState]
+    val FAILED    = "FAILED".asInstanceOf[TransitGatewayRegistrationState]
 
     val values = js.Object.freeze(js.Array(PENDING, AVAILABLE, DELETING, DELETED, FAILED))
   }

--- a/services/opsworks/src/main/scala/facade/amazonaws/services/OpsWorks.scala
+++ b/services/opsworks/src/main/scala/facade/amazonaws/services/OpsWorks.scala
@@ -9,22 +9,14 @@ import facade.amazonaws._
 package object opsworks {
   type AgentVersions                        = js.Array[AgentVersion]
   type AppAttributes                        = js.Dictionary[String]
-  type AppAttributesKeys                    = String
-  type AppType                              = String
   type Apps                                 = js.Array[App]
-  type Architecture                         = String
-  type AutoScalingType                      = String
   type BlockDeviceMappings                  = js.Array[BlockDeviceMapping]
-  type CloudWatchLogsEncoding               = String
-  type CloudWatchLogsInitialPosition        = String
   type CloudWatchLogsLogStreams             = js.Array[CloudWatchLogsLogStream]
-  type CloudWatchLogsTimeZone               = String
   type Commands                             = js.Array[Command]
   type DailyAutoScalingSchedule             = js.Dictionary[Switch]
   type DataSources                          = js.Array[DataSource]
   type DateTime                             = String
   type DeploymentCommandArgs                = js.Dictionary[Strings]
-  type DeploymentCommandName                = String
   type Deployments                          = js.Array[Deployment]
   type EcsClusters                          = js.Array[EcsCluster]
   type ElasticIps                           = js.Array[ElasticIp]
@@ -33,8 +25,6 @@ package object opsworks {
   type Hour                                 = String
   type Instances                            = js.Array[Instance]
   type LayerAttributes                      = js.Dictionary[String]
-  type LayerAttributesKeys                  = String
-  type LayerType                            = String
   type Layers                               = js.Array[Layer]
   type LoadBasedAutoScalingConfigurations   = js.Array[LoadBasedAutoScalingConfiguration]
   type MaxResults                           = Int
@@ -47,11 +37,8 @@ package object opsworks {
   type RaidArrays                           = js.Array[RaidArray]
   type RdsDbInstances                       = js.Array[RdsDbInstance]
   type ResourceArn                          = String
-  type RootDeviceType                       = String
   type ServiceErrors                        = js.Array[ServiceError]
-  type SourceType                           = String
   type StackAttributes                      = js.Dictionary[String]
-  type StackAttributesKeys                  = String
   type Stacks                               = js.Array[Stack]
   type Strings                              = js.Array[String]
   type Switch                               = String
@@ -62,9 +49,7 @@ package object opsworks {
   type TimeBasedAutoScalingConfigurations   = js.Array[TimeBasedAutoScalingConfiguration]
   type UserProfiles                         = js.Array[UserProfile]
   type ValidForInMinutes                    = Int
-  type VirtualizationType                   = String
   type VolumeConfigurations                 = js.Array[VolumeConfiguration]
-  type VolumeType                           = String
   type Volumes                              = js.Array[Volume]
 
   implicit final class OpsWorksOps(private val service: OpsWorks) extends AnyVal {
@@ -395,31 +380,34 @@ package opsworks {
       __obj.asInstanceOf[App]
     }
   }
-
-  object AppAttributesKeysEnum {
-    val DocumentRoot        = "DocumentRoot"
-    val RailsEnv            = "RailsEnv"
-    val AutoBundleOnDeploy  = "AutoBundleOnDeploy"
-    val AwsFlowRubySettings = "AwsFlowRubySettings"
+  @js.native
+  sealed trait AppAttributesKeys extends js.Any
+  object AppAttributesKeys extends js.Object {
+    val DocumentRoot        = "DocumentRoot".asInstanceOf[AppAttributesKeys]
+    val RailsEnv            = "RailsEnv".asInstanceOf[AppAttributesKeys]
+    val AutoBundleOnDeploy  = "AutoBundleOnDeploy".asInstanceOf[AppAttributesKeys]
+    val AwsFlowRubySettings = "AwsFlowRubySettings".asInstanceOf[AppAttributesKeys]
 
     val values = js.Object.freeze(js.Array(DocumentRoot, RailsEnv, AutoBundleOnDeploy, AwsFlowRubySettings))
   }
-
-  object AppTypeEnum {
-    val `aws-flow-ruby` = "aws-flow-ruby"
-    val java            = "java"
-    val rails           = "rails"
-    val php             = "php"
-    val nodejs          = "nodejs"
-    val static          = "static"
-    val other           = "other"
+  @js.native
+  sealed trait AppType extends js.Any
+  object AppType extends js.Object {
+    val `aws-flow-ruby` = "aws-flow-ruby".asInstanceOf[AppType]
+    val java            = "java".asInstanceOf[AppType]
+    val rails           = "rails".asInstanceOf[AppType]
+    val php             = "php".asInstanceOf[AppType]
+    val nodejs          = "nodejs".asInstanceOf[AppType]
+    val static          = "static".asInstanceOf[AppType]
+    val other           = "other".asInstanceOf[AppType]
 
     val values = js.Object.freeze(js.Array(`aws-flow-ruby`, java, rails, php, nodejs, static, other))
   }
-
-  object ArchitectureEnum {
-    val x86_64 = "x86_64"
-    val i386   = "i386"
+  @js.native
+  sealed trait Architecture extends js.Any
+  object Architecture extends js.Object {
+    val x86_64 = "x86_64".asInstanceOf[Architecture]
+    val i386   = "i386".asInstanceOf[Architecture]
 
     val values = js.Object.freeze(js.Array(x86_64, i386))
   }
@@ -544,10 +532,11 @@ package opsworks {
       __obj.asInstanceOf[AutoScalingThresholds]
     }
   }
-
-  object AutoScalingTypeEnum {
-    val load  = "load"
-    val timer = "timer"
+  @js.native
+  sealed trait AutoScalingType extends js.Any
+  object AutoScalingType extends js.Object {
+    val load  = "load".asInstanceOf[AutoScalingType]
+    val timer = "timer".asInstanceOf[AutoScalingType]
 
     val values = js.Object.freeze(js.Array(load, timer))
   }
@@ -731,99 +720,101 @@ package opsworks {
   /**
     * Specifies the encoding of the log file so that the file can be read correctly. The default is <code>utf_8</code>. Encodings supported by Python <code>codecs.decode()</code> can be used here.
     */
-  object CloudWatchLogsEncodingEnum {
-    val ascii           = "ascii"
-    val big5            = "big5"
-    val big5hkscs       = "big5hkscs"
-    val cp037           = "cp037"
-    val cp424           = "cp424"
-    val cp437           = "cp437"
-    val cp500           = "cp500"
-    val cp720           = "cp720"
-    val cp737           = "cp737"
-    val cp775           = "cp775"
-    val cp850           = "cp850"
-    val cp852           = "cp852"
-    val cp855           = "cp855"
-    val cp856           = "cp856"
-    val cp857           = "cp857"
-    val cp858           = "cp858"
-    val cp860           = "cp860"
-    val cp861           = "cp861"
-    val cp862           = "cp862"
-    val cp863           = "cp863"
-    val cp864           = "cp864"
-    val cp865           = "cp865"
-    val cp866           = "cp866"
-    val cp869           = "cp869"
-    val cp874           = "cp874"
-    val cp875           = "cp875"
-    val cp932           = "cp932"
-    val cp949           = "cp949"
-    val cp950           = "cp950"
-    val cp1006          = "cp1006"
-    val cp1026          = "cp1026"
-    val cp1140          = "cp1140"
-    val cp1250          = "cp1250"
-    val cp1251          = "cp1251"
-    val cp1252          = "cp1252"
-    val cp1253          = "cp1253"
-    val cp1254          = "cp1254"
-    val cp1255          = "cp1255"
-    val cp1256          = "cp1256"
-    val cp1257          = "cp1257"
-    val cp1258          = "cp1258"
-    val euc_jp          = "euc_jp"
-    val euc_jis_2004    = "euc_jis_2004"
-    val euc_jisx0213    = "euc_jisx0213"
-    val euc_kr          = "euc_kr"
-    val gb2312          = "gb2312"
-    val gbk             = "gbk"
-    val gb18030         = "gb18030"
-    val hz              = "hz"
-    val iso2022_jp      = "iso2022_jp"
-    val iso2022_jp_1    = "iso2022_jp_1"
-    val iso2022_jp_2    = "iso2022_jp_2"
-    val iso2022_jp_2004 = "iso2022_jp_2004"
-    val iso2022_jp_3    = "iso2022_jp_3"
-    val iso2022_jp_ext  = "iso2022_jp_ext"
-    val iso2022_kr      = "iso2022_kr"
-    val latin_1         = "latin_1"
-    val iso8859_2       = "iso8859_2"
-    val iso8859_3       = "iso8859_3"
-    val iso8859_4       = "iso8859_4"
-    val iso8859_5       = "iso8859_5"
-    val iso8859_6       = "iso8859_6"
-    val iso8859_7       = "iso8859_7"
-    val iso8859_8       = "iso8859_8"
-    val iso8859_9       = "iso8859_9"
-    val iso8859_10      = "iso8859_10"
-    val iso8859_13      = "iso8859_13"
-    val iso8859_14      = "iso8859_14"
-    val iso8859_15      = "iso8859_15"
-    val iso8859_16      = "iso8859_16"
-    val johab           = "johab"
-    val koi8_r          = "koi8_r"
-    val koi8_u          = "koi8_u"
-    val mac_cyrillic    = "mac_cyrillic"
-    val mac_greek       = "mac_greek"
-    val mac_iceland     = "mac_iceland"
-    val mac_latin2      = "mac_latin2"
-    val mac_roman       = "mac_roman"
-    val mac_turkish     = "mac_turkish"
-    val ptcp154         = "ptcp154"
-    val shift_jis       = "shift_jis"
-    val shift_jis_2004  = "shift_jis_2004"
-    val shift_jisx0213  = "shift_jisx0213"
-    val utf_32          = "utf_32"
-    val utf_32_be       = "utf_32_be"
-    val utf_32_le       = "utf_32_le"
-    val utf_16          = "utf_16"
-    val utf_16_be       = "utf_16_be"
-    val utf_16_le       = "utf_16_le"
-    val utf_7           = "utf_7"
-    val utf_8           = "utf_8"
-    val utf_8_sig       = "utf_8_sig"
+  @js.native
+  sealed trait CloudWatchLogsEncoding extends js.Any
+  object CloudWatchLogsEncoding extends js.Object {
+    val ascii           = "ascii".asInstanceOf[CloudWatchLogsEncoding]
+    val big5            = "big5".asInstanceOf[CloudWatchLogsEncoding]
+    val big5hkscs       = "big5hkscs".asInstanceOf[CloudWatchLogsEncoding]
+    val cp037           = "cp037".asInstanceOf[CloudWatchLogsEncoding]
+    val cp424           = "cp424".asInstanceOf[CloudWatchLogsEncoding]
+    val cp437           = "cp437".asInstanceOf[CloudWatchLogsEncoding]
+    val cp500           = "cp500".asInstanceOf[CloudWatchLogsEncoding]
+    val cp720           = "cp720".asInstanceOf[CloudWatchLogsEncoding]
+    val cp737           = "cp737".asInstanceOf[CloudWatchLogsEncoding]
+    val cp775           = "cp775".asInstanceOf[CloudWatchLogsEncoding]
+    val cp850           = "cp850".asInstanceOf[CloudWatchLogsEncoding]
+    val cp852           = "cp852".asInstanceOf[CloudWatchLogsEncoding]
+    val cp855           = "cp855".asInstanceOf[CloudWatchLogsEncoding]
+    val cp856           = "cp856".asInstanceOf[CloudWatchLogsEncoding]
+    val cp857           = "cp857".asInstanceOf[CloudWatchLogsEncoding]
+    val cp858           = "cp858".asInstanceOf[CloudWatchLogsEncoding]
+    val cp860           = "cp860".asInstanceOf[CloudWatchLogsEncoding]
+    val cp861           = "cp861".asInstanceOf[CloudWatchLogsEncoding]
+    val cp862           = "cp862".asInstanceOf[CloudWatchLogsEncoding]
+    val cp863           = "cp863".asInstanceOf[CloudWatchLogsEncoding]
+    val cp864           = "cp864".asInstanceOf[CloudWatchLogsEncoding]
+    val cp865           = "cp865".asInstanceOf[CloudWatchLogsEncoding]
+    val cp866           = "cp866".asInstanceOf[CloudWatchLogsEncoding]
+    val cp869           = "cp869".asInstanceOf[CloudWatchLogsEncoding]
+    val cp874           = "cp874".asInstanceOf[CloudWatchLogsEncoding]
+    val cp875           = "cp875".asInstanceOf[CloudWatchLogsEncoding]
+    val cp932           = "cp932".asInstanceOf[CloudWatchLogsEncoding]
+    val cp949           = "cp949".asInstanceOf[CloudWatchLogsEncoding]
+    val cp950           = "cp950".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1006          = "cp1006".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1026          = "cp1026".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1140          = "cp1140".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1250          = "cp1250".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1251          = "cp1251".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1252          = "cp1252".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1253          = "cp1253".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1254          = "cp1254".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1255          = "cp1255".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1256          = "cp1256".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1257          = "cp1257".asInstanceOf[CloudWatchLogsEncoding]
+    val cp1258          = "cp1258".asInstanceOf[CloudWatchLogsEncoding]
+    val euc_jp          = "euc_jp".asInstanceOf[CloudWatchLogsEncoding]
+    val euc_jis_2004    = "euc_jis_2004".asInstanceOf[CloudWatchLogsEncoding]
+    val euc_jisx0213    = "euc_jisx0213".asInstanceOf[CloudWatchLogsEncoding]
+    val euc_kr          = "euc_kr".asInstanceOf[CloudWatchLogsEncoding]
+    val gb2312          = "gb2312".asInstanceOf[CloudWatchLogsEncoding]
+    val gbk             = "gbk".asInstanceOf[CloudWatchLogsEncoding]
+    val gb18030         = "gb18030".asInstanceOf[CloudWatchLogsEncoding]
+    val hz              = "hz".asInstanceOf[CloudWatchLogsEncoding]
+    val iso2022_jp      = "iso2022_jp".asInstanceOf[CloudWatchLogsEncoding]
+    val iso2022_jp_1    = "iso2022_jp_1".asInstanceOf[CloudWatchLogsEncoding]
+    val iso2022_jp_2    = "iso2022_jp_2".asInstanceOf[CloudWatchLogsEncoding]
+    val iso2022_jp_2004 = "iso2022_jp_2004".asInstanceOf[CloudWatchLogsEncoding]
+    val iso2022_jp_3    = "iso2022_jp_3".asInstanceOf[CloudWatchLogsEncoding]
+    val iso2022_jp_ext  = "iso2022_jp_ext".asInstanceOf[CloudWatchLogsEncoding]
+    val iso2022_kr      = "iso2022_kr".asInstanceOf[CloudWatchLogsEncoding]
+    val latin_1         = "latin_1".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_2       = "iso8859_2".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_3       = "iso8859_3".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_4       = "iso8859_4".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_5       = "iso8859_5".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_6       = "iso8859_6".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_7       = "iso8859_7".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_8       = "iso8859_8".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_9       = "iso8859_9".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_10      = "iso8859_10".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_13      = "iso8859_13".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_14      = "iso8859_14".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_15      = "iso8859_15".asInstanceOf[CloudWatchLogsEncoding]
+    val iso8859_16      = "iso8859_16".asInstanceOf[CloudWatchLogsEncoding]
+    val johab           = "johab".asInstanceOf[CloudWatchLogsEncoding]
+    val koi8_r          = "koi8_r".asInstanceOf[CloudWatchLogsEncoding]
+    val koi8_u          = "koi8_u".asInstanceOf[CloudWatchLogsEncoding]
+    val mac_cyrillic    = "mac_cyrillic".asInstanceOf[CloudWatchLogsEncoding]
+    val mac_greek       = "mac_greek".asInstanceOf[CloudWatchLogsEncoding]
+    val mac_iceland     = "mac_iceland".asInstanceOf[CloudWatchLogsEncoding]
+    val mac_latin2      = "mac_latin2".asInstanceOf[CloudWatchLogsEncoding]
+    val mac_roman       = "mac_roman".asInstanceOf[CloudWatchLogsEncoding]
+    val mac_turkish     = "mac_turkish".asInstanceOf[CloudWatchLogsEncoding]
+    val ptcp154         = "ptcp154".asInstanceOf[CloudWatchLogsEncoding]
+    val shift_jis       = "shift_jis".asInstanceOf[CloudWatchLogsEncoding]
+    val shift_jis_2004  = "shift_jis_2004".asInstanceOf[CloudWatchLogsEncoding]
+    val shift_jisx0213  = "shift_jisx0213".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_32          = "utf_32".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_32_be       = "utf_32_be".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_32_le       = "utf_32_le".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_16          = "utf_16".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_16_be       = "utf_16_be".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_16_le       = "utf_16_le".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_7           = "utf_7".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_8           = "utf_8".asInstanceOf[CloudWatchLogsEncoding]
+    val utf_8_sig       = "utf_8_sig".asInstanceOf[CloudWatchLogsEncoding]
 
     val values = js.Object.freeze(
       js.Array(
@@ -926,9 +917,11 @@ package opsworks {
   /**
     * Specifies where to start to read data (start_of_file or end_of_file). The default is start_of_file. It's only used if there is no state persisted for that log stream.
     */
-  object CloudWatchLogsInitialPositionEnum {
-    val start_of_file = "start_of_file"
-    val end_of_file   = "end_of_file"
+  @js.native
+  sealed trait CloudWatchLogsInitialPosition extends js.Any
+  object CloudWatchLogsInitialPosition extends js.Object {
+    val start_of_file = "start_of_file".asInstanceOf[CloudWatchLogsInitialPosition]
+    val end_of_file   = "end_of_file".asInstanceOf[CloudWatchLogsInitialPosition]
 
     val values = js.Object.freeze(js.Array(start_of_file, end_of_file))
   }
@@ -985,9 +978,11 @@ package opsworks {
   /**
     * The preferred time zone for logs streamed to CloudWatch Logs. Valid values are <code>LOCAL</code> and <code>UTC</code>, for Coordinated Universal Time.
     */
-  object CloudWatchLogsTimeZoneEnum {
-    val LOCAL = "LOCAL"
-    val UTC   = "UTC"
+  @js.native
+  sealed trait CloudWatchLogsTimeZone extends js.Any
+  object CloudWatchLogsTimeZone extends js.Object {
+    val LOCAL = "LOCAL".asInstanceOf[CloudWatchLogsTimeZone]
+    val UTC   = "UTC".asInstanceOf[CloudWatchLogsTimeZone]
 
     val values = js.Object.freeze(js.Array(LOCAL, UTC))
   }
@@ -1678,20 +1673,21 @@ package opsworks {
       __obj.asInstanceOf[DeploymentCommand]
     }
   }
-
-  object DeploymentCommandNameEnum {
-    val install_dependencies    = "install_dependencies"
-    val update_dependencies     = "update_dependencies"
-    val update_custom_cookbooks = "update_custom_cookbooks"
-    val execute_recipes         = "execute_recipes"
-    val configure               = "configure"
-    val setup                   = "setup"
-    val deploy                  = "deploy"
-    val rollback                = "rollback"
-    val start                   = "start"
-    val stop                    = "stop"
-    val restart                 = "restart"
-    val undeploy                = "undeploy"
+  @js.native
+  sealed trait DeploymentCommandName extends js.Any
+  object DeploymentCommandName extends js.Object {
+    val install_dependencies    = "install_dependencies".asInstanceOf[DeploymentCommandName]
+    val update_dependencies     = "update_dependencies".asInstanceOf[DeploymentCommandName]
+    val update_custom_cookbooks = "update_custom_cookbooks".asInstanceOf[DeploymentCommandName]
+    val execute_recipes         = "execute_recipes".asInstanceOf[DeploymentCommandName]
+    val configure               = "configure".asInstanceOf[DeploymentCommandName]
+    val setup                   = "setup".asInstanceOf[DeploymentCommandName]
+    val deploy                  = "deploy".asInstanceOf[DeploymentCommandName]
+    val rollback                = "rollback".asInstanceOf[DeploymentCommandName]
+    val start                   = "start".asInstanceOf[DeploymentCommandName]
+    val stop                    = "stop".asInstanceOf[DeploymentCommandName]
+    val restart                 = "restart".asInstanceOf[DeploymentCommandName]
+    val undeploy                = "undeploy".asInstanceOf[DeploymentCommandName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3237,33 +3233,34 @@ package opsworks {
       __obj.asInstanceOf[Layer]
     }
   }
-
-  object LayerAttributesKeysEnum {
-    val EcsClusterArn               = "EcsClusterArn"
-    val EnableHaproxyStats          = "EnableHaproxyStats"
-    val HaproxyStatsUrl             = "HaproxyStatsUrl"
-    val HaproxyStatsUser            = "HaproxyStatsUser"
-    val HaproxyStatsPassword        = "HaproxyStatsPassword"
-    val HaproxyHealthCheckUrl       = "HaproxyHealthCheckUrl"
-    val HaproxyHealthCheckMethod    = "HaproxyHealthCheckMethod"
-    val MysqlRootPassword           = "MysqlRootPassword"
-    val MysqlRootPasswordUbiquitous = "MysqlRootPasswordUbiquitous"
-    val GangliaUrl                  = "GangliaUrl"
-    val GangliaUser                 = "GangliaUser"
-    val GangliaPassword             = "GangliaPassword"
-    val MemcachedMemory             = "MemcachedMemory"
-    val NodejsVersion               = "NodejsVersion"
-    val RubyVersion                 = "RubyVersion"
-    val RubygemsVersion             = "RubygemsVersion"
-    val ManageBundler               = "ManageBundler"
-    val BundlerVersion              = "BundlerVersion"
-    val RailsStack                  = "RailsStack"
-    val PassengerVersion            = "PassengerVersion"
-    val Jvm                         = "Jvm"
-    val JvmVersion                  = "JvmVersion"
-    val JvmOptions                  = "JvmOptions"
-    val JavaAppServer               = "JavaAppServer"
-    val JavaAppServerVersion        = "JavaAppServerVersion"
+  @js.native
+  sealed trait LayerAttributesKeys extends js.Any
+  object LayerAttributesKeys extends js.Object {
+    val EcsClusterArn               = "EcsClusterArn".asInstanceOf[LayerAttributesKeys]
+    val EnableHaproxyStats          = "EnableHaproxyStats".asInstanceOf[LayerAttributesKeys]
+    val HaproxyStatsUrl             = "HaproxyStatsUrl".asInstanceOf[LayerAttributesKeys]
+    val HaproxyStatsUser            = "HaproxyStatsUser".asInstanceOf[LayerAttributesKeys]
+    val HaproxyStatsPassword        = "HaproxyStatsPassword".asInstanceOf[LayerAttributesKeys]
+    val HaproxyHealthCheckUrl       = "HaproxyHealthCheckUrl".asInstanceOf[LayerAttributesKeys]
+    val HaproxyHealthCheckMethod    = "HaproxyHealthCheckMethod".asInstanceOf[LayerAttributesKeys]
+    val MysqlRootPassword           = "MysqlRootPassword".asInstanceOf[LayerAttributesKeys]
+    val MysqlRootPasswordUbiquitous = "MysqlRootPasswordUbiquitous".asInstanceOf[LayerAttributesKeys]
+    val GangliaUrl                  = "GangliaUrl".asInstanceOf[LayerAttributesKeys]
+    val GangliaUser                 = "GangliaUser".asInstanceOf[LayerAttributesKeys]
+    val GangliaPassword             = "GangliaPassword".asInstanceOf[LayerAttributesKeys]
+    val MemcachedMemory             = "MemcachedMemory".asInstanceOf[LayerAttributesKeys]
+    val NodejsVersion               = "NodejsVersion".asInstanceOf[LayerAttributesKeys]
+    val RubyVersion                 = "RubyVersion".asInstanceOf[LayerAttributesKeys]
+    val RubygemsVersion             = "RubygemsVersion".asInstanceOf[LayerAttributesKeys]
+    val ManageBundler               = "ManageBundler".asInstanceOf[LayerAttributesKeys]
+    val BundlerVersion              = "BundlerVersion".asInstanceOf[LayerAttributesKeys]
+    val RailsStack                  = "RailsStack".asInstanceOf[LayerAttributesKeys]
+    val PassengerVersion            = "PassengerVersion".asInstanceOf[LayerAttributesKeys]
+    val Jvm                         = "Jvm".asInstanceOf[LayerAttributesKeys]
+    val JvmVersion                  = "JvmVersion".asInstanceOf[LayerAttributesKeys]
+    val JvmOptions                  = "JvmOptions".asInstanceOf[LayerAttributesKeys]
+    val JavaAppServer               = "JavaAppServer".asInstanceOf[LayerAttributesKeys]
+    val JavaAppServerVersion        = "JavaAppServerVersion".asInstanceOf[LayerAttributesKeys]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3295,20 +3292,21 @@ package opsworks {
       )
     )
   }
-
-  object LayerTypeEnum {
-    val `aws-flow-ruby`     = "aws-flow-ruby"
-    val `ecs-cluster`       = "ecs-cluster"
-    val `java-app`          = "java-app"
-    val lb                  = "lb"
-    val web                 = "web"
-    val `php-app`           = "php-app"
-    val `rails-app`         = "rails-app"
-    val `nodejs-app`        = "nodejs-app"
-    val memcached           = "memcached"
-    val `db-master`         = "db-master"
-    val `monitoring-master` = "monitoring-master"
-    val custom              = "custom"
+  @js.native
+  sealed trait LayerType extends js.Any
+  object LayerType extends js.Object {
+    val `aws-flow-ruby`     = "aws-flow-ruby".asInstanceOf[LayerType]
+    val `ecs-cluster`       = "ecs-cluster".asInstanceOf[LayerType]
+    val `java-app`          = "java-app".asInstanceOf[LayerType]
+    val lb                  = "lb".asInstanceOf[LayerType]
+    val web                 = "web".asInstanceOf[LayerType]
+    val `php-app`           = "php-app".asInstanceOf[LayerType]
+    val `rails-app`         = "rails-app".asInstanceOf[LayerType]
+    val `nodejs-app`        = "nodejs-app".asInstanceOf[LayerType]
+    val memcached           = "memcached".asInstanceOf[LayerType]
+    val `db-master`         = "db-master".asInstanceOf[LayerType]
+    val `monitoring-master` = "monitoring-master".asInstanceOf[LayerType]
+    val custom              = "custom".asInstanceOf[LayerType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3885,10 +3883,11 @@ package opsworks {
       __obj.asInstanceOf[ReportedOs]
     }
   }
-
-  object RootDeviceTypeEnum {
-    val ebs              = "ebs"
-    val `instance-store` = "instance-store"
+  @js.native
+  sealed trait RootDeviceType extends js.Any
+  object RootDeviceType extends js.Object {
+    val ebs              = "ebs".asInstanceOf[RootDeviceType]
+    val `instance-store` = "instance-store".asInstanceOf[RootDeviceType]
 
     val values = js.Object.freeze(js.Array(ebs, `instance-store`))
   }
@@ -4090,12 +4089,13 @@ package opsworks {
       __obj.asInstanceOf[Source]
     }
   }
-
-  object SourceTypeEnum {
-    val git     = "git"
-    val svn     = "svn"
-    val archive = "archive"
-    val s3      = "s3"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val git     = "git".asInstanceOf[SourceType]
+    val svn     = "svn".asInstanceOf[SourceType]
+    val archive = "archive".asInstanceOf[SourceType]
+    val s3      = "s3".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(js.Array(git, svn, archive, s3))
   }
@@ -4212,9 +4212,10 @@ package opsworks {
       __obj.asInstanceOf[Stack]
     }
   }
-
-  object StackAttributesKeysEnum {
-    val Color = "Color"
+  @js.native
+  sealed trait StackAttributesKeys extends js.Any
+  object StackAttributesKeys extends js.Object {
+    val Color = "Color".asInstanceOf[StackAttributesKeys]
 
     val values = js.Object.freeze(js.Array(Color))
   }
@@ -4862,10 +4863,11 @@ package opsworks {
       __obj.asInstanceOf[UserProfile]
     }
   }
-
-  object VirtualizationTypeEnum {
-    val paravirtual = "paravirtual"
-    val hvm         = "hvm"
+  @js.native
+  sealed trait VirtualizationType extends js.Any
+  object VirtualizationType extends js.Object {
+    val paravirtual = "paravirtual".asInstanceOf[VirtualizationType]
+    val hvm         = "hvm".asInstanceOf[VirtualizationType]
 
     val values = js.Object.freeze(js.Array(paravirtual, hvm))
   }
@@ -4966,11 +4968,12 @@ package opsworks {
       __obj.asInstanceOf[VolumeConfiguration]
     }
   }
-
-  object VolumeTypeEnum {
-    val gp2      = "gp2"
-    val io1      = "io1"
-    val standard = "standard"
+  @js.native
+  sealed trait VolumeType extends js.Any
+  object VolumeType extends js.Object {
+    val gp2      = "gp2".asInstanceOf[VolumeType]
+    val io1      = "io1".asInstanceOf[VolumeType]
+    val standard = "standard".asInstanceOf[VolumeType]
 
     val values = js.Object.freeze(js.Array(gp2, io1, standard))
   }

--- a/services/opsworkscm/src/main/scala/facade/amazonaws/services/OpsWorksCM.scala
+++ b/services/opsworkscm/src/main/scala/facade/amazonaws/services/OpsWorksCM.scala
@@ -13,8 +13,6 @@ package object opsworkscm {
   type AttributeValue                 = String
   type BackupId                       = String
   type BackupRetentionCountDefinition = Int
-  type BackupStatus                   = String
-  type BackupType                     = String
   type Backups                        = js.Array[Backup]
   type CustomCertificate              = String
   type CustomDomain                   = String
@@ -24,15 +22,12 @@ package object opsworkscm {
   type EngineAttributes               = js.Array[EngineAttribute]
   type InstanceProfileArn             = String
   type KeyPair                        = String
-  type MaintenanceStatus              = String
   type MaxResults                     = Int
   type NextToken                      = String
-  type NodeAssociationStatus          = String
   type NodeAssociationStatusToken     = String
   type NodeName                       = String
   type ServerEvents                   = js.Array[ServerEvent]
   type ServerName                     = String
-  type ServerStatus                   = String
   type Servers                        = js.Array[Server]
   type ServiceRoleArn                 = String
   type Strings                        = js.Array[String]
@@ -281,19 +276,21 @@ package opsworkscm {
       __obj.asInstanceOf[Backup]
     }
   }
-
-  object BackupStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val OK          = "OK"
-    val FAILED      = "FAILED"
-    val DELETING    = "DELETING"
+  @js.native
+  sealed trait BackupStatus extends js.Any
+  object BackupStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[BackupStatus]
+    val OK          = "OK".asInstanceOf[BackupStatus]
+    val FAILED      = "FAILED".asInstanceOf[BackupStatus]
+    val DELETING    = "DELETING".asInstanceOf[BackupStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, OK, FAILED, DELETING))
   }
-
-  object BackupTypeEnum {
-    val AUTOMATED = "AUTOMATED"
-    val MANUAL    = "MANUAL"
+  @js.native
+  sealed trait BackupType extends js.Any
+  object BackupType extends js.Object {
+    val AUTOMATED = "AUTOMATED".asInstanceOf[BackupType]
+    val MANUAL    = "MANUAL".asInstanceOf[BackupType]
 
     val values = js.Object.freeze(js.Array(AUTOMATED, MANUAL))
   }
@@ -842,10 +839,11 @@ package opsworkscm {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object MaintenanceStatusEnum {
-    val SUCCESS = "SUCCESS"
-    val FAILED  = "FAILED"
+  @js.native
+  sealed trait MaintenanceStatus extends js.Any
+  object MaintenanceStatus extends js.Object {
+    val SUCCESS = "SUCCESS".asInstanceOf[MaintenanceStatus]
+    val FAILED  = "FAILED".asInstanceOf[MaintenanceStatus]
 
     val values = js.Object.freeze(js.Array(SUCCESS, FAILED))
   }
@@ -856,10 +854,12 @@ package opsworkscm {
     *  * <code>FAILED</code>: The association or disassociation failed.
     *  * <code>IN_PROGRESS</code>: The association or disassociation is still in progress.
     */
-  object NodeAssociationStatusEnum {
-    val SUCCESS     = "SUCCESS"
-    val FAILED      = "FAILED"
-    val IN_PROGRESS = "IN_PROGRESS"
+  @js.native
+  sealed trait NodeAssociationStatus extends js.Any
+  object NodeAssociationStatus extends js.Object {
+    val SUCCESS     = "SUCCESS".asInstanceOf[NodeAssociationStatus]
+    val FAILED      = "FAILED".asInstanceOf[NodeAssociationStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[NodeAssociationStatus]
 
     val values = js.Object.freeze(js.Array(SUCCESS, FAILED, IN_PROGRESS))
   }
@@ -1021,21 +1021,22 @@ package opsworkscm {
       __obj.asInstanceOf[ServerEvent]
     }
   }
-
-  object ServerStatusEnum {
-    val BACKING_UP        = "BACKING_UP"
-    val CONNECTION_LOST   = "CONNECTION_LOST"
-    val CREATING          = "CREATING"
-    val DELETING          = "DELETING"
-    val MODIFYING         = "MODIFYING"
-    val FAILED            = "FAILED"
-    val HEALTHY           = "HEALTHY"
-    val RUNNING           = "RUNNING"
-    val RESTORING         = "RESTORING"
-    val SETUP             = "SETUP"
-    val UNDER_MAINTENANCE = "UNDER_MAINTENANCE"
-    val UNHEALTHY         = "UNHEALTHY"
-    val TERMINATED        = "TERMINATED"
+  @js.native
+  sealed trait ServerStatus extends js.Any
+  object ServerStatus extends js.Object {
+    val BACKING_UP        = "BACKING_UP".asInstanceOf[ServerStatus]
+    val CONNECTION_LOST   = "CONNECTION_LOST".asInstanceOf[ServerStatus]
+    val CREATING          = "CREATING".asInstanceOf[ServerStatus]
+    val DELETING          = "DELETING".asInstanceOf[ServerStatus]
+    val MODIFYING         = "MODIFYING".asInstanceOf[ServerStatus]
+    val FAILED            = "FAILED".asInstanceOf[ServerStatus]
+    val HEALTHY           = "HEALTHY".asInstanceOf[ServerStatus]
+    val RUNNING           = "RUNNING".asInstanceOf[ServerStatus]
+    val RESTORING         = "RESTORING".asInstanceOf[ServerStatus]
+    val SETUP             = "SETUP".asInstanceOf[ServerStatus]
+    val UNDER_MAINTENANCE = "UNDER_MAINTENANCE".asInstanceOf[ServerStatus]
+    val UNHEALTHY         = "UNHEALTHY".asInstanceOf[ServerStatus]
+    val TERMINATED        = "TERMINATED".asInstanceOf[ServerStatus]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/organizations/src/main/scala/facade/amazonaws/services/Organizations.scala
+++ b/services/organizations/src/main/scala/facade/amazonaws/services/Organizations.scala
@@ -7,75 +7,59 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object organizations {
-  type AccountArn                 = String
-  type AccountId                  = String
-  type AccountJoinedMethod        = String
-  type AccountName                = String
-  type AccountStatus              = String
-  type Accounts                   = js.Array[Account]
-  type ActionType                 = String
-  type AwsManagedPolicy           = Boolean
-  type ChildId                    = String
-  type ChildType                  = String
-  type Children                   = js.Array[Child]
-  type CreateAccountFailureReason = String
-  type CreateAccountRequestId     = String
-  type CreateAccountState         = String
-  type CreateAccountStates        = js.Array[CreateAccountState]
-  type CreateAccountStatuses      = js.Array[CreateAccountStatus]
-  type EffectivePolicyType        = String
-  type Email                      = String
-  type EnabledServicePrincipals   = js.Array[EnabledServicePrincipal]
-  type GenericArn                 = String
-  type HandshakeArn               = String
-  type HandshakeId                = String
-  type HandshakeNotes             = String
-  type HandshakeParties           = js.Array[HandshakeParty]
-  type HandshakePartyId           = String
-  type HandshakePartyType         = String
-  type HandshakeResourceType      = String
-  type HandshakeResourceValue     = String
-  type HandshakeResources         = js.Array[HandshakeResource]
-  type HandshakeState             = String
-  type Handshakes                 = js.Array[Handshake]
-  type IAMUserAccessToBilling     = String
-  type MaxResults                 = Int
-  type NextToken                  = String
-  type OrganizationArn            = String
-  type OrganizationFeatureSet     = String
-  type OrganizationId             = String
-  type OrganizationalUnitArn      = String
-  type OrganizationalUnitId       = String
-  type OrganizationalUnitName     = String
-  type OrganizationalUnits        = js.Array[OrganizationalUnit]
-  type ParentId                   = String
-  type ParentType                 = String
-  type Parents                    = js.Array[Parent]
-  type Policies                   = js.Array[PolicySummary]
-  type PolicyArn                  = String
-  type PolicyContent              = String
-  type PolicyDescription          = String
-  type PolicyId                   = String
-  type PolicyName                 = String
-  type PolicyTargetId             = String
-  type PolicyTargets              = js.Array[PolicyTargetSummary]
-  type PolicyType                 = String
-  type PolicyTypeStatus           = String
-  type PolicyTypes                = js.Array[PolicyTypeSummary]
-  type RoleName                   = String
-  type RootArn                    = String
-  type RootId                     = String
-  type RootName                   = String
-  type Roots                      = js.Array[Root]
-  type ServicePrincipal           = String
-  type TagKey                     = String
-  type TagKeys                    = js.Array[TagKey]
-  type TagValue                   = String
-  type TaggableResourceId         = String
-  type Tags                       = js.Array[Tag]
-  type TargetName                 = String
-  type TargetType                 = String
-  type Timestamp                  = js.Date
+  type AccountArn               = String
+  type AccountId                = String
+  type AccountName              = String
+  type Accounts                 = js.Array[Account]
+  type AwsManagedPolicy         = Boolean
+  type ChildId                  = String
+  type Children                 = js.Array[Child]
+  type CreateAccountRequestId   = String
+  type CreateAccountStates      = js.Array[CreateAccountState]
+  type CreateAccountStatuses    = js.Array[CreateAccountStatus]
+  type Email                    = String
+  type EnabledServicePrincipals = js.Array[EnabledServicePrincipal]
+  type GenericArn               = String
+  type HandshakeArn             = String
+  type HandshakeId              = String
+  type HandshakeNotes           = String
+  type HandshakeParties         = js.Array[HandshakeParty]
+  type HandshakePartyId         = String
+  type HandshakeResourceValue   = String
+  type HandshakeResources       = js.Array[HandshakeResource]
+  type Handshakes               = js.Array[Handshake]
+  type MaxResults               = Int
+  type NextToken                = String
+  type OrganizationArn          = String
+  type OrganizationId           = String
+  type OrganizationalUnitArn    = String
+  type OrganizationalUnitId     = String
+  type OrganizationalUnitName   = String
+  type OrganizationalUnits      = js.Array[OrganizationalUnit]
+  type ParentId                 = String
+  type Parents                  = js.Array[Parent]
+  type Policies                 = js.Array[PolicySummary]
+  type PolicyArn                = String
+  type PolicyContent            = String
+  type PolicyDescription        = String
+  type PolicyId                 = String
+  type PolicyName               = String
+  type PolicyTargetId           = String
+  type PolicyTargets            = js.Array[PolicyTargetSummary]
+  type PolicyTypes              = js.Array[PolicyTypeSummary]
+  type RoleName                 = String
+  type RootArn                  = String
+  type RootId                   = String
+  type RootName                 = String
+  type Roots                    = js.Array[Root]
+  type ServicePrincipal         = String
+  type TagKey                   = String
+  type TagKeys                  = js.Array[TagKey]
+  type TagValue                 = String
+  type TaggableResourceId       = String
+  type Tags                     = js.Array[Tag]
+  type TargetName               = String
+  type Timestamp                = js.Date
 
   implicit final class OrganizationsOps(private val service: Organizations) extends AnyVal {
 
@@ -332,26 +316,29 @@ package organizations {
       __obj.asInstanceOf[Account]
     }
   }
-
-  object AccountJoinedMethodEnum {
-    val INVITED = "INVITED"
-    val CREATED = "CREATED"
+  @js.native
+  sealed trait AccountJoinedMethod extends js.Any
+  object AccountJoinedMethod extends js.Object {
+    val INVITED = "INVITED".asInstanceOf[AccountJoinedMethod]
+    val CREATED = "CREATED".asInstanceOf[AccountJoinedMethod]
 
     val values = js.Object.freeze(js.Array(INVITED, CREATED))
   }
-
-  object AccountStatusEnum {
-    val ACTIVE    = "ACTIVE"
-    val SUSPENDED = "SUSPENDED"
+  @js.native
+  sealed trait AccountStatus extends js.Any
+  object AccountStatus extends js.Object {
+    val ACTIVE    = "ACTIVE".asInstanceOf[AccountStatus]
+    val SUSPENDED = "SUSPENDED".asInstanceOf[AccountStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, SUSPENDED))
   }
-
-  object ActionTypeEnum {
-    val INVITE                                = "INVITE"
-    val ENABLE_ALL_FEATURES                   = "ENABLE_ALL_FEATURES"
-    val APPROVE_ALL_FEATURES                  = "APPROVE_ALL_FEATURES"
-    val ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE = "ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE"
+  @js.native
+  sealed trait ActionType extends js.Any
+  object ActionType extends js.Object {
+    val INVITE                                = "INVITE".asInstanceOf[ActionType]
+    val ENABLE_ALL_FEATURES                   = "ENABLE_ALL_FEATURES".asInstanceOf[ActionType]
+    val APPROVE_ALL_FEATURES                  = "APPROVE_ALL_FEATURES".asInstanceOf[ActionType]
+    val ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE = "ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE".asInstanceOf[ActionType]
 
     val values = js.Object.freeze(
       js.Array(INVITE, ENABLE_ALL_FEATURES, APPROVE_ALL_FEATURES, ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE)
@@ -434,22 +421,24 @@ package organizations {
       __obj.asInstanceOf[Child]
     }
   }
-
-  object ChildTypeEnum {
-    val ACCOUNT             = "ACCOUNT"
-    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT"
+  @js.native
+  sealed trait ChildType extends js.Any
+  object ChildType extends js.Object {
+    val ACCOUNT             = "ACCOUNT".asInstanceOf[ChildType]
+    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT".asInstanceOf[ChildType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT, ORGANIZATIONAL_UNIT))
   }
-
-  object CreateAccountFailureReasonEnum {
-    val ACCOUNT_LIMIT_EXCEEDED          = "ACCOUNT_LIMIT_EXCEEDED"
-    val EMAIL_ALREADY_EXISTS            = "EMAIL_ALREADY_EXISTS"
-    val INVALID_ADDRESS                 = "INVALID_ADDRESS"
-    val INVALID_EMAIL                   = "INVALID_EMAIL"
-    val CONCURRENT_ACCOUNT_MODIFICATION = "CONCURRENT_ACCOUNT_MODIFICATION"
-    val INTERNAL_FAILURE                = "INTERNAL_FAILURE"
-    val GOVCLOUD_ACCOUNT_ALREADY_EXISTS = "GOVCLOUD_ACCOUNT_ALREADY_EXISTS"
+  @js.native
+  sealed trait CreateAccountFailureReason extends js.Any
+  object CreateAccountFailureReason extends js.Object {
+    val ACCOUNT_LIMIT_EXCEEDED          = "ACCOUNT_LIMIT_EXCEEDED".asInstanceOf[CreateAccountFailureReason]
+    val EMAIL_ALREADY_EXISTS            = "EMAIL_ALREADY_EXISTS".asInstanceOf[CreateAccountFailureReason]
+    val INVALID_ADDRESS                 = "INVALID_ADDRESS".asInstanceOf[CreateAccountFailureReason]
+    val INVALID_EMAIL                   = "INVALID_EMAIL".asInstanceOf[CreateAccountFailureReason]
+    val CONCURRENT_ACCOUNT_MODIFICATION = "CONCURRENT_ACCOUNT_MODIFICATION".asInstanceOf[CreateAccountFailureReason]
+    val INTERNAL_FAILURE                = "INTERNAL_FAILURE".asInstanceOf[CreateAccountFailureReason]
+    val GOVCLOUD_ACCOUNT_ALREADY_EXISTS = "GOVCLOUD_ACCOUNT_ALREADY_EXISTS".asInstanceOf[CreateAccountFailureReason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -506,11 +495,12 @@ package organizations {
       __obj.asInstanceOf[CreateAccountResponse]
     }
   }
-
-  object CreateAccountStateEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait CreateAccountState extends js.Any
+  object CreateAccountState extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[CreateAccountState]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[CreateAccountState]
+    val FAILED      = "FAILED".asInstanceOf[CreateAccountState]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, SUCCEEDED, FAILED))
   }
@@ -1106,9 +1096,10 @@ package organizations {
       __obj.asInstanceOf[EffectivePolicy]
     }
   }
-
-  object EffectivePolicyTypeEnum {
-    val TAG_POLICY = "TAG_POLICY"
+  @js.native
+  sealed trait EffectivePolicyType extends js.Any
+  object EffectivePolicyType extends js.Object {
+    val TAG_POLICY = "TAG_POLICY".asInstanceOf[EffectivePolicyType]
 
     val values = js.Object.freeze(js.Array(TAG_POLICY))
   }
@@ -1305,11 +1296,12 @@ package organizations {
       __obj.asInstanceOf[HandshakeParty]
     }
   }
-
-  object HandshakePartyTypeEnum {
-    val ACCOUNT      = "ACCOUNT"
-    val ORGANIZATION = "ORGANIZATION"
-    val EMAIL        = "EMAIL"
+  @js.native
+  sealed trait HandshakePartyType extends js.Any
+  object HandshakePartyType extends js.Object {
+    val ACCOUNT      = "ACCOUNT".asInstanceOf[HandshakePartyType]
+    val ORGANIZATION = "ORGANIZATION".asInstanceOf[HandshakePartyType]
+    val EMAIL        = "EMAIL".asInstanceOf[HandshakePartyType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT, ORGANIZATION, EMAIL))
   }
@@ -1338,16 +1330,17 @@ package organizations {
       __obj.asInstanceOf[HandshakeResource]
     }
   }
-
-  object HandshakeResourceTypeEnum {
-    val ACCOUNT                  = "ACCOUNT"
-    val ORGANIZATION             = "ORGANIZATION"
-    val ORGANIZATION_FEATURE_SET = "ORGANIZATION_FEATURE_SET"
-    val EMAIL                    = "EMAIL"
-    val MASTER_EMAIL             = "MASTER_EMAIL"
-    val MASTER_NAME              = "MASTER_NAME"
-    val NOTES                    = "NOTES"
-    val PARENT_HANDSHAKE         = "PARENT_HANDSHAKE"
+  @js.native
+  sealed trait HandshakeResourceType extends js.Any
+  object HandshakeResourceType extends js.Object {
+    val ACCOUNT                  = "ACCOUNT".asInstanceOf[HandshakeResourceType]
+    val ORGANIZATION             = "ORGANIZATION".asInstanceOf[HandshakeResourceType]
+    val ORGANIZATION_FEATURE_SET = "ORGANIZATION_FEATURE_SET".asInstanceOf[HandshakeResourceType]
+    val EMAIL                    = "EMAIL".asInstanceOf[HandshakeResourceType]
+    val MASTER_EMAIL             = "MASTER_EMAIL".asInstanceOf[HandshakeResourceType]
+    val MASTER_NAME              = "MASTER_NAME".asInstanceOf[HandshakeResourceType]
+    val NOTES                    = "NOTES".asInstanceOf[HandshakeResourceType]
+    val PARENT_HANDSHAKE         = "PARENT_HANDSHAKE".asInstanceOf[HandshakeResourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1362,21 +1355,23 @@ package organizations {
       )
     )
   }
-
-  object HandshakeStateEnum {
-    val REQUESTED = "REQUESTED"
-    val OPEN      = "OPEN"
-    val CANCELED  = "CANCELED"
-    val ACCEPTED  = "ACCEPTED"
-    val DECLINED  = "DECLINED"
-    val EXPIRED   = "EXPIRED"
+  @js.native
+  sealed trait HandshakeState extends js.Any
+  object HandshakeState extends js.Object {
+    val REQUESTED = "REQUESTED".asInstanceOf[HandshakeState]
+    val OPEN      = "OPEN".asInstanceOf[HandshakeState]
+    val CANCELED  = "CANCELED".asInstanceOf[HandshakeState]
+    val ACCEPTED  = "ACCEPTED".asInstanceOf[HandshakeState]
+    val DECLINED  = "DECLINED".asInstanceOf[HandshakeState]
+    val EXPIRED   = "EXPIRED".asInstanceOf[HandshakeState]
 
     val values = js.Object.freeze(js.Array(REQUESTED, OPEN, CANCELED, ACCEPTED, DECLINED, EXPIRED))
   }
-
-  object IAMUserAccessToBillingEnum {
-    val ALLOW = "ALLOW"
-    val DENY  = "DENY"
+  @js.native
+  sealed trait IAMUserAccessToBilling extends js.Any
+  object IAMUserAccessToBilling extends js.Object {
+    val ALLOW = "ALLOW".asInstanceOf[IAMUserAccessToBilling]
+    val DENY  = "DENY".asInstanceOf[IAMUserAccessToBilling]
 
     val values = js.Object.freeze(js.Array(ALLOW, DENY))
   }
@@ -2062,10 +2057,11 @@ package organizations {
       __obj.asInstanceOf[Organization]
     }
   }
-
-  object OrganizationFeatureSetEnum {
-    val ALL                  = "ALL"
-    val CONSOLIDATED_BILLING = "CONSOLIDATED_BILLING"
+  @js.native
+  sealed trait OrganizationFeatureSet extends js.Any
+  object OrganizationFeatureSet extends js.Object {
+    val ALL                  = "ALL".asInstanceOf[OrganizationFeatureSet]
+    val CONSOLIDATED_BILLING = "CONSOLIDATED_BILLING".asInstanceOf[OrganizationFeatureSet]
 
     val values = js.Object.freeze(js.Array(ALL, CONSOLIDATED_BILLING))
   }
@@ -2116,10 +2112,11 @@ package organizations {
       __obj.asInstanceOf[Parent]
     }
   }
-
-  object ParentTypeEnum {
-    val ROOT                = "ROOT"
-    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT"
+  @js.native
+  sealed trait ParentType extends js.Any
+  object ParentType extends js.Object {
+    val ROOT                = "ROOT".asInstanceOf[ParentType]
+    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT".asInstanceOf[ParentType]
 
     val values = js.Object.freeze(js.Array(ROOT, ORGANIZATIONAL_UNIT))
   }
@@ -2207,18 +2204,20 @@ package organizations {
       __obj.asInstanceOf[PolicyTargetSummary]
     }
   }
-
-  object PolicyTypeEnum {
-    val SERVICE_CONTROL_POLICY = "SERVICE_CONTROL_POLICY"
-    val TAG_POLICY             = "TAG_POLICY"
+  @js.native
+  sealed trait PolicyType extends js.Any
+  object PolicyType extends js.Object {
+    val SERVICE_CONTROL_POLICY = "SERVICE_CONTROL_POLICY".asInstanceOf[PolicyType]
+    val TAG_POLICY             = "TAG_POLICY".asInstanceOf[PolicyType]
 
     val values = js.Object.freeze(js.Array(SERVICE_CONTROL_POLICY, TAG_POLICY))
   }
-
-  object PolicyTypeStatusEnum {
-    val ENABLED         = "ENABLED"
-    val PENDING_ENABLE  = "PENDING_ENABLE"
-    val PENDING_DISABLE = "PENDING_DISABLE"
+  @js.native
+  sealed trait PolicyTypeStatus extends js.Any
+  object PolicyTypeStatus extends js.Object {
+    val ENABLED         = "ENABLED".asInstanceOf[PolicyTypeStatus]
+    val PENDING_ENABLE  = "PENDING_ENABLE".asInstanceOf[PolicyTypeStatus]
+    val PENDING_DISABLE = "PENDING_DISABLE".asInstanceOf[PolicyTypeStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, PENDING_ENABLE, PENDING_DISABLE))
   }
@@ -2335,11 +2334,12 @@ package organizations {
       __obj.asInstanceOf[TagResourceRequest]
     }
   }
-
-  object TargetTypeEnum {
-    val ACCOUNT             = "ACCOUNT"
-    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT"
-    val ROOT                = "ROOT"
+  @js.native
+  sealed trait TargetType extends js.Any
+  object TargetType extends js.Object {
+    val ACCOUNT             = "ACCOUNT".asInstanceOf[TargetType]
+    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT".asInstanceOf[TargetType]
+    val ROOT                = "ROOT".asInstanceOf[TargetType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT, ORGANIZATIONAL_UNIT, ROOT))
   }

--- a/services/personalize/src/main/scala/facade/amazonaws/services/Personalize.scala
+++ b/services/personalize/src/main/scala/facade/amazonaws/services/Personalize.scala
@@ -54,7 +54,6 @@ package object personalize {
   type ParameterValue                         = String
   type PerformAutoML                          = Boolean
   type PerformHPO                             = Boolean
-  type RecipeProvider                         = String
   type RecipeType                             = String
   type Recipes                                = js.Array[RecipeSummary]
   type ResourceConfig                         = js.Dictionary[ParameterValue]
@@ -67,7 +66,6 @@ package object personalize {
   type TrackingId                             = String
   type TrainingHours                          = Double
   type TrainingInputMode                      = String
-  type TrainingMode                           = String
   type TransactionsPerSecond                  = Int
   type Tunable                                = Boolean
 
@@ -2648,9 +2646,10 @@ package personalize {
       __obj.asInstanceOf[Recipe]
     }
   }
-
-  object RecipeProviderEnum {
-    val SERVICE = "SERVICE"
+  @js.native
+  sealed trait RecipeProvider extends js.Any
+  object RecipeProvider extends js.Object {
+    val SERVICE = "SERVICE".asInstanceOf[RecipeProvider]
 
     val values = js.Object.freeze(js.Array(SERVICE))
   }
@@ -2917,10 +2916,11 @@ package personalize {
       __obj.asInstanceOf[SolutionVersionSummary]
     }
   }
-
-  object TrainingModeEnum {
-    val FULL   = "FULL"
-    val UPDATE = "UPDATE"
+  @js.native
+  sealed trait TrainingMode extends js.Any
+  object TrainingMode extends js.Object {
+    val FULL   = "FULL".asInstanceOf[TrainingMode]
+    val UPDATE = "UPDATE".asInstanceOf[TrainingMode]
 
     val values = js.Object.freeze(js.Array(FULL, UPDATE))
   }

--- a/services/pi/src/main/scala/facade/amazonaws/services/PI.scala
+++ b/services/pi/src/main/scala/facade/amazonaws/services/PI.scala
@@ -18,7 +18,6 @@ package object pi {
   type MetricQueryList             = js.Array[MetricQuery]
   type MetricValuesList            = js.Array[Double]
   type ResponsePartitionKeyList    = js.Array[ResponsePartitionKey]
-  type ServiceType                 = String
   type StringList                  = js.Array[String]
 
   implicit final class PIOps(private val service: PI) extends AnyVal {
@@ -377,9 +376,10 @@ package pi {
       __obj.asInstanceOf[ResponseResourceMetricKey]
     }
   }
-
-  object ServiceTypeEnum {
-    val RDS = "RDS"
+  @js.native
+  sealed trait ServiceType extends js.Any
+  object ServiceType extends js.Object {
+    val RDS = "RDS".asInstanceOf[ServiceType]
 
     val values = js.Object.freeze(js.Array(RDS))
   }

--- a/services/pinpoint/src/main/scala/facade/amazonaws/services/Pinpoint.scala
+++ b/services/pinpoint/src/main/scala/facade/amazonaws/services/Pinpoint.scala
@@ -7,18 +7,6 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object pinpoint {
-  type Action                          = String
-  type AttributeType                   = String
-  type CampaignStatus                  = String
-  type ChannelType                     = String
-  type DeliveryStatus                  = String
-  type DimensionType                   = String
-  type Duration                        = String
-  type FilterType                      = String
-  type Format                          = String
-  type Frequency                       = String
-  type Include                         = String
-  type JobStatus                       = String
   type ListOfActivityResponse          = js.Array[ActivityResponse]
   type ListOfApplicationResponse       = js.Array[ApplicationResponse]
   type ListOfCampaignResponse          = js.Array[CampaignResponse]
@@ -58,15 +46,6 @@ package object pinpoint {
   type MapOf__double                   = js.Dictionary[__double]
   type MapOf__integer                  = js.Dictionary[__integer]
   type MapOf__string                   = js.Dictionary[__string]
-  type MessageType                     = String
-  type Mode                            = String
-  type Operator                        = String
-  type RecencyType                     = String
-  type SegmentType                     = String
-  type SourceType                      = String
-  type State                           = String
-  type TemplateType                    = String
-  type Type                            = String
   type __blob                          = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type __boolean                       = Boolean
   type __double                        = Double
@@ -1085,11 +1064,12 @@ package pinpoint {
       __obj.asInstanceOf[APNSVoipSandboxChannelResponse]
     }
   }
-
-  object ActionEnum {
-    val OPEN_APP  = "OPEN_APP"
-    val DEEP_LINK = "DEEP_LINK"
-    val URL       = "URL"
+  @js.native
+  sealed trait Action extends js.Any
+  object Action extends js.Object {
+    val OPEN_APP  = "OPEN_APP".asInstanceOf[Action]
+    val DEEP_LINK = "DEEP_LINK".asInstanceOf[Action]
+    val URL       = "URL".asInstanceOf[Action]
 
     val values = js.Object.freeze(js.Array(OPEN_APP, DEEP_LINK, URL))
   }
@@ -1433,10 +1413,11 @@ package pinpoint {
       __obj.asInstanceOf[AttributeDimension]
     }
   }
-
-  object AttributeTypeEnum {
-    val INCLUSIVE = "INCLUSIVE"
-    val EXCLUSIVE = "EXCLUSIVE"
+  @js.native
+  sealed trait AttributeType extends js.Any
+  object AttributeType extends js.Object {
+    val INCLUSIVE = "INCLUSIVE".asInstanceOf[AttributeType]
+    val EXCLUSIVE = "EXCLUSIVE".asInstanceOf[AttributeType]
 
     val values = js.Object.freeze(js.Array(INCLUSIVE, EXCLUSIVE))
   }
@@ -1899,14 +1880,15 @@ package pinpoint {
       __obj.asInstanceOf[CampaignState]
     }
   }
-
-  object CampaignStatusEnum {
-    val SCHEDULED        = "SCHEDULED"
-    val EXECUTING        = "EXECUTING"
-    val PENDING_NEXT_RUN = "PENDING_NEXT_RUN"
-    val COMPLETED        = "COMPLETED"
-    val PAUSED           = "PAUSED"
-    val DELETED          = "DELETED"
+  @js.native
+  sealed trait CampaignStatus extends js.Any
+  object CampaignStatus extends js.Object {
+    val SCHEDULED        = "SCHEDULED".asInstanceOf[CampaignStatus]
+    val EXECUTING        = "EXECUTING".asInstanceOf[CampaignStatus]
+    val PENDING_NEXT_RUN = "PENDING_NEXT_RUN".asInstanceOf[CampaignStatus]
+    val COMPLETED        = "COMPLETED".asInstanceOf[CampaignStatus]
+    val PAUSED           = "PAUSED".asInstanceOf[CampaignStatus]
+    val DELETED          = "DELETED".asInstanceOf[CampaignStatus]
 
     val values = js.Object.freeze(js.Array(SCHEDULED, EXECUTING, PENDING_NEXT_RUN, COMPLETED, PAUSED, DELETED))
   }
@@ -1977,19 +1959,20 @@ package pinpoint {
       __obj.asInstanceOf[ChannelResponse]
     }
   }
-
-  object ChannelTypeEnum {
-    val GCM               = "GCM"
-    val APNS              = "APNS"
-    val APNS_SANDBOX      = "APNS_SANDBOX"
-    val APNS_VOIP         = "APNS_VOIP"
-    val APNS_VOIP_SANDBOX = "APNS_VOIP_SANDBOX"
-    val ADM               = "ADM"
-    val SMS               = "SMS"
-    val VOICE             = "VOICE"
-    val EMAIL             = "EMAIL"
-    val BAIDU             = "BAIDU"
-    val CUSTOM            = "CUSTOM"
+  @js.native
+  sealed trait ChannelType extends js.Any
+  object ChannelType extends js.Object {
+    val GCM               = "GCM".asInstanceOf[ChannelType]
+    val APNS              = "APNS".asInstanceOf[ChannelType]
+    val APNS_SANDBOX      = "APNS_SANDBOX".asInstanceOf[ChannelType]
+    val APNS_VOIP         = "APNS_VOIP".asInstanceOf[ChannelType]
+    val APNS_VOIP_SANDBOX = "APNS_VOIP_SANDBOX".asInstanceOf[ChannelType]
+    val ADM               = "ADM".asInstanceOf[ChannelType]
+    val SMS               = "SMS".asInstanceOf[ChannelType]
+    val VOICE             = "VOICE".asInstanceOf[ChannelType]
+    val EMAIL             = "EMAIL".asInstanceOf[ChannelType]
+    val BAIDU             = "BAIDU".asInstanceOf[ChannelType]
+    val CUSTOM            = "CUSTOM".asInstanceOf[ChannelType]
 
     val values = js.Object.freeze(
       js.Array(GCM, APNS, APNS_SANDBOX, APNS_VOIP, APNS_VOIP_SANDBOX, ADM, SMS, VOICE, EMAIL, BAIDU, CUSTOM)
@@ -3375,24 +3358,26 @@ package pinpoint {
       __obj.asInstanceOf[DeleteVoiceTemplateResponse]
     }
   }
-
-  object DeliveryStatusEnum {
-    val SUCCESSFUL        = "SUCCESSFUL"
-    val THROTTLED         = "THROTTLED"
-    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE"
-    val PERMANENT_FAILURE = "PERMANENT_FAILURE"
-    val UNKNOWN_FAILURE   = "UNKNOWN_FAILURE"
-    val OPT_OUT           = "OPT_OUT"
-    val DUPLICATE         = "DUPLICATE"
+  @js.native
+  sealed trait DeliveryStatus extends js.Any
+  object DeliveryStatus extends js.Object {
+    val SUCCESSFUL        = "SUCCESSFUL".asInstanceOf[DeliveryStatus]
+    val THROTTLED         = "THROTTLED".asInstanceOf[DeliveryStatus]
+    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE".asInstanceOf[DeliveryStatus]
+    val PERMANENT_FAILURE = "PERMANENT_FAILURE".asInstanceOf[DeliveryStatus]
+    val UNKNOWN_FAILURE   = "UNKNOWN_FAILURE".asInstanceOf[DeliveryStatus]
+    val OPT_OUT           = "OPT_OUT".asInstanceOf[DeliveryStatus]
+    val DUPLICATE         = "DUPLICATE".asInstanceOf[DeliveryStatus]
 
     val values = js.Object.freeze(
       js.Array(SUCCESSFUL, THROTTLED, TEMPORARY_FAILURE, PERMANENT_FAILURE, UNKNOWN_FAILURE, OPT_OUT, DUPLICATE)
     )
   }
-
-  object DimensionTypeEnum {
-    val INCLUSIVE = "INCLUSIVE"
-    val EXCLUSIVE = "EXCLUSIVE"
+  @js.native
+  sealed trait DimensionType extends js.Any
+  object DimensionType extends js.Object {
+    val INCLUSIVE = "INCLUSIVE".asInstanceOf[DimensionType]
+    val EXCLUSIVE = "EXCLUSIVE".asInstanceOf[DimensionType]
 
     val values = js.Object.freeze(js.Array(INCLUSIVE, EXCLUSIVE))
   }
@@ -3441,12 +3426,13 @@ package pinpoint {
       __obj.asInstanceOf[DirectMessageConfiguration]
     }
   }
-
-  object DurationEnum {
-    val HR_24  = "HR_24"
-    val DAY_7  = "DAY_7"
-    val DAY_14 = "DAY_14"
-    val DAY_30 = "DAY_30"
+  @js.native
+  sealed trait Duration extends js.Any
+  object Duration extends js.Object {
+    val HR_24  = "HR_24".asInstanceOf[Duration]
+    val DAY_7  = "DAY_7".asInstanceOf[Duration]
+    val DAY_14 = "DAY_14".asInstanceOf[Duration]
+    val DAY_30 = "DAY_30".asInstanceOf[Duration]
 
     val values = js.Object.freeze(js.Array(HR_24, DAY_7, DAY_14, DAY_30))
   }
@@ -4450,28 +4436,31 @@ package pinpoint {
       __obj.asInstanceOf[ExportJobsResponse]
     }
   }
-
-  object FilterTypeEnum {
-    val SYSTEM   = "SYSTEM"
-    val ENDPOINT = "ENDPOINT"
+  @js.native
+  sealed trait FilterType extends js.Any
+  object FilterType extends js.Object {
+    val SYSTEM   = "SYSTEM".asInstanceOf[FilterType]
+    val ENDPOINT = "ENDPOINT".asInstanceOf[FilterType]
 
     val values = js.Object.freeze(js.Array(SYSTEM, ENDPOINT))
   }
-
-  object FormatEnum {
-    val CSV  = "CSV"
-    val JSON = "JSON"
+  @js.native
+  sealed trait Format extends js.Any
+  object Format extends js.Object {
+    val CSV  = "CSV".asInstanceOf[Format]
+    val JSON = "JSON".asInstanceOf[Format]
 
     val values = js.Object.freeze(js.Array(CSV, JSON))
   }
-
-  object FrequencyEnum {
-    val ONCE    = "ONCE"
-    val HOURLY  = "HOURLY"
-    val DAILY   = "DAILY"
-    val WEEKLY  = "WEEKLY"
-    val MONTHLY = "MONTHLY"
-    val EVENT   = "EVENT"
+  @js.native
+  sealed trait Frequency extends js.Any
+  object Frequency extends js.Object {
+    val ONCE    = "ONCE".asInstanceOf[Frequency]
+    val HOURLY  = "HOURLY".asInstanceOf[Frequency]
+    val DAILY   = "DAILY".asInstanceOf[Frequency]
+    val WEEKLY  = "WEEKLY".asInstanceOf[Frequency]
+    val MONTHLY = "MONTHLY".asInstanceOf[Frequency]
+    val EVENT   = "EVENT".asInstanceOf[Frequency]
 
     val values = js.Object.freeze(js.Array(ONCE, HOURLY, DAILY, WEEKLY, MONTHLY, EVENT))
   }
@@ -6553,11 +6542,12 @@ package pinpoint {
       __obj.asInstanceOf[ImportJobsResponse]
     }
   }
-
-  object IncludeEnum {
-    val ALL  = "ALL"
-    val ANY  = "ANY"
-    val NONE = "NONE"
+  @js.native
+  sealed trait Include extends js.Any
+  object Include extends js.Object {
+    val ALL  = "ALL".asInstanceOf[Include]
+    val ANY  = "ANY".asInstanceOf[Include]
+    val NONE = "NONE".asInstanceOf[Include]
 
     val values = js.Object.freeze(js.Array(ALL, ANY, NONE))
   }
@@ -6583,17 +6573,18 @@ package pinpoint {
       __obj.asInstanceOf[ItemResponse]
     }
   }
-
-  object JobStatusEnum {
-    val CREATED                      = "CREATED"
-    val PREPARING_FOR_INITIALIZATION = "PREPARING_FOR_INITIALIZATION"
-    val INITIALIZING                 = "INITIALIZING"
-    val PROCESSING                   = "PROCESSING"
-    val PENDING_JOB                  = "PENDING_JOB"
-    val COMPLETING                   = "COMPLETING"
-    val COMPLETED                    = "COMPLETED"
-    val FAILING                      = "FAILING"
-    val FAILED                       = "FAILED"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val CREATED                      = "CREATED".asInstanceOf[JobStatus]
+    val PREPARING_FOR_INITIALIZATION = "PREPARING_FOR_INITIALIZATION".asInstanceOf[JobStatus]
+    val INITIALIZING                 = "INITIALIZING".asInstanceOf[JobStatus]
+    val PROCESSING                   = "PROCESSING".asInstanceOf[JobStatus]
+    val PENDING_JOB                  = "PENDING_JOB".asInstanceOf[JobStatus]
+    val COMPLETING                   = "COMPLETING".asInstanceOf[JobStatus]
+    val COMPLETED                    = "COMPLETED".asInstanceOf[JobStatus]
+    val FAILING                      = "FAILING".asInstanceOf[JobStatus]
+    val FAILED                       = "FAILED".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -7265,10 +7256,11 @@ package pinpoint {
       __obj.asInstanceOf[MessageResult]
     }
   }
-
-  object MessageTypeEnum {
-    val TRANSACTIONAL = "TRANSACTIONAL"
-    val PROMOTIONAL   = "PROMOTIONAL"
+  @js.native
+  sealed trait MessageType extends js.Any
+  object MessageType extends js.Object {
+    val TRANSACTIONAL = "TRANSACTIONAL".asInstanceOf[MessageType]
+    val PROMOTIONAL   = "PROMOTIONAL".asInstanceOf[MessageType]
 
     val values = js.Object.freeze(js.Array(TRANSACTIONAL, PROMOTIONAL))
   }
@@ -7296,10 +7288,11 @@ package pinpoint {
       __obj.asInstanceOf[MetricDimension]
     }
   }
-
-  object ModeEnum {
-    val DELIVERY = "DELIVERY"
-    val FILTER   = "FILTER"
+  @js.native
+  sealed trait Mode extends js.Any
+  object Mode extends js.Object {
+    val DELIVERY = "DELIVERY".asInstanceOf[Mode]
+    val FILTER   = "FILTER".asInstanceOf[Mode]
 
     val values = js.Object.freeze(js.Array(DELIVERY, FILTER))
   }
@@ -7432,10 +7425,11 @@ package pinpoint {
       __obj.asInstanceOf[NumberValidateResponse]
     }
   }
-
-  object OperatorEnum {
-    val ALL = "ALL"
-    val ANY = "ANY"
+  @js.native
+  sealed trait Operator extends js.Any
+  object Operator extends js.Object {
+    val ALL = "ALL".asInstanceOf[Operator]
+    val ANY = "ANY".asInstanceOf[Operator]
 
     val values = js.Object.freeze(js.Array(ALL, ANY))
   }
@@ -7808,10 +7802,11 @@ package pinpoint {
       __obj.asInstanceOf[RecencyDimension]
     }
   }
-
-  object RecencyTypeEnum {
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait RecencyType extends js.Any
+  object RecencyType extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[RecencyType]
+    val INACTIVE = "INACTIVE".asInstanceOf[RecencyType]
 
     val values = js.Object.freeze(js.Array(ACTIVE, INACTIVE))
   }
@@ -8440,10 +8435,11 @@ package pinpoint {
       __obj.asInstanceOf[SegmentResponse]
     }
   }
-
-  object SegmentTypeEnum {
-    val DIMENSIONAL = "DIMENSIONAL"
-    val IMPORT      = "IMPORT"
+  @js.native
+  sealed trait SegmentType extends js.Any
+  object SegmentType extends js.Object {
+    val DIMENSIONAL = "DIMENSIONAL".asInstanceOf[SegmentType]
+    val IMPORT      = "IMPORT".asInstanceOf[SegmentType]
 
     val values = js.Object.freeze(js.Array(DIMENSIONAL, IMPORT))
   }
@@ -8735,11 +8731,12 @@ package pinpoint {
       __obj.asInstanceOf[SimpleEmailPart]
     }
   }
-
-  object SourceTypeEnum {
-    val ALL  = "ALL"
-    val ANY  = "ANY"
-    val NONE = "NONE"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val ALL  = "ALL".asInstanceOf[SourceType]
+    val ANY  = "ANY".asInstanceOf[SourceType]
+    val NONE = "NONE".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(js.Array(ALL, ANY, NONE))
   }
@@ -8765,13 +8762,14 @@ package pinpoint {
       __obj.asInstanceOf[StartCondition]
     }
   }
-
-  object StateEnum {
-    val DRAFT     = "DRAFT"
-    val ACTIVE    = "ACTIVE"
-    val COMPLETED = "COMPLETED"
-    val CANCELLED = "CANCELLED"
-    val CLOSED    = "CLOSED"
+  @js.native
+  sealed trait State extends js.Any
+  object State extends js.Object {
+    val DRAFT     = "DRAFT".asInstanceOf[State]
+    val ACTIVE    = "ACTIVE".asInstanceOf[State]
+    val COMPLETED = "COMPLETED".asInstanceOf[State]
+    val CANCELLED = "CANCELLED".asInstanceOf[State]
+    val CLOSED    = "CLOSED".asInstanceOf[State]
 
     val values = js.Object.freeze(js.Array(DRAFT, ACTIVE, COMPLETED, CANCELLED, CLOSED))
   }
@@ -8931,12 +8929,13 @@ package pinpoint {
       __obj.asInstanceOf[TemplateResponse]
     }
   }
-
-  object TemplateTypeEnum {
-    val EMAIL = "EMAIL"
-    val SMS   = "SMS"
-    val VOICE = "VOICE"
-    val PUSH  = "PUSH"
+  @js.native
+  sealed trait TemplateType extends js.Any
+  object TemplateType extends js.Object {
+    val EMAIL = "EMAIL".asInstanceOf[TemplateType]
+    val SMS   = "SMS".asInstanceOf[TemplateType]
+    val VOICE = "VOICE".asInstanceOf[TemplateType]
+    val PUSH  = "PUSH".asInstanceOf[TemplateType]
 
     val values = js.Object.freeze(js.Array(EMAIL, SMS, VOICE, PUSH))
   }
@@ -9075,11 +9074,12 @@ package pinpoint {
       __obj.asInstanceOf[TreatmentResource]
     }
   }
-
-  object TypeEnum {
-    val ALL  = "ALL"
-    val ANY  = "ANY"
-    val NONE = "NONE"
+  @js.native
+  sealed trait Type extends js.Any
+  object Type extends js.Object {
+    val ALL  = "ALL".asInstanceOf[Type]
+    val ANY  = "ANY".asInstanceOf[Type]
+    val NONE = "NONE".asInstanceOf[Type]
 
     val values = js.Object.freeze(js.Array(ALL, ANY, NONE))
   }

--- a/services/pinpointemail/src/main/scala/facade/amazonaws/services/PinpointEmail.scala
+++ b/services/pinpointemail/src/main/scala/facade/amazonaws/services/PinpointEmail.scala
@@ -7,88 +7,78 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object pinpointemail {
-  type AmazonResourceName                   = String
-  type BehaviorOnMxFailure                  = String
-  type BlacklistEntries                     = js.Array[BlacklistEntry]
-  type BlacklistItemName                    = String
-  type BlacklistItemNames                   = js.Array[BlacklistItemName]
-  type BlacklistReport                      = js.Dictionary[BlacklistEntries]
-  type BlacklistingDescription              = String
-  type CampaignId                           = String
-  type Charset                              = String
-  type CloudWatchDimensionConfigurations    = js.Array[CloudWatchDimensionConfiguration]
-  type ConfigurationSetName                 = String
-  type ConfigurationSetNameList             = js.Array[ConfigurationSetName]
-  type CustomRedirectDomain                 = String
-  type DailyVolumes                         = js.Array[DailyVolume]
-  type DedicatedIpList                      = js.Array[DedicatedIp]
-  type DefaultDimensionValue                = String
-  type DeliverabilityDashboardAccountStatus = String
-  type DeliverabilityTestReports            = js.Array[DeliverabilityTestReport]
-  type DeliverabilityTestStatus             = String
-  type DeliverabilityTestSubject            = String
-  type DimensionName                        = String
-  type DimensionValueSource                 = String
-  type DkimStatus                           = String
-  type DnsToken                             = String
-  type DnsTokenList                         = js.Array[DnsToken]
-  type Domain                               = String
-  type DomainDeliverabilityCampaignList     = js.Array[DomainDeliverabilityCampaign]
-  type DomainDeliverabilityTrackingOptions  = js.Array[DomainDeliverabilityTrackingOption]
-  type DomainIspPlacements                  = js.Array[DomainIspPlacement]
-  type EmailAddress                         = String
-  type EmailAddressList                     = js.Array[EmailAddress]
-  type Enabled                              = Boolean
-  type Esp                                  = String
-  type Esps                                 = js.Array[Esp]
-  type EventDestinationName                 = String
-  type EventDestinations                    = js.Array[EventDestination]
-  type EventType                            = String
-  type EventTypes                           = js.Array[EventType]
-  type GeneralEnforcementStatus             = String
-  type Identity                             = String
-  type IdentityInfoList                     = js.Array[IdentityInfo]
-  type IdentityType                         = String
-  type ImageUrl                             = String
-  type Ip                                   = String
-  type IpList                               = js.Array[Ip]
-  type IspName                              = String
-  type IspNameList                          = js.Array[IspName]
-  type IspPlacements                        = js.Array[IspPlacement]
-  type LastFreshStart                       = js.Date
-  type ListOfDedicatedIpPools               = js.Array[PoolName]
-  type MailFromDomainName                   = String
-  type MailFromDomainStatus                 = String
-  type Max24HourSend                        = Double
-  type MaxItems                             = Int
-  type MaxSendRate                          = Double
-  type MessageContent                       = String
-  type MessageData                          = String
-  type MessageTagList                       = js.Array[MessageTag]
-  type MessageTagName                       = String
-  type MessageTagValue                      = String
-  type NextToken                            = String
-  type OutboundMessageId                    = String
-  type Percentage                           = Double
-  type Percentage100Wrapper                 = Int
-  type PoolName                             = String
-  type RawMessageData                       = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type RblName                              = String
-  type ReportId                             = String
-  type ReportName                           = String
-  type SendingPoolName                      = String
-  type SentLast24Hours                      = Double
-  type Subject                              = String
-  type TagKey                               = String
-  type TagKeyList                           = js.Array[TagKey]
-  type TagList                              = js.Array[Tag]
-  type TagValue                             = String
-  type TemplateArn                          = String
-  type TemplateData                         = String
-  type Timestamp                            = js.Date
-  type TlsPolicy                            = String
-  type Volume                               = Double
-  type WarmupStatus                         = String
+  type AmazonResourceName                  = String
+  type BlacklistEntries                    = js.Array[BlacklistEntry]
+  type BlacklistItemName                   = String
+  type BlacklistItemNames                  = js.Array[BlacklistItemName]
+  type BlacklistReport                     = js.Dictionary[BlacklistEntries]
+  type BlacklistingDescription             = String
+  type CampaignId                          = String
+  type Charset                             = String
+  type CloudWatchDimensionConfigurations   = js.Array[CloudWatchDimensionConfiguration]
+  type ConfigurationSetName                = String
+  type ConfigurationSetNameList            = js.Array[ConfigurationSetName]
+  type CustomRedirectDomain                = String
+  type DailyVolumes                        = js.Array[DailyVolume]
+  type DedicatedIpList                     = js.Array[DedicatedIp]
+  type DefaultDimensionValue               = String
+  type DeliverabilityTestReports           = js.Array[DeliverabilityTestReport]
+  type DeliverabilityTestSubject           = String
+  type DimensionName                       = String
+  type DnsToken                            = String
+  type DnsTokenList                        = js.Array[DnsToken]
+  type Domain                              = String
+  type DomainDeliverabilityCampaignList    = js.Array[DomainDeliverabilityCampaign]
+  type DomainDeliverabilityTrackingOptions = js.Array[DomainDeliverabilityTrackingOption]
+  type DomainIspPlacements                 = js.Array[DomainIspPlacement]
+  type EmailAddress                        = String
+  type EmailAddressList                    = js.Array[EmailAddress]
+  type Enabled                             = Boolean
+  type Esp                                 = String
+  type Esps                                = js.Array[Esp]
+  type EventDestinationName                = String
+  type EventDestinations                   = js.Array[EventDestination]
+  type EventTypes                          = js.Array[EventType]
+  type GeneralEnforcementStatus            = String
+  type Identity                            = String
+  type IdentityInfoList                    = js.Array[IdentityInfo]
+  type ImageUrl                            = String
+  type Ip                                  = String
+  type IpList                              = js.Array[Ip]
+  type IspName                             = String
+  type IspNameList                         = js.Array[IspName]
+  type IspPlacements                       = js.Array[IspPlacement]
+  type LastFreshStart                      = js.Date
+  type ListOfDedicatedIpPools              = js.Array[PoolName]
+  type MailFromDomainName                  = String
+  type Max24HourSend                       = Double
+  type MaxItems                            = Int
+  type MaxSendRate                         = Double
+  type MessageContent                      = String
+  type MessageData                         = String
+  type MessageTagList                      = js.Array[MessageTag]
+  type MessageTagName                      = String
+  type MessageTagValue                     = String
+  type NextToken                           = String
+  type OutboundMessageId                   = String
+  type Percentage                          = Double
+  type Percentage100Wrapper                = Int
+  type PoolName                            = String
+  type RawMessageData                      = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type RblName                             = String
+  type ReportId                            = String
+  type ReportName                          = String
+  type SendingPoolName                     = String
+  type SentLast24Hours                     = Double
+  type Subject                             = String
+  type TagKey                              = String
+  type TagKeyList                          = js.Array[TagKey]
+  type TagList                             = js.Array[Tag]
+  type TagValue                            = String
+  type TemplateArn                         = String
+  type TemplateData                        = String
+  type Timestamp                           = js.Date
+  type Volume                              = Double
 
   implicit final class PinpointEmailOps(private val service: PinpointEmail) extends AnyVal {
 
@@ -321,9 +311,11 @@ package pinpointemail {
     * The action that you want Amazon Pinpoint to take if it can't read the required MX record for a custom MAIL FROM domain. When you set this value to <code>UseDefaultValue</code>, Amazon Pinpoint uses <i>amazonses.com</i> as the MAIL FROM domain. When you set this value to <code>RejectMessage</code>, Amazon Pinpoint returns a <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the email.
     *  These behaviors are taken when the custom MAIL FROM domain configuration is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.
     */
-  object BehaviorOnMxFailureEnum {
-    val USE_DEFAULT_VALUE = "USE_DEFAULT_VALUE"
-    val REJECT_MESSAGE    = "REJECT_MESSAGE"
+  @js.native
+  sealed trait BehaviorOnMxFailure extends js.Any
+  object BehaviorOnMxFailure extends js.Object {
+    val USE_DEFAULT_VALUE = "USE_DEFAULT_VALUE".asInstanceOf[BehaviorOnMxFailure]
+    val REJECT_MESSAGE    = "REJECT_MESSAGE".asInstanceOf[BehaviorOnMxFailure]
 
     val values = js.Object.freeze(js.Array(USE_DEFAULT_VALUE, REJECT_MESSAGE))
   }
@@ -896,10 +888,12 @@ package pinpointemail {
   /**
     * The current status of your Deliverability dashboard subscription. If this value is <code>PENDING_EXPIRATION</code>, your subscription is scheduled to expire at the end of the current calendar month.
     */
-  object DeliverabilityDashboardAccountStatusEnum {
-    val ACTIVE             = "ACTIVE"
-    val PENDING_EXPIRATION = "PENDING_EXPIRATION"
-    val DISABLED           = "DISABLED"
+  @js.native
+  sealed trait DeliverabilityDashboardAccountStatus extends js.Any
+  object DeliverabilityDashboardAccountStatus extends js.Object {
+    val ACTIVE             = "ACTIVE".asInstanceOf[DeliverabilityDashboardAccountStatus]
+    val PENDING_EXPIRATION = "PENDING_EXPIRATION".asInstanceOf[DeliverabilityDashboardAccountStatus]
+    val DISABLED           = "DISABLED".asInstanceOf[DeliverabilityDashboardAccountStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, PENDING_EXPIRATION, DISABLED))
   }
@@ -941,9 +935,11 @@ package pinpointemail {
   /**
     * The status of a predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.
     */
-  object DeliverabilityTestStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
+  @js.native
+  sealed trait DeliverabilityTestStatus extends js.Any
+  object DeliverabilityTestStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[DeliverabilityTestStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[DeliverabilityTestStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETED))
   }
@@ -998,10 +994,12 @@ package pinpointemail {
   /**
     * The location where Amazon Pinpoint finds the value of a dimension to publish to Amazon CloudWatch. If you want Amazon Pinpoint to use the message tags that you specify using an X-SES-MESSAGE-TAGS header or a parameter to the SendEmail/SendRawEmail API, choose <code>messageTag</code>. If you want Amazon Pinpoint to use your own email headers, choose <code>emailHeader</code>. If you want Amazon Pinpoint to use link tags, choose <code>linkTags</code>.
     */
-  object DimensionValueSourceEnum {
-    val MESSAGE_TAG  = "MESSAGE_TAG"
-    val EMAIL_HEADER = "EMAIL_HEADER"
-    val LINK_TAG     = "LINK_TAG"
+  @js.native
+  sealed trait DimensionValueSource extends js.Any
+  object DimensionValueSource extends js.Object {
+    val MESSAGE_TAG  = "MESSAGE_TAG".asInstanceOf[DimensionValueSource]
+    val EMAIL_HEADER = "EMAIL_HEADER".asInstanceOf[DimensionValueSource]
+    val LINK_TAG     = "LINK_TAG".asInstanceOf[DimensionValueSource]
 
     val values = js.Object.freeze(js.Array(MESSAGE_TAG, EMAIL_HEADER, LINK_TAG))
   }
@@ -1039,12 +1037,14 @@ package pinpointemail {
     *  * <code>TEMPORARY_FAILURE</code> – A temporary issue is preventing Amazon Pinpoint from determining the DKIM authentication status of the domain.
     *  * <code>NOT_STARTED</code> – The DKIM verification process hasn't been initiated for the domain.
     */
-  object DkimStatusEnum {
-    val PENDING           = "PENDING"
-    val SUCCESS           = "SUCCESS"
-    val FAILED            = "FAILED"
-    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE"
-    val NOT_STARTED       = "NOT_STARTED"
+  @js.native
+  sealed trait DkimStatus extends js.Any
+  object DkimStatus extends js.Object {
+    val PENDING           = "PENDING".asInstanceOf[DkimStatus]
+    val SUCCESS           = "SUCCESS".asInstanceOf[DkimStatus]
+    val FAILED            = "FAILED".asInstanceOf[DkimStatus]
+    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE".asInstanceOf[DkimStatus]
+    val NOT_STARTED       = "NOT_STARTED".asInstanceOf[DkimStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, SUCCESS, FAILED, TEMPORARY_FAILURE, NOT_STARTED))
   }
@@ -1270,15 +1270,17 @@ package pinpointemail {
   /**
     * An email sending event type. For example, email sends, opens, and bounces are all email events.
     */
-  object EventTypeEnum {
-    val SEND              = "SEND"
-    val REJECT            = "REJECT"
-    val BOUNCE            = "BOUNCE"
-    val COMPLAINT         = "COMPLAINT"
-    val DELIVERY          = "DELIVERY"
-    val OPEN              = "OPEN"
-    val CLICK             = "CLICK"
-    val RENDERING_FAILURE = "RENDERING_FAILURE"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val SEND              = "SEND".asInstanceOf[EventType]
+    val REJECT            = "REJECT".asInstanceOf[EventType]
+    val BOUNCE            = "BOUNCE".asInstanceOf[EventType]
+    val COMPLAINT         = "COMPLAINT".asInstanceOf[EventType]
+    val DELIVERY          = "DELIVERY".asInstanceOf[EventType]
+    val OPEN              = "OPEN".asInstanceOf[EventType]
+    val CLICK             = "CLICK".asInstanceOf[EventType]
+    val RENDERING_FAILURE = "RENDERING_FAILURE".asInstanceOf[EventType]
 
     val values = js.Object.freeze(js.Array(SEND, REJECT, BOUNCE, COMPLAINT, DELIVERY, OPEN, CLICK, RENDERING_FAILURE))
   }
@@ -1840,10 +1842,12 @@ package pinpointemail {
     * * <code>EMAIL_ADDRESS</code> – The identity is an email address.
     *  * <code>DOMAIN</code> – The identity is a domain.
     */
-  object IdentityTypeEnum {
-    val EMAIL_ADDRESS  = "EMAIL_ADDRESS"
-    val DOMAIN         = "DOMAIN"
-    val MANAGED_DOMAIN = "MANAGED_DOMAIN"
+  @js.native
+  sealed trait IdentityType extends js.Any
+  object IdentityType extends js.Object {
+    val EMAIL_ADDRESS  = "EMAIL_ADDRESS".asInstanceOf[IdentityType]
+    val DOMAIN         = "DOMAIN".asInstanceOf[IdentityType]
+    val MANAGED_DOMAIN = "MANAGED_DOMAIN".asInstanceOf[IdentityType]
 
     val values = js.Object.freeze(js.Array(EMAIL_ADDRESS, DOMAIN, MANAGED_DOMAIN))
   }
@@ -2221,11 +2225,13 @@ package pinpointemail {
     *  * <code>FAILED</code> – Amazon Pinpoint can't find the required MX record, or the record no longer exists.
     *  * <code>TEMPORARY_FAILURE</code> – A temporary issue occurred, which prevented Amazon Pinpoint from determining the status of the MAIL FROM domain.
     */
-  object MailFromDomainStatusEnum {
-    val PENDING           = "PENDING"
-    val SUCCESS           = "SUCCESS"
-    val FAILED            = "FAILED"
-    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE"
+  @js.native
+  sealed trait MailFromDomainStatus extends js.Any
+  object MailFromDomainStatus extends js.Object {
+    val PENDING           = "PENDING".asInstanceOf[MailFromDomainStatus]
+    val SUCCESS           = "SUCCESS".asInstanceOf[MailFromDomainStatus]
+    val FAILED            = "FAILED".asInstanceOf[MailFromDomainStatus]
+    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE".asInstanceOf[MailFromDomainStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, SUCCESS, FAILED, TEMPORARY_FAILURE))
   }
@@ -3083,9 +3089,11 @@ package pinpointemail {
   /**
     * Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only delivered if a TLS connection can be established. If the value is <code>Optional</code>, messages can be delivered in plain text if a TLS connection can't be established.
     */
-  object TlsPolicyEnum {
-    val REQUIRE  = "REQUIRE"
-    val OPTIONAL = "OPTIONAL"
+  @js.native
+  sealed trait TlsPolicy extends js.Any
+  object TlsPolicy extends js.Object {
+    val REQUIRE  = "REQUIRE".asInstanceOf[TlsPolicy]
+    val OPTIONAL = "OPTIONAL".asInstanceOf[TlsPolicy]
 
     val values = js.Object.freeze(js.Array(REQUIRE, OPTIONAL))
   }
@@ -3220,9 +3228,11 @@ package pinpointemail {
   /**
     * The warmup status of a dedicated IP.
     */
-  object WarmupStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val DONE        = "DONE"
+  @js.native
+  sealed trait WarmupStatus extends js.Any
+  object WarmupStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[WarmupStatus]
+    val DONE        = "DONE".asInstanceOf[WarmupStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, DONE))
   }

--- a/services/pinpointsmsvoice/src/main/scala/facade/amazonaws/services/PinpointSMSVoice.scala
+++ b/services/pinpointsmsvoice/src/main/scala/facade/amazonaws/services/PinpointSMSVoice.scala
@@ -9,7 +9,6 @@ import facade.amazonaws._
 package object pinpointsmsvoice {
   type ConfigurationSets            = js.Array[WordCharactersWithDelimiters]
   type EventDestinations            = js.Array[EventDestination]
-  type EventType                    = String
   type EventTypes                   = js.Array[EventType]
   type NextTokenString              = String
   type NonEmptyString               = String
@@ -340,14 +339,16 @@ package pinpointsmsvoice {
   /**
     * The types of events that are sent to the event destination.
     */
-  object EventTypeEnum {
-    val INITIATED_CALL = "INITIATED_CALL"
-    val RINGING        = "RINGING"
-    val ANSWERED       = "ANSWERED"
-    val COMPLETED_CALL = "COMPLETED_CALL"
-    val BUSY           = "BUSY"
-    val FAILED         = "FAILED"
-    val NO_ANSWER      = "NO_ANSWER"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val INITIATED_CALL = "INITIATED_CALL".asInstanceOf[EventType]
+    val RINGING        = "RINGING".asInstanceOf[EventType]
+    val ANSWERED       = "ANSWERED".asInstanceOf[EventType]
+    val COMPLETED_CALL = "COMPLETED_CALL".asInstanceOf[EventType]
+    val BUSY           = "BUSY".asInstanceOf[EventType]
+    val FAILED         = "FAILED".asInstanceOf[EventType]
+    val NO_ANSWER      = "NO_ANSWER".asInstanceOf[EventType]
 
     val values = js.Object.freeze(js.Array(INITIATED_CALL, RINGING, ANSWERED, COMPLETED_CALL, BUSY, FAILED, NO_ANSWER))
   }

--- a/services/polly/src/main/scala/facade/amazonaws/services/Polly.scala
+++ b/services/polly/src/main/scala/facade/amazonaws/services/Polly.scala
@@ -11,11 +11,8 @@ package object polly {
   type AudioStream                    = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type ContentType                    = String
   type DateTime                       = js.Date
-  type Engine                         = String
   type EngineList                     = js.Array[Engine]
-  type Gender                         = String
   type IncludeAdditionalLanguageCodes = Boolean
-  type LanguageCode                   = String
   type LanguageCodeList               = js.Array[LanguageCode]
   type LanguageName                   = String
   type LastModified                   = js.Date
@@ -27,7 +24,6 @@ package object polly {
   type LexiconNameList                = js.Array[LexiconName]
   type MaxResults                     = Int
   type NextToken                      = String
-  type OutputFormat                   = String
   type OutputS3BucketName             = String
   type OutputS3KeyPrefix              = String
   type OutputUri                      = String
@@ -35,15 +31,11 @@ package object polly {
   type SampleRate                     = String
   type Size                           = Int
   type SnsTopicArn                    = String
-  type SpeechMarkType                 = String
   type SpeechMarkTypeList             = js.Array[SpeechMarkType]
   type SynthesisTasks                 = js.Array[SynthesisTask]
   type TaskId                         = String
-  type TaskStatus                     = String
   type TaskStatusReason               = String
   type Text                           = String
-  type TextType                       = String
-  type VoiceId                        = String
   type VoiceList                      = js.Array[Voice]
   type VoiceName                      = String
 
@@ -168,17 +160,19 @@ package polly {
       __obj.asInstanceOf[DescribeVoicesOutput]
     }
   }
-
-  object EngineEnum {
-    val standard = "standard"
-    val neural   = "neural"
+  @js.native
+  sealed trait Engine extends js.Any
+  object Engine extends js.Object {
+    val standard = "standard".asInstanceOf[Engine]
+    val neural   = "neural".asInstanceOf[Engine]
 
     val values = js.Object.freeze(js.Array(standard, neural))
   }
-
-  object GenderEnum {
-    val Female = "Female"
-    val Male   = "Male"
+  @js.native
+  sealed trait Gender extends js.Any
+  object Gender extends js.Object {
+    val Female = "Female".asInstanceOf[Gender]
+    val Male   = "Male".asInstanceOf[Gender]
 
     val values = js.Object.freeze(js.Array(Female, Male))
   }
@@ -253,37 +247,38 @@ package polly {
       __obj.asInstanceOf[GetSpeechSynthesisTaskOutput]
     }
   }
-
-  object LanguageCodeEnum {
-    val arb         = "arb"
-    val `cmn-CN`    = "cmn-CN"
-    val `cy-GB`     = "cy-GB"
-    val `da-DK`     = "da-DK"
-    val `de-DE`     = "de-DE"
-    val `en-AU`     = "en-AU"
-    val `en-GB`     = "en-GB"
-    val `en-GB-WLS` = "en-GB-WLS"
-    val `en-IN`     = "en-IN"
-    val `en-US`     = "en-US"
-    val `es-ES`     = "es-ES"
-    val `es-MX`     = "es-MX"
-    val `es-US`     = "es-US"
-    val `fr-CA`     = "fr-CA"
-    val `fr-FR`     = "fr-FR"
-    val `is-IS`     = "is-IS"
-    val `it-IT`     = "it-IT"
-    val `ja-JP`     = "ja-JP"
-    val `hi-IN`     = "hi-IN"
-    val `ko-KR`     = "ko-KR"
-    val `nb-NO`     = "nb-NO"
-    val `nl-NL`     = "nl-NL"
-    val `pl-PL`     = "pl-PL"
-    val `pt-BR`     = "pt-BR"
-    val `pt-PT`     = "pt-PT"
-    val `ro-RO`     = "ro-RO"
-    val `ru-RU`     = "ru-RU"
-    val `sv-SE`     = "sv-SE"
-    val `tr-TR`     = "tr-TR"
+  @js.native
+  sealed trait LanguageCode extends js.Any
+  object LanguageCode extends js.Object {
+    val arb         = "arb".asInstanceOf[LanguageCode]
+    val `cmn-CN`    = "cmn-CN".asInstanceOf[LanguageCode]
+    val `cy-GB`     = "cy-GB".asInstanceOf[LanguageCode]
+    val `da-DK`     = "da-DK".asInstanceOf[LanguageCode]
+    val `de-DE`     = "de-DE".asInstanceOf[LanguageCode]
+    val `en-AU`     = "en-AU".asInstanceOf[LanguageCode]
+    val `en-GB`     = "en-GB".asInstanceOf[LanguageCode]
+    val `en-GB-WLS` = "en-GB-WLS".asInstanceOf[LanguageCode]
+    val `en-IN`     = "en-IN".asInstanceOf[LanguageCode]
+    val `en-US`     = "en-US".asInstanceOf[LanguageCode]
+    val `es-ES`     = "es-ES".asInstanceOf[LanguageCode]
+    val `es-MX`     = "es-MX".asInstanceOf[LanguageCode]
+    val `es-US`     = "es-US".asInstanceOf[LanguageCode]
+    val `fr-CA`     = "fr-CA".asInstanceOf[LanguageCode]
+    val `fr-FR`     = "fr-FR".asInstanceOf[LanguageCode]
+    val `is-IS`     = "is-IS".asInstanceOf[LanguageCode]
+    val `it-IT`     = "it-IT".asInstanceOf[LanguageCode]
+    val `ja-JP`     = "ja-JP".asInstanceOf[LanguageCode]
+    val `hi-IN`     = "hi-IN".asInstanceOf[LanguageCode]
+    val `ko-KR`     = "ko-KR".asInstanceOf[LanguageCode]
+    val `nb-NO`     = "nb-NO".asInstanceOf[LanguageCode]
+    val `nl-NL`     = "nl-NL".asInstanceOf[LanguageCode]
+    val `pl-PL`     = "pl-PL".asInstanceOf[LanguageCode]
+    val `pt-BR`     = "pt-BR".asInstanceOf[LanguageCode]
+    val `pt-PT`     = "pt-PT".asInstanceOf[LanguageCode]
+    val `ro-RO`     = "ro-RO".asInstanceOf[LanguageCode]
+    val `ru-RU`     = "ru-RU".asInstanceOf[LanguageCode]
+    val `sv-SE`     = "sv-SE".asInstanceOf[LanguageCode]
+    val `tr-TR`     = "tr-TR".asInstanceOf[LanguageCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -473,12 +468,13 @@ package polly {
       __obj.asInstanceOf[ListSpeechSynthesisTasksOutput]
     }
   }
-
-  object OutputFormatEnum {
-    val json       = "json"
-    val mp3        = "mp3"
-    val ogg_vorbis = "ogg_vorbis"
-    val pcm        = "pcm"
+  @js.native
+  sealed trait OutputFormat extends js.Any
+  object OutputFormat extends js.Object {
+    val json       = "json".asInstanceOf[OutputFormat]
+    val mp3        = "mp3".asInstanceOf[OutputFormat]
+    val ogg_vorbis = "ogg_vorbis".asInstanceOf[OutputFormat]
+    val pcm        = "pcm".asInstanceOf[OutputFormat]
 
     val values = js.Object.freeze(js.Array(json, mp3, ogg_vorbis, pcm))
   }
@@ -516,12 +512,13 @@ package polly {
       __obj.asInstanceOf[PutLexiconOutput]
     }
   }
-
-  object SpeechMarkTypeEnum {
-    val sentence = "sentence"
-    val ssml     = "ssml"
-    val viseme   = "viseme"
-    val word     = "word"
+  @js.native
+  sealed trait SpeechMarkType extends js.Any
+  object SpeechMarkType extends js.Object {
+    val sentence = "sentence".asInstanceOf[SpeechMarkType]
+    val ssml     = "ssml".asInstanceOf[SpeechMarkType]
+    val viseme   = "viseme".asInstanceOf[SpeechMarkType]
+    val word     = "word".asInstanceOf[SpeechMarkType]
 
     val values = js.Object.freeze(js.Array(sentence, ssml, viseme, word))
   }
@@ -717,19 +714,21 @@ package polly {
       __obj.asInstanceOf[SynthesizeSpeechOutput]
     }
   }
-
-  object TaskStatusEnum {
-    val scheduled  = "scheduled"
-    val inProgress = "inProgress"
-    val completed  = "completed"
-    val failed     = "failed"
+  @js.native
+  sealed trait TaskStatus extends js.Any
+  object TaskStatus extends js.Object {
+    val scheduled  = "scheduled".asInstanceOf[TaskStatus]
+    val inProgress = "inProgress".asInstanceOf[TaskStatus]
+    val completed  = "completed".asInstanceOf[TaskStatus]
+    val failed     = "failed".asInstanceOf[TaskStatus]
 
     val values = js.Object.freeze(js.Array(scheduled, inProgress, completed, failed))
   }
-
-  object TextTypeEnum {
-    val ssml = "ssml"
-    val text = "text"
+  @js.native
+  sealed trait TextType extends js.Any
+  object TextType extends js.Object {
+    val ssml = "ssml".asInstanceOf[TextType]
+    val text = "text".asInstanceOf[TextType]
 
     val values = js.Object.freeze(js.Array(ssml, text))
   }
@@ -770,68 +769,69 @@ package polly {
       __obj.asInstanceOf[Voice]
     }
   }
-
-  object VoiceIdEnum {
-    val Aditi     = "Aditi"
-    val Amy       = "Amy"
-    val Astrid    = "Astrid"
-    val Bianca    = "Bianca"
-    val Brian     = "Brian"
-    val Camila    = "Camila"
-    val Carla     = "Carla"
-    val Carmen    = "Carmen"
-    val Celine    = "Celine"
-    val Chantal   = "Chantal"
-    val Conchita  = "Conchita"
-    val Cristiano = "Cristiano"
-    val Dora      = "Dora"
-    val Emma      = "Emma"
-    val Enrique   = "Enrique"
-    val Ewa       = "Ewa"
-    val Filiz     = "Filiz"
-    val Geraint   = "Geraint"
-    val Giorgio   = "Giorgio"
-    val Gwyneth   = "Gwyneth"
-    val Hans      = "Hans"
-    val Ines      = "Ines"
-    val Ivy       = "Ivy"
-    val Jacek     = "Jacek"
-    val Jan       = "Jan"
-    val Joanna    = "Joanna"
-    val Joey      = "Joey"
-    val Justin    = "Justin"
-    val Karl      = "Karl"
-    val Kendra    = "Kendra"
-    val Kimberly  = "Kimberly"
-    val Lea       = "Lea"
-    val Liv       = "Liv"
-    val Lotte     = "Lotte"
-    val Lucia     = "Lucia"
-    val Lupe      = "Lupe"
-    val Mads      = "Mads"
-    val Maja      = "Maja"
-    val Marlene   = "Marlene"
-    val Mathieu   = "Mathieu"
-    val Matthew   = "Matthew"
-    val Maxim     = "Maxim"
-    val Mia       = "Mia"
-    val Miguel    = "Miguel"
-    val Mizuki    = "Mizuki"
-    val Naja      = "Naja"
-    val Nicole    = "Nicole"
-    val Penelope  = "Penelope"
-    val Raveena   = "Raveena"
-    val Ricardo   = "Ricardo"
-    val Ruben     = "Ruben"
-    val Russell   = "Russell"
-    val Salli     = "Salli"
-    val Seoyeon   = "Seoyeon"
-    val Takumi    = "Takumi"
-    val Tatyana   = "Tatyana"
-    val Vicki     = "Vicki"
-    val Vitoria   = "Vitoria"
-    val Zeina     = "Zeina"
-    val Zhiyu     = "Zhiyu"
+  @js.native
+  sealed trait VoiceId extends js.Any
+  object VoiceId extends js.Object {
+    val Aditi     = "Aditi".asInstanceOf[VoiceId]
+    val Amy       = "Amy".asInstanceOf[VoiceId]
+    val Astrid    = "Astrid".asInstanceOf[VoiceId]
+    val Bianca    = "Bianca".asInstanceOf[VoiceId]
+    val Brian     = "Brian".asInstanceOf[VoiceId]
+    val Camila    = "Camila".asInstanceOf[VoiceId]
+    val Carla     = "Carla".asInstanceOf[VoiceId]
+    val Carmen    = "Carmen".asInstanceOf[VoiceId]
+    val Celine    = "Celine".asInstanceOf[VoiceId]
+    val Chantal   = "Chantal".asInstanceOf[VoiceId]
+    val Conchita  = "Conchita".asInstanceOf[VoiceId]
+    val Cristiano = "Cristiano".asInstanceOf[VoiceId]
+    val Dora      = "Dora".asInstanceOf[VoiceId]
+    val Emma      = "Emma".asInstanceOf[VoiceId]
+    val Enrique   = "Enrique".asInstanceOf[VoiceId]
+    val Ewa       = "Ewa".asInstanceOf[VoiceId]
+    val Filiz     = "Filiz".asInstanceOf[VoiceId]
+    val Geraint   = "Geraint".asInstanceOf[VoiceId]
+    val Giorgio   = "Giorgio".asInstanceOf[VoiceId]
+    val Gwyneth   = "Gwyneth".asInstanceOf[VoiceId]
+    val Hans      = "Hans".asInstanceOf[VoiceId]
+    val Ines      = "Ines".asInstanceOf[VoiceId]
+    val Ivy       = "Ivy".asInstanceOf[VoiceId]
+    val Jacek     = "Jacek".asInstanceOf[VoiceId]
+    val Jan       = "Jan".asInstanceOf[VoiceId]
+    val Joanna    = "Joanna".asInstanceOf[VoiceId]
+    val Joey      = "Joey".asInstanceOf[VoiceId]
+    val Justin    = "Justin".asInstanceOf[VoiceId]
+    val Karl      = "Karl".asInstanceOf[VoiceId]
+    val Kendra    = "Kendra".asInstanceOf[VoiceId]
+    val Kimberly  = "Kimberly".asInstanceOf[VoiceId]
+    val Lea       = "Lea".asInstanceOf[VoiceId]
+    val Liv       = "Liv".asInstanceOf[VoiceId]
+    val Lotte     = "Lotte".asInstanceOf[VoiceId]
+    val Lucia     = "Lucia".asInstanceOf[VoiceId]
+    val Lupe      = "Lupe".asInstanceOf[VoiceId]
+    val Mads      = "Mads".asInstanceOf[VoiceId]
+    val Maja      = "Maja".asInstanceOf[VoiceId]
+    val Marlene   = "Marlene".asInstanceOf[VoiceId]
+    val Mathieu   = "Mathieu".asInstanceOf[VoiceId]
+    val Matthew   = "Matthew".asInstanceOf[VoiceId]
+    val Maxim     = "Maxim".asInstanceOf[VoiceId]
+    val Mia       = "Mia".asInstanceOf[VoiceId]
+    val Miguel    = "Miguel".asInstanceOf[VoiceId]
+    val Mizuki    = "Mizuki".asInstanceOf[VoiceId]
+    val Naja      = "Naja".asInstanceOf[VoiceId]
+    val Nicole    = "Nicole".asInstanceOf[VoiceId]
+    val Penelope  = "Penelope".asInstanceOf[VoiceId]
+    val Raveena   = "Raveena".asInstanceOf[VoiceId]
+    val Ricardo   = "Ricardo".asInstanceOf[VoiceId]
+    val Ruben     = "Ruben".asInstanceOf[VoiceId]
+    val Russell   = "Russell".asInstanceOf[VoiceId]
+    val Salli     = "Salli".asInstanceOf[VoiceId]
+    val Seoyeon   = "Seoyeon".asInstanceOf[VoiceId]
+    val Takumi    = "Takumi".asInstanceOf[VoiceId]
+    val Tatyana   = "Tatyana".asInstanceOf[VoiceId]
+    val Vicki     = "Vicki".asInstanceOf[VoiceId]
+    val Vitoria   = "Vitoria".asInstanceOf[VoiceId]
+    val Zeina     = "Zeina".asInstanceOf[VoiceId]
+    val Zhiyu     = "Zhiyu".asInstanceOf[VoiceId]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/pricing/src/main/scala/facade/amazonaws/services/Pricing.scala
+++ b/services/pricing/src/main/scala/facade/amazonaws/services/Pricing.scala
@@ -10,7 +10,6 @@ package object pricing {
   type AttributeNameList  = js.Array[String]
   type AttributeValueList = js.Array[AttributeValue]
   type BoxedInteger       = Int
-  type FilterType         = String
   type Filters            = js.Array[Filter]
   type PriceList          = js.Array[PriceListItemJSON]
   type PriceListItemJSON  = String
@@ -139,9 +138,10 @@ package pricing {
       __obj.asInstanceOf[Filter]
     }
   }
-
-  object FilterTypeEnum {
-    val TERM_MATCH = "TERM_MATCH"
+  @js.native
+  sealed trait FilterType extends js.Any
+  object FilterType extends js.Object {
+    val TERM_MATCH = "TERM_MATCH".asInstanceOf[FilterType]
 
     val values = js.Object.freeze(js.Array(TERM_MATCH))
   }

--- a/services/qldb/src/main/scala/facade/amazonaws/services/QLDB.scala
+++ b/services/qldb/src/main/scala/facade/amazonaws/services/QLDB.scala
@@ -7,27 +7,23 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object qldb {
-  type Arn                    = String
-  type DeletionProtection     = Boolean
-  type Digest                 = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type ExportStatus           = String
-  type IonText                = String
-  type JournalS3ExportList    = js.Array[JournalS3ExportDescription]
-  type LedgerList             = js.Array[LedgerSummary]
-  type LedgerName             = String
-  type LedgerState            = String
-  type MaxResults             = Int
-  type NextToken              = String
-  type PermissionsMode        = String
-  type S3Bucket               = String
-  type S3ObjectEncryptionType = String
-  type S3Prefix               = String
-  type TagKey                 = String
-  type TagKeyList             = js.Array[TagKey]
-  type TagValue               = String
-  type Tags                   = js.Dictionary[TagValue]
-  type Timestamp              = js.Date
-  type UniqueId               = String
+  type Arn                 = String
+  type DeletionProtection  = Boolean
+  type Digest              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type IonText             = String
+  type JournalS3ExportList = js.Array[JournalS3ExportDescription]
+  type LedgerList          = js.Array[LedgerSummary]
+  type LedgerName          = String
+  type MaxResults          = Int
+  type NextToken           = String
+  type S3Bucket            = String
+  type S3Prefix            = String
+  type TagKey              = String
+  type TagKeyList          = js.Array[TagKey]
+  type TagValue            = String
+  type Tags                = js.Dictionary[TagValue]
+  type Timestamp           = js.Date
+  type UniqueId            = String
 
   implicit final class QLDBOps(private val service: QLDB) extends AnyVal {
 
@@ -297,11 +293,12 @@ package qldb {
       __obj.asInstanceOf[ExportJournalToS3Response]
     }
   }
-
-  object ExportStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
-    val CANCELLED   = "CANCELLED"
+  @js.native
+  sealed trait ExportStatus extends js.Any
+  object ExportStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[ExportStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[ExportStatus]
+    val CANCELLED   = "CANCELLED".asInstanceOf[ExportStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETED, CANCELLED))
   }
@@ -479,12 +476,13 @@ package qldb {
       __obj.asInstanceOf[JournalS3ExportDescription]
     }
   }
-
-  object LedgerStateEnum {
-    val CREATING = "CREATING"
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
-    val DELETED  = "DELETED"
+  @js.native
+  sealed trait LedgerState extends js.Any
+  object LedgerState extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[LedgerState]
+    val ACTIVE   = "ACTIVE".asInstanceOf[LedgerState]
+    val DELETING = "DELETING".asInstanceOf[LedgerState]
+    val DELETED  = "DELETED".asInstanceOf[LedgerState]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING, DELETED))
   }
@@ -666,9 +664,10 @@ package qldb {
       __obj.asInstanceOf[ListTagsForResourceResponse]
     }
   }
-
-  object PermissionsModeEnum {
-    val ALLOW_ALL = "ALLOW_ALL"
+  @js.native
+  sealed trait PermissionsMode extends js.Any
+  object PermissionsMode extends js.Object {
+    val ALLOW_ALL = "ALLOW_ALL".asInstanceOf[PermissionsMode]
 
     val values = js.Object.freeze(js.Array(ALLOW_ALL))
   }
@@ -723,11 +722,12 @@ package qldb {
       __obj.asInstanceOf[S3ExportConfiguration]
     }
   }
-
-  object S3ObjectEncryptionTypeEnum {
-    val SSE_KMS       = "SSE_KMS"
-    val SSE_S3        = "SSE_S3"
-    val NO_ENCRYPTION = "NO_ENCRYPTION"
+  @js.native
+  sealed trait S3ObjectEncryptionType extends js.Any
+  object S3ObjectEncryptionType extends js.Object {
+    val SSE_KMS       = "SSE_KMS".asInstanceOf[S3ObjectEncryptionType]
+    val SSE_S3        = "SSE_S3".asInstanceOf[S3ObjectEncryptionType]
+    val NO_ENCRYPTION = "NO_ENCRYPTION".asInstanceOf[S3ObjectEncryptionType]
 
     val values = js.Object.freeze(js.Array(SSE_KMS, SSE_S3, NO_ENCRYPTION))
   }

--- a/services/quicksight/src/main/scala/facade/amazonaws/services/QuickSight.scala
+++ b/services/quicksight/src/main/scala/facade/amazonaws/services/QuickSight.scala
@@ -11,12 +11,10 @@ package object quicksight {
   type ActiveIAMPolicyAssignmentList  = js.Array[ActiveIAMPolicyAssignment]
   type AliasName                      = String
   type Arn                            = String
-  type AssignmentStatus               = String
   type AwsAccountId                   = String
   type CalculatedColumnList           = js.Array[CalculatedColumn]
   type Catalog                        = String
   type ClusterId                      = String
-  type ColumnDataType                 = String
   type ColumnGroupColumnSchemaList    = js.Array[ColumnGroupColumnSchema]
   type ColumnGroupList                = js.Array[ColumnGroup]
   type ColumnGroupName                = String
@@ -27,21 +25,15 @@ package object quicksight {
   type ColumnSchemaList               = js.Array[ColumnSchema]
   type ColumnTagList                  = js.Array[ColumnTag]
   type CustomSqlName                  = String
-  type DashboardBehavior              = String
   type DashboardErrorList             = js.Array[DashboardError]
-  type DashboardErrorType             = String
   type DashboardName                  = String
   type DashboardSummaryList           = js.Array[DashboardSummary]
-  type DashboardUIState               = String
   type DashboardVersionSummaryList    = js.Array[DashboardVersionSummary]
   type DataSetConfigurationList       = js.Array[DataSetConfiguration]
-  type DataSetImportMode              = String
   type DataSetName                    = String
   type DataSetReferenceList           = js.Array[DataSetReference]
   type DataSetSummaryList             = js.Array[DataSetSummary]
-  type DataSourceErrorInfoType        = String
   type DataSourceList                 = js.Array[DataSource]
-  type DataSourceType                 = String
   type Database                       = String
   type DateTimeParameterList          = js.Array[DateTimeParameter]
   type DecimalParameterList           = js.Array[DecimalParameter]
@@ -50,9 +42,6 @@ package object quicksight {
   type DoubleList                     = js.Array[Double]
   type EmbeddingUrl                   = String
   type Expression                     = String
-  type FileFormat                     = String
-  type GeoSpatialCountryCode          = String
-  type GeoSpatialDataRole             = String
   type GroupDescription               = String
   type GroupList                      = js.Array[Group]
   type GroupMemberList                = js.Array[GroupMember]
@@ -64,19 +53,12 @@ package object quicksight {
   type IdentityMap                    = js.Dictionary[IdentityNameList]
   type IdentityName                   = String
   type IdentityNameList               = js.Array[IdentityName]
-  type IdentityType                   = String
-  type IngestionErrorType             = String
   type IngestionId                    = String
   type IngestionMaxResults            = Int
-  type IngestionRequestSource         = String
-  type IngestionRequestType           = String
-  type IngestionStatus                = String
   type Ingestions                     = js.Array[Ingestion]
-  type InputColumnDataType            = String
   type InputColumnList                = js.Array[InputColumn]
   type InstanceId                     = String
   type IntegerParameterList           = js.Array[IntegerParameter]
-  type JoinType                       = String
   type LogicalTableAlias              = String
   type LogicalTableId                 = String
   type LogicalTableMap                = js.Dictionary[LogicalTable]
@@ -100,10 +82,8 @@ package object quicksight {
   type ResourceId                     = String
   type ResourceName                   = String
   type ResourcePermissionList         = js.Array[ResourcePermission]
-  type ResourceStatus                 = String
   type RestrictiveResourceId          = String
   type RoleSessionName                = String
-  type RowLevelPermissionPolicy       = String
   type S3Bucket                       = String
   type S3Key                          = String
   type SessionLifetimeInMinutes       = Double
@@ -118,11 +98,9 @@ package object quicksight {
   type TagValue                       = String
   type TemplateAliasList              = js.Array[TemplateAlias]
   type TemplateErrorList              = js.Array[TemplateError]
-  type TemplateErrorType              = String
   type TemplateName                   = String
   type TemplateSummaryList            = js.Array[TemplateSummary]
   type TemplateVersionSummaryList     = js.Array[TemplateVersionSummary]
-  type TextQualifier                  = String
   type Timestamp                      = js.Date
   type TimestampList                  = js.Array[Timestamp]
   type TransformOperationList         = js.Array[TransformOperation]
@@ -130,7 +108,6 @@ package object quicksight {
   type UpdateResourcePermissionList   = js.Array[ResourcePermission]
   type UserList                       = js.Array[User]
   type UserName                       = String
-  type UserRole                       = String
   type Username                       = String
   type VersionDescription             = String
   type VersionNumber                  = Double
@@ -458,11 +435,12 @@ package quicksight {
       __obj.asInstanceOf[AmazonElasticsearchParameters]
     }
   }
-
-  object AssignmentStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DRAFT    = "DRAFT"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait AssignmentStatus extends js.Any
+  object AssignmentStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[AssignmentStatus]
+    val DRAFT    = "DRAFT".asInstanceOf[AssignmentStatus]
+    val DISABLED = "DISABLED".asInstanceOf[AssignmentStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DRAFT, DISABLED))
   }
@@ -663,12 +641,13 @@ package quicksight {
       __obj.asInstanceOf[CastColumnTypeOperation]
     }
   }
-
-  object ColumnDataTypeEnum {
-    val STRING   = "STRING"
-    val INTEGER  = "INTEGER"
-    val DECIMAL  = "DECIMAL"
-    val DATETIME = "DATETIME"
+  @js.native
+  sealed trait ColumnDataType extends js.Any
+  object ColumnDataType extends js.Object {
+    val STRING   = "STRING".asInstanceOf[ColumnDataType]
+    val INTEGER  = "INTEGER".asInstanceOf[ColumnDataType]
+    val DECIMAL  = "DECIMAL".asInstanceOf[ColumnDataType]
+    val DATETIME = "DATETIME".asInstanceOf[ColumnDataType]
 
     val values = js.Object.freeze(js.Array(STRING, INTEGER, DECIMAL, DATETIME))
   }
@@ -1453,10 +1432,11 @@ package quicksight {
       __obj.asInstanceOf[Dashboard]
     }
   }
-
-  object DashboardBehaviorEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait DashboardBehavior extends js.Any
+  object DashboardBehavior extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[DashboardBehavior]
+    val DISABLED = "DISABLED".asInstanceOf[DashboardBehavior]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -1482,16 +1462,17 @@ package quicksight {
       __obj.asInstanceOf[DashboardError]
     }
   }
-
-  object DashboardErrorTypeEnum {
-    val DATA_SET_NOT_FOUND              = "DATA_SET_NOT_FOUND"
-    val INTERNAL_FAILURE                = "INTERNAL_FAILURE"
-    val PARAMETER_VALUE_INCOMPATIBLE    = "PARAMETER_VALUE_INCOMPATIBLE"
-    val PARAMETER_TYPE_INVALID          = "PARAMETER_TYPE_INVALID"
-    val PARAMETER_NOT_FOUND             = "PARAMETER_NOT_FOUND"
-    val COLUMN_TYPE_MISMATCH            = "COLUMN_TYPE_MISMATCH"
-    val COLUMN_GEOGRAPHIC_ROLE_MISMATCH = "COLUMN_GEOGRAPHIC_ROLE_MISMATCH"
-    val COLUMN_REPLACEMENT_MISSING      = "COLUMN_REPLACEMENT_MISSING"
+  @js.native
+  sealed trait DashboardErrorType extends js.Any
+  object DashboardErrorType extends js.Object {
+    val DATA_SET_NOT_FOUND              = "DATA_SET_NOT_FOUND".asInstanceOf[DashboardErrorType]
+    val INTERNAL_FAILURE                = "INTERNAL_FAILURE".asInstanceOf[DashboardErrorType]
+    val PARAMETER_VALUE_INCOMPATIBLE    = "PARAMETER_VALUE_INCOMPATIBLE".asInstanceOf[DashboardErrorType]
+    val PARAMETER_TYPE_INVALID          = "PARAMETER_TYPE_INVALID".asInstanceOf[DashboardErrorType]
+    val PARAMETER_NOT_FOUND             = "PARAMETER_NOT_FOUND".asInstanceOf[DashboardErrorType]
+    val COLUMN_TYPE_MISMATCH            = "COLUMN_TYPE_MISMATCH".asInstanceOf[DashboardErrorType]
+    val COLUMN_GEOGRAPHIC_ROLE_MISMATCH = "COLUMN_GEOGRAPHIC_ROLE_MISMATCH".asInstanceOf[DashboardErrorType]
+    val COLUMN_REPLACEMENT_MISSING      = "COLUMN_REPLACEMENT_MISSING".asInstanceOf[DashboardErrorType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1611,10 +1592,11 @@ package quicksight {
       __obj.asInstanceOf[DashboardSummary]
     }
   }
-
-  object DashboardUIStateEnum {
-    val EXPANDED  = "EXPANDED"
-    val COLLAPSED = "COLLAPSED"
+  @js.native
+  sealed trait DashboardUIState extends js.Any
+  object DashboardUIState extends js.Object {
+    val EXPANDED  = "EXPANDED".asInstanceOf[DashboardUIState]
+    val COLLAPSED = "COLLAPSED".asInstanceOf[DashboardUIState]
 
     val values = js.Object.freeze(js.Array(EXPANDED, COLLAPSED))
   }
@@ -1770,10 +1752,11 @@ package quicksight {
       __obj.asInstanceOf[DataSetConfiguration]
     }
   }
-
-  object DataSetImportModeEnum {
-    val SPICE        = "SPICE"
-    val DIRECT_QUERY = "DIRECT_QUERY"
+  @js.native
+  sealed trait DataSetImportMode extends js.Any
+  object DataSetImportMode extends js.Object {
+    val SPICE        = "SPICE".asInstanceOf[DataSetImportMode]
+    val DIRECT_QUERY = "DIRECT_QUERY".asInstanceOf[DataSetImportMode]
 
     val values = js.Object.freeze(js.Array(SPICE, DIRECT_QUERY))
   }
@@ -1949,14 +1932,15 @@ package quicksight {
       __obj.asInstanceOf[DataSourceErrorInfo]
     }
   }
-
-  object DataSourceErrorInfoTypeEnum {
-    val TIMEOUT                      = "TIMEOUT"
-    val ENGINE_VERSION_NOT_SUPPORTED = "ENGINE_VERSION_NOT_SUPPORTED"
-    val UNKNOWN_HOST                 = "UNKNOWN_HOST"
-    val GENERIC_SQL_FAILURE          = "GENERIC_SQL_FAILURE"
-    val CONFLICT                     = "CONFLICT"
-    val UNKNOWN                      = "UNKNOWN"
+  @js.native
+  sealed trait DataSourceErrorInfoType extends js.Any
+  object DataSourceErrorInfoType extends js.Object {
+    val TIMEOUT                      = "TIMEOUT".asInstanceOf[DataSourceErrorInfoType]
+    val ENGINE_VERSION_NOT_SUPPORTED = "ENGINE_VERSION_NOT_SUPPORTED".asInstanceOf[DataSourceErrorInfoType]
+    val UNKNOWN_HOST                 = "UNKNOWN_HOST".asInstanceOf[DataSourceErrorInfoType]
+    val GENERIC_SQL_FAILURE          = "GENERIC_SQL_FAILURE".asInstanceOf[DataSourceErrorInfoType]
+    val CONFLICT                     = "CONFLICT".asInstanceOf[DataSourceErrorInfoType]
+    val UNKNOWN                      = "UNKNOWN".asInstanceOf[DataSourceErrorInfoType]
 
     val values = js.Object.freeze(
       js.Array(TIMEOUT, ENGINE_VERSION_NOT_SUPPORTED, UNKNOWN_HOST, GENERIC_SQL_FAILURE, CONFLICT, UNKNOWN)
@@ -2041,29 +2025,30 @@ package quicksight {
       __obj.asInstanceOf[DataSourceParameters]
     }
   }
-
-  object DataSourceTypeEnum {
-    val ADOBE_ANALYTICS      = "ADOBE_ANALYTICS"
-    val AMAZON_ELASTICSEARCH = "AMAZON_ELASTICSEARCH"
-    val ATHENA               = "ATHENA"
-    val AURORA               = "AURORA"
-    val AURORA_POSTGRESQL    = "AURORA_POSTGRESQL"
-    val AWS_IOT_ANALYTICS    = "AWS_IOT_ANALYTICS"
-    val GITHUB               = "GITHUB"
-    val JIRA                 = "JIRA"
-    val MARIADB              = "MARIADB"
-    val MYSQL                = "MYSQL"
-    val POSTGRESQL           = "POSTGRESQL"
-    val PRESTO               = "PRESTO"
-    val REDSHIFT             = "REDSHIFT"
-    val S3                   = "S3"
-    val SALESFORCE           = "SALESFORCE"
-    val SERVICENOW           = "SERVICENOW"
-    val SNOWFLAKE            = "SNOWFLAKE"
-    val SPARK                = "SPARK"
-    val SQLSERVER            = "SQLSERVER"
-    val TERADATA             = "TERADATA"
-    val TWITTER              = "TWITTER"
+  @js.native
+  sealed trait DataSourceType extends js.Any
+  object DataSourceType extends js.Object {
+    val ADOBE_ANALYTICS      = "ADOBE_ANALYTICS".asInstanceOf[DataSourceType]
+    val AMAZON_ELASTICSEARCH = "AMAZON_ELASTICSEARCH".asInstanceOf[DataSourceType]
+    val ATHENA               = "ATHENA".asInstanceOf[DataSourceType]
+    val AURORA               = "AURORA".asInstanceOf[DataSourceType]
+    val AURORA_POSTGRESQL    = "AURORA_POSTGRESQL".asInstanceOf[DataSourceType]
+    val AWS_IOT_ANALYTICS    = "AWS_IOT_ANALYTICS".asInstanceOf[DataSourceType]
+    val GITHUB               = "GITHUB".asInstanceOf[DataSourceType]
+    val JIRA                 = "JIRA".asInstanceOf[DataSourceType]
+    val MARIADB              = "MARIADB".asInstanceOf[DataSourceType]
+    val MYSQL                = "MYSQL".asInstanceOf[DataSourceType]
+    val POSTGRESQL           = "POSTGRESQL".asInstanceOf[DataSourceType]
+    val PRESTO               = "PRESTO".asInstanceOf[DataSourceType]
+    val REDSHIFT             = "REDSHIFT".asInstanceOf[DataSourceType]
+    val S3                   = "S3".asInstanceOf[DataSourceType]
+    val SALESFORCE           = "SALESFORCE".asInstanceOf[DataSourceType]
+    val SERVICENOW           = "SERVICENOW".asInstanceOf[DataSourceType]
+    val SNOWFLAKE            = "SNOWFLAKE".asInstanceOf[DataSourceType]
+    val SPARK                = "SPARK".asInstanceOf[DataSourceType]
+    val SQLSERVER            = "SQLSERVER".asInstanceOf[DataSourceType]
+    val TERADATA             = "TERADATA".asInstanceOf[DataSourceType]
+    val TWITTER              = "TWITTER".asInstanceOf[DataSourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3253,14 +3238,15 @@ package quicksight {
       __obj.asInstanceOf[ExportToCSVOption]
     }
   }
-
-  object FileFormatEnum {
-    val CSV  = "CSV"
-    val TSV  = "TSV"
-    val CLF  = "CLF"
-    val ELF  = "ELF"
-    val XLSX = "XLSX"
-    val JSON = "JSON"
+  @js.native
+  sealed trait FileFormat extends js.Any
+  object FileFormat extends js.Object {
+    val CSV  = "CSV".asInstanceOf[FileFormat]
+    val TSV  = "TSV".asInstanceOf[FileFormat]
+    val CLF  = "CLF".asInstanceOf[FileFormat]
+    val ELF  = "ELF".asInstanceOf[FileFormat]
+    val XLSX = "XLSX".asInstanceOf[FileFormat]
+    val JSON = "JSON".asInstanceOf[FileFormat]
 
     val values = js.Object.freeze(js.Array(CSV, TSV, CLF, ELF, XLSX, JSON))
   }
@@ -3312,21 +3298,23 @@ package quicksight {
       __obj.asInstanceOf[GeoSpatialColumnGroup]
     }
   }
-
-  object GeoSpatialCountryCodeEnum {
-    val US = "US"
+  @js.native
+  sealed trait GeoSpatialCountryCode extends js.Any
+  object GeoSpatialCountryCode extends js.Object {
+    val US = "US".asInstanceOf[GeoSpatialCountryCode]
 
     val values = js.Object.freeze(js.Array(US))
   }
-
-  object GeoSpatialDataRoleEnum {
-    val COUNTRY   = "COUNTRY"
-    val STATE     = "STATE"
-    val COUNTY    = "COUNTY"
-    val CITY      = "CITY"
-    val POSTCODE  = "POSTCODE"
-    val LONGITUDE = "LONGITUDE"
-    val LATITUDE  = "LATITUDE"
+  @js.native
+  sealed trait GeoSpatialDataRole extends js.Any
+  object GeoSpatialDataRole extends js.Object {
+    val COUNTRY   = "COUNTRY".asInstanceOf[GeoSpatialDataRole]
+    val STATE     = "STATE".asInstanceOf[GeoSpatialDataRole]
+    val COUNTY    = "COUNTY".asInstanceOf[GeoSpatialDataRole]
+    val CITY      = "CITY".asInstanceOf[GeoSpatialDataRole]
+    val POSTCODE  = "POSTCODE".asInstanceOf[GeoSpatialDataRole]
+    val LONGITUDE = "LONGITUDE".asInstanceOf[GeoSpatialDataRole]
+    val LATITUDE  = "LATITUDE".asInstanceOf[GeoSpatialDataRole]
 
     val values = js.Object.freeze(js.Array(COUNTRY, STATE, COUNTY, CITY, POSTCODE, LONGITUDE, LATITUDE))
   }
@@ -3494,10 +3482,11 @@ package quicksight {
       __obj.asInstanceOf[IAMPolicyAssignmentSummary]
     }
   }
-
-  object IdentityTypeEnum {
-    val IAM        = "IAM"
-    val QUICKSIGHT = "QUICKSIGHT"
+  @js.native
+  sealed trait IdentityType extends js.Any
+  object IdentityType extends js.Object {
+    val IAM        = "IAM".asInstanceOf[IdentityType]
+    val QUICKSIGHT = "QUICKSIGHT".asInstanceOf[IdentityType]
 
     val values = js.Object.freeze(js.Array(IAM, QUICKSIGHT))
   }
@@ -3552,48 +3541,49 @@ package quicksight {
       __obj.asInstanceOf[Ingestion]
     }
   }
-
-  object IngestionErrorTypeEnum {
-    val FAILURE_TO_ASSUME_ROLE             = "FAILURE_TO_ASSUME_ROLE"
-    val INGESTION_SUPERSEDED               = "INGESTION_SUPERSEDED"
-    val INGESTION_CANCELED                 = "INGESTION_CANCELED"
-    val DATA_SET_DELETED                   = "DATA_SET_DELETED"
-    val DATA_SET_NOT_SPICE                 = "DATA_SET_NOT_SPICE"
-    val S3_UPLOADED_FILE_DELETED           = "S3_UPLOADED_FILE_DELETED"
-    val S3_MANIFEST_ERROR                  = "S3_MANIFEST_ERROR"
-    val DATA_TOLERANCE_EXCEPTION           = "DATA_TOLERANCE_EXCEPTION"
-    val SPICE_TABLE_NOT_FOUND              = "SPICE_TABLE_NOT_FOUND"
-    val DATA_SET_SIZE_LIMIT_EXCEEDED       = "DATA_SET_SIZE_LIMIT_EXCEEDED"
-    val ROW_SIZE_LIMIT_EXCEEDED            = "ROW_SIZE_LIMIT_EXCEEDED"
-    val ACCOUNT_CAPACITY_LIMIT_EXCEEDED    = "ACCOUNT_CAPACITY_LIMIT_EXCEEDED"
-    val CUSTOMER_ERROR                     = "CUSTOMER_ERROR"
-    val DATA_SOURCE_NOT_FOUND              = "DATA_SOURCE_NOT_FOUND"
-    val IAM_ROLE_NOT_AVAILABLE             = "IAM_ROLE_NOT_AVAILABLE"
-    val CONNECTION_FAILURE                 = "CONNECTION_FAILURE"
-    val SQL_TABLE_NOT_FOUND                = "SQL_TABLE_NOT_FOUND"
-    val PERMISSION_DENIED                  = "PERMISSION_DENIED"
-    val SSL_CERTIFICATE_VALIDATION_FAILURE = "SSL_CERTIFICATE_VALIDATION_FAILURE"
-    val OAUTH_TOKEN_FAILURE                = "OAUTH_TOKEN_FAILURE"
-    val SOURCE_API_LIMIT_EXCEEDED_FAILURE  = "SOURCE_API_LIMIT_EXCEEDED_FAILURE"
-    val PASSWORD_AUTHENTICATION_FAILURE    = "PASSWORD_AUTHENTICATION_FAILURE"
-    val SQL_SCHEMA_MISMATCH_ERROR          = "SQL_SCHEMA_MISMATCH_ERROR"
-    val INVALID_DATE_FORMAT                = "INVALID_DATE_FORMAT"
-    val INVALID_DATAPREP_SYNTAX            = "INVALID_DATAPREP_SYNTAX"
-    val SOURCE_RESOURCE_LIMIT_EXCEEDED     = "SOURCE_RESOURCE_LIMIT_EXCEEDED"
-    val SQL_INVALID_PARAMETER_VALUE        = "SQL_INVALID_PARAMETER_VALUE"
-    val QUERY_TIMEOUT                      = "QUERY_TIMEOUT"
-    val SQL_NUMERIC_OVERFLOW               = "SQL_NUMERIC_OVERFLOW"
-    val UNRESOLVABLE_HOST                  = "UNRESOLVABLE_HOST"
-    val UNROUTABLE_HOST                    = "UNROUTABLE_HOST"
-    val SQL_EXCEPTION                      = "SQL_EXCEPTION"
-    val S3_FILE_INACCESSIBLE               = "S3_FILE_INACCESSIBLE"
-    val IOT_FILE_NOT_FOUND                 = "IOT_FILE_NOT_FOUND"
-    val IOT_DATA_SET_FILE_EMPTY            = "IOT_DATA_SET_FILE_EMPTY"
-    val INVALID_DATA_SOURCE_CONFIG         = "INVALID_DATA_SOURCE_CONFIG"
-    val DATA_SOURCE_AUTH_FAILED            = "DATA_SOURCE_AUTH_FAILED"
-    val DATA_SOURCE_CONNECTION_FAILED      = "DATA_SOURCE_CONNECTION_FAILED"
-    val FAILURE_TO_PROCESS_JSON_FILE       = "FAILURE_TO_PROCESS_JSON_FILE"
-    val INTERNAL_SERVICE_ERROR             = "INTERNAL_SERVICE_ERROR"
+  @js.native
+  sealed trait IngestionErrorType extends js.Any
+  object IngestionErrorType extends js.Object {
+    val FAILURE_TO_ASSUME_ROLE             = "FAILURE_TO_ASSUME_ROLE".asInstanceOf[IngestionErrorType]
+    val INGESTION_SUPERSEDED               = "INGESTION_SUPERSEDED".asInstanceOf[IngestionErrorType]
+    val INGESTION_CANCELED                 = "INGESTION_CANCELED".asInstanceOf[IngestionErrorType]
+    val DATA_SET_DELETED                   = "DATA_SET_DELETED".asInstanceOf[IngestionErrorType]
+    val DATA_SET_NOT_SPICE                 = "DATA_SET_NOT_SPICE".asInstanceOf[IngestionErrorType]
+    val S3_UPLOADED_FILE_DELETED           = "S3_UPLOADED_FILE_DELETED".asInstanceOf[IngestionErrorType]
+    val S3_MANIFEST_ERROR                  = "S3_MANIFEST_ERROR".asInstanceOf[IngestionErrorType]
+    val DATA_TOLERANCE_EXCEPTION           = "DATA_TOLERANCE_EXCEPTION".asInstanceOf[IngestionErrorType]
+    val SPICE_TABLE_NOT_FOUND              = "SPICE_TABLE_NOT_FOUND".asInstanceOf[IngestionErrorType]
+    val DATA_SET_SIZE_LIMIT_EXCEEDED       = "DATA_SET_SIZE_LIMIT_EXCEEDED".asInstanceOf[IngestionErrorType]
+    val ROW_SIZE_LIMIT_EXCEEDED            = "ROW_SIZE_LIMIT_EXCEEDED".asInstanceOf[IngestionErrorType]
+    val ACCOUNT_CAPACITY_LIMIT_EXCEEDED    = "ACCOUNT_CAPACITY_LIMIT_EXCEEDED".asInstanceOf[IngestionErrorType]
+    val CUSTOMER_ERROR                     = "CUSTOMER_ERROR".asInstanceOf[IngestionErrorType]
+    val DATA_SOURCE_NOT_FOUND              = "DATA_SOURCE_NOT_FOUND".asInstanceOf[IngestionErrorType]
+    val IAM_ROLE_NOT_AVAILABLE             = "IAM_ROLE_NOT_AVAILABLE".asInstanceOf[IngestionErrorType]
+    val CONNECTION_FAILURE                 = "CONNECTION_FAILURE".asInstanceOf[IngestionErrorType]
+    val SQL_TABLE_NOT_FOUND                = "SQL_TABLE_NOT_FOUND".asInstanceOf[IngestionErrorType]
+    val PERMISSION_DENIED                  = "PERMISSION_DENIED".asInstanceOf[IngestionErrorType]
+    val SSL_CERTIFICATE_VALIDATION_FAILURE = "SSL_CERTIFICATE_VALIDATION_FAILURE".asInstanceOf[IngestionErrorType]
+    val OAUTH_TOKEN_FAILURE                = "OAUTH_TOKEN_FAILURE".asInstanceOf[IngestionErrorType]
+    val SOURCE_API_LIMIT_EXCEEDED_FAILURE  = "SOURCE_API_LIMIT_EXCEEDED_FAILURE".asInstanceOf[IngestionErrorType]
+    val PASSWORD_AUTHENTICATION_FAILURE    = "PASSWORD_AUTHENTICATION_FAILURE".asInstanceOf[IngestionErrorType]
+    val SQL_SCHEMA_MISMATCH_ERROR          = "SQL_SCHEMA_MISMATCH_ERROR".asInstanceOf[IngestionErrorType]
+    val INVALID_DATE_FORMAT                = "INVALID_DATE_FORMAT".asInstanceOf[IngestionErrorType]
+    val INVALID_DATAPREP_SYNTAX            = "INVALID_DATAPREP_SYNTAX".asInstanceOf[IngestionErrorType]
+    val SOURCE_RESOURCE_LIMIT_EXCEEDED     = "SOURCE_RESOURCE_LIMIT_EXCEEDED".asInstanceOf[IngestionErrorType]
+    val SQL_INVALID_PARAMETER_VALUE        = "SQL_INVALID_PARAMETER_VALUE".asInstanceOf[IngestionErrorType]
+    val QUERY_TIMEOUT                      = "QUERY_TIMEOUT".asInstanceOf[IngestionErrorType]
+    val SQL_NUMERIC_OVERFLOW               = "SQL_NUMERIC_OVERFLOW".asInstanceOf[IngestionErrorType]
+    val UNRESOLVABLE_HOST                  = "UNRESOLVABLE_HOST".asInstanceOf[IngestionErrorType]
+    val UNROUTABLE_HOST                    = "UNROUTABLE_HOST".asInstanceOf[IngestionErrorType]
+    val SQL_EXCEPTION                      = "SQL_EXCEPTION".asInstanceOf[IngestionErrorType]
+    val S3_FILE_INACCESSIBLE               = "S3_FILE_INACCESSIBLE".asInstanceOf[IngestionErrorType]
+    val IOT_FILE_NOT_FOUND                 = "IOT_FILE_NOT_FOUND".asInstanceOf[IngestionErrorType]
+    val IOT_DATA_SET_FILE_EMPTY            = "IOT_DATA_SET_FILE_EMPTY".asInstanceOf[IngestionErrorType]
+    val INVALID_DATA_SOURCE_CONFIG         = "INVALID_DATA_SOURCE_CONFIG".asInstanceOf[IngestionErrorType]
+    val DATA_SOURCE_AUTH_FAILED            = "DATA_SOURCE_AUTH_FAILED".asInstanceOf[IngestionErrorType]
+    val DATA_SOURCE_CONNECTION_FAILED      = "DATA_SOURCE_CONNECTION_FAILED".asInstanceOf[IngestionErrorType]
+    val FAILURE_TO_PROCESS_JSON_FILE       = "FAILURE_TO_PROCESS_JSON_FILE".asInstanceOf[IngestionErrorType]
+    val INTERNAL_SERVICE_ERROR             = "INTERNAL_SERVICE_ERROR".asInstanceOf[IngestionErrorType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3640,30 +3630,33 @@ package quicksight {
       )
     )
   }
-
-  object IngestionRequestSourceEnum {
-    val MANUAL    = "MANUAL"
-    val SCHEDULED = "SCHEDULED"
+  @js.native
+  sealed trait IngestionRequestSource extends js.Any
+  object IngestionRequestSource extends js.Object {
+    val MANUAL    = "MANUAL".asInstanceOf[IngestionRequestSource]
+    val SCHEDULED = "SCHEDULED".asInstanceOf[IngestionRequestSource]
 
     val values = js.Object.freeze(js.Array(MANUAL, SCHEDULED))
   }
-
-  object IngestionRequestTypeEnum {
-    val INITIAL_INGESTION   = "INITIAL_INGESTION"
-    val EDIT                = "EDIT"
-    val INCREMENTAL_REFRESH = "INCREMENTAL_REFRESH"
-    val FULL_REFRESH        = "FULL_REFRESH"
+  @js.native
+  sealed trait IngestionRequestType extends js.Any
+  object IngestionRequestType extends js.Object {
+    val INITIAL_INGESTION   = "INITIAL_INGESTION".asInstanceOf[IngestionRequestType]
+    val EDIT                = "EDIT".asInstanceOf[IngestionRequestType]
+    val INCREMENTAL_REFRESH = "INCREMENTAL_REFRESH".asInstanceOf[IngestionRequestType]
+    val FULL_REFRESH        = "FULL_REFRESH".asInstanceOf[IngestionRequestType]
 
     val values = js.Object.freeze(js.Array(INITIAL_INGESTION, EDIT, INCREMENTAL_REFRESH, FULL_REFRESH))
   }
-
-  object IngestionStatusEnum {
-    val INITIALIZED = "INITIALIZED"
-    val QUEUED      = "QUEUED"
-    val RUNNING     = "RUNNING"
-    val FAILED      = "FAILED"
-    val COMPLETED   = "COMPLETED"
-    val CANCELLED   = "CANCELLED"
+  @js.native
+  sealed trait IngestionStatus extends js.Any
+  object IngestionStatus extends js.Object {
+    val INITIALIZED = "INITIALIZED".asInstanceOf[IngestionStatus]
+    val QUEUED      = "QUEUED".asInstanceOf[IngestionStatus]
+    val RUNNING     = "RUNNING".asInstanceOf[IngestionStatus]
+    val FAILED      = "FAILED".asInstanceOf[IngestionStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[IngestionStatus]
+    val CANCELLED   = "CANCELLED".asInstanceOf[IngestionStatus]
 
     val values = js.Object.freeze(js.Array(INITIALIZED, QUEUED, RUNNING, FAILED, COMPLETED, CANCELLED))
   }
@@ -3691,15 +3684,16 @@ package quicksight {
       __obj.asInstanceOf[InputColumn]
     }
   }
-
-  object InputColumnDataTypeEnum {
-    val STRING   = "STRING"
-    val INTEGER  = "INTEGER"
-    val DECIMAL  = "DECIMAL"
-    val DATETIME = "DATETIME"
-    val BIT      = "BIT"
-    val BOOLEAN  = "BOOLEAN"
-    val JSON     = "JSON"
+  @js.native
+  sealed trait InputColumnDataType extends js.Any
+  object InputColumnDataType extends js.Object {
+    val STRING   = "STRING".asInstanceOf[InputColumnDataType]
+    val INTEGER  = "INTEGER".asInstanceOf[InputColumnDataType]
+    val DECIMAL  = "DECIMAL".asInstanceOf[InputColumnDataType]
+    val DATETIME = "DATETIME".asInstanceOf[InputColumnDataType]
+    val BIT      = "BIT".asInstanceOf[InputColumnDataType]
+    val BOOLEAN  = "BOOLEAN".asInstanceOf[InputColumnDataType]
+    val JSON     = "JSON".asInstanceOf[InputColumnDataType]
 
     val values = js.Object.freeze(js.Array(STRING, INTEGER, DECIMAL, DATETIME, BIT, BOOLEAN, JSON))
   }
@@ -3778,12 +3772,13 @@ package quicksight {
       __obj.asInstanceOf[JoinInstruction]
     }
   }
-
-  object JoinTypeEnum {
-    val INNER = "INNER"
-    val OUTER = "OUTER"
-    val LEFT  = "LEFT"
-    val RIGHT = "RIGHT"
+  @js.native
+  sealed trait JoinType extends js.Any
+  object JoinType extends js.Object {
+    val INNER = "INNER".asInstanceOf[JoinType]
+    val OUTER = "OUTER".asInstanceOf[JoinType]
+    val LEFT  = "LEFT".asInstanceOf[JoinType]
+    val RIGHT = "RIGHT".asInstanceOf[JoinType]
 
     val values = js.Object.freeze(js.Array(INNER, OUTER, LEFT, RIGHT))
   }
@@ -5056,14 +5051,15 @@ package quicksight {
       __obj.asInstanceOf[ResourcePermission]
     }
   }
-
-  object ResourceStatusEnum {
-    val CREATION_IN_PROGRESS = "CREATION_IN_PROGRESS"
-    val CREATION_SUCCESSFUL  = "CREATION_SUCCESSFUL"
-    val CREATION_FAILED      = "CREATION_FAILED"
-    val UPDATE_IN_PROGRESS   = "UPDATE_IN_PROGRESS"
-    val UPDATE_SUCCESSFUL    = "UPDATE_SUCCESSFUL"
-    val UPDATE_FAILED        = "UPDATE_FAILED"
+  @js.native
+  sealed trait ResourceStatus extends js.Any
+  object ResourceStatus extends js.Object {
+    val CREATION_IN_PROGRESS = "CREATION_IN_PROGRESS".asInstanceOf[ResourceStatus]
+    val CREATION_SUCCESSFUL  = "CREATION_SUCCESSFUL".asInstanceOf[ResourceStatus]
+    val CREATION_FAILED      = "CREATION_FAILED".asInstanceOf[ResourceStatus]
+    val UPDATE_IN_PROGRESS   = "UPDATE_IN_PROGRESS".asInstanceOf[ResourceStatus]
+    val UPDATE_SUCCESSFUL    = "UPDATE_SUCCESSFUL".asInstanceOf[ResourceStatus]
+    val UPDATE_FAILED        = "UPDATE_FAILED".asInstanceOf[ResourceStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5122,10 +5118,11 @@ package quicksight {
       __obj.asInstanceOf[RowLevelPermissionDataSet]
     }
   }
-
-  object RowLevelPermissionPolicyEnum {
-    val GRANT_ACCESS = "GRANT_ACCESS"
-    val DENY_ACCESS  = "DENY_ACCESS"
+  @js.native
+  sealed trait RowLevelPermissionPolicy extends js.Any
+  object RowLevelPermissionPolicy extends js.Object {
+    val GRANT_ACCESS = "GRANT_ACCESS".asInstanceOf[RowLevelPermissionPolicy]
+    val DENY_ACCESS  = "DENY_ACCESS".asInstanceOf[RowLevelPermissionPolicy]
 
     val values = js.Object.freeze(js.Array(GRANT_ACCESS, DENY_ACCESS))
   }
@@ -5508,10 +5505,11 @@ package quicksight {
       __obj.asInstanceOf[TemplateError]
     }
   }
-
-  object TemplateErrorTypeEnum {
-    val DATA_SET_NOT_FOUND = "DATA_SET_NOT_FOUND"
-    val INTERNAL_FAILURE   = "INTERNAL_FAILURE"
+  @js.native
+  sealed trait TemplateErrorType extends js.Any
+  object TemplateErrorType extends js.Object {
+    val DATA_SET_NOT_FOUND = "DATA_SET_NOT_FOUND".asInstanceOf[TemplateErrorType]
+    val INTERNAL_FAILURE   = "INTERNAL_FAILURE".asInstanceOf[TemplateErrorType]
 
     val values = js.Object.freeze(js.Array(DATA_SET_NOT_FOUND, INTERNAL_FAILURE))
   }
@@ -5711,10 +5709,11 @@ package quicksight {
       __obj.asInstanceOf[TeradataParameters]
     }
   }
-
-  object TextQualifierEnum {
-    val DOUBLE_QUOTE = "DOUBLE_QUOTE"
-    val SINGLE_QUOTE = "SINGLE_QUOTE"
+  @js.native
+  sealed trait TextQualifier extends js.Any
+  object TextQualifier extends js.Object {
+    val DOUBLE_QUOTE = "DOUBLE_QUOTE".asInstanceOf[TextQualifier]
+    val SINGLE_QUOTE = "SINGLE_QUOTE".asInstanceOf[TextQualifier]
 
     val values = js.Object.freeze(js.Array(DOUBLE_QUOTE, SINGLE_QUOTE))
   }
@@ -6628,13 +6627,14 @@ package quicksight {
       __obj.asInstanceOf[User]
     }
   }
-
-  object UserRoleEnum {
-    val ADMIN             = "ADMIN"
-    val AUTHOR            = "AUTHOR"
-    val READER            = "READER"
-    val RESTRICTED_AUTHOR = "RESTRICTED_AUTHOR"
-    val RESTRICTED_READER = "RESTRICTED_READER"
+  @js.native
+  sealed trait UserRole extends js.Any
+  object UserRole extends js.Object {
+    val ADMIN             = "ADMIN".asInstanceOf[UserRole]
+    val AUTHOR            = "AUTHOR".asInstanceOf[UserRole]
+    val READER            = "READER".asInstanceOf[UserRole]
+    val RESTRICTED_AUTHOR = "RESTRICTED_AUTHOR".asInstanceOf[UserRole]
+    val RESTRICTED_READER = "RESTRICTED_READER".asInstanceOf[UserRole]
 
     val values = js.Object.freeze(js.Array(ADMIN, AUTHOR, READER, RESTRICTED_AUTHOR, RESTRICTED_READER))
   }

--- a/services/ram/src/main/scala/facade/amazonaws/services/RAM.scala
+++ b/services/ram/src/main/scala/facade/amazonaws/services/RAM.scala
@@ -16,19 +16,12 @@ package object ram {
   type PrincipalList                  = js.Array[Principal]
   type ResourceArnList                = js.Array[String]
   type ResourceList                   = js.Array[Resource]
-  type ResourceOwner                  = String
   type ResourceShareArnList           = js.Array[String]
   type ResourceShareAssociationList   = js.Array[ResourceShareAssociation]
-  type ResourceShareAssociationStatus = String
-  type ResourceShareAssociationType   = String
-  type ResourceShareFeatureSet        = String
   type ResourceShareInvitationArnList = js.Array[String]
   type ResourceShareInvitationList    = js.Array[ResourceShareInvitation]
-  type ResourceShareInvitationStatus  = String
   type ResourceShareList              = js.Array[ResourceShare]
   type ResourceSharePermissionList    = js.Array[ResourceSharePermissionSummary]
-  type ResourceShareStatus            = String
-  type ResourceStatus                 = String
   type TagFilters                     = js.Array[TagFilter]
   type TagKey                         = String
   type TagKeyList                     = js.Array[TagKey]
@@ -1128,10 +1121,11 @@ package ram {
       __obj.asInstanceOf[Resource]
     }
   }
-
-  object ResourceOwnerEnum {
-    val SELF             = "SELF"
-    val `OTHER-ACCOUNTS` = "OTHER-ACCOUNTS"
+  @js.native
+  sealed trait ResourceOwner extends js.Any
+  object ResourceOwner extends js.Object {
+    val SELF             = "SELF".asInstanceOf[ResourceOwner]
+    val `OTHER-ACCOUNTS` = "OTHER-ACCOUNTS".asInstanceOf[ResourceOwner]
 
     val values = js.Object.freeze(js.Array(SELF, `OTHER-ACCOUNTS`))
   }
@@ -1224,28 +1218,31 @@ package ram {
       __obj.asInstanceOf[ResourceShareAssociation]
     }
   }
-
-  object ResourceShareAssociationStatusEnum {
-    val ASSOCIATING    = "ASSOCIATING"
-    val ASSOCIATED     = "ASSOCIATED"
-    val FAILED         = "FAILED"
-    val DISASSOCIATING = "DISASSOCIATING"
-    val DISASSOCIATED  = "DISASSOCIATED"
+  @js.native
+  sealed trait ResourceShareAssociationStatus extends js.Any
+  object ResourceShareAssociationStatus extends js.Object {
+    val ASSOCIATING    = "ASSOCIATING".asInstanceOf[ResourceShareAssociationStatus]
+    val ASSOCIATED     = "ASSOCIATED".asInstanceOf[ResourceShareAssociationStatus]
+    val FAILED         = "FAILED".asInstanceOf[ResourceShareAssociationStatus]
+    val DISASSOCIATING = "DISASSOCIATING".asInstanceOf[ResourceShareAssociationStatus]
+    val DISASSOCIATED  = "DISASSOCIATED".asInstanceOf[ResourceShareAssociationStatus]
 
     val values = js.Object.freeze(js.Array(ASSOCIATING, ASSOCIATED, FAILED, DISASSOCIATING, DISASSOCIATED))
   }
-
-  object ResourceShareAssociationTypeEnum {
-    val PRINCIPAL = "PRINCIPAL"
-    val RESOURCE  = "RESOURCE"
+  @js.native
+  sealed trait ResourceShareAssociationType extends js.Any
+  object ResourceShareAssociationType extends js.Object {
+    val PRINCIPAL = "PRINCIPAL".asInstanceOf[ResourceShareAssociationType]
+    val RESOURCE  = "RESOURCE".asInstanceOf[ResourceShareAssociationType]
 
     val values = js.Object.freeze(js.Array(PRINCIPAL, RESOURCE))
   }
-
-  object ResourceShareFeatureSetEnum {
-    val CREATED_FROM_POLICY   = "CREATED_FROM_POLICY"
-    val PROMOTING_TO_STANDARD = "PROMOTING_TO_STANDARD"
-    val STANDARD              = "STANDARD"
+  @js.native
+  sealed trait ResourceShareFeatureSet extends js.Any
+  object ResourceShareFeatureSet extends js.Object {
+    val CREATED_FROM_POLICY   = "CREATED_FROM_POLICY".asInstanceOf[ResourceShareFeatureSet]
+    val PROMOTING_TO_STANDARD = "PROMOTING_TO_STANDARD".asInstanceOf[ResourceShareFeatureSet]
+    val STANDARD              = "STANDARD".asInstanceOf[ResourceShareFeatureSet]
 
     val values = js.Object.freeze(js.Array(CREATED_FROM_POLICY, PROMOTING_TO_STANDARD, STANDARD))
   }
@@ -1293,12 +1290,13 @@ package ram {
       __obj.asInstanceOf[ResourceShareInvitation]
     }
   }
-
-  object ResourceShareInvitationStatusEnum {
-    val PENDING  = "PENDING"
-    val ACCEPTED = "ACCEPTED"
-    val REJECTED = "REJECTED"
-    val EXPIRED  = "EXPIRED"
+  @js.native
+  sealed trait ResourceShareInvitationStatus extends js.Any
+  object ResourceShareInvitationStatus extends js.Object {
+    val PENDING  = "PENDING".asInstanceOf[ResourceShareInvitationStatus]
+    val ACCEPTED = "ACCEPTED".asInstanceOf[ResourceShareInvitationStatus]
+    val REJECTED = "REJECTED".asInstanceOf[ResourceShareInvitationStatus]
+    val EXPIRED  = "EXPIRED".asInstanceOf[ResourceShareInvitationStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, ACCEPTED, REJECTED, EXPIRED))
   }
@@ -1382,23 +1380,25 @@ package ram {
       __obj.asInstanceOf[ResourceSharePermissionSummary]
     }
   }
-
-  object ResourceShareStatusEnum {
-    val PENDING  = "PENDING"
-    val ACTIVE   = "ACTIVE"
-    val FAILED   = "FAILED"
-    val DELETING = "DELETING"
-    val DELETED  = "DELETED"
+  @js.native
+  sealed trait ResourceShareStatus extends js.Any
+  object ResourceShareStatus extends js.Object {
+    val PENDING  = "PENDING".asInstanceOf[ResourceShareStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[ResourceShareStatus]
+    val FAILED   = "FAILED".asInstanceOf[ResourceShareStatus]
+    val DELETING = "DELETING".asInstanceOf[ResourceShareStatus]
+    val DELETED  = "DELETED".asInstanceOf[ResourceShareStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, ACTIVE, FAILED, DELETING, DELETED))
   }
-
-  object ResourceStatusEnum {
-    val AVAILABLE                   = "AVAILABLE"
-    val ZONAL_RESOURCE_INACCESSIBLE = "ZONAL_RESOURCE_INACCESSIBLE"
-    val LIMIT_EXCEEDED              = "LIMIT_EXCEEDED"
-    val UNAVAILABLE                 = "UNAVAILABLE"
-    val PENDING                     = "PENDING"
+  @js.native
+  sealed trait ResourceStatus extends js.Any
+  object ResourceStatus extends js.Object {
+    val AVAILABLE                   = "AVAILABLE".asInstanceOf[ResourceStatus]
+    val ZONAL_RESOURCE_INACCESSIBLE = "ZONAL_RESOURCE_INACCESSIBLE".asInstanceOf[ResourceStatus]
+    val LIMIT_EXCEEDED              = "LIMIT_EXCEEDED".asInstanceOf[ResourceStatus]
+    val UNAVAILABLE                 = "UNAVAILABLE".asInstanceOf[ResourceStatus]
+    val PENDING                     = "PENDING".asInstanceOf[ResourceStatus]
 
     val values =
       js.Object.freeze(js.Array(AVAILABLE, ZONAL_RESOURCE_INACCESSIBLE, LIMIT_EXCEEDED, UNAVAILABLE, PENDING))

--- a/services/rds/src/main/scala/facade/amazonaws/services/RDS.scala
+++ b/services/rds/src/main/scala/facade/amazonaws/services/RDS.scala
@@ -8,11 +8,7 @@ import facade.amazonaws._
 
 package object rds {
   type AccountQuotaList                        = js.Array[AccountQuota]
-  type ActivityStreamMode                      = String
-  type ActivityStreamStatus                    = String
-  type ApplyMethod                             = String
   type AttributeValueList                      = js.Array[String]
-  type AuthScheme                              = String
   type AvailabilityZoneList                    = js.Array[AvailabilityZone]
   type AvailabilityZones                       = js.Array[String]
   type AvailableProcessorFeatureList           = js.Array[AvailableProcessorFeature]
@@ -36,7 +32,6 @@ package object rds {
   type DBParameterGroupList                    = js.Array[DBParameterGroup]
   type DBParameterGroupStatusList              = js.Array[DBParameterGroupStatus]
   type DBProxyList                             = js.Array[DBProxy]
-  type DBProxyStatus                           = String
   type DBSecurityGroupMembershipList           = js.Array[DBSecurityGroupMembership]
   type DBSecurityGroupNameList                 = js.Array[String]
   type DBSecurityGroups                        = js.Array[DBSecurityGroup]
@@ -48,7 +43,6 @@ package object rds {
   type DoubleOptional                          = Double
   type DoubleRangeList                         = js.Array[DoubleRange]
   type EC2SecurityGroupList                    = js.Array[EC2SecurityGroup]
-  type EngineFamily                            = String
   type EngineModeList                          = js.Array[String]
   type EventCategoriesList                     = js.Array[String]
   type EventCategoriesMapList                  = js.Array[EventCategoriesMap]
@@ -60,7 +54,6 @@ package object rds {
   type FilterValueList                         = js.Array[String]
   type GlobalClusterList                       = js.Array[GlobalCluster]
   type GlobalClusterMemberList                 = js.Array[GlobalClusterMember]
-  type IAMAuthMode                             = String
   type IPRangeList                             = js.Array[IPRange]
   type InstallationMediaList                   = js.Array[InstallationMedia]
   type IntegerOptional                         = Int
@@ -96,7 +89,6 @@ package object rds {
   type ReservedDBInstancesOfferingList         = js.Array[ReservedDBInstancesOffering]
   type SourceIdsList                           = js.Array[String]
   type SourceRegionList                        = js.Array[SourceRegion]
-  type SourceType                              = String
   type StringList                              = js.Array[String]
   type StringSensitive                         = String
   type SubnetIdentifierList                    = js.Array[String]
@@ -107,7 +99,6 @@ package object rds {
   type TagList                                 = js.Array[Tag]
   type TargetGroupList                         = js.Array[DBProxyTargetGroup]
   type TargetList                              = js.Array[DBProxyTarget]
-  type TargetType                              = String
   type UserAuthConfigInfoList                  = js.Array[UserAuthConfigInfo]
   type UserAuthConfigList                      = js.Array[UserAuthConfig]
   type ValidStorageOptionsList                 = js.Array[ValidStorageOptions]
@@ -739,19 +730,21 @@ package rds {
       __obj.asInstanceOf[AccountQuota]
     }
   }
-
-  object ActivityStreamModeEnum {
-    val sync  = "sync"
-    val async = "async"
+  @js.native
+  sealed trait ActivityStreamMode extends js.Any
+  object ActivityStreamMode extends js.Object {
+    val sync  = "sync".asInstanceOf[ActivityStreamMode]
+    val async = "async".asInstanceOf[ActivityStreamMode]
 
     val values = js.Object.freeze(js.Array(sync, async))
   }
-
-  object ActivityStreamStatusEnum {
-    val stopped  = "stopped"
-    val starting = "starting"
-    val started  = "started"
-    val stopping = "stopping"
+  @js.native
+  sealed trait ActivityStreamStatus extends js.Any
+  object ActivityStreamStatus extends js.Object {
+    val stopped  = "stopped".asInstanceOf[ActivityStreamStatus]
+    val starting = "starting".asInstanceOf[ActivityStreamStatus]
+    val started  = "started".asInstanceOf[ActivityStreamStatus]
+    val stopping = "stopping".asInstanceOf[ActivityStreamStatus]
 
     val values = js.Object.freeze(js.Array(stopped, starting, started, stopping))
   }
@@ -867,10 +860,11 @@ package rds {
       __obj.asInstanceOf[AddTagsToResourceMessage]
     }
   }
-
-  object ApplyMethodEnum {
-    val immediate        = "immediate"
-    val `pending-reboot` = "pending-reboot"
+  @js.native
+  sealed trait ApplyMethod extends js.Any
+  object ApplyMethod extends js.Object {
+    val immediate        = "immediate".asInstanceOf[ApplyMethod]
+    val `pending-reboot` = "pending-reboot".asInstanceOf[ApplyMethod]
 
     val values = js.Object.freeze(js.Array(immediate, `pending-reboot`))
   }
@@ -919,9 +913,10 @@ package rds {
       __obj.asInstanceOf[ApplyPendingMaintenanceActionResult]
     }
   }
-
-  object AuthSchemeEnum {
-    val SECRETS = "SECRETS"
+  @js.native
+  sealed trait AuthScheme extends js.Any
+  object AuthScheme extends js.Object {
+    val SECRETS = "SECRETS".asInstanceOf[AuthScheme]
 
     val values = js.Object.freeze(js.Array(SECRETS))
   }
@@ -3939,14 +3934,15 @@ package rds {
       __obj.asInstanceOf[DBProxy]
     }
   }
-
-  object DBProxyStatusEnum {
-    val available                      = "available"
-    val modifying                      = "modifying"
-    val `incompatible-network`         = "incompatible-network"
-    val `insufficient-resource-limits` = "insufficient-resource-limits"
-    val creating                       = "creating"
-    val deleting                       = "deleting"
+  @js.native
+  sealed trait DBProxyStatus extends js.Any
+  object DBProxyStatus extends js.Object {
+    val available                      = "available".asInstanceOf[DBProxyStatus]
+    val modifying                      = "modifying".asInstanceOf[DBProxyStatus]
+    val `incompatible-network`         = "incompatible-network".asInstanceOf[DBProxyStatus]
+    val `insufficient-resource-limits` = "insufficient-resource-limits".asInstanceOf[DBProxyStatus]
+    val creating                       = "creating".asInstanceOf[DBProxyStatus]
+    val deleting                       = "deleting".asInstanceOf[DBProxyStatus]
 
     val values = js.Object.freeze(
       js.Array(available, modifying, `incompatible-network`, `insufficient-resource-limits`, creating, deleting)
@@ -6462,9 +6458,10 @@ package rds {
       __obj.asInstanceOf[EngineDefaults]
     }
   }
-
-  object EngineFamilyEnum {
-    val MYSQL = "MYSQL"
+  @js.native
+  sealed trait EngineFamily extends js.Any
+  object EngineFamily extends js.Object {
+    val MYSQL = "MYSQL".asInstanceOf[EngineFamily]
 
     val values = js.Object.freeze(js.Array(MYSQL))
   }
@@ -6878,10 +6875,11 @@ package rds {
       __obj.asInstanceOf[GlobalClustersMessage]
     }
   }
-
-  object IAMAuthModeEnum {
-    val DISABLED = "DISABLED"
-    val REQUIRED = "REQUIRED"
+  @js.native
+  sealed trait IAMAuthMode extends js.Any
+  object IAMAuthMode extends js.Object {
+    val DISABLED = "DISABLED".asInstanceOf[IAMAuthMode]
+    val REQUIRED = "REQUIRED".asInstanceOf[IAMAuthMode]
 
     val values = js.Object.freeze(js.Array(DISABLED, REQUIRED))
   }
@@ -10223,14 +10221,15 @@ package rds {
       __obj.asInstanceOf[SourceRegionMessage]
     }
   }
-
-  object SourceTypeEnum {
-    val `db-instance`         = "db-instance"
-    val `db-parameter-group`  = "db-parameter-group"
-    val `db-security-group`   = "db-security-group"
-    val `db-snapshot`         = "db-snapshot"
-    val `db-cluster`          = "db-cluster"
-    val `db-cluster-snapshot` = "db-cluster-snapshot"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val `db-instance`         = "db-instance".asInstanceOf[SourceType]
+    val `db-parameter-group`  = "db-parameter-group".asInstanceOf[SourceType]
+    val `db-security-group`   = "db-security-group".asInstanceOf[SourceType]
+    val `db-snapshot`         = "db-snapshot".asInstanceOf[SourceType]
+    val `db-cluster`          = "db-cluster".asInstanceOf[SourceType]
+    val `db-cluster-snapshot` = "db-cluster-snapshot".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -10582,11 +10581,12 @@ package rds {
       __obj.asInstanceOf[TagListMessage]
     }
   }
-
-  object TargetTypeEnum {
-    val RDS_INSTANCE            = "RDS_INSTANCE"
-    val RDS_SERVERLESS_ENDPOINT = "RDS_SERVERLESS_ENDPOINT"
-    val TRACKED_CLUSTER         = "TRACKED_CLUSTER"
+  @js.native
+  sealed trait TargetType extends js.Any
+  object TargetType extends js.Object {
+    val RDS_INSTANCE            = "RDS_INSTANCE".asInstanceOf[TargetType]
+    val RDS_SERVERLESS_ENDPOINT = "RDS_SERVERLESS_ENDPOINT".asInstanceOf[TargetType]
+    val TRACKED_CLUSTER         = "TRACKED_CLUSTER".asInstanceOf[TargetType]
 
     val values = js.Object.freeze(js.Array(RDS_INSTANCE, RDS_SERVERLESS_ENDPOINT, TRACKED_CLUSTER))
   }

--- a/services/rdsdataservice/src/main/scala/facade/amazonaws/services/RDSDataService.scala
+++ b/services/rdsdataservice/src/main/scala/facade/amazonaws/services/RDSDataService.scala
@@ -18,7 +18,6 @@ package object rdsdataservice {
   type BoxedInteger        = Int
   type BoxedLong           = Double
   type DbName              = String
-  type DecimalReturnType   = String
   type DoubleArray         = js.Array[BoxedDouble]
   type FieldList           = js.Array[Field]
   type Id                  = String
@@ -35,7 +34,6 @@ package object rdsdataservice {
   type SqlStatementResults = js.Array[SqlStatementResult]
   type StringArray         = js.Array[String]
   type TransactionStatus   = String
-  type TypeHint            = String
   type UpdateResults       = js.Array[UpdateResult]
 
   implicit final class RDSDataServiceOps(private val service: RDSDataService) extends AnyVal {
@@ -311,10 +309,11 @@ package rdsdataservice {
       __obj.asInstanceOf[CommitTransactionResponse]
     }
   }
-
-  object DecimalReturnTypeEnum {
-    val DOUBLE_OR_LONG = "DOUBLE_OR_LONG"
-    val STRING         = "STRING"
+  @js.native
+  sealed trait DecimalReturnType extends js.Any
+  object DecimalReturnType extends js.Object {
+    val DOUBLE_OR_LONG = "DOUBLE_OR_LONG".asInstanceOf[DecimalReturnType]
+    val STRING         = "STRING".asInstanceOf[DecimalReturnType]
 
     val values = js.Object.freeze(js.Array(DOUBLE_OR_LONG, STRING))
   }
@@ -678,12 +677,13 @@ package rdsdataservice {
       __obj.asInstanceOf[StructValue]
     }
   }
-
-  object TypeHintEnum {
-    val DATE      = "DATE"
-    val DECIMAL   = "DECIMAL"
-    val TIME      = "TIME"
-    val TIMESTAMP = "TIMESTAMP"
+  @js.native
+  sealed trait TypeHint extends js.Any
+  object TypeHint extends js.Object {
+    val DATE      = "DATE".asInstanceOf[TypeHint]
+    val DECIMAL   = "DECIMAL".asInstanceOf[TypeHint]
+    val TIME      = "TIME".asInstanceOf[TypeHint]
+    val TIMESTAMP = "TIMESTAMP".asInstanceOf[TypeHint]
 
     val values = js.Object.freeze(js.Array(DATE, DECIMAL, TIME, TIMESTAMP))
   }

--- a/services/redshift/src/main/scala/facade/amazonaws/services/Redshift.scala
+++ b/services/redshift/src/main/scala/facade/amazonaws/services/Redshift.scala
@@ -8,7 +8,6 @@ import facade.amazonaws._
 
 package object redshift {
   type AccountsWithRestoreAccessList      = js.Array[AccountWithRestoreAccess]
-  type ActionType                         = String
   type AssociatedClusterList              = js.Array[ClusterAssociatedToSchedule]
   type AttributeList                      = js.Array[AccountAttribute]
   type AttributeNameList                  = js.Array[String]
@@ -48,48 +47,35 @@ package object redshift {
   type ImportTablesNotStarted             = js.Array[String]
   type IntegerOptional                    = Int
   type LongOptional                       = Double
-  type Mode                               = String
   type NodeConfigurationOptionList        = js.Array[NodeConfigurationOption]
   type NodeConfigurationOptionsFilterList = js.Array[NodeConfigurationOptionsFilter]
-  type NodeConfigurationOptionsFilterName = String
-  type OperatorType                       = String
   type OrderableClusterOptionsList        = js.Array[OrderableClusterOption]
-  type ParameterApplyType                 = String
   type ParameterGroupList                 = js.Array[ClusterParameterGroup]
   type ParametersList                     = js.Array[Parameter]
   type PendingActionsList                 = js.Array[String]
   type RecurringChargeList                = js.Array[RecurringCharge]
   type ReservedNodeList                   = js.Array[ReservedNode]
   type ReservedNodeOfferingList           = js.Array[ReservedNodeOffering]
-  type ReservedNodeOfferingType           = String
   type RestorableNodeTypeList             = js.Array[String]
   type RevisionTargetsList                = js.Array[RevisionTarget]
   type ScheduleDefinitionList             = js.Array[String]
-  type ScheduleState                      = String
   type ScheduledActionFilterList          = js.Array[ScheduledActionFilter]
-  type ScheduledActionFilterName          = String
   type ScheduledActionList                = js.Array[ScheduledAction]
-  type ScheduledActionState               = String
   type ScheduledActionTimeList            = js.Array[TStamp]
-  type ScheduledActionTypeValues          = String
   type ScheduledSnapshotTimeList          = js.Array[TStamp]
   type SensitiveString                    = String
-  type SnapshotAttributeToSortBy          = String
   type SnapshotCopyGrantList              = js.Array[SnapshotCopyGrant]
   type SnapshotIdentifierList             = js.Array[String]
   type SnapshotList                       = js.Array[Snapshot]
   type SnapshotScheduleList               = js.Array[SnapshotSchedule]
   type SnapshotSortingEntityList          = js.Array[SnapshotSortingEntity]
-  type SortByOrder                        = String
   type SourceIdsList                      = js.Array[String]
-  type SourceType                         = String
   type SubnetIdentifierList               = js.Array[String]
   type SubnetList                         = js.Array[Subnet]
   type SupportedOperationList             = js.Array[SupportedOperation]
   type SupportedPlatformsList             = js.Array[SupportedPlatform]
   type TStamp                             = js.Date
   type TableRestoreStatusList             = js.Array[TableRestoreStatus]
-  type TableRestoreStatusType             = String
   type TagKeyList                         = js.Array[String]
   type TagList                            = js.Array[Tag]
   type TagValueList                       = js.Array[String]
@@ -572,11 +558,12 @@ package redshift {
       __obj.asInstanceOf[AccountWithRestoreAccess]
     }
   }
-
-  object ActionTypeEnum {
-    val `restore-cluster`       = "restore-cluster"
-    val `recommend-node-config` = "recommend-node-config"
-    val `resize-cluster`        = "resize-cluster"
+  @js.native
+  sealed trait ActionType extends js.Any
+  object ActionType extends js.Object {
+    val `restore-cluster`       = "restore-cluster".asInstanceOf[ActionType]
+    val `recommend-node-config` = "recommend-node-config".asInstanceOf[ActionType]
+    val `resize-cluster`        = "resize-cluster".asInstanceOf[ActionType]
 
     val values = js.Object.freeze(js.Array(`restore-cluster`, `recommend-node-config`, `resize-cluster`))
   }
@@ -4128,10 +4115,11 @@ package redshift {
       __obj.asInstanceOf[MaintenanceTrack]
     }
   }
-
-  object ModeEnum {
-    val standard           = "standard"
-    val `high-performance` = "high-performance"
+  @js.native
+  sealed trait Mode extends js.Any
+  object Mode extends js.Object {
+    val standard           = "standard".asInstanceOf[Mode]
+    val `high-performance` = "high-performance".asInstanceOf[Mode]
 
     val values = js.Object.freeze(js.Array(standard, `high-performance`))
   }
@@ -4728,12 +4716,14 @@ package redshift {
       __obj.asInstanceOf[NodeConfigurationOptionsFilter]
     }
   }
-
-  object NodeConfigurationOptionsFilterNameEnum {
-    val NodeType                        = "NodeType"
-    val NumberOfNodes                   = "NumberOfNodes"
-    val EstimatedDiskUtilizationPercent = "EstimatedDiskUtilizationPercent"
-    val Mode                            = "Mode"
+  @js.native
+  sealed trait NodeConfigurationOptionsFilterName extends js.Any
+  object NodeConfigurationOptionsFilterName extends js.Object {
+    val NodeType      = "NodeType".asInstanceOf[NodeConfigurationOptionsFilterName]
+    val NumberOfNodes = "NumberOfNodes".asInstanceOf[NodeConfigurationOptionsFilterName]
+    val EstimatedDiskUtilizationPercent =
+      "EstimatedDiskUtilizationPercent".asInstanceOf[NodeConfigurationOptionsFilterName]
+    val Mode = "Mode".asInstanceOf[NodeConfigurationOptionsFilterName]
 
     val values = js.Object.freeze(js.Array(NodeType, NumberOfNodes, EstimatedDiskUtilizationPercent, Mode))
   }
@@ -4758,15 +4748,16 @@ package redshift {
       __obj.asInstanceOf[NodeConfigurationOptionsMessage]
     }
   }
-
-  object OperatorTypeEnum {
-    val eq      = "eq"
-    val lt      = "lt"
-    val gt      = "gt"
-    val le      = "le"
-    val ge      = "ge"
-    val in      = "in"
-    val between = "between"
+  @js.native
+  sealed trait OperatorType extends js.Any
+  object OperatorType extends js.Object {
+    val eq      = "eq".asInstanceOf[OperatorType]
+    val lt      = "lt".asInstanceOf[OperatorType]
+    val gt      = "gt".asInstanceOf[OperatorType]
+    val le      = "le".asInstanceOf[OperatorType]
+    val ge      = "ge".asInstanceOf[OperatorType]
+    val in      = "in".asInstanceOf[OperatorType]
+    val between = "between".asInstanceOf[OperatorType]
 
     val values = js.Object.freeze(js.Array(eq, lt, gt, le, ge, in, between))
   }
@@ -4863,10 +4854,11 @@ package redshift {
       __obj.asInstanceOf[Parameter]
     }
   }
-
-  object ParameterApplyTypeEnum {
-    val static  = "static"
-    val dynamic = "dynamic"
+  @js.native
+  sealed trait ParameterApplyType extends js.Any
+  object ParameterApplyType extends js.Object {
+    val static  = "static".asInstanceOf[ParameterApplyType]
+    val dynamic = "dynamic".asInstanceOf[ParameterApplyType]
 
     val values = js.Object.freeze(js.Array(static, dynamic))
   }
@@ -5118,10 +5110,11 @@ package redshift {
       __obj.asInstanceOf[ReservedNodeOffering]
     }
   }
-
-  object ReservedNodeOfferingTypeEnum {
-    val Regular    = "Regular"
-    val Upgradable = "Upgradable"
+  @js.native
+  sealed trait ReservedNodeOfferingType extends js.Any
+  object ReservedNodeOfferingType extends js.Object {
+    val Regular    = "Regular".asInstanceOf[ReservedNodeOfferingType]
+    val Upgradable = "Upgradable".asInstanceOf[ReservedNodeOfferingType]
 
     val values = js.Object.freeze(js.Array(Regular, Upgradable))
   }
@@ -5715,11 +5708,12 @@ package redshift {
       __obj.asInstanceOf[RotateEncryptionKeyResult]
     }
   }
-
-  object ScheduleStateEnum {
-    val MODIFYING = "MODIFYING"
-    val ACTIVE    = "ACTIVE"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait ScheduleState extends js.Any
+  object ScheduleState extends js.Object {
+    val MODIFYING = "MODIFYING".asInstanceOf[ScheduleState]
+    val ACTIVE    = "ACTIVE".asInstanceOf[ScheduleState]
+    val FAILED    = "FAILED".asInstanceOf[ScheduleState]
 
     val values = js.Object.freeze(js.Array(MODIFYING, ACTIVE, FAILED))
   }
@@ -5792,17 +5786,19 @@ package redshift {
       __obj.asInstanceOf[ScheduledActionFilter]
     }
   }
-
-  object ScheduledActionFilterNameEnum {
-    val `cluster-identifier` = "cluster-identifier"
-    val `iam-role`           = "iam-role"
+  @js.native
+  sealed trait ScheduledActionFilterName extends js.Any
+  object ScheduledActionFilterName extends js.Object {
+    val `cluster-identifier` = "cluster-identifier".asInstanceOf[ScheduledActionFilterName]
+    val `iam-role`           = "iam-role".asInstanceOf[ScheduledActionFilterName]
 
     val values = js.Object.freeze(js.Array(`cluster-identifier`, `iam-role`))
   }
-
-  object ScheduledActionStateEnum {
-    val ACTIVE   = "ACTIVE"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait ScheduledActionState extends js.Any
+  object ScheduledActionState extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[ScheduledActionState]
+    val DISABLED = "DISABLED".asInstanceOf[ScheduledActionState]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DISABLED))
   }
@@ -5825,9 +5821,10 @@ package redshift {
       __obj.asInstanceOf[ScheduledActionType]
     }
   }
-
-  object ScheduledActionTypeValuesEnum {
-    val ResizeCluster = "ResizeCluster"
+  @js.native
+  sealed trait ScheduledActionTypeValues extends js.Any
+  object ScheduledActionTypeValues extends js.Object {
+    val ResizeCluster = "ResizeCluster".asInstanceOf[ScheduledActionTypeValues]
 
     val values = js.Object.freeze(js.Array(ResizeCluster))
   }
@@ -5983,11 +5980,12 @@ package redshift {
       __obj.asInstanceOf[Snapshot]
     }
   }
-
-  object SnapshotAttributeToSortByEnum {
-    val SOURCE_TYPE = "SOURCE_TYPE"
-    val TOTAL_SIZE  = "TOTAL_SIZE"
-    val CREATE_TIME = "CREATE_TIME"
+  @js.native
+  sealed trait SnapshotAttributeToSortBy extends js.Any
+  object SnapshotAttributeToSortBy extends js.Object {
+    val SOURCE_TYPE = "SOURCE_TYPE".asInstanceOf[SnapshotAttributeToSortBy]
+    val TOTAL_SIZE  = "TOTAL_SIZE".asInstanceOf[SnapshotAttributeToSortBy]
+    val CREATE_TIME = "CREATE_TIME".asInstanceOf[SnapshotAttributeToSortBy]
 
     val values = js.Object.freeze(js.Array(SOURCE_TYPE, TOTAL_SIZE, CREATE_TIME))
   }
@@ -6152,20 +6150,22 @@ package redshift {
       __obj.asInstanceOf[SnapshotSortingEntity]
     }
   }
-
-  object SortByOrderEnum {
-    val ASC  = "ASC"
-    val DESC = "DESC"
+  @js.native
+  sealed trait SortByOrder extends js.Any
+  object SortByOrder extends js.Object {
+    val ASC  = "ASC".asInstanceOf[SortByOrder]
+    val DESC = "DESC".asInstanceOf[SortByOrder]
 
     val values = js.Object.freeze(js.Array(ASC, DESC))
   }
-
-  object SourceTypeEnum {
-    val cluster                   = "cluster"
-    val `cluster-parameter-group` = "cluster-parameter-group"
-    val `cluster-security-group`  = "cluster-security-group"
-    val `cluster-snapshot`        = "cluster-snapshot"
-    val `scheduled-action`        = "scheduled-action"
+  @js.native
+  sealed trait SourceType extends js.Any
+  object SourceType extends js.Object {
+    val cluster                   = "cluster".asInstanceOf[SourceType]
+    val `cluster-parameter-group` = "cluster-parameter-group".asInstanceOf[SourceType]
+    val `cluster-security-group`  = "cluster-security-group".asInstanceOf[SourceType]
+    val `cluster-snapshot`        = "cluster-snapshot".asInstanceOf[SourceType]
+    val `scheduled-action`        = "scheduled-action".asInstanceOf[SourceType]
 
     val values = js.Object.freeze(
       js.Array(cluster, `cluster-parameter-group`, `cluster-security-group`, `cluster-snapshot`, `scheduled-action`)
@@ -6316,13 +6316,14 @@ package redshift {
       __obj.asInstanceOf[TableRestoreStatusMessage]
     }
   }
-
-  object TableRestoreStatusTypeEnum {
-    val PENDING     = "PENDING"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
-    val CANCELED    = "CANCELED"
+  @js.native
+  sealed trait TableRestoreStatusType extends js.Any
+  object TableRestoreStatusType extends js.Object {
+    val PENDING     = "PENDING".asInstanceOf[TableRestoreStatusType]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[TableRestoreStatusType]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[TableRestoreStatusType]
+    val FAILED      = "FAILED".asInstanceOf[TableRestoreStatusType]
+    val CANCELED    = "CANCELED".asInstanceOf[TableRestoreStatusType]
 
     val values = js.Object.freeze(js.Array(PENDING, IN_PROGRESS, SUCCEEDED, FAILED, CANCELED))
   }

--- a/services/rekognition/src/main/scala/facade/amazonaws/services/Rekognition.scala
+++ b/services/rekognition/src/main/scala/facade/amazonaws/services/Rekognition.scala
@@ -8,12 +8,10 @@ import facade.amazonaws._
 
 package object rekognition {
   type Assets                                         = js.Array[Asset]
-  type Attribute                                      = String
   type Attributes                                     = js.Array[Attribute]
   type BoundingBoxHeight                              = Float
   type BoundingBoxWidth                               = Float
   type CelebrityList                                  = js.Array[Celebrity]
-  type CelebrityRecognitionSortBy                     = String
   type CelebrityRecognitions                          = js.Array[CelebrityRecognition]
   type ClientRequestToken                             = String
   type CollectionId                                   = String
@@ -21,18 +19,14 @@ package object rekognition {
   type CompareFacesMatchList                          = js.Array[CompareFacesMatch]
   type CompareFacesUnmatchList                        = js.Array[ComparedFace]
   type ComparedFaceList                               = js.Array[ComparedFace]
-  type ContentClassifier                              = String
   type ContentClassifiers                             = js.Array[ContentClassifier]
   type ContentModerationDetections                    = js.Array[ContentModerationDetection]
-  type ContentModerationSortBy                        = String
   type CustomLabels                                   = js.Array[CustomLabel]
   type DateTime                                       = js.Date
   type Degree                                         = Float
-  type EmotionName                                    = String
   type Emotions                                       = js.Array[Emotion]
   type ExtendedPaginationToken                        = String
   type ExternalImageId                                = String
-  type FaceAttributes                                 = String
   type FaceDetailList                                 = js.Array[FaceDetail]
   type FaceDetections                                 = js.Array[FaceDetection]
   type FaceId                                         = String
@@ -41,9 +35,7 @@ package object rekognition {
   type FaceMatchList                                  = js.Array[FaceMatch]
   type FaceModelVersionList                           = js.Array[String]
   type FaceRecordList                                 = js.Array[FaceRecord]
-  type FaceSearchSortBy                               = String
   type FlowDefinitionArn                              = String
-  type GenderType                                     = String
   type HumanLoopActivationConditionsEvaluationResults = String
   type HumanLoopActivationReason                      = String
   type HumanLoopActivationReasons                     = js.Array[HumanLoopActivationReason]
@@ -57,16 +49,13 @@ package object rekognition {
   type JobTag                                         = String
   type KinesisDataArn                                 = String
   type KinesisVideoArn                                = String
-  type LabelDetectionSortBy                           = String
   type LabelDetections                                = js.Array[LabelDetection]
   type Labels                                         = js.Array[Label]
-  type LandmarkType                                   = String
   type Landmarks                                      = js.Array[Landmark]
   type MaxFaces                                       = Int
   type MaxFacesToIndex                                = Int
   type MaxResults                                     = Int
   type ModerationLabels                               = js.Array[ModerationLabel]
-  type OrientationCorrection                          = String
   type PageSize                                       = Int
   type PaginationToken                                = String
   type Parents                                        = js.Array[Parent]
@@ -74,19 +63,14 @@ package object rekognition {
   type PersonDetections                               = js.Array[PersonDetection]
   type PersonIndex                                    = Double
   type PersonMatches                                  = js.Array[PersonMatch]
-  type PersonTrackingSortBy                           = String
   type Polygon                                        = js.Array[Point]
   type ProjectArn                                     = String
   type ProjectDescriptions                            = js.Array[ProjectDescription]
   type ProjectName                                    = String
-  type ProjectStatus                                  = String
   type ProjectVersionArn                              = String
   type ProjectVersionDescriptions                     = js.Array[ProjectVersionDescription]
-  type ProjectVersionStatus                           = String
   type ProjectVersionsPageSize                        = Int
   type ProjectsPageSize                               = Int
-  type QualityFilter                                  = String
-  type Reason                                         = String
   type Reasons                                        = js.Array[Reason]
   type RegionsOfInterest                              = js.Array[RegionOfInterest]
   type RekognitionUniqueId                            = String
@@ -100,10 +84,8 @@ package object rekognition {
   type StreamProcessorArn                             = String
   type StreamProcessorList                            = js.Array[StreamProcessor]
   type StreamProcessorName                            = String
-  type StreamProcessorStatus                          = String
   type TextDetectionList                              = js.Array[TextDetection]
   type TextDetectionResults                           = js.Array[TextDetectionResult]
-  type TextTypes                                      = String
   type Timestamp                                      = Double
   type UInteger                                       = Int
   type ULong                                          = Double
@@ -112,7 +94,6 @@ package object rekognition {
   type Urls                                           = js.Array[Url]
   type VersionName                                    = String
   type VersionNames                                   = js.Array[VersionName]
-  type VideoJobStatus                                 = String
 
   implicit final class RekognitionOps(private val service: Rekognition) extends AnyVal {
 
@@ -312,10 +293,11 @@ package rekognition {
       __obj.asInstanceOf[Asset]
     }
   }
-
-  object AttributeEnum {
-    val DEFAULT = "DEFAULT"
-    val ALL     = "ALL"
+  @js.native
+  sealed trait Attribute extends js.Any
+  object Attribute extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[Attribute]
+    val ALL     = "ALL".asInstanceOf[Attribute]
 
     val values = js.Object.freeze(js.Array(DEFAULT, ALL))
   }
@@ -460,10 +442,11 @@ package rekognition {
       __obj.asInstanceOf[CelebrityRecognition]
     }
   }
-
-  object CelebrityRecognitionSortByEnum {
-    val ID        = "ID"
-    val TIMESTAMP = "TIMESTAMP"
+  @js.native
+  sealed trait CelebrityRecognitionSortBy extends js.Any
+  object CelebrityRecognitionSortBy extends js.Object {
+    val ID        = "ID".asInstanceOf[CelebrityRecognitionSortBy]
+    val TIMESTAMP = "TIMESTAMP".asInstanceOf[CelebrityRecognitionSortBy]
 
     val values = js.Object.freeze(js.Array(ID, TIMESTAMP))
   }
@@ -601,10 +584,12 @@ package rekognition {
       __obj.asInstanceOf[ComparedSourceImageFace]
     }
   }
-
-  object ContentClassifierEnum {
-    val FreeOfPersonallyIdentifiableInformation = "FreeOfPersonallyIdentifiableInformation"
-    val FreeOfAdultContent                      = "FreeOfAdultContent"
+  @js.native
+  sealed trait ContentClassifier extends js.Any
+  object ContentClassifier extends js.Object {
+    val FreeOfPersonallyIdentifiableInformation =
+      "FreeOfPersonallyIdentifiableInformation".asInstanceOf[ContentClassifier]
+    val FreeOfAdultContent = "FreeOfAdultContent".asInstanceOf[ContentClassifier]
 
     val values = js.Object.freeze(js.Array(FreeOfPersonallyIdentifiableInformation, FreeOfAdultContent))
   }
@@ -630,10 +615,11 @@ package rekognition {
       __obj.asInstanceOf[ContentModerationDetection]
     }
   }
-
-  object ContentModerationSortByEnum {
-    val NAME      = "NAME"
-    val TIMESTAMP = "TIMESTAMP"
+  @js.native
+  sealed trait ContentModerationSortBy extends js.Any
+  object ContentModerationSortBy extends js.Object {
+    val NAME      = "NAME".asInstanceOf[ContentModerationSortBy]
+    val TIMESTAMP = "TIMESTAMP".asInstanceOf[ContentModerationSortBy]
 
     val values = js.Object.freeze(js.Array(NAME, TIMESTAMP))
   }
@@ -1406,17 +1392,18 @@ package rekognition {
       __obj.asInstanceOf[Emotion]
     }
   }
-
-  object EmotionNameEnum {
-    val HAPPY     = "HAPPY"
-    val SAD       = "SAD"
-    val ANGRY     = "ANGRY"
-    val CONFUSED  = "CONFUSED"
-    val DISGUSTED = "DISGUSTED"
-    val SURPRISED = "SURPRISED"
-    val CALM      = "CALM"
-    val UNKNOWN   = "UNKNOWN"
-    val FEAR      = "FEAR"
+  @js.native
+  sealed trait EmotionName extends js.Any
+  object EmotionName extends js.Object {
+    val HAPPY     = "HAPPY".asInstanceOf[EmotionName]
+    val SAD       = "SAD".asInstanceOf[EmotionName]
+    val ANGRY     = "ANGRY".asInstanceOf[EmotionName]
+    val CONFUSED  = "CONFUSED".asInstanceOf[EmotionName]
+    val DISGUSTED = "DISGUSTED".asInstanceOf[EmotionName]
+    val SURPRISED = "SURPRISED".asInstanceOf[EmotionName]
+    val CALM      = "CALM".asInstanceOf[EmotionName]
+    val UNKNOWN   = "UNKNOWN".asInstanceOf[EmotionName]
+    val FEAR      = "FEAR".asInstanceOf[EmotionName]
 
     val values = js.Object.freeze(js.Array(HAPPY, SAD, ANGRY, CONFUSED, DISGUSTED, SURPRISED, CALM, UNKNOWN, FEAR))
   }
@@ -1517,10 +1504,11 @@ package rekognition {
       __obj.asInstanceOf[Face]
     }
   }
-
-  object FaceAttributesEnum {
-    val DEFAULT = "DEFAULT"
-    val ALL     = "ALL"
+  @js.native
+  sealed trait FaceAttributes extends js.Any
+  object FaceAttributes extends js.Object {
+    val DEFAULT = "DEFAULT".asInstanceOf[FaceAttributes]
+    val ALL     = "ALL".asInstanceOf[FaceAttributes]
 
     val values = js.Object.freeze(js.Array(DEFAULT, ALL))
   }
@@ -1679,10 +1667,11 @@ package rekognition {
       __obj.asInstanceOf[FaceSearchSettings]
     }
   }
-
-  object FaceSearchSortByEnum {
-    val INDEX     = "INDEX"
-    val TIMESTAMP = "TIMESTAMP"
+  @js.native
+  sealed trait FaceSearchSortBy extends js.Any
+  object FaceSearchSortBy extends js.Object {
+    val INDEX     = "INDEX".asInstanceOf[FaceSearchSortBy]
+    val TIMESTAMP = "TIMESTAMP".asInstanceOf[FaceSearchSortBy]
 
     val values = js.Object.freeze(js.Array(INDEX, TIMESTAMP))
   }
@@ -1711,10 +1700,11 @@ package rekognition {
       __obj.asInstanceOf[Gender]
     }
   }
-
-  object GenderTypeEnum {
-    val Male   = "Male"
-    val Female = "Female"
+  @js.native
+  sealed trait GenderType extends js.Any
+  object GenderType extends js.Object {
+    val Male   = "Male".asInstanceOf[GenderType]
+    val Female = "Female".asInstanceOf[GenderType]
 
     val values = js.Object.freeze(js.Array(Male, Female))
   }
@@ -2479,10 +2469,11 @@ package rekognition {
       __obj.asInstanceOf[LabelDetection]
     }
   }
-
-  object LabelDetectionSortByEnum {
-    val NAME      = "NAME"
-    val TIMESTAMP = "TIMESTAMP"
+  @js.native
+  sealed trait LabelDetectionSortBy extends js.Any
+  object LabelDetectionSortBy extends js.Object {
+    val NAME      = "NAME".asInstanceOf[LabelDetectionSortBy]
+    val TIMESTAMP = "TIMESTAMP".asInstanceOf[LabelDetectionSortBy]
 
     val values = js.Object.freeze(js.Array(NAME, TIMESTAMP))
   }
@@ -2511,38 +2502,39 @@ package rekognition {
       __obj.asInstanceOf[Landmark]
     }
   }
-
-  object LandmarkTypeEnum {
-    val eyeLeft           = "eyeLeft"
-    val eyeRight          = "eyeRight"
-    val nose              = "nose"
-    val mouthLeft         = "mouthLeft"
-    val mouthRight        = "mouthRight"
-    val leftEyeBrowLeft   = "leftEyeBrowLeft"
-    val leftEyeBrowRight  = "leftEyeBrowRight"
-    val leftEyeBrowUp     = "leftEyeBrowUp"
-    val rightEyeBrowLeft  = "rightEyeBrowLeft"
-    val rightEyeBrowRight = "rightEyeBrowRight"
-    val rightEyeBrowUp    = "rightEyeBrowUp"
-    val leftEyeLeft       = "leftEyeLeft"
-    val leftEyeRight      = "leftEyeRight"
-    val leftEyeUp         = "leftEyeUp"
-    val leftEyeDown       = "leftEyeDown"
-    val rightEyeLeft      = "rightEyeLeft"
-    val rightEyeRight     = "rightEyeRight"
-    val rightEyeUp        = "rightEyeUp"
-    val rightEyeDown      = "rightEyeDown"
-    val noseLeft          = "noseLeft"
-    val noseRight         = "noseRight"
-    val mouthUp           = "mouthUp"
-    val mouthDown         = "mouthDown"
-    val leftPupil         = "leftPupil"
-    val rightPupil        = "rightPupil"
-    val upperJawlineLeft  = "upperJawlineLeft"
-    val midJawlineLeft    = "midJawlineLeft"
-    val chinBottom        = "chinBottom"
-    val midJawlineRight   = "midJawlineRight"
-    val upperJawlineRight = "upperJawlineRight"
+  @js.native
+  sealed trait LandmarkType extends js.Any
+  object LandmarkType extends js.Object {
+    val eyeLeft           = "eyeLeft".asInstanceOf[LandmarkType]
+    val eyeRight          = "eyeRight".asInstanceOf[LandmarkType]
+    val nose              = "nose".asInstanceOf[LandmarkType]
+    val mouthLeft         = "mouthLeft".asInstanceOf[LandmarkType]
+    val mouthRight        = "mouthRight".asInstanceOf[LandmarkType]
+    val leftEyeBrowLeft   = "leftEyeBrowLeft".asInstanceOf[LandmarkType]
+    val leftEyeBrowRight  = "leftEyeBrowRight".asInstanceOf[LandmarkType]
+    val leftEyeBrowUp     = "leftEyeBrowUp".asInstanceOf[LandmarkType]
+    val rightEyeBrowLeft  = "rightEyeBrowLeft".asInstanceOf[LandmarkType]
+    val rightEyeBrowRight = "rightEyeBrowRight".asInstanceOf[LandmarkType]
+    val rightEyeBrowUp    = "rightEyeBrowUp".asInstanceOf[LandmarkType]
+    val leftEyeLeft       = "leftEyeLeft".asInstanceOf[LandmarkType]
+    val leftEyeRight      = "leftEyeRight".asInstanceOf[LandmarkType]
+    val leftEyeUp         = "leftEyeUp".asInstanceOf[LandmarkType]
+    val leftEyeDown       = "leftEyeDown".asInstanceOf[LandmarkType]
+    val rightEyeLeft      = "rightEyeLeft".asInstanceOf[LandmarkType]
+    val rightEyeRight     = "rightEyeRight".asInstanceOf[LandmarkType]
+    val rightEyeUp        = "rightEyeUp".asInstanceOf[LandmarkType]
+    val rightEyeDown      = "rightEyeDown".asInstanceOf[LandmarkType]
+    val noseLeft          = "noseLeft".asInstanceOf[LandmarkType]
+    val noseRight         = "noseRight".asInstanceOf[LandmarkType]
+    val mouthUp           = "mouthUp".asInstanceOf[LandmarkType]
+    val mouthDown         = "mouthDown".asInstanceOf[LandmarkType]
+    val leftPupil         = "leftPupil".asInstanceOf[LandmarkType]
+    val rightPupil        = "rightPupil".asInstanceOf[LandmarkType]
+    val upperJawlineLeft  = "upperJawlineLeft".asInstanceOf[LandmarkType]
+    val midJawlineLeft    = "midJawlineLeft".asInstanceOf[LandmarkType]
+    val chinBottom        = "chinBottom".asInstanceOf[LandmarkType]
+    val midJawlineRight   = "midJawlineRight".asInstanceOf[LandmarkType]
+    val upperJawlineRight = "upperJawlineRight".asInstanceOf[LandmarkType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2797,12 +2789,13 @@ package rekognition {
       __obj.asInstanceOf[NotificationChannel]
     }
   }
-
-  object OrientationCorrectionEnum {
-    val ROTATE_0   = "ROTATE_0"
-    val ROTATE_90  = "ROTATE_90"
-    val ROTATE_180 = "ROTATE_180"
-    val ROTATE_270 = "ROTATE_270"
+  @js.native
+  sealed trait OrientationCorrection extends js.Any
+  object OrientationCorrection extends js.Object {
+    val ROTATE_0   = "ROTATE_0".asInstanceOf[OrientationCorrection]
+    val ROTATE_90  = "ROTATE_90".asInstanceOf[OrientationCorrection]
+    val ROTATE_180 = "ROTATE_180".asInstanceOf[OrientationCorrection]
+    val ROTATE_270 = "ROTATE_270".asInstanceOf[OrientationCorrection]
 
     val values = js.Object.freeze(js.Array(ROTATE_0, ROTATE_90, ROTATE_180, ROTATE_270))
   }
@@ -2920,10 +2913,11 @@ package rekognition {
       __obj.asInstanceOf[PersonMatch]
     }
   }
-
-  object PersonTrackingSortByEnum {
-    val INDEX     = "INDEX"
-    val TIMESTAMP = "TIMESTAMP"
+  @js.native
+  sealed trait PersonTrackingSortBy extends js.Any
+  object PersonTrackingSortBy extends js.Object {
+    val INDEX     = "INDEX".asInstanceOf[PersonTrackingSortBy]
+    val TIMESTAMP = "TIMESTAMP".asInstanceOf[PersonTrackingSortBy]
 
     val values = js.Object.freeze(js.Array(INDEX, TIMESTAMP))
   }
@@ -3000,11 +2994,12 @@ package rekognition {
       __obj.asInstanceOf[ProjectDescription]
     }
   }
-
-  object ProjectStatusEnum {
-    val CREATING = "CREATING"
-    val CREATED  = "CREATED"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait ProjectStatus extends js.Any
+  object ProjectStatus extends js.Object {
+    val CREATING = "CREATING".asInstanceOf[ProjectStatus]
+    val CREATED  = "CREATED".asInstanceOf[ProjectStatus]
+    val DELETING = "DELETING".asInstanceOf[ProjectStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, CREATED, DELETING))
   }
@@ -3059,17 +3054,18 @@ package rekognition {
       __obj.asInstanceOf[ProjectVersionDescription]
     }
   }
-
-  object ProjectVersionStatusEnum {
-    val TRAINING_IN_PROGRESS = "TRAINING_IN_PROGRESS"
-    val TRAINING_COMPLETED   = "TRAINING_COMPLETED"
-    val TRAINING_FAILED      = "TRAINING_FAILED"
-    val STARTING             = "STARTING"
-    val RUNNING              = "RUNNING"
-    val FAILED               = "FAILED"
-    val STOPPING             = "STOPPING"
-    val STOPPED              = "STOPPED"
-    val DELETING             = "DELETING"
+  @js.native
+  sealed trait ProjectVersionStatus extends js.Any
+  object ProjectVersionStatus extends js.Object {
+    val TRAINING_IN_PROGRESS = "TRAINING_IN_PROGRESS".asInstanceOf[ProjectVersionStatus]
+    val TRAINING_COMPLETED   = "TRAINING_COMPLETED".asInstanceOf[ProjectVersionStatus]
+    val TRAINING_FAILED      = "TRAINING_FAILED".asInstanceOf[ProjectVersionStatus]
+    val STARTING             = "STARTING".asInstanceOf[ProjectVersionStatus]
+    val RUNNING              = "RUNNING".asInstanceOf[ProjectVersionStatus]
+    val FAILED               = "FAILED".asInstanceOf[ProjectVersionStatus]
+    val STOPPING             = "STOPPING".asInstanceOf[ProjectVersionStatus]
+    val STOPPED              = "STOPPED".asInstanceOf[ProjectVersionStatus]
+    val DELETING             = "DELETING".asInstanceOf[ProjectVersionStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3085,25 +3081,27 @@ package rekognition {
       )
     )
   }
-
-  object QualityFilterEnum {
-    val NONE   = "NONE"
-    val AUTO   = "AUTO"
-    val LOW    = "LOW"
-    val MEDIUM = "MEDIUM"
-    val HIGH   = "HIGH"
+  @js.native
+  sealed trait QualityFilter extends js.Any
+  object QualityFilter extends js.Object {
+    val NONE   = "NONE".asInstanceOf[QualityFilter]
+    val AUTO   = "AUTO".asInstanceOf[QualityFilter]
+    val LOW    = "LOW".asInstanceOf[QualityFilter]
+    val MEDIUM = "MEDIUM".asInstanceOf[QualityFilter]
+    val HIGH   = "HIGH".asInstanceOf[QualityFilter]
 
     val values = js.Object.freeze(js.Array(NONE, AUTO, LOW, MEDIUM, HIGH))
   }
-
-  object ReasonEnum {
-    val EXCEEDS_MAX_FACES  = "EXCEEDS_MAX_FACES"
-    val EXTREME_POSE       = "EXTREME_POSE"
-    val LOW_BRIGHTNESS     = "LOW_BRIGHTNESS"
-    val LOW_SHARPNESS      = "LOW_SHARPNESS"
-    val LOW_CONFIDENCE     = "LOW_CONFIDENCE"
-    val SMALL_BOUNDING_BOX = "SMALL_BOUNDING_BOX"
-    val LOW_FACE_QUALITY   = "LOW_FACE_QUALITY"
+  @js.native
+  sealed trait Reason extends js.Any
+  object Reason extends js.Object {
+    val EXCEEDS_MAX_FACES  = "EXCEEDS_MAX_FACES".asInstanceOf[Reason]
+    val EXTREME_POSE       = "EXTREME_POSE".asInstanceOf[Reason]
+    val LOW_BRIGHTNESS     = "LOW_BRIGHTNESS".asInstanceOf[Reason]
+    val LOW_SHARPNESS      = "LOW_SHARPNESS".asInstanceOf[Reason]
+    val LOW_CONFIDENCE     = "LOW_CONFIDENCE".asInstanceOf[Reason]
+    val SMALL_BOUNDING_BOX = "SMALL_BOUNDING_BOX".asInstanceOf[Reason]
+    val LOW_FACE_QUALITY   = "LOW_FACE_QUALITY".asInstanceOf[Reason]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3883,13 +3881,14 @@ package rekognition {
       __obj.asInstanceOf[StreamProcessorSettings]
     }
   }
-
-  object StreamProcessorStatusEnum {
-    val STOPPED  = "STOPPED"
-    val STARTING = "STARTING"
-    val RUNNING  = "RUNNING"
-    val FAILED   = "FAILED"
-    val STOPPING = "STOPPING"
+  @js.native
+  sealed trait StreamProcessorStatus extends js.Any
+  object StreamProcessorStatus extends js.Object {
+    val STOPPED  = "STOPPED".asInstanceOf[StreamProcessorStatus]
+    val STARTING = "STARTING".asInstanceOf[StreamProcessorStatus]
+    val RUNNING  = "RUNNING".asInstanceOf[StreamProcessorStatus]
+    val FAILED   = "FAILED".asInstanceOf[StreamProcessorStatus]
+    val STOPPING = "STOPPING".asInstanceOf[StreamProcessorStatus]
 
     val values = js.Object.freeze(js.Array(STOPPED, STARTING, RUNNING, FAILED, STOPPING))
   }
@@ -4038,10 +4037,11 @@ package rekognition {
       __obj.asInstanceOf[TextDetectionResult]
     }
   }
-
-  object TextTypesEnum {
-    val LINE = "LINE"
-    val WORD = "WORD"
+  @js.native
+  sealed trait TextTypes extends js.Any
+  object TextTypes extends js.Object {
+    val LINE = "LINE".asInstanceOf[TextTypes]
+    val WORD = "WORD".asInstanceOf[TextTypes]
 
     val values = js.Object.freeze(js.Array(LINE, WORD))
   }
@@ -4127,11 +4127,12 @@ package rekognition {
       __obj.asInstanceOf[Video]
     }
   }
-
-  object VideoJobStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val SUCCEEDED   = "SUCCEEDED"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait VideoJobStatus extends js.Any
+  object VideoJobStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[VideoJobStatus]
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[VideoJobStatus]
+    val FAILED      = "FAILED".asInstanceOf[VideoJobStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, SUCCEEDED, FAILED))
   }

--- a/services/resourcegroups/src/main/scala/facade/amazonaws/services/ResourceGroups.scala
+++ b/services/resourcegroups/src/main/scala/facade/amazonaws/services/ResourceGroups.scala
@@ -10,7 +10,6 @@ package object resourcegroups {
   type GroupArn               = String
   type GroupDescription       = String
   type GroupFilterList        = js.Array[GroupFilter]
-  type GroupFilterName        = String
   type GroupFilterValue       = String
   type GroupFilterValues      = js.Array[GroupFilterValue]
   type GroupIdentifierList    = js.Array[GroupIdentifier]
@@ -19,13 +18,10 @@ package object resourcegroups {
   type MaxResults             = Int
   type NextToken              = String
   type Query                  = String
-  type QueryErrorCode         = String
   type QueryErrorList         = js.Array[QueryError]
   type QueryErrorMessage      = String
-  type QueryType              = String
   type ResourceArn            = String
   type ResourceFilterList     = js.Array[ResourceFilter]
-  type ResourceFilterName     = String
   type ResourceFilterValue    = String
   type ResourceFilterValues   = js.Array[ResourceFilterValue]
   type ResourceIdentifierList = js.Array[ResourceIdentifier]
@@ -319,9 +315,10 @@ package resourcegroups {
       __obj.asInstanceOf[GroupFilter]
     }
   }
-
-  object GroupFilterNameEnum {
-    val `resource-type` = "resource-type"
+  @js.native
+  sealed trait GroupFilterName extends js.Any
+  object GroupFilterName extends js.Object {
+    val `resource-type` = "resource-type".asInstanceOf[GroupFilterName]
 
     val values = js.Object.freeze(js.Array(`resource-type`))
   }
@@ -486,17 +483,19 @@ package resourcegroups {
       __obj.asInstanceOf[QueryError]
     }
   }
-
-  object QueryErrorCodeEnum {
-    val CLOUDFORMATION_STACK_INACTIVE     = "CLOUDFORMATION_STACK_INACTIVE"
-    val CLOUDFORMATION_STACK_NOT_EXISTING = "CLOUDFORMATION_STACK_NOT_EXISTING"
+  @js.native
+  sealed trait QueryErrorCode extends js.Any
+  object QueryErrorCode extends js.Object {
+    val CLOUDFORMATION_STACK_INACTIVE     = "CLOUDFORMATION_STACK_INACTIVE".asInstanceOf[QueryErrorCode]
+    val CLOUDFORMATION_STACK_NOT_EXISTING = "CLOUDFORMATION_STACK_NOT_EXISTING".asInstanceOf[QueryErrorCode]
 
     val values = js.Object.freeze(js.Array(CLOUDFORMATION_STACK_INACTIVE, CLOUDFORMATION_STACK_NOT_EXISTING))
   }
-
-  object QueryTypeEnum {
-    val TAG_FILTERS_1_0          = "TAG_FILTERS_1_0"
-    val CLOUDFORMATION_STACK_1_0 = "CLOUDFORMATION_STACK_1_0"
+  @js.native
+  sealed trait QueryType extends js.Any
+  object QueryType extends js.Object {
+    val TAG_FILTERS_1_0          = "TAG_FILTERS_1_0".asInstanceOf[QueryType]
+    val CLOUDFORMATION_STACK_1_0 = "CLOUDFORMATION_STACK_1_0".asInstanceOf[QueryType]
 
     val values = js.Object.freeze(js.Array(TAG_FILTERS_1_0, CLOUDFORMATION_STACK_1_0))
   }
@@ -524,9 +523,10 @@ package resourcegroups {
       __obj.asInstanceOf[ResourceFilter]
     }
   }
-
-  object ResourceFilterNameEnum {
-    val `resource-type` = "resource-type"
+  @js.native
+  sealed trait ResourceFilterName extends js.Any
+  object ResourceFilterName extends js.Object {
+    val `resource-type` = "resource-type".asInstanceOf[ResourceFilterName]
 
     val values = js.Object.freeze(js.Array(`resource-type`))
   }

--- a/services/resourcegroupstaggingapi/src/main/scala/facade/amazonaws/services/ResourceGroupsTaggingAPI.scala
+++ b/services/resourcegroupstaggingapi/src/main/scala/facade/amazonaws/services/ResourceGroupsTaggingAPI.scala
@@ -9,12 +9,10 @@ import facade.amazonaws._
 package object resourcegroupstaggingapi {
   type AmazonResourceType             = String
   type ComplianceStatus               = Boolean
-  type ErrorCode                      = String
   type ErrorMessage                   = String
   type ExcludeCompliantResources      = Boolean
   type FailedResourcesMap             = js.Dictionary[FailureInfo]
   type GroupBy                        = js.Array[GroupByAttribute]
-  type GroupByAttribute               = String
   type IncludeComplianceDetails       = Boolean
   type LastUpdated                    = String
   type MaxResultsGetComplianceSummary = Int
@@ -45,7 +43,6 @@ package object resourcegroupstaggingapi {
   type TagsPerPage                    = Int
   type TargetId                       = String
   type TargetIdFilterList             = js.Array[TargetId]
-  type TargetIdType                   = String
 
   implicit final class ResourceGroupsTaggingAPIOps(private val service: ResourceGroupsTaggingAPI) extends AnyVal {
 
@@ -146,10 +143,11 @@ package resourcegroupstaggingapi {
       __obj.asInstanceOf[DescribeReportCreationOutput]
     }
   }
-
-  object ErrorCodeEnum {
-    val InternalServiceException  = "InternalServiceException"
-    val InvalidParameterException = "InvalidParameterException"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val InternalServiceException  = "InternalServiceException".asInstanceOf[ErrorCode]
+    val InvalidParameterException = "InvalidParameterException".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(js.Array(InternalServiceException, InvalidParameterException))
   }
@@ -365,11 +363,12 @@ package resourcegroupstaggingapi {
       __obj.asInstanceOf[GetTagValuesOutput]
     }
   }
-
-  object GroupByAttributeEnum {
-    val TARGET_ID     = "TARGET_ID"
-    val REGION        = "REGION"
-    val RESOURCE_TYPE = "RESOURCE_TYPE"
+  @js.native
+  sealed trait GroupByAttribute extends js.Any
+  object GroupByAttribute extends js.Object {
+    val TARGET_ID     = "TARGET_ID".asInstanceOf[GroupByAttribute]
+    val REGION        = "REGION".asInstanceOf[GroupByAttribute]
+    val RESOURCE_TYPE = "RESOURCE_TYPE".asInstanceOf[GroupByAttribute]
 
     val values = js.Object.freeze(js.Array(TARGET_ID, REGION, RESOURCE_TYPE))
   }
@@ -546,11 +545,12 @@ package resourcegroupstaggingapi {
       __obj.asInstanceOf[TagResourcesOutput]
     }
   }
-
-  object TargetIdTypeEnum {
-    val ACCOUNT = "ACCOUNT"
-    val OU      = "OU"
-    val ROOT    = "ROOT"
+  @js.native
+  sealed trait TargetIdType extends js.Any
+  object TargetIdType extends js.Object {
+    val ACCOUNT = "ACCOUNT".asInstanceOf[TargetIdType]
+    val OU      = "OU".asInstanceOf[TargetIdType]
+    val ROOT    = "ROOT".asInstanceOf[TargetIdType]
 
     val values = js.Object.freeze(js.Array(ACCOUNT, OU, ROOT))
   }

--- a/services/robomaker/src/main/scala/facade/amazonaws/services/RoboMaker.scala
+++ b/services/robomaker/src/main/scala/facade/amazonaws/services/RoboMaker.scala
@@ -7,7 +7,6 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object robomaker {
-  type Architecture                       = String
   type Arn                                = String
   type Arns                               = js.Array[Arn]
   type BatchTimeoutInSeconds              = Double
@@ -20,9 +19,7 @@ package object robomaker {
   type DataSourceNames                    = js.Array[Name]
   type DataSources                        = js.Array[DataSource]
   type DeploymentApplicationConfigs       = js.Array[DeploymentApplicationConfig]
-  type DeploymentJobErrorCode             = String
   type DeploymentJobs                     = js.Array[DeploymentJob]
-  type DeploymentStatus                   = String
   type DeploymentTimeout                  = Double
   type DeploymentVersion                  = String
   type EnvironmentVariableKey             = String
@@ -30,7 +27,6 @@ package object robomaker {
   type EnvironmentVariableValue           = String
   type FailedAt                           = js.Date
   type FailedCreateSimulationJobRequests  = js.Array[FailedCreateSimulationJobRequest]
-  type FailureBehavior                    = String
   type FilterValues                       = js.Array[Name]
   type Filters                            = js.Array[Filter]
   type Fleets                             = js.Array[Fleet]
@@ -52,17 +48,12 @@ package object robomaker {
   type Percentage                         = Int
   type Port                               = Int
   type PortMappingList                    = js.Array[PortMapping]
-  type RenderingEngineType                = String
   type RenderingEngineVersionType         = String
   type RevisionId                         = String
   type RobotApplicationConfigs            = js.Array[RobotApplicationConfig]
   type RobotApplicationNames              = js.Array[Name]
   type RobotApplicationSummaries          = js.Array[RobotApplicationSummary]
-  type RobotDeploymentStep                = String
   type RobotDeploymentSummary             = js.Array[RobotDeployment]
-  type RobotSoftwareSuiteType             = String
-  type RobotSoftwareSuiteVersionType      = String
-  type RobotStatus                        = String
   type Robots                             = js.Array[Robot]
   type S3Bucket                           = String
   type S3Etag                             = String
@@ -73,14 +64,9 @@ package object robomaker {
   type SimulationApplicationConfigs       = js.Array[SimulationApplicationConfig]
   type SimulationApplicationNames         = js.Array[Name]
   type SimulationApplicationSummaries     = js.Array[SimulationApplicationSummary]
-  type SimulationJobBatchErrorCode        = String
-  type SimulationJobBatchStatus           = String
   type SimulationJobBatchSummaries        = js.Array[SimulationJobBatchSummary]
-  type SimulationJobErrorCode             = String
-  type SimulationJobStatus                = String
   type SimulationJobSummaries             = js.Array[SimulationJobSummary]
   type SimulationJobs                     = js.Array[SimulationJob]
-  type SimulationSoftwareSuiteType        = String
   type SimulationSoftwareSuiteVersionType = String
   type SimulationTimeMillis               = Double
   type SourceConfigs                      = js.Array[SourceConfig]
@@ -270,11 +256,12 @@ package robomaker {
         params: UpdateSimulationApplicationRequest
     ): Request[UpdateSimulationApplicationResponse] = js.native
   }
-
-  object ArchitectureEnum {
-    val X86_64 = "X86_64"
-    val ARM64  = "ARM64"
-    val ARMHF  = "ARMHF"
+  @js.native
+  sealed trait Architecture extends js.Any
+  object Architecture extends js.Object {
+    val X86_64 = "X86_64".asInstanceOf[Architecture]
+    val ARM64  = "ARM64".asInstanceOf[Architecture]
+    val ARMHF  = "ARMHF".asInstanceOf[Architecture]
 
     val values = js.Object.freeze(js.Array(X86_64, ARM64, ARMHF))
   }
@@ -1259,26 +1246,27 @@ package robomaker {
       __obj.asInstanceOf[DeploymentJob]
     }
   }
-
-  object DeploymentJobErrorCodeEnum {
-    val ResourceNotFound                    = "ResourceNotFound"
-    val EnvironmentSetupError               = "EnvironmentSetupError"
-    val EtagMismatch                        = "EtagMismatch"
-    val FailureThresholdBreached            = "FailureThresholdBreached"
-    val RobotDeploymentAborted              = "RobotDeploymentAborted"
-    val RobotDeploymentNoResponse           = "RobotDeploymentNoResponse"
-    val RobotAgentConnectionTimeout         = "RobotAgentConnectionTimeout"
-    val GreengrassDeploymentFailed          = "GreengrassDeploymentFailed"
-    val MissingRobotArchitecture            = "MissingRobotArchitecture"
-    val MissingRobotApplicationArchitecture = "MissingRobotApplicationArchitecture"
-    val MissingRobotDeploymentResource      = "MissingRobotDeploymentResource"
-    val GreengrassGroupVersionDoesNotExist  = "GreengrassGroupVersionDoesNotExist"
-    val ExtractingBundleFailure             = "ExtractingBundleFailure"
-    val PreLaunchFileFailure                = "PreLaunchFileFailure"
-    val PostLaunchFileFailure               = "PostLaunchFileFailure"
-    val BadPermissionError                  = "BadPermissionError"
-    val DownloadConditionFailed             = "DownloadConditionFailed"
-    val InternalServerError                 = "InternalServerError"
+  @js.native
+  sealed trait DeploymentJobErrorCode extends js.Any
+  object DeploymentJobErrorCode extends js.Object {
+    val ResourceNotFound                    = "ResourceNotFound".asInstanceOf[DeploymentJobErrorCode]
+    val EnvironmentSetupError               = "EnvironmentSetupError".asInstanceOf[DeploymentJobErrorCode]
+    val EtagMismatch                        = "EtagMismatch".asInstanceOf[DeploymentJobErrorCode]
+    val FailureThresholdBreached            = "FailureThresholdBreached".asInstanceOf[DeploymentJobErrorCode]
+    val RobotDeploymentAborted              = "RobotDeploymentAborted".asInstanceOf[DeploymentJobErrorCode]
+    val RobotDeploymentNoResponse           = "RobotDeploymentNoResponse".asInstanceOf[DeploymentJobErrorCode]
+    val RobotAgentConnectionTimeout         = "RobotAgentConnectionTimeout".asInstanceOf[DeploymentJobErrorCode]
+    val GreengrassDeploymentFailed          = "GreengrassDeploymentFailed".asInstanceOf[DeploymentJobErrorCode]
+    val MissingRobotArchitecture            = "MissingRobotArchitecture".asInstanceOf[DeploymentJobErrorCode]
+    val MissingRobotApplicationArchitecture = "MissingRobotApplicationArchitecture".asInstanceOf[DeploymentJobErrorCode]
+    val MissingRobotDeploymentResource      = "MissingRobotDeploymentResource".asInstanceOf[DeploymentJobErrorCode]
+    val GreengrassGroupVersionDoesNotExist  = "GreengrassGroupVersionDoesNotExist".asInstanceOf[DeploymentJobErrorCode]
+    val ExtractingBundleFailure             = "ExtractingBundleFailure".asInstanceOf[DeploymentJobErrorCode]
+    val PreLaunchFileFailure                = "PreLaunchFileFailure".asInstanceOf[DeploymentJobErrorCode]
+    val PostLaunchFileFailure               = "PostLaunchFileFailure".asInstanceOf[DeploymentJobErrorCode]
+    val BadPermissionError                  = "BadPermissionError".asInstanceOf[DeploymentJobErrorCode]
+    val DownloadConditionFailed             = "DownloadConditionFailed".asInstanceOf[DeploymentJobErrorCode]
+    val InternalServerError                 = "InternalServerError".asInstanceOf[DeploymentJobErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1336,14 +1324,15 @@ package robomaker {
       __obj.asInstanceOf[DeploymentLaunchConfig]
     }
   }
-
-  object DeploymentStatusEnum {
-    val Pending    = "Pending"
-    val Preparing  = "Preparing"
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Succeeded  = "Succeeded"
-    val Canceled   = "Canceled"
+  @js.native
+  sealed trait DeploymentStatus extends js.Any
+  object DeploymentStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[DeploymentStatus]
+    val Preparing  = "Preparing".asInstanceOf[DeploymentStatus]
+    val InProgress = "InProgress".asInstanceOf[DeploymentStatus]
+    val Failed     = "Failed".asInstanceOf[DeploymentStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[DeploymentStatus]
+    val Canceled   = "Canceled".asInstanceOf[DeploymentStatus]
 
     val values = js.Object.freeze(js.Array(Pending, Preparing, InProgress, Failed, Succeeded, Canceled))
   }
@@ -1874,10 +1863,11 @@ package robomaker {
       __obj.asInstanceOf[FailedCreateSimulationJobRequest]
     }
   }
-
-  object FailureBehaviorEnum {
-    val Fail     = "Fail"
-    val Continue = "Continue"
+  @js.native
+  sealed trait FailureBehavior extends js.Any
+  object FailureBehavior extends js.Object {
+    val Fail     = "Fail".asInstanceOf[FailureBehavior]
+    val Continue = "Continue".asInstanceOf[FailureBehavior]
 
     val values = js.Object.freeze(js.Array(Fail, Continue))
   }
@@ -2508,9 +2498,10 @@ package robomaker {
       __obj.asInstanceOf[RenderingEngine]
     }
   }
-
-  object RenderingEngineTypeEnum {
-    val OGRE = "OGRE"
+  @js.native
+  sealed trait RenderingEngineType extends js.Any
+  object RenderingEngineType extends js.Object {
+    val OGRE = "OGRE".asInstanceOf[RenderingEngineType]
 
     val values = js.Object.freeze(js.Array(OGRE))
   }
@@ -2683,15 +2674,16 @@ package robomaker {
       __obj.asInstanceOf[RobotDeployment]
     }
   }
-
-  object RobotDeploymentStepEnum {
-    val Validating                 = "Validating"
-    val DownloadingExtracting      = "DownloadingExtracting"
-    val ExecutingDownloadCondition = "ExecutingDownloadCondition"
-    val ExecutingPreLaunch         = "ExecutingPreLaunch"
-    val Launching                  = "Launching"
-    val ExecutingPostLaunch        = "ExecutingPostLaunch"
-    val Finished                   = "Finished"
+  @js.native
+  sealed trait RobotDeploymentStep extends js.Any
+  object RobotDeploymentStep extends js.Object {
+    val Validating                 = "Validating".asInstanceOf[RobotDeploymentStep]
+    val DownloadingExtracting      = "DownloadingExtracting".asInstanceOf[RobotDeploymentStep]
+    val ExecutingDownloadCondition = "ExecutingDownloadCondition".asInstanceOf[RobotDeploymentStep]
+    val ExecutingPreLaunch         = "ExecutingPreLaunch".asInstanceOf[RobotDeploymentStep]
+    val Launching                  = "Launching".asInstanceOf[RobotDeploymentStep]
+    val ExecutingPostLaunch        = "ExecutingPostLaunch".asInstanceOf[RobotDeploymentStep]
+    val Finished                   = "Finished".asInstanceOf[RobotDeploymentStep]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2727,30 +2719,33 @@ package robomaker {
       __obj.asInstanceOf[RobotSoftwareSuite]
     }
   }
-
-  object RobotSoftwareSuiteTypeEnum {
-    val ROS  = "ROS"
-    val ROS2 = "ROS2"
+  @js.native
+  sealed trait RobotSoftwareSuiteType extends js.Any
+  object RobotSoftwareSuiteType extends js.Object {
+    val ROS  = "ROS".asInstanceOf[RobotSoftwareSuiteType]
+    val ROS2 = "ROS2".asInstanceOf[RobotSoftwareSuiteType]
 
     val values = js.Object.freeze(js.Array(ROS, ROS2))
   }
-
-  object RobotSoftwareSuiteVersionTypeEnum {
-    val Kinetic = "Kinetic"
-    val Melodic = "Melodic"
-    val Dashing = "Dashing"
+  @js.native
+  sealed trait RobotSoftwareSuiteVersionType extends js.Any
+  object RobotSoftwareSuiteVersionType extends js.Object {
+    val Kinetic = "Kinetic".asInstanceOf[RobotSoftwareSuiteVersionType]
+    val Melodic = "Melodic".asInstanceOf[RobotSoftwareSuiteVersionType]
+    val Dashing = "Dashing".asInstanceOf[RobotSoftwareSuiteVersionType]
 
     val values = js.Object.freeze(js.Array(Kinetic, Melodic, Dashing))
   }
-
-  object RobotStatusEnum {
-    val Available            = "Available"
-    val Registered           = "Registered"
-    val PendingNewDeployment = "PendingNewDeployment"
-    val Deploying            = "Deploying"
-    val Failed               = "Failed"
-    val InSync               = "InSync"
-    val NoResponse           = "NoResponse"
+  @js.native
+  sealed trait RobotStatus extends js.Any
+  object RobotStatus extends js.Object {
+    val Available            = "Available".asInstanceOf[RobotStatus]
+    val Registered           = "Registered".asInstanceOf[RobotStatus]
+    val PendingNewDeployment = "PendingNewDeployment".asInstanceOf[RobotStatus]
+    val Deploying            = "Deploying".asInstanceOf[RobotStatus]
+    val Failed               = "Failed".asInstanceOf[RobotStatus]
+    val InSync               = "InSync".asInstanceOf[RobotStatus]
+    val NoResponse           = "NoResponse".asInstanceOf[RobotStatus]
 
     val values =
       js.Object.freeze(js.Array(Available, Registered, PendingNewDeployment, Deploying, Failed, InSync, NoResponse))
@@ -2941,23 +2936,25 @@ package robomaker {
       __obj.asInstanceOf[SimulationJob]
     }
   }
-
-  object SimulationJobBatchErrorCodeEnum {
-    val InternalServiceError = "InternalServiceError"
+  @js.native
+  sealed trait SimulationJobBatchErrorCode extends js.Any
+  object SimulationJobBatchErrorCode extends js.Object {
+    val InternalServiceError = "InternalServiceError".asInstanceOf[SimulationJobBatchErrorCode]
 
     val values = js.Object.freeze(js.Array(InternalServiceError))
   }
-
-  object SimulationJobBatchStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Completed  = "Completed"
-    val Canceled   = "Canceled"
-    val Canceling  = "Canceling"
-    val Completing = "Completing"
-    val TimingOut  = "TimingOut"
-    val TimedOut   = "TimedOut"
+  @js.native
+  sealed trait SimulationJobBatchStatus extends js.Any
+  object SimulationJobBatchStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[SimulationJobBatchStatus]
+    val InProgress = "InProgress".asInstanceOf[SimulationJobBatchStatus]
+    val Failed     = "Failed".asInstanceOf[SimulationJobBatchStatus]
+    val Completed  = "Completed".asInstanceOf[SimulationJobBatchStatus]
+    val Canceled   = "Canceled".asInstanceOf[SimulationJobBatchStatus]
+    val Canceling  = "Canceling".asInstanceOf[SimulationJobBatchStatus]
+    val Completing = "Completing".asInstanceOf[SimulationJobBatchStatus]
+    val TimingOut  = "TimingOut".asInstanceOf[SimulationJobBatchStatus]
+    val TimedOut   = "TimedOut".asInstanceOf[SimulationJobBatchStatus]
 
     val values = js.Object.freeze(
       js.Array(Pending, InProgress, Failed, Completed, Canceled, Canceling, Completing, TimingOut, TimedOut)
@@ -3000,35 +2997,38 @@ package robomaker {
       __obj.asInstanceOf[SimulationJobBatchSummary]
     }
   }
-
-  object SimulationJobErrorCodeEnum {
-    val InternalServiceError                       = "InternalServiceError"
-    val RobotApplicationCrash                      = "RobotApplicationCrash"
-    val SimulationApplicationCrash                 = "SimulationApplicationCrash"
-    val BadPermissionsRobotApplication             = "BadPermissionsRobotApplication"
-    val BadPermissionsSimulationApplication        = "BadPermissionsSimulationApplication"
-    val BadPermissionsS3Object                     = "BadPermissionsS3Object"
-    val BadPermissionsS3Output                     = "BadPermissionsS3Output"
-    val BadPermissionsCloudwatchLogs               = "BadPermissionsCloudwatchLogs"
-    val SubnetIpLimitExceeded                      = "SubnetIpLimitExceeded"
-    val ENILimitExceeded                           = "ENILimitExceeded"
-    val BadPermissionsUserCredentials              = "BadPermissionsUserCredentials"
-    val InvalidBundleRobotApplication              = "InvalidBundleRobotApplication"
-    val InvalidBundleSimulationApplication         = "InvalidBundleSimulationApplication"
-    val InvalidS3Resource                          = "InvalidS3Resource"
-    val LimitExceeded                              = "LimitExceeded"
-    val MismatchedEtag                             = "MismatchedEtag"
-    val RobotApplicationVersionMismatchedEtag      = "RobotApplicationVersionMismatchedEtag"
-    val SimulationApplicationVersionMismatchedEtag = "SimulationApplicationVersionMismatchedEtag"
-    val ResourceNotFound                           = "ResourceNotFound"
-    val RequestThrottled                           = "RequestThrottled"
-    val BatchTimedOut                              = "BatchTimedOut"
-    val BatchCanceled                              = "BatchCanceled"
-    val InvalidInput                               = "InvalidInput"
-    val WrongRegionS3Bucket                        = "WrongRegionS3Bucket"
-    val WrongRegionS3Output                        = "WrongRegionS3Output"
-    val WrongRegionRobotApplication                = "WrongRegionRobotApplication"
-    val WrongRegionSimulationApplication           = "WrongRegionSimulationApplication"
+  @js.native
+  sealed trait SimulationJobErrorCode extends js.Any
+  object SimulationJobErrorCode extends js.Object {
+    val InternalServiceError                = "InternalServiceError".asInstanceOf[SimulationJobErrorCode]
+    val RobotApplicationCrash               = "RobotApplicationCrash".asInstanceOf[SimulationJobErrorCode]
+    val SimulationApplicationCrash          = "SimulationApplicationCrash".asInstanceOf[SimulationJobErrorCode]
+    val BadPermissionsRobotApplication      = "BadPermissionsRobotApplication".asInstanceOf[SimulationJobErrorCode]
+    val BadPermissionsSimulationApplication = "BadPermissionsSimulationApplication".asInstanceOf[SimulationJobErrorCode]
+    val BadPermissionsS3Object              = "BadPermissionsS3Object".asInstanceOf[SimulationJobErrorCode]
+    val BadPermissionsS3Output              = "BadPermissionsS3Output".asInstanceOf[SimulationJobErrorCode]
+    val BadPermissionsCloudwatchLogs        = "BadPermissionsCloudwatchLogs".asInstanceOf[SimulationJobErrorCode]
+    val SubnetIpLimitExceeded               = "SubnetIpLimitExceeded".asInstanceOf[SimulationJobErrorCode]
+    val ENILimitExceeded                    = "ENILimitExceeded".asInstanceOf[SimulationJobErrorCode]
+    val BadPermissionsUserCredentials       = "BadPermissionsUserCredentials".asInstanceOf[SimulationJobErrorCode]
+    val InvalidBundleRobotApplication       = "InvalidBundleRobotApplication".asInstanceOf[SimulationJobErrorCode]
+    val InvalidBundleSimulationApplication  = "InvalidBundleSimulationApplication".asInstanceOf[SimulationJobErrorCode]
+    val InvalidS3Resource                   = "InvalidS3Resource".asInstanceOf[SimulationJobErrorCode]
+    val LimitExceeded                       = "LimitExceeded".asInstanceOf[SimulationJobErrorCode]
+    val MismatchedEtag                      = "MismatchedEtag".asInstanceOf[SimulationJobErrorCode]
+    val RobotApplicationVersionMismatchedEtag =
+      "RobotApplicationVersionMismatchedEtag".asInstanceOf[SimulationJobErrorCode]
+    val SimulationApplicationVersionMismatchedEtag =
+      "SimulationApplicationVersionMismatchedEtag".asInstanceOf[SimulationJobErrorCode]
+    val ResourceNotFound                 = "ResourceNotFound".asInstanceOf[SimulationJobErrorCode]
+    val RequestThrottled                 = "RequestThrottled".asInstanceOf[SimulationJobErrorCode]
+    val BatchTimedOut                    = "BatchTimedOut".asInstanceOf[SimulationJobErrorCode]
+    val BatchCanceled                    = "BatchCanceled".asInstanceOf[SimulationJobErrorCode]
+    val InvalidInput                     = "InvalidInput".asInstanceOf[SimulationJobErrorCode]
+    val WrongRegionS3Bucket              = "WrongRegionS3Bucket".asInstanceOf[SimulationJobErrorCode]
+    val WrongRegionS3Output              = "WrongRegionS3Output".asInstanceOf[SimulationJobErrorCode]
+    val WrongRegionRobotApplication      = "WrongRegionRobotApplication".asInstanceOf[SimulationJobErrorCode]
+    val WrongRegionSimulationApplication = "WrongRegionSimulationApplication".asInstanceOf[SimulationJobErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3113,18 +3113,19 @@ package robomaker {
       __obj.asInstanceOf[SimulationJobRequest]
     }
   }
-
-  object SimulationJobStatusEnum {
-    val Pending       = "Pending"
-    val Preparing     = "Preparing"
-    val Running       = "Running"
-    val Restarting    = "Restarting"
-    val Completed     = "Completed"
-    val Failed        = "Failed"
-    val RunningFailed = "RunningFailed"
-    val Terminating   = "Terminating"
-    val Terminated    = "Terminated"
-    val Canceled      = "Canceled"
+  @js.native
+  sealed trait SimulationJobStatus extends js.Any
+  object SimulationJobStatus extends js.Object {
+    val Pending       = "Pending".asInstanceOf[SimulationJobStatus]
+    val Preparing     = "Preparing".asInstanceOf[SimulationJobStatus]
+    val Running       = "Running".asInstanceOf[SimulationJobStatus]
+    val Restarting    = "Restarting".asInstanceOf[SimulationJobStatus]
+    val Completed     = "Completed".asInstanceOf[SimulationJobStatus]
+    val Failed        = "Failed".asInstanceOf[SimulationJobStatus]
+    val RunningFailed = "RunningFailed".asInstanceOf[SimulationJobStatus]
+    val Terminating   = "Terminating".asInstanceOf[SimulationJobStatus]
+    val Terminated    = "Terminated".asInstanceOf[SimulationJobStatus]
+    val Canceled      = "Canceled".asInstanceOf[SimulationJobStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3202,10 +3203,11 @@ package robomaker {
       __obj.asInstanceOf[SimulationSoftwareSuite]
     }
   }
-
-  object SimulationSoftwareSuiteTypeEnum {
-    val Gazebo     = "Gazebo"
-    val RosbagPlay = "RosbagPlay"
+  @js.native
+  sealed trait SimulationSoftwareSuiteType extends js.Any
+  object SimulationSoftwareSuiteType extends js.Object {
+    val Gazebo     = "Gazebo".asInstanceOf[SimulationSoftwareSuiteType]
+    val RosbagPlay = "RosbagPlay".asInstanceOf[SimulationSoftwareSuiteType]
 
     val values = js.Object.freeze(js.Array(Gazebo, RosbagPlay))
   }

--- a/services/route53/src/main/scala/facade/amazonaws/services/Route53.scala
+++ b/services/route53/src/main/scala/facade/amazonaws/services/Route53.scala
@@ -7,18 +7,13 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object route53 {
-  type AccountLimitType                  = String
   type AlarmName                         = String
   type AliasHealthEnabled                = Boolean
   type AssociateVPCComment               = String
-  type ChangeAction                      = String
-  type ChangeStatus                      = String
   type Changes                           = js.Array[Change]
   type CheckerIpRanges                   = js.Array[IPAddressCidr]
   type ChildHealthCheckList              = js.Array[HealthCheckId]
   type CloudWatchLogsLogGroupArn         = String
-  type CloudWatchRegion                  = String
-  type ComparisonOperator                = String
   type DNSName                           = String
   type DNSRCode                          = String
   type DelegationSetNameServers          = js.Array[DNSName]
@@ -42,19 +37,15 @@ package object route53 {
   type HealthCheckId                     = String
   type HealthCheckNonce                  = String
   type HealthCheckObservations           = js.Array[HealthCheckObservation]
-  type HealthCheckRegion                 = String
   type HealthCheckRegionList             = js.Array[HealthCheckRegion]
-  type HealthCheckType                   = String
   type HealthCheckVersion                = Double
   type HealthChecks                      = js.Array[HealthCheck]
   type HealthThreshold                   = Int
   type HostedZoneCount                   = Double
-  type HostedZoneLimitType               = String
   type HostedZoneRRSetCount              = Double
   type HostedZones                       = js.Array[HostedZone]
   type IPAddress                         = String
   type IPAddressCidr                     = String
-  type InsufficientDataHealthStatus      = String
   type Inverted                          = Boolean
   type IsPrivateZone                     = Boolean
   type LimitValue                        = Double
@@ -74,28 +65,22 @@ package object route53 {
   type QueryLoggingConfigId              = String
   type QueryLoggingConfigs               = js.Array[QueryLoggingConfig]
   type RData                             = String
-  type RRType                            = String
   type RecordData                        = js.Array[RecordDataEntry]
   type RecordDataEntry                   = String
   type RequestInterval                   = Int
-  type ResettableElementName             = String
   type ResettableElementNameList         = js.Array[ResettableElementName]
   type ResourceDescription               = String
   type ResourceId                        = String
   type ResourcePath                      = String
-  type ResourceRecordSetFailover         = String
   type ResourceRecordSetIdentifier       = String
   type ResourceRecordSetMultiValueAnswer = Boolean
-  type ResourceRecordSetRegion           = String
   type ResourceRecordSetWeight           = Double
   type ResourceRecordSets                = js.Array[ResourceRecordSet]
   type ResourceRecords                   = js.Array[ResourceRecord]
   type ResourceTagSetList                = js.Array[ResourceTagSet]
   type ResourceURI                       = String
-  type ReusableDelegationSetLimitType    = String
   type SearchString                      = String
   type ServicePrincipal                  = String
-  type Statistic                         = String
   type Status                            = String
   type SubnetMask                        = String
   type TTL                               = Double
@@ -104,7 +89,6 @@ package object route53 {
   type TagList                           = js.Array[Tag]
   type TagResourceId                     = String
   type TagResourceIdList                 = js.Array[TagResourceId]
-  type TagResourceType                   = String
   type TagValue                          = String
   type Threshold                         = Double
   type TimeStamp                         = js.Date
@@ -123,7 +107,6 @@ package object route53 {
   type TransportProtocol                 = String
   type UsageCount                        = Double
   type VPCId                             = String
-  type VPCRegion                         = String
   type VPCs                              = js.Array[VPC]
 
   implicit final class Route53Ops(private val service: Route53) extends AnyVal {
@@ -415,13 +398,14 @@ package route53 {
       __obj.asInstanceOf[AccountLimit]
     }
   }
-
-  object AccountLimitTypeEnum {
-    val MAX_HEALTH_CHECKS_BY_OWNER            = "MAX_HEALTH_CHECKS_BY_OWNER"
-    val MAX_HOSTED_ZONES_BY_OWNER             = "MAX_HOSTED_ZONES_BY_OWNER"
-    val MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER = "MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER"
-    val MAX_REUSABLE_DELEGATION_SETS_BY_OWNER = "MAX_REUSABLE_DELEGATION_SETS_BY_OWNER"
-    val MAX_TRAFFIC_POLICIES_BY_OWNER         = "MAX_TRAFFIC_POLICIES_BY_OWNER"
+  @js.native
+  sealed trait AccountLimitType extends js.Any
+  object AccountLimitType extends js.Object {
+    val MAX_HEALTH_CHECKS_BY_OWNER            = "MAX_HEALTH_CHECKS_BY_OWNER".asInstanceOf[AccountLimitType]
+    val MAX_HOSTED_ZONES_BY_OWNER             = "MAX_HOSTED_ZONES_BY_OWNER".asInstanceOf[AccountLimitType]
+    val MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER = "MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER".asInstanceOf[AccountLimitType]
+    val MAX_REUSABLE_DELEGATION_SETS_BY_OWNER = "MAX_REUSABLE_DELEGATION_SETS_BY_OWNER".asInstanceOf[AccountLimitType]
+    val MAX_TRAFFIC_POLICIES_BY_OWNER         = "MAX_TRAFFIC_POLICIES_BY_OWNER".asInstanceOf[AccountLimitType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -559,11 +543,12 @@ package route53 {
       __obj.asInstanceOf[Change]
     }
   }
-
-  object ChangeActionEnum {
-    val CREATE = "CREATE"
-    val DELETE = "DELETE"
-    val UPSERT = "UPSERT"
+  @js.native
+  sealed trait ChangeAction extends js.Any
+  object ChangeAction extends js.Object {
+    val CREATE = "CREATE".asInstanceOf[ChangeAction]
+    val DELETE = "DELETE".asInstanceOf[ChangeAction]
+    val UPSERT = "UPSERT".asInstanceOf[ChangeAction]
 
     val values = js.Object.freeze(js.Array(CREATE, DELETE, UPSERT))
   }
@@ -666,10 +651,11 @@ package route53 {
       __obj.asInstanceOf[ChangeResourceRecordSetsResponse]
     }
   }
-
-  object ChangeStatusEnum {
-    val PENDING = "PENDING"
-    val INSYNC  = "INSYNC"
+  @js.native
+  sealed trait ChangeStatus extends js.Any
+  object ChangeStatus extends js.Object {
+    val PENDING = "PENDING".asInstanceOf[ChangeStatus]
+    val INSYNC  = "INSYNC".asInstanceOf[ChangeStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, INSYNC))
   }
@@ -761,29 +747,30 @@ package route53 {
       __obj.asInstanceOf[CloudWatchAlarmConfiguration]
     }
   }
-
-  object CloudWatchRegionEnum {
-    val `us-east-1`      = "us-east-1"
-    val `us-east-2`      = "us-east-2"
-    val `us-west-1`      = "us-west-1"
-    val `us-west-2`      = "us-west-2"
-    val `ca-central-1`   = "ca-central-1"
-    val `eu-central-1`   = "eu-central-1"
-    val `eu-west-1`      = "eu-west-1"
-    val `eu-west-2`      = "eu-west-2"
-    val `eu-west-3`      = "eu-west-3"
-    val `ap-east-1`      = "ap-east-1"
-    val `me-south-1`     = "me-south-1"
-    val `ap-south-1`     = "ap-south-1"
-    val `ap-southeast-1` = "ap-southeast-1"
-    val `ap-southeast-2` = "ap-southeast-2"
-    val `ap-northeast-1` = "ap-northeast-1"
-    val `ap-northeast-2` = "ap-northeast-2"
-    val `ap-northeast-3` = "ap-northeast-3"
-    val `eu-north-1`     = "eu-north-1"
-    val `sa-east-1`      = "sa-east-1"
-    val `cn-northwest-1` = "cn-northwest-1"
-    val `cn-north-1`     = "cn-north-1"
+  @js.native
+  sealed trait CloudWatchRegion extends js.Any
+  object CloudWatchRegion extends js.Object {
+    val `us-east-1`      = "us-east-1".asInstanceOf[CloudWatchRegion]
+    val `us-east-2`      = "us-east-2".asInstanceOf[CloudWatchRegion]
+    val `us-west-1`      = "us-west-1".asInstanceOf[CloudWatchRegion]
+    val `us-west-2`      = "us-west-2".asInstanceOf[CloudWatchRegion]
+    val `ca-central-1`   = "ca-central-1".asInstanceOf[CloudWatchRegion]
+    val `eu-central-1`   = "eu-central-1".asInstanceOf[CloudWatchRegion]
+    val `eu-west-1`      = "eu-west-1".asInstanceOf[CloudWatchRegion]
+    val `eu-west-2`      = "eu-west-2".asInstanceOf[CloudWatchRegion]
+    val `eu-west-3`      = "eu-west-3".asInstanceOf[CloudWatchRegion]
+    val `ap-east-1`      = "ap-east-1".asInstanceOf[CloudWatchRegion]
+    val `me-south-1`     = "me-south-1".asInstanceOf[CloudWatchRegion]
+    val `ap-south-1`     = "ap-south-1".asInstanceOf[CloudWatchRegion]
+    val `ap-southeast-1` = "ap-southeast-1".asInstanceOf[CloudWatchRegion]
+    val `ap-southeast-2` = "ap-southeast-2".asInstanceOf[CloudWatchRegion]
+    val `ap-northeast-1` = "ap-northeast-1".asInstanceOf[CloudWatchRegion]
+    val `ap-northeast-2` = "ap-northeast-2".asInstanceOf[CloudWatchRegion]
+    val `ap-northeast-3` = "ap-northeast-3".asInstanceOf[CloudWatchRegion]
+    val `eu-north-1`     = "eu-north-1".asInstanceOf[CloudWatchRegion]
+    val `sa-east-1`      = "sa-east-1".asInstanceOf[CloudWatchRegion]
+    val `cn-northwest-1` = "cn-northwest-1".asInstanceOf[CloudWatchRegion]
+    val `cn-north-1`     = "cn-north-1".asInstanceOf[CloudWatchRegion]
 
     val values = js.Object.freeze(
       js.Array(
@@ -811,12 +798,13 @@ package route53 {
       )
     )
   }
-
-  object ComparisonOperatorEnum {
-    val GreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold"
-    val GreaterThanThreshold          = "GreaterThanThreshold"
-    val LessThanThreshold             = "LessThanThreshold"
-    val LessThanOrEqualToThreshold    = "LessThanOrEqualToThreshold"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val GreaterThanOrEqualToThreshold = "GreaterThanOrEqualToThreshold".asInstanceOf[ComparisonOperator]
+    val GreaterThanThreshold          = "GreaterThanThreshold".asInstanceOf[ComparisonOperator]
+    val LessThanThreshold             = "LessThanThreshold".asInstanceOf[ComparisonOperator]
+    val LessThanOrEqualToThreshold    = "LessThanOrEqualToThreshold".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(
       js.Array(GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold)
@@ -2499,16 +2487,17 @@ package route53 {
       __obj.asInstanceOf[HealthCheckObservation]
     }
   }
-
-  object HealthCheckRegionEnum {
-    val `us-east-1`      = "us-east-1"
-    val `us-west-1`      = "us-west-1"
-    val `us-west-2`      = "us-west-2"
-    val `eu-west-1`      = "eu-west-1"
-    val `ap-southeast-1` = "ap-southeast-1"
-    val `ap-southeast-2` = "ap-southeast-2"
-    val `ap-northeast-1` = "ap-northeast-1"
-    val `sa-east-1`      = "sa-east-1"
+  @js.native
+  sealed trait HealthCheckRegion extends js.Any
+  object HealthCheckRegion extends js.Object {
+    val `us-east-1`      = "us-east-1".asInstanceOf[HealthCheckRegion]
+    val `us-west-1`      = "us-west-1".asInstanceOf[HealthCheckRegion]
+    val `us-west-2`      = "us-west-2".asInstanceOf[HealthCheckRegion]
+    val `eu-west-1`      = "eu-west-1".asInstanceOf[HealthCheckRegion]
+    val `ap-southeast-1` = "ap-southeast-1".asInstanceOf[HealthCheckRegion]
+    val `ap-southeast-2` = "ap-southeast-2".asInstanceOf[HealthCheckRegion]
+    val `ap-northeast-1` = "ap-northeast-1".asInstanceOf[HealthCheckRegion]
+    val `sa-east-1`      = "sa-east-1".asInstanceOf[HealthCheckRegion]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2523,15 +2512,16 @@ package route53 {
       )
     )
   }
-
-  object HealthCheckTypeEnum {
-    val HTTP              = "HTTP"
-    val HTTPS             = "HTTPS"
-    val HTTP_STR_MATCH    = "HTTP_STR_MATCH"
-    val HTTPS_STR_MATCH   = "HTTPS_STR_MATCH"
-    val TCP               = "TCP"
-    val CALCULATED        = "CALCULATED"
-    val CLOUDWATCH_METRIC = "CLOUDWATCH_METRIC"
+  @js.native
+  sealed trait HealthCheckType extends js.Any
+  object HealthCheckType extends js.Object {
+    val HTTP              = "HTTP".asInstanceOf[HealthCheckType]
+    val HTTPS             = "HTTPS".asInstanceOf[HealthCheckType]
+    val HTTP_STR_MATCH    = "HTTP_STR_MATCH".asInstanceOf[HealthCheckType]
+    val HTTPS_STR_MATCH   = "HTTPS_STR_MATCH".asInstanceOf[HealthCheckType]
+    val TCP               = "TCP".asInstanceOf[HealthCheckType]
+    val CALCULATED        = "CALCULATED".asInstanceOf[HealthCheckType]
+    val CLOUDWATCH_METRIC = "CLOUDWATCH_METRIC".asInstanceOf[HealthCheckType]
 
     val values =
       js.Object.freeze(js.Array(HTTP, HTTPS, HTTP_STR_MATCH, HTTPS_STR_MATCH, TCP, CALCULATED, CLOUDWATCH_METRIC))
@@ -2618,18 +2608,20 @@ package route53 {
       __obj.asInstanceOf[HostedZoneLimit]
     }
   }
-
-  object HostedZoneLimitTypeEnum {
-    val MAX_RRSETS_BY_ZONE          = "MAX_RRSETS_BY_ZONE"
-    val MAX_VPCS_ASSOCIATED_BY_ZONE = "MAX_VPCS_ASSOCIATED_BY_ZONE"
+  @js.native
+  sealed trait HostedZoneLimitType extends js.Any
+  object HostedZoneLimitType extends js.Object {
+    val MAX_RRSETS_BY_ZONE          = "MAX_RRSETS_BY_ZONE".asInstanceOf[HostedZoneLimitType]
+    val MAX_VPCS_ASSOCIATED_BY_ZONE = "MAX_VPCS_ASSOCIATED_BY_ZONE".asInstanceOf[HostedZoneLimitType]
 
     val values = js.Object.freeze(js.Array(MAX_RRSETS_BY_ZONE, MAX_VPCS_ASSOCIATED_BY_ZONE))
   }
-
-  object InsufficientDataHealthStatusEnum {
-    val Healthy         = "Healthy"
-    val Unhealthy       = "Unhealthy"
-    val LastKnownStatus = "LastKnownStatus"
+  @js.native
+  sealed trait InsufficientDataHealthStatus extends js.Any
+  object InsufficientDataHealthStatus extends js.Object {
+    val Healthy         = "Healthy".asInstanceOf[InsufficientDataHealthStatus]
+    val Unhealthy       = "Unhealthy".asInstanceOf[InsufficientDataHealthStatus]
+    val LastKnownStatus = "LastKnownStatus".asInstanceOf[InsufficientDataHealthStatus]
 
     val values = js.Object.freeze(js.Array(Healthy, Unhealthy, LastKnownStatus))
   }
@@ -3565,29 +3557,31 @@ package route53 {
       __obj.asInstanceOf[QueryLoggingConfig]
     }
   }
-
-  object RRTypeEnum {
-    val SOA   = "SOA"
-    val A     = "A"
-    val TXT   = "TXT"
-    val NS    = "NS"
-    val CNAME = "CNAME"
-    val MX    = "MX"
-    val NAPTR = "NAPTR"
-    val PTR   = "PTR"
-    val SRV   = "SRV"
-    val SPF   = "SPF"
-    val AAAA  = "AAAA"
-    val CAA   = "CAA"
+  @js.native
+  sealed trait RRType extends js.Any
+  object RRType extends js.Object {
+    val SOA   = "SOA".asInstanceOf[RRType]
+    val A     = "A".asInstanceOf[RRType]
+    val TXT   = "TXT".asInstanceOf[RRType]
+    val NS    = "NS".asInstanceOf[RRType]
+    val CNAME = "CNAME".asInstanceOf[RRType]
+    val MX    = "MX".asInstanceOf[RRType]
+    val NAPTR = "NAPTR".asInstanceOf[RRType]
+    val PTR   = "PTR".asInstanceOf[RRType]
+    val SRV   = "SRV".asInstanceOf[RRType]
+    val SPF   = "SPF".asInstanceOf[RRType]
+    val AAAA  = "AAAA".asInstanceOf[RRType]
+    val CAA   = "CAA".asInstanceOf[RRType]
 
     val values = js.Object.freeze(js.Array(SOA, A, TXT, NS, CNAME, MX, NAPTR, PTR, SRV, SPF, AAAA, CAA))
   }
-
-  object ResettableElementNameEnum {
-    val FullyQualifiedDomainName = "FullyQualifiedDomainName"
-    val Regions                  = "Regions"
-    val ResourcePath             = "ResourcePath"
-    val ChildHealthChecks        = "ChildHealthChecks"
+  @js.native
+  sealed trait ResettableElementName extends js.Any
+  object ResettableElementName extends js.Object {
+    val FullyQualifiedDomainName = "FullyQualifiedDomainName".asInstanceOf[ResettableElementName]
+    val Regions                  = "Regions".asInstanceOf[ResettableElementName]
+    val ResourcePath             = "ResourcePath".asInstanceOf[ResettableElementName]
+    val ChildHealthChecks        = "ChildHealthChecks".asInstanceOf[ResettableElementName]
 
     val values = js.Object.freeze(js.Array(FullyQualifiedDomainName, Regions, ResourcePath, ChildHealthChecks))
   }
@@ -3671,36 +3665,38 @@ package route53 {
       __obj.asInstanceOf[ResourceRecordSet]
     }
   }
-
-  object ResourceRecordSetFailoverEnum {
-    val PRIMARY   = "PRIMARY"
-    val SECONDARY = "SECONDARY"
+  @js.native
+  sealed trait ResourceRecordSetFailover extends js.Any
+  object ResourceRecordSetFailover extends js.Object {
+    val PRIMARY   = "PRIMARY".asInstanceOf[ResourceRecordSetFailover]
+    val SECONDARY = "SECONDARY".asInstanceOf[ResourceRecordSetFailover]
 
     val values = js.Object.freeze(js.Array(PRIMARY, SECONDARY))
   }
-
-  object ResourceRecordSetRegionEnum {
-    val `us-east-1`      = "us-east-1"
-    val `us-east-2`      = "us-east-2"
-    val `us-west-1`      = "us-west-1"
-    val `us-west-2`      = "us-west-2"
-    val `ca-central-1`   = "ca-central-1"
-    val `eu-west-1`      = "eu-west-1"
-    val `eu-west-2`      = "eu-west-2"
-    val `eu-west-3`      = "eu-west-3"
-    val `eu-central-1`   = "eu-central-1"
-    val `ap-southeast-1` = "ap-southeast-1"
-    val `ap-southeast-2` = "ap-southeast-2"
-    val `ap-northeast-1` = "ap-northeast-1"
-    val `ap-northeast-2` = "ap-northeast-2"
-    val `ap-northeast-3` = "ap-northeast-3"
-    val `eu-north-1`     = "eu-north-1"
-    val `sa-east-1`      = "sa-east-1"
-    val `cn-north-1`     = "cn-north-1"
-    val `cn-northwest-1` = "cn-northwest-1"
-    val `ap-east-1`      = "ap-east-1"
-    val `me-south-1`     = "me-south-1"
-    val `ap-south-1`     = "ap-south-1"
+  @js.native
+  sealed trait ResourceRecordSetRegion extends js.Any
+  object ResourceRecordSetRegion extends js.Object {
+    val `us-east-1`      = "us-east-1".asInstanceOf[ResourceRecordSetRegion]
+    val `us-east-2`      = "us-east-2".asInstanceOf[ResourceRecordSetRegion]
+    val `us-west-1`      = "us-west-1".asInstanceOf[ResourceRecordSetRegion]
+    val `us-west-2`      = "us-west-2".asInstanceOf[ResourceRecordSetRegion]
+    val `ca-central-1`   = "ca-central-1".asInstanceOf[ResourceRecordSetRegion]
+    val `eu-west-1`      = "eu-west-1".asInstanceOf[ResourceRecordSetRegion]
+    val `eu-west-2`      = "eu-west-2".asInstanceOf[ResourceRecordSetRegion]
+    val `eu-west-3`      = "eu-west-3".asInstanceOf[ResourceRecordSetRegion]
+    val `eu-central-1`   = "eu-central-1".asInstanceOf[ResourceRecordSetRegion]
+    val `ap-southeast-1` = "ap-southeast-1".asInstanceOf[ResourceRecordSetRegion]
+    val `ap-southeast-2` = "ap-southeast-2".asInstanceOf[ResourceRecordSetRegion]
+    val `ap-northeast-1` = "ap-northeast-1".asInstanceOf[ResourceRecordSetRegion]
+    val `ap-northeast-2` = "ap-northeast-2".asInstanceOf[ResourceRecordSetRegion]
+    val `ap-northeast-3` = "ap-northeast-3".asInstanceOf[ResourceRecordSetRegion]
+    val `eu-north-1`     = "eu-north-1".asInstanceOf[ResourceRecordSetRegion]
+    val `sa-east-1`      = "sa-east-1".asInstanceOf[ResourceRecordSetRegion]
+    val `cn-north-1`     = "cn-north-1".asInstanceOf[ResourceRecordSetRegion]
+    val `cn-northwest-1` = "cn-northwest-1".asInstanceOf[ResourceRecordSetRegion]
+    val `ap-east-1`      = "ap-east-1".asInstanceOf[ResourceRecordSetRegion]
+    val `me-south-1`     = "me-south-1".asInstanceOf[ResourceRecordSetRegion]
+    val `ap-south-1`     = "ap-south-1".asInstanceOf[ResourceRecordSetRegion]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3777,19 +3773,22 @@ package route53 {
       __obj.asInstanceOf[ReusableDelegationSetLimit]
     }
   }
-
-  object ReusableDelegationSetLimitTypeEnum {
-    val MAX_ZONES_BY_REUSABLE_DELEGATION_SET = "MAX_ZONES_BY_REUSABLE_DELEGATION_SET"
+  @js.native
+  sealed trait ReusableDelegationSetLimitType extends js.Any
+  object ReusableDelegationSetLimitType extends js.Object {
+    val MAX_ZONES_BY_REUSABLE_DELEGATION_SET =
+      "MAX_ZONES_BY_REUSABLE_DELEGATION_SET".asInstanceOf[ReusableDelegationSetLimitType]
 
     val values = js.Object.freeze(js.Array(MAX_ZONES_BY_REUSABLE_DELEGATION_SET))
   }
-
-  object StatisticEnum {
-    val Average     = "Average"
-    val Sum         = "Sum"
-    val SampleCount = "SampleCount"
-    val Maximum     = "Maximum"
-    val Minimum     = "Minimum"
+  @js.native
+  sealed trait Statistic extends js.Any
+  object Statistic extends js.Object {
+    val Average     = "Average".asInstanceOf[Statistic]
+    val Sum         = "Sum".asInstanceOf[Statistic]
+    val SampleCount = "SampleCount".asInstanceOf[Statistic]
+    val Maximum     = "Maximum".asInstanceOf[Statistic]
+    val Minimum     = "Minimum".asInstanceOf[Statistic]
 
     val values = js.Object.freeze(js.Array(Average, Sum, SampleCount, Maximum, Minimum))
   }
@@ -3837,10 +3836,11 @@ package route53 {
       __obj.asInstanceOf[Tag]
     }
   }
-
-  object TagResourceTypeEnum {
-    val healthcheck = "healthcheck"
-    val hostedzone  = "hostedzone"
+  @js.native
+  sealed trait TagResourceType extends js.Any
+  object TagResourceType extends js.Object {
+    val healthcheck = "healthcheck".asInstanceOf[TagResourceType]
+    val hostedzone  = "hostedzone".asInstanceOf[TagResourceType]
 
     val values = js.Object.freeze(js.Array(healthcheck, hostedzone))
   }
@@ -4288,28 +4288,29 @@ package route53 {
       __obj.asInstanceOf[VPC]
     }
   }
-
-  object VPCRegionEnum {
-    val `us-east-1`      = "us-east-1"
-    val `us-east-2`      = "us-east-2"
-    val `us-west-1`      = "us-west-1"
-    val `us-west-2`      = "us-west-2"
-    val `eu-west-1`      = "eu-west-1"
-    val `eu-west-2`      = "eu-west-2"
-    val `eu-west-3`      = "eu-west-3"
-    val `eu-central-1`   = "eu-central-1"
-    val `ap-east-1`      = "ap-east-1"
-    val `me-south-1`     = "me-south-1"
-    val `ap-southeast-1` = "ap-southeast-1"
-    val `ap-southeast-2` = "ap-southeast-2"
-    val `ap-south-1`     = "ap-south-1"
-    val `ap-northeast-1` = "ap-northeast-1"
-    val `ap-northeast-2` = "ap-northeast-2"
-    val `ap-northeast-3` = "ap-northeast-3"
-    val `eu-north-1`     = "eu-north-1"
-    val `sa-east-1`      = "sa-east-1"
-    val `ca-central-1`   = "ca-central-1"
-    val `cn-north-1`     = "cn-north-1"
+  @js.native
+  sealed trait VPCRegion extends js.Any
+  object VPCRegion extends js.Object {
+    val `us-east-1`      = "us-east-1".asInstanceOf[VPCRegion]
+    val `us-east-2`      = "us-east-2".asInstanceOf[VPCRegion]
+    val `us-west-1`      = "us-west-1".asInstanceOf[VPCRegion]
+    val `us-west-2`      = "us-west-2".asInstanceOf[VPCRegion]
+    val `eu-west-1`      = "eu-west-1".asInstanceOf[VPCRegion]
+    val `eu-west-2`      = "eu-west-2".asInstanceOf[VPCRegion]
+    val `eu-west-3`      = "eu-west-3".asInstanceOf[VPCRegion]
+    val `eu-central-1`   = "eu-central-1".asInstanceOf[VPCRegion]
+    val `ap-east-1`      = "ap-east-1".asInstanceOf[VPCRegion]
+    val `me-south-1`     = "me-south-1".asInstanceOf[VPCRegion]
+    val `ap-southeast-1` = "ap-southeast-1".asInstanceOf[VPCRegion]
+    val `ap-southeast-2` = "ap-southeast-2".asInstanceOf[VPCRegion]
+    val `ap-south-1`     = "ap-south-1".asInstanceOf[VPCRegion]
+    val `ap-northeast-1` = "ap-northeast-1".asInstanceOf[VPCRegion]
+    val `ap-northeast-2` = "ap-northeast-2".asInstanceOf[VPCRegion]
+    val `ap-northeast-3` = "ap-northeast-3".asInstanceOf[VPCRegion]
+    val `eu-north-1`     = "eu-north-1".asInstanceOf[VPCRegion]
+    val `sa-east-1`      = "sa-east-1".asInstanceOf[VPCRegion]
+    val `ca-central-1`   = "ca-central-1".asInstanceOf[VPCRegion]
+    val `cn-north-1`     = "cn-north-1".asInstanceOf[VPCRegion]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/route53domains/src/main/scala/facade/amazonaws/services/Route53Domains.scala
+++ b/services/route53domains/src/main/scala/facade/amazonaws/services/Route53Domains.scala
@@ -12,12 +12,9 @@ package object route53domains {
   type City                  = String
   type ContactName           = String
   type ContactNumber         = String
-  type ContactType           = String
-  type CountryCode           = String
   type CurrentExpiryYear     = Int
   type DNSSec                = String
   type DomainAuthCode        = String
-  type DomainAvailability    = String
   type DomainName            = String
   type DomainStatus          = String
   type DomainStatusList      = js.Array[DomainStatus]
@@ -27,7 +24,6 @@ package object route53domains {
   type Email                 = String
   type ErrorMessage          = String
   type ExtraParamList        = js.Array[ExtraParam]
-  type ExtraParamName        = String
   type ExtraParamValue       = String
   type FIAuthKey             = String
   type GlueIp                = String
@@ -37,13 +33,10 @@ package object route53domains {
   type LangCode              = String
   type NameserverList        = js.Array[Nameserver]
   type OperationId           = String
-  type OperationStatus       = String
   type OperationSummaryList  = js.Array[OperationSummary]
-  type OperationType         = String
   type PageMarker            = String
   type PageMaxItems          = Int
   type Price                 = Double
-  type ReachabilityStatus    = String
   type RegistrarName         = String
   type RegistrarUrl          = String
   type RegistrarWhoIsServer  = String
@@ -55,7 +48,6 @@ package object route53domains {
   type TagList               = js.Array[Tag]
   type TagValue              = String
   type Timestamp             = js.Date
-  type Transferable          = String
   type ZipCode               = String
 
   implicit final class Route53DomainsOps(private val service: Route53Domains) extends AnyVal {
@@ -347,247 +339,249 @@ package route53domains {
       __obj.asInstanceOf[ContactDetail]
     }
   }
-
-  object ContactTypeEnum {
-    val PERSON      = "PERSON"
-    val COMPANY     = "COMPANY"
-    val ASSOCIATION = "ASSOCIATION"
-    val PUBLIC_BODY = "PUBLIC_BODY"
-    val RESELLER    = "RESELLER"
+  @js.native
+  sealed trait ContactType extends js.Any
+  object ContactType extends js.Object {
+    val PERSON      = "PERSON".asInstanceOf[ContactType]
+    val COMPANY     = "COMPANY".asInstanceOf[ContactType]
+    val ASSOCIATION = "ASSOCIATION".asInstanceOf[ContactType]
+    val PUBLIC_BODY = "PUBLIC_BODY".asInstanceOf[ContactType]
+    val RESELLER    = "RESELLER".asInstanceOf[ContactType]
 
     val values = js.Object.freeze(js.Array(PERSON, COMPANY, ASSOCIATION, PUBLIC_BODY, RESELLER))
   }
-
-  object CountryCodeEnum {
-    val AD = "AD"
-    val AE = "AE"
-    val AF = "AF"
-    val AG = "AG"
-    val AI = "AI"
-    val AL = "AL"
-    val AM = "AM"
-    val AN = "AN"
-    val AO = "AO"
-    val AQ = "AQ"
-    val AR = "AR"
-    val AS = "AS"
-    val AT = "AT"
-    val AU = "AU"
-    val AW = "AW"
-    val AZ = "AZ"
-    val BA = "BA"
-    val BB = "BB"
-    val BD = "BD"
-    val BE = "BE"
-    val BF = "BF"
-    val BG = "BG"
-    val BH = "BH"
-    val BI = "BI"
-    val BJ = "BJ"
-    val BL = "BL"
-    val BM = "BM"
-    val BN = "BN"
-    val BO = "BO"
-    val BR = "BR"
-    val BS = "BS"
-    val BT = "BT"
-    val BW = "BW"
-    val BY = "BY"
-    val BZ = "BZ"
-    val CA = "CA"
-    val CC = "CC"
-    val CD = "CD"
-    val CF = "CF"
-    val CG = "CG"
-    val CH = "CH"
-    val CI = "CI"
-    val CK = "CK"
-    val CL = "CL"
-    val CM = "CM"
-    val CN = "CN"
-    val CO = "CO"
-    val CR = "CR"
-    val CU = "CU"
-    val CV = "CV"
-    val CX = "CX"
-    val CY = "CY"
-    val CZ = "CZ"
-    val DE = "DE"
-    val DJ = "DJ"
-    val DK = "DK"
-    val DM = "DM"
-    val DO = "DO"
-    val DZ = "DZ"
-    val EC = "EC"
-    val EE = "EE"
-    val EG = "EG"
-    val ER = "ER"
-    val ES = "ES"
-    val ET = "ET"
-    val FI = "FI"
-    val FJ = "FJ"
-    val FK = "FK"
-    val FM = "FM"
-    val FO = "FO"
-    val FR = "FR"
-    val GA = "GA"
-    val GB = "GB"
-    val GD = "GD"
-    val GE = "GE"
-    val GH = "GH"
-    val GI = "GI"
-    val GL = "GL"
-    val GM = "GM"
-    val GN = "GN"
-    val GQ = "GQ"
-    val GR = "GR"
-    val GT = "GT"
-    val GU = "GU"
-    val GW = "GW"
-    val GY = "GY"
-    val HK = "HK"
-    val HN = "HN"
-    val HR = "HR"
-    val HT = "HT"
-    val HU = "HU"
-    val ID = "ID"
-    val IE = "IE"
-    val IL = "IL"
-    val IM = "IM"
-    val IN = "IN"
-    val IQ = "IQ"
-    val IR = "IR"
-    val IS = "IS"
-    val IT = "IT"
-    val JM = "JM"
-    val JO = "JO"
-    val JP = "JP"
-    val KE = "KE"
-    val KG = "KG"
-    val KH = "KH"
-    val KI = "KI"
-    val KM = "KM"
-    val KN = "KN"
-    val KP = "KP"
-    val KR = "KR"
-    val KW = "KW"
-    val KY = "KY"
-    val KZ = "KZ"
-    val LA = "LA"
-    val LB = "LB"
-    val LC = "LC"
-    val LI = "LI"
-    val LK = "LK"
-    val LR = "LR"
-    val LS = "LS"
-    val LT = "LT"
-    val LU = "LU"
-    val LV = "LV"
-    val LY = "LY"
-    val MA = "MA"
-    val MC = "MC"
-    val MD = "MD"
-    val ME = "ME"
-    val MF = "MF"
-    val MG = "MG"
-    val MH = "MH"
-    val MK = "MK"
-    val ML = "ML"
-    val MM = "MM"
-    val MN = "MN"
-    val MO = "MO"
-    val MP = "MP"
-    val MR = "MR"
-    val MS = "MS"
-    val MT = "MT"
-    val MU = "MU"
-    val MV = "MV"
-    val MW = "MW"
-    val MX = "MX"
-    val MY = "MY"
-    val MZ = "MZ"
-    val NA = "NA"
-    val NC = "NC"
-    val NE = "NE"
-    val NG = "NG"
-    val NI = "NI"
-    val NL = "NL"
-    val NO = "NO"
-    val NP = "NP"
-    val NR = "NR"
-    val NU = "NU"
-    val NZ = "NZ"
-    val OM = "OM"
-    val PA = "PA"
-    val PE = "PE"
-    val PF = "PF"
-    val PG = "PG"
-    val PH = "PH"
-    val PK = "PK"
-    val PL = "PL"
-    val PM = "PM"
-    val PN = "PN"
-    val PR = "PR"
-    val PT = "PT"
-    val PW = "PW"
-    val PY = "PY"
-    val QA = "QA"
-    val RO = "RO"
-    val RS = "RS"
-    val RU = "RU"
-    val RW = "RW"
-    val SA = "SA"
-    val SB = "SB"
-    val SC = "SC"
-    val SD = "SD"
-    val SE = "SE"
-    val SG = "SG"
-    val SH = "SH"
-    val SI = "SI"
-    val SK = "SK"
-    val SL = "SL"
-    val SM = "SM"
-    val SN = "SN"
-    val SO = "SO"
-    val SR = "SR"
-    val ST = "ST"
-    val SV = "SV"
-    val SY = "SY"
-    val SZ = "SZ"
-    val TC = "TC"
-    val TD = "TD"
-    val TG = "TG"
-    val TH = "TH"
-    val TJ = "TJ"
-    val TK = "TK"
-    val TL = "TL"
-    val TM = "TM"
-    val TN = "TN"
-    val TO = "TO"
-    val TR = "TR"
-    val TT = "TT"
-    val TV = "TV"
-    val TW = "TW"
-    val TZ = "TZ"
-    val UA = "UA"
-    val UG = "UG"
-    val US = "US"
-    val UY = "UY"
-    val UZ = "UZ"
-    val VA = "VA"
-    val VC = "VC"
-    val VE = "VE"
-    val VG = "VG"
-    val VI = "VI"
-    val VN = "VN"
-    val VU = "VU"
-    val WF = "WF"
-    val WS = "WS"
-    val YE = "YE"
-    val YT = "YT"
-    val ZA = "ZA"
-    val ZM = "ZM"
-    val ZW = "ZW"
+  @js.native
+  sealed trait CountryCode extends js.Any
+  object CountryCode extends js.Object {
+    val AD = "AD".asInstanceOf[CountryCode]
+    val AE = "AE".asInstanceOf[CountryCode]
+    val AF = "AF".asInstanceOf[CountryCode]
+    val AG = "AG".asInstanceOf[CountryCode]
+    val AI = "AI".asInstanceOf[CountryCode]
+    val AL = "AL".asInstanceOf[CountryCode]
+    val AM = "AM".asInstanceOf[CountryCode]
+    val AN = "AN".asInstanceOf[CountryCode]
+    val AO = "AO".asInstanceOf[CountryCode]
+    val AQ = "AQ".asInstanceOf[CountryCode]
+    val AR = "AR".asInstanceOf[CountryCode]
+    val AS = "AS".asInstanceOf[CountryCode]
+    val AT = "AT".asInstanceOf[CountryCode]
+    val AU = "AU".asInstanceOf[CountryCode]
+    val AW = "AW".asInstanceOf[CountryCode]
+    val AZ = "AZ".asInstanceOf[CountryCode]
+    val BA = "BA".asInstanceOf[CountryCode]
+    val BB = "BB".asInstanceOf[CountryCode]
+    val BD = "BD".asInstanceOf[CountryCode]
+    val BE = "BE".asInstanceOf[CountryCode]
+    val BF = "BF".asInstanceOf[CountryCode]
+    val BG = "BG".asInstanceOf[CountryCode]
+    val BH = "BH".asInstanceOf[CountryCode]
+    val BI = "BI".asInstanceOf[CountryCode]
+    val BJ = "BJ".asInstanceOf[CountryCode]
+    val BL = "BL".asInstanceOf[CountryCode]
+    val BM = "BM".asInstanceOf[CountryCode]
+    val BN = "BN".asInstanceOf[CountryCode]
+    val BO = "BO".asInstanceOf[CountryCode]
+    val BR = "BR".asInstanceOf[CountryCode]
+    val BS = "BS".asInstanceOf[CountryCode]
+    val BT = "BT".asInstanceOf[CountryCode]
+    val BW = "BW".asInstanceOf[CountryCode]
+    val BY = "BY".asInstanceOf[CountryCode]
+    val BZ = "BZ".asInstanceOf[CountryCode]
+    val CA = "CA".asInstanceOf[CountryCode]
+    val CC = "CC".asInstanceOf[CountryCode]
+    val CD = "CD".asInstanceOf[CountryCode]
+    val CF = "CF".asInstanceOf[CountryCode]
+    val CG = "CG".asInstanceOf[CountryCode]
+    val CH = "CH".asInstanceOf[CountryCode]
+    val CI = "CI".asInstanceOf[CountryCode]
+    val CK = "CK".asInstanceOf[CountryCode]
+    val CL = "CL".asInstanceOf[CountryCode]
+    val CM = "CM".asInstanceOf[CountryCode]
+    val CN = "CN".asInstanceOf[CountryCode]
+    val CO = "CO".asInstanceOf[CountryCode]
+    val CR = "CR".asInstanceOf[CountryCode]
+    val CU = "CU".asInstanceOf[CountryCode]
+    val CV = "CV".asInstanceOf[CountryCode]
+    val CX = "CX".asInstanceOf[CountryCode]
+    val CY = "CY".asInstanceOf[CountryCode]
+    val CZ = "CZ".asInstanceOf[CountryCode]
+    val DE = "DE".asInstanceOf[CountryCode]
+    val DJ = "DJ".asInstanceOf[CountryCode]
+    val DK = "DK".asInstanceOf[CountryCode]
+    val DM = "DM".asInstanceOf[CountryCode]
+    val DO = "DO".asInstanceOf[CountryCode]
+    val DZ = "DZ".asInstanceOf[CountryCode]
+    val EC = "EC".asInstanceOf[CountryCode]
+    val EE = "EE".asInstanceOf[CountryCode]
+    val EG = "EG".asInstanceOf[CountryCode]
+    val ER = "ER".asInstanceOf[CountryCode]
+    val ES = "ES".asInstanceOf[CountryCode]
+    val ET = "ET".asInstanceOf[CountryCode]
+    val FI = "FI".asInstanceOf[CountryCode]
+    val FJ = "FJ".asInstanceOf[CountryCode]
+    val FK = "FK".asInstanceOf[CountryCode]
+    val FM = "FM".asInstanceOf[CountryCode]
+    val FO = "FO".asInstanceOf[CountryCode]
+    val FR = "FR".asInstanceOf[CountryCode]
+    val GA = "GA".asInstanceOf[CountryCode]
+    val GB = "GB".asInstanceOf[CountryCode]
+    val GD = "GD".asInstanceOf[CountryCode]
+    val GE = "GE".asInstanceOf[CountryCode]
+    val GH = "GH".asInstanceOf[CountryCode]
+    val GI = "GI".asInstanceOf[CountryCode]
+    val GL = "GL".asInstanceOf[CountryCode]
+    val GM = "GM".asInstanceOf[CountryCode]
+    val GN = "GN".asInstanceOf[CountryCode]
+    val GQ = "GQ".asInstanceOf[CountryCode]
+    val GR = "GR".asInstanceOf[CountryCode]
+    val GT = "GT".asInstanceOf[CountryCode]
+    val GU = "GU".asInstanceOf[CountryCode]
+    val GW = "GW".asInstanceOf[CountryCode]
+    val GY = "GY".asInstanceOf[CountryCode]
+    val HK = "HK".asInstanceOf[CountryCode]
+    val HN = "HN".asInstanceOf[CountryCode]
+    val HR = "HR".asInstanceOf[CountryCode]
+    val HT = "HT".asInstanceOf[CountryCode]
+    val HU = "HU".asInstanceOf[CountryCode]
+    val ID = "ID".asInstanceOf[CountryCode]
+    val IE = "IE".asInstanceOf[CountryCode]
+    val IL = "IL".asInstanceOf[CountryCode]
+    val IM = "IM".asInstanceOf[CountryCode]
+    val IN = "IN".asInstanceOf[CountryCode]
+    val IQ = "IQ".asInstanceOf[CountryCode]
+    val IR = "IR".asInstanceOf[CountryCode]
+    val IS = "IS".asInstanceOf[CountryCode]
+    val IT = "IT".asInstanceOf[CountryCode]
+    val JM = "JM".asInstanceOf[CountryCode]
+    val JO = "JO".asInstanceOf[CountryCode]
+    val JP = "JP".asInstanceOf[CountryCode]
+    val KE = "KE".asInstanceOf[CountryCode]
+    val KG = "KG".asInstanceOf[CountryCode]
+    val KH = "KH".asInstanceOf[CountryCode]
+    val KI = "KI".asInstanceOf[CountryCode]
+    val KM = "KM".asInstanceOf[CountryCode]
+    val KN = "KN".asInstanceOf[CountryCode]
+    val KP = "KP".asInstanceOf[CountryCode]
+    val KR = "KR".asInstanceOf[CountryCode]
+    val KW = "KW".asInstanceOf[CountryCode]
+    val KY = "KY".asInstanceOf[CountryCode]
+    val KZ = "KZ".asInstanceOf[CountryCode]
+    val LA = "LA".asInstanceOf[CountryCode]
+    val LB = "LB".asInstanceOf[CountryCode]
+    val LC = "LC".asInstanceOf[CountryCode]
+    val LI = "LI".asInstanceOf[CountryCode]
+    val LK = "LK".asInstanceOf[CountryCode]
+    val LR = "LR".asInstanceOf[CountryCode]
+    val LS = "LS".asInstanceOf[CountryCode]
+    val LT = "LT".asInstanceOf[CountryCode]
+    val LU = "LU".asInstanceOf[CountryCode]
+    val LV = "LV".asInstanceOf[CountryCode]
+    val LY = "LY".asInstanceOf[CountryCode]
+    val MA = "MA".asInstanceOf[CountryCode]
+    val MC = "MC".asInstanceOf[CountryCode]
+    val MD = "MD".asInstanceOf[CountryCode]
+    val ME = "ME".asInstanceOf[CountryCode]
+    val MF = "MF".asInstanceOf[CountryCode]
+    val MG = "MG".asInstanceOf[CountryCode]
+    val MH = "MH".asInstanceOf[CountryCode]
+    val MK = "MK".asInstanceOf[CountryCode]
+    val ML = "ML".asInstanceOf[CountryCode]
+    val MM = "MM".asInstanceOf[CountryCode]
+    val MN = "MN".asInstanceOf[CountryCode]
+    val MO = "MO".asInstanceOf[CountryCode]
+    val MP = "MP".asInstanceOf[CountryCode]
+    val MR = "MR".asInstanceOf[CountryCode]
+    val MS = "MS".asInstanceOf[CountryCode]
+    val MT = "MT".asInstanceOf[CountryCode]
+    val MU = "MU".asInstanceOf[CountryCode]
+    val MV = "MV".asInstanceOf[CountryCode]
+    val MW = "MW".asInstanceOf[CountryCode]
+    val MX = "MX".asInstanceOf[CountryCode]
+    val MY = "MY".asInstanceOf[CountryCode]
+    val MZ = "MZ".asInstanceOf[CountryCode]
+    val NA = "NA".asInstanceOf[CountryCode]
+    val NC = "NC".asInstanceOf[CountryCode]
+    val NE = "NE".asInstanceOf[CountryCode]
+    val NG = "NG".asInstanceOf[CountryCode]
+    val NI = "NI".asInstanceOf[CountryCode]
+    val NL = "NL".asInstanceOf[CountryCode]
+    val NO = "NO".asInstanceOf[CountryCode]
+    val NP = "NP".asInstanceOf[CountryCode]
+    val NR = "NR".asInstanceOf[CountryCode]
+    val NU = "NU".asInstanceOf[CountryCode]
+    val NZ = "NZ".asInstanceOf[CountryCode]
+    val OM = "OM".asInstanceOf[CountryCode]
+    val PA = "PA".asInstanceOf[CountryCode]
+    val PE = "PE".asInstanceOf[CountryCode]
+    val PF = "PF".asInstanceOf[CountryCode]
+    val PG = "PG".asInstanceOf[CountryCode]
+    val PH = "PH".asInstanceOf[CountryCode]
+    val PK = "PK".asInstanceOf[CountryCode]
+    val PL = "PL".asInstanceOf[CountryCode]
+    val PM = "PM".asInstanceOf[CountryCode]
+    val PN = "PN".asInstanceOf[CountryCode]
+    val PR = "PR".asInstanceOf[CountryCode]
+    val PT = "PT".asInstanceOf[CountryCode]
+    val PW = "PW".asInstanceOf[CountryCode]
+    val PY = "PY".asInstanceOf[CountryCode]
+    val QA = "QA".asInstanceOf[CountryCode]
+    val RO = "RO".asInstanceOf[CountryCode]
+    val RS = "RS".asInstanceOf[CountryCode]
+    val RU = "RU".asInstanceOf[CountryCode]
+    val RW = "RW".asInstanceOf[CountryCode]
+    val SA = "SA".asInstanceOf[CountryCode]
+    val SB = "SB".asInstanceOf[CountryCode]
+    val SC = "SC".asInstanceOf[CountryCode]
+    val SD = "SD".asInstanceOf[CountryCode]
+    val SE = "SE".asInstanceOf[CountryCode]
+    val SG = "SG".asInstanceOf[CountryCode]
+    val SH = "SH".asInstanceOf[CountryCode]
+    val SI = "SI".asInstanceOf[CountryCode]
+    val SK = "SK".asInstanceOf[CountryCode]
+    val SL = "SL".asInstanceOf[CountryCode]
+    val SM = "SM".asInstanceOf[CountryCode]
+    val SN = "SN".asInstanceOf[CountryCode]
+    val SO = "SO".asInstanceOf[CountryCode]
+    val SR = "SR".asInstanceOf[CountryCode]
+    val ST = "ST".asInstanceOf[CountryCode]
+    val SV = "SV".asInstanceOf[CountryCode]
+    val SY = "SY".asInstanceOf[CountryCode]
+    val SZ = "SZ".asInstanceOf[CountryCode]
+    val TC = "TC".asInstanceOf[CountryCode]
+    val TD = "TD".asInstanceOf[CountryCode]
+    val TG = "TG".asInstanceOf[CountryCode]
+    val TH = "TH".asInstanceOf[CountryCode]
+    val TJ = "TJ".asInstanceOf[CountryCode]
+    val TK = "TK".asInstanceOf[CountryCode]
+    val TL = "TL".asInstanceOf[CountryCode]
+    val TM = "TM".asInstanceOf[CountryCode]
+    val TN = "TN".asInstanceOf[CountryCode]
+    val TO = "TO".asInstanceOf[CountryCode]
+    val TR = "TR".asInstanceOf[CountryCode]
+    val TT = "TT".asInstanceOf[CountryCode]
+    val TV = "TV".asInstanceOf[CountryCode]
+    val TW = "TW".asInstanceOf[CountryCode]
+    val TZ = "TZ".asInstanceOf[CountryCode]
+    val UA = "UA".asInstanceOf[CountryCode]
+    val UG = "UG".asInstanceOf[CountryCode]
+    val US = "US".asInstanceOf[CountryCode]
+    val UY = "UY".asInstanceOf[CountryCode]
+    val UZ = "UZ".asInstanceOf[CountryCode]
+    val VA = "VA".asInstanceOf[CountryCode]
+    val VC = "VC".asInstanceOf[CountryCode]
+    val VE = "VE".asInstanceOf[CountryCode]
+    val VG = "VG".asInstanceOf[CountryCode]
+    val VI = "VI".asInstanceOf[CountryCode]
+    val VN = "VN".asInstanceOf[CountryCode]
+    val VU = "VU".asInstanceOf[CountryCode]
+    val WF = "WF".asInstanceOf[CountryCode]
+    val WS = "WS".asInstanceOf[CountryCode]
+    val YE = "YE".asInstanceOf[CountryCode]
+    val YT = "YT".asInstanceOf[CountryCode]
+    val ZA = "ZA".asInstanceOf[CountryCode]
+    val ZM = "ZM".asInstanceOf[CountryCode]
+    val ZW = "ZW".asInstanceOf[CountryCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -933,16 +927,17 @@ package route53domains {
       __obj.asInstanceOf[DisableDomainTransferLockResponse]
     }
   }
-
-  object DomainAvailabilityEnum {
-    val AVAILABLE              = "AVAILABLE"
-    val AVAILABLE_RESERVED     = "AVAILABLE_RESERVED"
-    val AVAILABLE_PREORDER     = "AVAILABLE_PREORDER"
-    val UNAVAILABLE            = "UNAVAILABLE"
-    val UNAVAILABLE_PREMIUM    = "UNAVAILABLE_PREMIUM"
-    val UNAVAILABLE_RESTRICTED = "UNAVAILABLE_RESTRICTED"
-    val RESERVED               = "RESERVED"
-    val DONT_KNOW              = "DONT_KNOW"
+  @js.native
+  sealed trait DomainAvailability extends js.Any
+  object DomainAvailability extends js.Object {
+    val AVAILABLE              = "AVAILABLE".asInstanceOf[DomainAvailability]
+    val AVAILABLE_RESERVED     = "AVAILABLE_RESERVED".asInstanceOf[DomainAvailability]
+    val AVAILABLE_PREORDER     = "AVAILABLE_PREORDER".asInstanceOf[DomainAvailability]
+    val UNAVAILABLE            = "UNAVAILABLE".asInstanceOf[DomainAvailability]
+    val UNAVAILABLE_PREMIUM    = "UNAVAILABLE_PREMIUM".asInstanceOf[DomainAvailability]
+    val UNAVAILABLE_RESTRICTED = "UNAVAILABLE_RESTRICTED".asInstanceOf[DomainAvailability]
+    val RESERVED               = "RESERVED".asInstanceOf[DomainAvailability]
+    val DONT_KNOW              = "DONT_KNOW".asInstanceOf[DomainAvailability]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1141,34 +1136,35 @@ package route53domains {
       __obj.asInstanceOf[ExtraParam]
     }
   }
-
-  object ExtraParamNameEnum {
-    val DUNS_NUMBER               = "DUNS_NUMBER"
-    val BRAND_NUMBER              = "BRAND_NUMBER"
-    val BIRTH_DEPARTMENT          = "BIRTH_DEPARTMENT"
-    val BIRTH_DATE_IN_YYYY_MM_DD  = "BIRTH_DATE_IN_YYYY_MM_DD"
-    val BIRTH_COUNTRY             = "BIRTH_COUNTRY"
-    val BIRTH_CITY                = "BIRTH_CITY"
-    val DOCUMENT_NUMBER           = "DOCUMENT_NUMBER"
-    val AU_ID_NUMBER              = "AU_ID_NUMBER"
-    val AU_ID_TYPE                = "AU_ID_TYPE"
-    val CA_LEGAL_TYPE             = "CA_LEGAL_TYPE"
-    val CA_BUSINESS_ENTITY_TYPE   = "CA_BUSINESS_ENTITY_TYPE"
-    val ES_IDENTIFICATION         = "ES_IDENTIFICATION"
-    val ES_IDENTIFICATION_TYPE    = "ES_IDENTIFICATION_TYPE"
-    val ES_LEGAL_FORM             = "ES_LEGAL_FORM"
-    val FI_BUSINESS_NUMBER        = "FI_BUSINESS_NUMBER"
-    val FI_ID_NUMBER              = "FI_ID_NUMBER"
-    val FI_NATIONALITY            = "FI_NATIONALITY"
-    val FI_ORGANIZATION_TYPE      = "FI_ORGANIZATION_TYPE"
-    val IT_PIN                    = "IT_PIN"
-    val IT_REGISTRANT_ENTITY_TYPE = "IT_REGISTRANT_ENTITY_TYPE"
-    val RU_PASSPORT_DATA          = "RU_PASSPORT_DATA"
-    val SE_ID_NUMBER              = "SE_ID_NUMBER"
-    val SG_ID_NUMBER              = "SG_ID_NUMBER"
-    val VAT_NUMBER                = "VAT_NUMBER"
-    val UK_CONTACT_TYPE           = "UK_CONTACT_TYPE"
-    val UK_COMPANY_NUMBER         = "UK_COMPANY_NUMBER"
+  @js.native
+  sealed trait ExtraParamName extends js.Any
+  object ExtraParamName extends js.Object {
+    val DUNS_NUMBER               = "DUNS_NUMBER".asInstanceOf[ExtraParamName]
+    val BRAND_NUMBER              = "BRAND_NUMBER".asInstanceOf[ExtraParamName]
+    val BIRTH_DEPARTMENT          = "BIRTH_DEPARTMENT".asInstanceOf[ExtraParamName]
+    val BIRTH_DATE_IN_YYYY_MM_DD  = "BIRTH_DATE_IN_YYYY_MM_DD".asInstanceOf[ExtraParamName]
+    val BIRTH_COUNTRY             = "BIRTH_COUNTRY".asInstanceOf[ExtraParamName]
+    val BIRTH_CITY                = "BIRTH_CITY".asInstanceOf[ExtraParamName]
+    val DOCUMENT_NUMBER           = "DOCUMENT_NUMBER".asInstanceOf[ExtraParamName]
+    val AU_ID_NUMBER              = "AU_ID_NUMBER".asInstanceOf[ExtraParamName]
+    val AU_ID_TYPE                = "AU_ID_TYPE".asInstanceOf[ExtraParamName]
+    val CA_LEGAL_TYPE             = "CA_LEGAL_TYPE".asInstanceOf[ExtraParamName]
+    val CA_BUSINESS_ENTITY_TYPE   = "CA_BUSINESS_ENTITY_TYPE".asInstanceOf[ExtraParamName]
+    val ES_IDENTIFICATION         = "ES_IDENTIFICATION".asInstanceOf[ExtraParamName]
+    val ES_IDENTIFICATION_TYPE    = "ES_IDENTIFICATION_TYPE".asInstanceOf[ExtraParamName]
+    val ES_LEGAL_FORM             = "ES_LEGAL_FORM".asInstanceOf[ExtraParamName]
+    val FI_BUSINESS_NUMBER        = "FI_BUSINESS_NUMBER".asInstanceOf[ExtraParamName]
+    val FI_ID_NUMBER              = "FI_ID_NUMBER".asInstanceOf[ExtraParamName]
+    val FI_NATIONALITY            = "FI_NATIONALITY".asInstanceOf[ExtraParamName]
+    val FI_ORGANIZATION_TYPE      = "FI_ORGANIZATION_TYPE".asInstanceOf[ExtraParamName]
+    val IT_PIN                    = "IT_PIN".asInstanceOf[ExtraParamName]
+    val IT_REGISTRANT_ENTITY_TYPE = "IT_REGISTRANT_ENTITY_TYPE".asInstanceOf[ExtraParamName]
+    val RU_PASSPORT_DATA          = "RU_PASSPORT_DATA".asInstanceOf[ExtraParamName]
+    val SE_ID_NUMBER              = "SE_ID_NUMBER".asInstanceOf[ExtraParamName]
+    val SG_ID_NUMBER              = "SG_ID_NUMBER".asInstanceOf[ExtraParamName]
+    val VAT_NUMBER                = "VAT_NUMBER".asInstanceOf[ExtraParamName]
+    val UK_CONTACT_TYPE           = "UK_CONTACT_TYPE".asInstanceOf[ExtraParamName]
+    val UK_COMPANY_NUMBER         = "UK_COMPANY_NUMBER".asInstanceOf[ExtraParamName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1610,13 +1606,14 @@ package route53domains {
   trait OperationLimitExceededException extends js.Object {
     val message: ErrorMessage
   }
-
-  object OperationStatusEnum {
-    val SUBMITTED   = "SUBMITTED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val ERROR       = "ERROR"
-    val SUCCESSFUL  = "SUCCESSFUL"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait OperationStatus extends js.Any
+  object OperationStatus extends js.Object {
+    val SUBMITTED   = "SUBMITTED".asInstanceOf[OperationStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[OperationStatus]
+    val ERROR       = "ERROR".asInstanceOf[OperationStatus]
+    val SUCCESSFUL  = "SUCCESSFUL".asInstanceOf[OperationStatus]
+    val FAILED      = "FAILED".asInstanceOf[OperationStatus]
 
     val values = js.Object.freeze(js.Array(SUBMITTED, IN_PROGRESS, ERROR, SUCCESSFUL, FAILED))
   }
@@ -1650,24 +1647,25 @@ package route53domains {
       __obj.asInstanceOf[OperationSummary]
     }
   }
-
-  object OperationTypeEnum {
-    val REGISTER_DOMAIN           = "REGISTER_DOMAIN"
-    val DELETE_DOMAIN             = "DELETE_DOMAIN"
-    val TRANSFER_IN_DOMAIN        = "TRANSFER_IN_DOMAIN"
-    val UPDATE_DOMAIN_CONTACT     = "UPDATE_DOMAIN_CONTACT"
-    val UPDATE_NAMESERVER         = "UPDATE_NAMESERVER"
-    val CHANGE_PRIVACY_PROTECTION = "CHANGE_PRIVACY_PROTECTION"
-    val DOMAIN_LOCK               = "DOMAIN_LOCK"
-    val ENABLE_AUTORENEW          = "ENABLE_AUTORENEW"
-    val DISABLE_AUTORENEW         = "DISABLE_AUTORENEW"
-    val ADD_DNSSEC                = "ADD_DNSSEC"
-    val REMOVE_DNSSEC             = "REMOVE_DNSSEC"
-    val EXPIRE_DOMAIN             = "EXPIRE_DOMAIN"
-    val TRANSFER_OUT_DOMAIN       = "TRANSFER_OUT_DOMAIN"
-    val CHANGE_DOMAIN_OWNER       = "CHANGE_DOMAIN_OWNER"
-    val RENEW_DOMAIN              = "RENEW_DOMAIN"
-    val PUSH_DOMAIN               = "PUSH_DOMAIN"
+  @js.native
+  sealed trait OperationType extends js.Any
+  object OperationType extends js.Object {
+    val REGISTER_DOMAIN           = "REGISTER_DOMAIN".asInstanceOf[OperationType]
+    val DELETE_DOMAIN             = "DELETE_DOMAIN".asInstanceOf[OperationType]
+    val TRANSFER_IN_DOMAIN        = "TRANSFER_IN_DOMAIN".asInstanceOf[OperationType]
+    val UPDATE_DOMAIN_CONTACT     = "UPDATE_DOMAIN_CONTACT".asInstanceOf[OperationType]
+    val UPDATE_NAMESERVER         = "UPDATE_NAMESERVER".asInstanceOf[OperationType]
+    val CHANGE_PRIVACY_PROTECTION = "CHANGE_PRIVACY_PROTECTION".asInstanceOf[OperationType]
+    val DOMAIN_LOCK               = "DOMAIN_LOCK".asInstanceOf[OperationType]
+    val ENABLE_AUTORENEW          = "ENABLE_AUTORENEW".asInstanceOf[OperationType]
+    val DISABLE_AUTORENEW         = "DISABLE_AUTORENEW".asInstanceOf[OperationType]
+    val ADD_DNSSEC                = "ADD_DNSSEC".asInstanceOf[OperationType]
+    val REMOVE_DNSSEC             = "REMOVE_DNSSEC".asInstanceOf[OperationType]
+    val EXPIRE_DOMAIN             = "EXPIRE_DOMAIN".asInstanceOf[OperationType]
+    val TRANSFER_OUT_DOMAIN       = "TRANSFER_OUT_DOMAIN".asInstanceOf[OperationType]
+    val CHANGE_DOMAIN_OWNER       = "CHANGE_DOMAIN_OWNER".asInstanceOf[OperationType]
+    val RENEW_DOMAIN              = "RENEW_DOMAIN".asInstanceOf[OperationType]
+    val PUSH_DOMAIN               = "PUSH_DOMAIN".asInstanceOf[OperationType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1690,11 +1688,12 @@ package route53domains {
       )
     )
   }
-
-  object ReachabilityStatusEnum {
-    val PENDING = "PENDING"
-    val DONE    = "DONE"
-    val EXPIRED = "EXPIRED"
+  @js.native
+  sealed trait ReachabilityStatus extends js.Any
+  object ReachabilityStatus extends js.Object {
+    val PENDING = "PENDING".asInstanceOf[ReachabilityStatus]
+    val DONE    = "DONE".asInstanceOf[ReachabilityStatus]
+    val EXPIRED = "EXPIRED".asInstanceOf[ReachabilityStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, DONE, EXPIRED))
   }
@@ -2020,10 +2019,12 @@ package route53domains {
     *  </dd> <dt>DONT_KNOW</dt> <dd> Reserved for future use.
     *  </dd> </dl>
     */
-  object TransferableEnum {
-    val TRANSFERABLE   = "TRANSFERABLE"
-    val UNTRANSFERABLE = "UNTRANSFERABLE"
-    val DONT_KNOW      = "DONT_KNOW"
+  @js.native
+  sealed trait Transferable extends js.Any
+  object Transferable extends js.Object {
+    val TRANSFERABLE   = "TRANSFERABLE".asInstanceOf[Transferable]
+    val UNTRANSFERABLE = "UNTRANSFERABLE".asInstanceOf[Transferable]
+    val DONT_KNOW      = "DONT_KNOW".asInstanceOf[Transferable]
 
     val values = js.Object.freeze(js.Array(TRANSFERABLE, UNTRANSFERABLE, DONT_KNOW))
   }

--- a/services/route53resolver/src/main/scala/facade/amazonaws/services/Route53Resolver.scala
+++ b/services/route53resolver/src/main/scala/facade/amazonaws/services/Route53Resolver.scala
@@ -7,43 +7,36 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object route53resolver {
-  type AccountId                     = String
-  type Arn                           = String
-  type CreatorRequestId              = String
-  type DomainName                    = String
-  type FilterName                    = String
-  type FilterValue                   = String
-  type FilterValues                  = js.Array[FilterValue]
-  type Filters                       = js.Array[Filter]
-  type Ip                            = String
-  type IpAddressCount                = Int
-  type IpAddressStatus               = String
-  type IpAddressesRequest            = js.Array[IpAddressRequest]
-  type IpAddressesResponse           = js.Array[IpAddressResponse]
-  type MaxResults                    = Int
-  type Name                          = String
-  type NextToken                     = String
-  type Port                          = Int
-  type ResolverEndpointDirection     = String
-  type ResolverEndpointStatus        = String
-  type ResolverEndpoints             = js.Array[ResolverEndpoint]
-  type ResolverRuleAssociationStatus = String
-  type ResolverRuleAssociations      = js.Array[ResolverRuleAssociation]
-  type ResolverRulePolicy            = String
-  type ResolverRuleStatus            = String
-  type ResolverRules                 = js.Array[ResolverRule]
-  type ResourceId                    = String
-  type Rfc3339TimeString             = String
-  type RuleTypeOption                = String
-  type SecurityGroupIds              = js.Array[ResourceId]
-  type ShareStatus                   = String
-  type StatusMessage                 = String
-  type SubnetId                      = String
-  type TagKey                        = String
-  type TagKeyList                    = js.Array[TagKey]
-  type TagList                       = js.Array[Tag]
-  type TagValue                      = String
-  type TargetList                    = js.Array[TargetAddress]
+  type AccountId                = String
+  type Arn                      = String
+  type CreatorRequestId         = String
+  type DomainName               = String
+  type FilterName               = String
+  type FilterValue              = String
+  type FilterValues             = js.Array[FilterValue]
+  type Filters                  = js.Array[Filter]
+  type Ip                       = String
+  type IpAddressCount           = Int
+  type IpAddressesRequest       = js.Array[IpAddressRequest]
+  type IpAddressesResponse      = js.Array[IpAddressResponse]
+  type MaxResults               = Int
+  type Name                     = String
+  type NextToken                = String
+  type Port                     = Int
+  type ResolverEndpoints        = js.Array[ResolverEndpoint]
+  type ResolverRuleAssociations = js.Array[ResolverRuleAssociation]
+  type ResolverRulePolicy       = String
+  type ResolverRules            = js.Array[ResolverRule]
+  type ResourceId               = String
+  type Rfc3339TimeString        = String
+  type SecurityGroupIds         = js.Array[ResourceId]
+  type StatusMessage            = String
+  type SubnetId                 = String
+  type TagKey                   = String
+  type TagKeyList               = js.Array[TagKey]
+  type TagList                  = js.Array[Tag]
+  type TagValue                 = String
+  type TargetList               = js.Array[TargetAddress]
 
   implicit final class Route53ResolverOps(private val service: Route53Resolver) extends AnyVal {
 
@@ -692,18 +685,19 @@ package route53resolver {
       __obj.asInstanceOf[IpAddressResponse]
     }
   }
-
-  object IpAddressStatusEnum {
-    val CREATING                  = "CREATING"
-    val FAILED_CREATION           = "FAILED_CREATION"
-    val ATTACHING                 = "ATTACHING"
-    val ATTACHED                  = "ATTACHED"
-    val REMAP_DETACHING           = "REMAP_DETACHING"
-    val REMAP_ATTACHING           = "REMAP_ATTACHING"
-    val DETACHING                 = "DETACHING"
-    val FAILED_RESOURCE_GONE      = "FAILED_RESOURCE_GONE"
-    val DELETING                  = "DELETING"
-    val DELETE_FAILED_FAS_EXPIRED = "DELETE_FAILED_FAS_EXPIRED"
+  @js.native
+  sealed trait IpAddressStatus extends js.Any
+  object IpAddressStatus extends js.Object {
+    val CREATING                  = "CREATING".asInstanceOf[IpAddressStatus]
+    val FAILED_CREATION           = "FAILED_CREATION".asInstanceOf[IpAddressStatus]
+    val ATTACHING                 = "ATTACHING".asInstanceOf[IpAddressStatus]
+    val ATTACHED                  = "ATTACHED".asInstanceOf[IpAddressStatus]
+    val REMAP_DETACHING           = "REMAP_DETACHING".asInstanceOf[IpAddressStatus]
+    val REMAP_ATTACHING           = "REMAP_ATTACHING".asInstanceOf[IpAddressStatus]
+    val DETACHING                 = "DETACHING".asInstanceOf[IpAddressStatus]
+    val FAILED_RESOURCE_GONE      = "FAILED_RESOURCE_GONE".asInstanceOf[IpAddressStatus]
+    val DELETING                  = "DELETING".asInstanceOf[IpAddressStatus]
+    val DELETE_FAILED_FAS_EXPIRED = "DELETE_FAILED_FAS_EXPIRED".asInstanceOf[IpAddressStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1058,21 +1052,23 @@ package route53resolver {
       __obj.asInstanceOf[ResolverEndpoint]
     }
   }
-
-  object ResolverEndpointDirectionEnum {
-    val INBOUND  = "INBOUND"
-    val OUTBOUND = "OUTBOUND"
+  @js.native
+  sealed trait ResolverEndpointDirection extends js.Any
+  object ResolverEndpointDirection extends js.Object {
+    val INBOUND  = "INBOUND".asInstanceOf[ResolverEndpointDirection]
+    val OUTBOUND = "OUTBOUND".asInstanceOf[ResolverEndpointDirection]
 
     val values = js.Object.freeze(js.Array(INBOUND, OUTBOUND))
   }
-
-  object ResolverEndpointStatusEnum {
-    val CREATING        = "CREATING"
-    val OPERATIONAL     = "OPERATIONAL"
-    val UPDATING        = "UPDATING"
-    val AUTO_RECOVERING = "AUTO_RECOVERING"
-    val ACTION_NEEDED   = "ACTION_NEEDED"
-    val DELETING        = "DELETING"
+  @js.native
+  sealed trait ResolverEndpointStatus extends js.Any
+  object ResolverEndpointStatus extends js.Object {
+    val CREATING        = "CREATING".asInstanceOf[ResolverEndpointStatus]
+    val OPERATIONAL     = "OPERATIONAL".asInstanceOf[ResolverEndpointStatus]
+    val UPDATING        = "UPDATING".asInstanceOf[ResolverEndpointStatus]
+    val AUTO_RECOVERING = "AUTO_RECOVERING".asInstanceOf[ResolverEndpointStatus]
+    val ACTION_NEEDED   = "ACTION_NEEDED".asInstanceOf[ResolverEndpointStatus]
+    val DELETING        = "DELETING".asInstanceOf[ResolverEndpointStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, OPERATIONAL, UPDATING, AUTO_RECOVERING, ACTION_NEEDED, DELETING))
   }
@@ -1162,13 +1158,14 @@ package route53resolver {
       __obj.asInstanceOf[ResolverRuleAssociation]
     }
   }
-
-  object ResolverRuleAssociationStatusEnum {
-    val CREATING   = "CREATING"
-    val COMPLETE   = "COMPLETE"
-    val DELETING   = "DELETING"
-    val FAILED     = "FAILED"
-    val OVERRIDDEN = "OVERRIDDEN"
+  @js.native
+  sealed trait ResolverRuleAssociationStatus extends js.Any
+  object ResolverRuleAssociationStatus extends js.Object {
+    val CREATING   = "CREATING".asInstanceOf[ResolverRuleAssociationStatus]
+    val COMPLETE   = "COMPLETE".asInstanceOf[ResolverRuleAssociationStatus]
+    val DELETING   = "DELETING".asInstanceOf[ResolverRuleAssociationStatus]
+    val FAILED     = "FAILED".asInstanceOf[ResolverRuleAssociationStatus]
+    val OVERRIDDEN = "OVERRIDDEN".asInstanceOf[ResolverRuleAssociationStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, COMPLETE, DELETING, FAILED, OVERRIDDEN))
   }
@@ -1197,28 +1194,31 @@ package route53resolver {
       __obj.asInstanceOf[ResolverRuleConfig]
     }
   }
-
-  object ResolverRuleStatusEnum {
-    val COMPLETE = "COMPLETE"
-    val DELETING = "DELETING"
-    val UPDATING = "UPDATING"
-    val FAILED   = "FAILED"
+  @js.native
+  sealed trait ResolverRuleStatus extends js.Any
+  object ResolverRuleStatus extends js.Object {
+    val COMPLETE = "COMPLETE".asInstanceOf[ResolverRuleStatus]
+    val DELETING = "DELETING".asInstanceOf[ResolverRuleStatus]
+    val UPDATING = "UPDATING".asInstanceOf[ResolverRuleStatus]
+    val FAILED   = "FAILED".asInstanceOf[ResolverRuleStatus]
 
     val values = js.Object.freeze(js.Array(COMPLETE, DELETING, UPDATING, FAILED))
   }
-
-  object RuleTypeOptionEnum {
-    val FORWARD   = "FORWARD"
-    val SYSTEM    = "SYSTEM"
-    val RECURSIVE = "RECURSIVE"
+  @js.native
+  sealed trait RuleTypeOption extends js.Any
+  object RuleTypeOption extends js.Object {
+    val FORWARD   = "FORWARD".asInstanceOf[RuleTypeOption]
+    val SYSTEM    = "SYSTEM".asInstanceOf[RuleTypeOption]
+    val RECURSIVE = "RECURSIVE".asInstanceOf[RuleTypeOption]
 
     val values = js.Object.freeze(js.Array(FORWARD, SYSTEM, RECURSIVE))
   }
-
-  object ShareStatusEnum {
-    val NOT_SHARED     = "NOT_SHARED"
-    val SHARED_WITH_ME = "SHARED_WITH_ME"
-    val SHARED_BY_ME   = "SHARED_BY_ME"
+  @js.native
+  sealed trait ShareStatus extends js.Any
+  object ShareStatus extends js.Object {
+    val NOT_SHARED     = "NOT_SHARED".asInstanceOf[ShareStatus]
+    val SHARED_WITH_ME = "SHARED_WITH_ME".asInstanceOf[ShareStatus]
+    val SHARED_BY_ME   = "SHARED_BY_ME".asInstanceOf[ShareStatus]
 
     val values = js.Object.freeze(js.Array(NOT_SHARED, SHARED_WITH_ME, SHARED_BY_ME))
   }

--- a/services/s3/src/main/scala/facade/amazonaws/services/S3.scala
+++ b/services/s3/src/main/scala/facade/amazonaws/services/S3.scala
@@ -7,250 +7,200 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object s3 {
-  type AbortDate                         = js.Date
-  type AbortRuleId                       = String
-  type AcceptRanges                      = String
-  type AccountId                         = String
-  type AllowQuotedRecordDelimiter        = Boolean
-  type AllowedHeader                     = String
-  type AllowedHeaders                    = js.Array[AllowedHeader]
-  type AllowedMethod                     = String
-  type AllowedMethods                    = js.Array[AllowedMethod]
-  type AllowedOrigin                     = String
-  type AllowedOrigins                    = js.Array[AllowedOrigin]
-  type AnalyticsConfigurationList        = js.Array[AnalyticsConfiguration]
-  type AnalyticsId                       = String
-  type AnalyticsS3ExportFileFormat       = String
-  type Body                              = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type BucketAccelerateStatus            = String
-  type BucketCannedACL                   = String
-  type BucketLocationConstraint          = String
-  type BucketLogsPermission              = String
-  type BucketName                        = String
-  type BucketVersioningStatus            = String
-  type Buckets                           = js.Array[Bucket]
-  type BypassGovernanceRetention         = Boolean
-  type BytesProcessed                    = Double
-  type BytesReturned                     = Double
-  type BytesScanned                      = Double
-  type CORSRules                         = js.Array[CORSRule]
-  type CacheControl                      = String
-  type CloudFunction                     = String
-  type CloudFunctionInvocationRole       = String
-  type Code                              = String
-  type Comments                          = String
-  type CommonPrefixList                  = js.Array[CommonPrefix]
-  type CompletedPartList                 = js.Array[CompletedPart]
-  type CompressionType                   = String
-  type ConfirmRemoveSelfBucketAccess     = Boolean
-  type ContentDisposition                = String
-  type ContentEncoding                   = String
-  type ContentLanguage                   = String
-  type ContentLength                     = Double
-  type ContentMD5                        = String
-  type ContentRange                      = String
-  type ContentType                       = String
-  type CopySource                        = String
-  type CopySourceIfMatch                 = String
-  type CopySourceIfModifiedSince         = js.Date
-  type CopySourceIfNoneMatch             = String
-  type CopySourceIfUnmodifiedSince       = js.Date
-  type CopySourceRange                   = String
-  type CopySourceSSECustomerAlgorithm    = String
-  type CopySourceSSECustomerKey          = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type CopySourceSSECustomerKeyMD5       = String
-  type CopySourceVersionId               = String
-  type CreationDate                      = js.Date
-  type Date                              = js.Date
-  type Days                              = Int
-  type DaysAfterInitiation               = Int
-  type DeleteMarker                      = Boolean
-  type DeleteMarkerReplicationStatus     = String
-  type DeleteMarkerVersionId             = String
-  type DeleteMarkers                     = js.Array[DeleteMarkerEntry]
-  type DeletedObjects                    = js.Array[DeletedObject]
-  type Delimiter                         = String
-  type Description                       = String
-  type DisplayName                       = String
-  type ETag                              = String
-  type EmailAddress                      = String
-  type EnableRequestProgress             = Boolean
-  type EncodingType                      = String
-  type End                               = Double
-  type Errors                            = js.Array[Error]
-  type Event                             = String
-  type EventList                         = js.Array[Event]
-  type ExistingObjectReplicationStatus   = String
-  type Expiration                        = String
-  type ExpirationStatus                  = String
-  type ExpiredObjectDeleteMarker         = Boolean
-  type Expires                           = js.Date
-  type ExposeHeader                      = String
-  type ExposeHeaders                     = js.Array[ExposeHeader]
-  type Expression                        = String
-  type ExpressionType                    = String
-  type FetchOwner                        = Boolean
-  type FieldDelimiter                    = String
-  type FileHeaderInfo                    = String
-  type FilterRuleList                    = js.Array[FilterRule]
-  type FilterRuleName                    = String
-  type FilterRuleValue                   = String
-  type GrantFullControl                  = String
-  type GrantRead                         = String
-  type GrantReadACP                      = String
-  type GrantWrite                        = String
-  type GrantWriteACP                     = String
-  type Grants                            = js.Array[Grant]
-  type HostName                          = String
-  type HttpErrorCodeReturnedEquals       = String
-  type HttpRedirectCode                  = String
-  type ID                                = String
-  type IfMatch                           = String
-  type IfModifiedSince                   = js.Date
-  type IfNoneMatch                       = String
-  type IfUnmodifiedSince                 = js.Date
-  type Initiated                         = js.Date
-  type InventoryConfigurationList        = js.Array[InventoryConfiguration]
-  type InventoryFormat                   = String
-  type InventoryFrequency                = String
-  type InventoryId                       = String
-  type InventoryIncludedObjectVersions   = String
-  type InventoryOptionalField            = String
-  type InventoryOptionalFields           = js.Array[InventoryOptionalField]
-  type IsEnabled                         = Boolean
-  type IsLatest                          = Boolean
-  type IsPublic                          = Boolean
-  type IsTruncated                       = Boolean
-  type JSONType                          = String
-  type KMSContext                        = String
-  type KeyCount                          = Int
-  type KeyMarker                         = String
-  type KeyPrefixEquals                   = String
-  type LambdaFunctionArn                 = String
-  type LambdaFunctionConfigurationList   = js.Array[LambdaFunctionConfiguration]
-  type LastModified                      = js.Date
-  type LifecycleRules                    = js.Array[LifecycleRule]
-  type Location                          = String
-  type LocationPrefix                    = String
-  type MFA                               = String
-  type MFADelete                         = String
-  type MFADeleteStatus                   = String
-  type Marker                            = String
-  type MaxAgeSeconds                     = Int
-  type MaxKeys                           = Int
-  type MaxParts                          = Int
-  type MaxUploads                        = Int
-  type Message                           = String
-  type Metadata                          = js.Dictionary[MetadataValue]
-  type MetadataDirective                 = String
-  type MetadataKey                       = String
-  type MetadataValue                     = String
-  type MetricsConfigurationList          = js.Array[MetricsConfiguration]
-  type MetricsId                         = String
-  type MetricsStatus                     = String
-  type Minutes                           = Int
-  type MissingMeta                       = Int
-  type MultipartUploadId                 = String
-  type MultipartUploadList               = js.Array[MultipartUpload]
-  type NextKeyMarker                     = String
-  type NextMarker                        = String
-  type NextPartNumberMarker              = Int
-  type NextToken                         = String
-  type NextUploadIdMarker                = String
-  type NextVersionIdMarker               = String
-  type NoncurrentVersionTransitionList   = js.Array[NoncurrentVersionTransition]
-  type NotificationId                    = String
-  type ObjectCannedACL                   = String
-  type ObjectIdentifierList              = js.Array[ObjectIdentifier]
-  type ObjectKey                         = String
-  type ObjectList                        = js.Array[Object]
-  type ObjectLockEnabled                 = String
-  type ObjectLockEnabledForBucket        = Boolean
-  type ObjectLockLegalHoldStatus         = String
-  type ObjectLockMode                    = String
-  type ObjectLockRetainUntilDate         = js.Date
-  type ObjectLockRetentionMode           = String
-  type ObjectLockToken                   = String
-  type ObjectStorageClass                = String
-  type ObjectVersionId                   = String
-  type ObjectVersionList                 = js.Array[ObjectVersion]
-  type ObjectVersionStorageClass         = String
-  type OwnerOverride                     = String
-  type PartNumber                        = Int
-  type PartNumberMarker                  = Int
-  type Parts                             = js.Array[Part]
-  type PartsCount                        = Int
-  type Payer                             = String
-  type Permission                        = String
-  type Policy                            = String
-  type Prefix                            = String
-  type Priority                          = Int
-  type Protocol                          = String
-  type QueueArn                          = String
-  type QueueConfigurationList            = js.Array[QueueConfiguration]
-  type Quiet                             = Boolean
-  type QuoteCharacter                    = String
-  type QuoteEscapeCharacter              = String
-  type QuoteFields                       = String
-  type Range                             = String
-  type RecordDelimiter                   = String
-  type ReplaceKeyPrefixWith              = String
-  type ReplaceKeyWith                    = String
-  type ReplicaKmsKeyID                   = String
-  type ReplicationRuleStatus             = String
-  type ReplicationRules                  = js.Array[ReplicationRule]
-  type ReplicationStatus                 = String
-  type ReplicationTimeStatus             = String
-  type RequestCharged                    = String
-  type RequestPayer                      = String
-  type ResponseCacheControl              = String
-  type ResponseContentDisposition        = String
-  type ResponseContentEncoding           = String
-  type ResponseContentLanguage           = String
-  type ResponseContentType               = String
-  type ResponseExpires                   = js.Date
-  type Restore                           = String
-  type RestoreOutputPath                 = String
-  type RestoreRequestType                = String
-  type Role                              = String
-  type RoutingRules                      = js.Array[RoutingRule]
-  type Rules                             = js.Array[Rule]
-  type SSECustomerAlgorithm              = String
-  type SSECustomerKey                    = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type SSECustomerKeyMD5                 = String
-  type SSEKMSEncryptionContext           = String
-  type SSEKMSKeyId                       = String
-  type ServerSideEncryption              = String
-  type ServerSideEncryptionRules         = js.Array[ServerSideEncryptionRule]
-  type Setting                           = Boolean
-  type Size                              = Int
-  type SseKmsEncryptedObjectsStatus      = String
-  type Start                             = Double
-  type StartAfter                        = String
-  type StorageClass                      = String
-  type StorageClassAnalysisSchemaVersion = String
-  type Suffix                            = String
-  type TagCount                          = Int
-  type TagSet                            = js.Array[Tag]
-  type TaggingDirective                  = String
-  type TaggingHeader                     = String
-  type TargetBucket                      = String
-  type TargetGrants                      = js.Array[TargetGrant]
-  type TargetPrefix                      = String
-  type Tier                              = String
-  type Token                             = String
-  type TopicArn                          = String
-  type TopicConfigurationList            = js.Array[TopicConfiguration]
-  type TransitionList                    = js.Array[Transition]
-  type TransitionStorageClass            = String
-  type Type                              = String
-  type URI                               = String
-  type UploadIdMarker                    = String
-  type UserMetadata                      = js.Array[MetadataEntry]
-  type Value                             = String
-  type VersionIdMarker                   = String
-  type WebsiteRedirectLocation           = String
-  type Years                             = Int
+  type AbortDate                       = js.Date
+  type AbortRuleId                     = String
+  type AcceptRanges                    = String
+  type AccountId                       = String
+  type AllowQuotedRecordDelimiter      = Boolean
+  type AllowedHeader                   = String
+  type AllowedHeaders                  = js.Array[AllowedHeader]
+  type AllowedMethod                   = String
+  type AllowedMethods                  = js.Array[AllowedMethod]
+  type AllowedOrigin                   = String
+  type AllowedOrigins                  = js.Array[AllowedOrigin]
+  type AnalyticsConfigurationList      = js.Array[AnalyticsConfiguration]
+  type AnalyticsId                     = String
+  type Body                            = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type BucketName                      = String
+  type Buckets                         = js.Array[Bucket]
+  type BypassGovernanceRetention       = Boolean
+  type BytesProcessed                  = Double
+  type BytesReturned                   = Double
+  type BytesScanned                    = Double
+  type CORSRules                       = js.Array[CORSRule]
+  type CacheControl                    = String
+  type CloudFunction                   = String
+  type CloudFunctionInvocationRole     = String
+  type Code                            = String
+  type Comments                        = String
+  type CommonPrefixList                = js.Array[CommonPrefix]
+  type CompletedPartList               = js.Array[CompletedPart]
+  type ConfirmRemoveSelfBucketAccess   = Boolean
+  type ContentDisposition              = String
+  type ContentEncoding                 = String
+  type ContentLanguage                 = String
+  type ContentLength                   = Double
+  type ContentMD5                      = String
+  type ContentRange                    = String
+  type ContentType                     = String
+  type CopySource                      = String
+  type CopySourceIfMatch               = String
+  type CopySourceIfModifiedSince       = js.Date
+  type CopySourceIfNoneMatch           = String
+  type CopySourceIfUnmodifiedSince     = js.Date
+  type CopySourceRange                 = String
+  type CopySourceSSECustomerAlgorithm  = String
+  type CopySourceSSECustomerKey        = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type CopySourceSSECustomerKeyMD5     = String
+  type CopySourceVersionId             = String
+  type CreationDate                    = js.Date
+  type Date                            = js.Date
+  type Days                            = Int
+  type DaysAfterInitiation             = Int
+  type DeleteMarker                    = Boolean
+  type DeleteMarkerVersionId           = String
+  type DeleteMarkers                   = js.Array[DeleteMarkerEntry]
+  type DeletedObjects                  = js.Array[DeletedObject]
+  type Delimiter                       = String
+  type Description                     = String
+  type DisplayName                     = String
+  type ETag                            = String
+  type EmailAddress                    = String
+  type EnableRequestProgress           = Boolean
+  type End                             = Double
+  type Errors                          = js.Array[Error]
+  type EventList                       = js.Array[Event]
+  type Expiration                      = String
+  type ExpiredObjectDeleteMarker       = Boolean
+  type Expires                         = js.Date
+  type ExposeHeader                    = String
+  type ExposeHeaders                   = js.Array[ExposeHeader]
+  type Expression                      = String
+  type FetchOwner                      = Boolean
+  type FieldDelimiter                  = String
+  type FilterRuleList                  = js.Array[FilterRule]
+  type FilterRuleValue                 = String
+  type GrantFullControl                = String
+  type GrantRead                       = String
+  type GrantReadACP                    = String
+  type GrantWrite                      = String
+  type GrantWriteACP                   = String
+  type Grants                          = js.Array[Grant]
+  type HostName                        = String
+  type HttpErrorCodeReturnedEquals     = String
+  type HttpRedirectCode                = String
+  type ID                              = String
+  type IfMatch                         = String
+  type IfModifiedSince                 = js.Date
+  type IfNoneMatch                     = String
+  type IfUnmodifiedSince               = js.Date
+  type Initiated                       = js.Date
+  type InventoryConfigurationList      = js.Array[InventoryConfiguration]
+  type InventoryId                     = String
+  type InventoryOptionalFields         = js.Array[InventoryOptionalField]
+  type IsEnabled                       = Boolean
+  type IsLatest                        = Boolean
+  type IsPublic                        = Boolean
+  type IsTruncated                     = Boolean
+  type KMSContext                      = String
+  type KeyCount                        = Int
+  type KeyMarker                       = String
+  type KeyPrefixEquals                 = String
+  type LambdaFunctionArn               = String
+  type LambdaFunctionConfigurationList = js.Array[LambdaFunctionConfiguration]
+  type LastModified                    = js.Date
+  type LifecycleRules                  = js.Array[LifecycleRule]
+  type Location                        = String
+  type LocationPrefix                  = String
+  type MFA                             = String
+  type Marker                          = String
+  type MaxAgeSeconds                   = Int
+  type MaxKeys                         = Int
+  type MaxParts                        = Int
+  type MaxUploads                      = Int
+  type Message                         = String
+  type Metadata                        = js.Dictionary[MetadataValue]
+  type MetadataKey                     = String
+  type MetadataValue                   = String
+  type MetricsConfigurationList        = js.Array[MetricsConfiguration]
+  type MetricsId                       = String
+  type Minutes                         = Int
+  type MissingMeta                     = Int
+  type MultipartUploadId               = String
+  type MultipartUploadList             = js.Array[MultipartUpload]
+  type NextKeyMarker                   = String
+  type NextMarker                      = String
+  type NextPartNumberMarker            = Int
+  type NextToken                       = String
+  type NextUploadIdMarker              = String
+  type NextVersionIdMarker             = String
+  type NoncurrentVersionTransitionList = js.Array[NoncurrentVersionTransition]
+  type NotificationId                  = String
+  type ObjectIdentifierList            = js.Array[ObjectIdentifier]
+  type ObjectKey                       = String
+  type ObjectList                      = js.Array[Object]
+  type ObjectLockEnabledForBucket      = Boolean
+  type ObjectLockRetainUntilDate       = js.Date
+  type ObjectLockToken                 = String
+  type ObjectVersionId                 = String
+  type ObjectVersionList               = js.Array[ObjectVersion]
+  type PartNumber                      = Int
+  type PartNumberMarker                = Int
+  type Parts                           = js.Array[Part]
+  type PartsCount                      = Int
+  type Policy                          = String
+  type Prefix                          = String
+  type Priority                        = Int
+  type QueueArn                        = String
+  type QueueConfigurationList          = js.Array[QueueConfiguration]
+  type Quiet                           = Boolean
+  type QuoteCharacter                  = String
+  type QuoteEscapeCharacter            = String
+  type Range                           = String
+  type RecordDelimiter                 = String
+  type ReplaceKeyPrefixWith            = String
+  type ReplaceKeyWith                  = String
+  type ReplicaKmsKeyID                 = String
+  type ReplicationRules                = js.Array[ReplicationRule]
+  type ResponseCacheControl            = String
+  type ResponseContentDisposition      = String
+  type ResponseContentEncoding         = String
+  type ResponseContentLanguage         = String
+  type ResponseContentType             = String
+  type ResponseExpires                 = js.Date
+  type Restore                         = String
+  type RestoreOutputPath               = String
+  type Role                            = String
+  type RoutingRules                    = js.Array[RoutingRule]
+  type Rules                           = js.Array[Rule]
+  type SSECustomerAlgorithm            = String
+  type SSECustomerKey                  = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type SSECustomerKeyMD5               = String
+  type SSEKMSEncryptionContext         = String
+  type SSEKMSKeyId                     = String
+  type ServerSideEncryptionRules       = js.Array[ServerSideEncryptionRule]
+  type Setting                         = Boolean
+  type Size                            = Int
+  type Start                           = Double
+  type StartAfter                      = String
+  type Suffix                          = String
+  type TagCount                        = Int
+  type TagSet                          = js.Array[Tag]
+  type TaggingHeader                   = String
+  type TargetBucket                    = String
+  type TargetGrants                    = js.Array[TargetGrant]
+  type TargetPrefix                    = String
+  type Token                           = String
+  type TopicArn                        = String
+  type TopicConfigurationList          = js.Array[TopicConfiguration]
+  type TransitionList                  = js.Array[Transition]
+  type URI                             = String
+  type UploadIdMarker                  = String
+  type UserMetadata                    = js.Array[MetadataEntry]
+  type Value                           = String
+  type VersionIdMarker                 = String
+  type WebsiteRedirectLocation         = String
+  type Years                           = Int
 
   implicit final class S3Ops(private val service: S3) extends AnyVal {
 
@@ -829,9 +779,10 @@ package s3 {
       __obj.asInstanceOf[AnalyticsS3BucketDestination]
     }
   }
-
-  object AnalyticsS3ExportFileFormatEnum {
-    val CSV = "CSV"
+  @js.native
+  sealed trait AnalyticsS3ExportFileFormat extends js.Any
+  object AnalyticsS3ExportFileFormat extends js.Object {
+    val CSV = "CSV".asInstanceOf[AnalyticsS3ExportFileFormat]
 
     val values = js.Object.freeze(js.Array(CSV))
   }
@@ -857,19 +808,21 @@ package s3 {
       __obj.asInstanceOf[Bucket]
     }
   }
-
-  object BucketAccelerateStatusEnum {
-    val Enabled   = "Enabled"
-    val Suspended = "Suspended"
+  @js.native
+  sealed trait BucketAccelerateStatus extends js.Any
+  object BucketAccelerateStatus extends js.Object {
+    val Enabled   = "Enabled".asInstanceOf[BucketAccelerateStatus]
+    val Suspended = "Suspended".asInstanceOf[BucketAccelerateStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Suspended))
   }
-
-  object BucketCannedACLEnum {
-    val `private`            = "private"
-    val `public-read`        = "public-read"
-    val `public-read-write`  = "public-read-write"
-    val `authenticated-read` = "authenticated-read"
+  @js.native
+  sealed trait BucketCannedACL extends js.Any
+  object BucketCannedACL extends js.Object {
+    val `private`            = "private".asInstanceOf[BucketCannedACL]
+    val `public-read`        = "public-read".asInstanceOf[BucketCannedACL]
+    val `public-read-write`  = "public-read-write".asInstanceOf[BucketCannedACL]
+    val `authenticated-read` = "authenticated-read".asInstanceOf[BucketCannedACL]
 
     val values = js.Object.freeze(js.Array(`private`, `public-read`, `public-read-write`, `authenticated-read`))
   }
@@ -894,19 +847,20 @@ package s3 {
       __obj.asInstanceOf[BucketLifecycleConfiguration]
     }
   }
-
-  object BucketLocationConstraintEnum {
-    val EU               = "EU"
-    val `eu-west-1`      = "eu-west-1"
-    val `us-west-1`      = "us-west-1"
-    val `us-west-2`      = "us-west-2"
-    val `ap-south-1`     = "ap-south-1"
-    val `ap-southeast-1` = "ap-southeast-1"
-    val `ap-southeast-2` = "ap-southeast-2"
-    val `ap-northeast-1` = "ap-northeast-1"
-    val `sa-east-1`      = "sa-east-1"
-    val `cn-north-1`     = "cn-north-1"
-    val `eu-central-1`   = "eu-central-1"
+  @js.native
+  sealed trait BucketLocationConstraint extends js.Any
+  object BucketLocationConstraint extends js.Object {
+    val EU               = "EU".asInstanceOf[BucketLocationConstraint]
+    val `eu-west-1`      = "eu-west-1".asInstanceOf[BucketLocationConstraint]
+    val `us-west-1`      = "us-west-1".asInstanceOf[BucketLocationConstraint]
+    val `us-west-2`      = "us-west-2".asInstanceOf[BucketLocationConstraint]
+    val `ap-south-1`     = "ap-south-1".asInstanceOf[BucketLocationConstraint]
+    val `ap-southeast-1` = "ap-southeast-1".asInstanceOf[BucketLocationConstraint]
+    val `ap-southeast-2` = "ap-southeast-2".asInstanceOf[BucketLocationConstraint]
+    val `ap-northeast-1` = "ap-northeast-1".asInstanceOf[BucketLocationConstraint]
+    val `sa-east-1`      = "sa-east-1".asInstanceOf[BucketLocationConstraint]
+    val `cn-north-1`     = "cn-north-1".asInstanceOf[BucketLocationConstraint]
+    val `eu-central-1`   = "eu-central-1".asInstanceOf[BucketLocationConstraint]
 
     val values = js.Object.freeze(
       js.Array(
@@ -943,18 +897,20 @@ package s3 {
       __obj.asInstanceOf[BucketLoggingStatus]
     }
   }
-
-  object BucketLogsPermissionEnum {
-    val FULL_CONTROL = "FULL_CONTROL"
-    val READ         = "READ"
-    val WRITE        = "WRITE"
+  @js.native
+  sealed trait BucketLogsPermission extends js.Any
+  object BucketLogsPermission extends js.Object {
+    val FULL_CONTROL = "FULL_CONTROL".asInstanceOf[BucketLogsPermission]
+    val READ         = "READ".asInstanceOf[BucketLogsPermission]
+    val WRITE        = "WRITE".asInstanceOf[BucketLogsPermission]
 
     val values = js.Object.freeze(js.Array(FULL_CONTROL, READ, WRITE))
   }
-
-  object BucketVersioningStatusEnum {
-    val Enabled   = "Enabled"
-    val Suspended = "Suspended"
+  @js.native
+  sealed trait BucketVersioningStatus extends js.Any
+  object BucketVersioningStatus extends js.Object {
+    val Enabled   = "Enabled".asInstanceOf[BucketVersioningStatus]
+    val Suspended = "Suspended".asInstanceOf[BucketVersioningStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Suspended))
   }
@@ -1243,11 +1199,12 @@ package s3 {
       __obj.asInstanceOf[CompletedPart]
     }
   }
-
-  object CompressionTypeEnum {
-    val NONE  = "NONE"
-    val GZIP  = "GZIP"
-    val BZIP2 = "BZIP2"
+  @js.native
+  sealed trait CompressionType extends js.Any
+  object CompressionType extends js.Object {
+    val NONE  = "NONE".asInstanceOf[CompressionType]
+    val GZIP  = "GZIP".asInstanceOf[CompressionType]
+    val BZIP2 = "BZIP2".asInstanceOf[CompressionType]
 
     val values = js.Object.freeze(js.Array(NONE, GZIP, BZIP2))
   }
@@ -2051,10 +2008,11 @@ package s3 {
       __obj.asInstanceOf[DeleteMarkerReplication]
     }
   }
-
-  object DeleteMarkerReplicationStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait DeleteMarkerReplicationStatus extends js.Any
+  object DeleteMarkerReplicationStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[DeleteMarkerReplicationStatus]
+    val Disabled = "Disabled".asInstanceOf[DeleteMarkerReplicationStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
@@ -2298,8 +2256,10 @@ package s3 {
   /**
     * Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.
     */
-  object EncodingTypeEnum {
-    val url = "url"
+  @js.native
+  sealed trait EncodingType extends js.Any
+  object EncodingType extends js.Object {
+    val url = "url".asInstanceOf[EncodingType]
 
     val values = js.Object.freeze(js.Array(url))
   }
@@ -2418,24 +2378,27 @@ package s3 {
   /**
     * The bucket event for which to send notifications.
     */
-  object EventEnum {
-    val `s3:ReducedRedundancyLostObject`                   = "s3:ReducedRedundancyLostObject"
-    val `s3:ObjectCreated:*`                               = "s3:ObjectCreated:*"
-    val `s3:ObjectCreated:Put`                             = "s3:ObjectCreated:Put"
-    val `s3:ObjectCreated:Post`                            = "s3:ObjectCreated:Post"
-    val `s3:ObjectCreated:Copy`                            = "s3:ObjectCreated:Copy"
-    val `s3:ObjectCreated:CompleteMultipartUpload`         = "s3:ObjectCreated:CompleteMultipartUpload"
-    val `s3:ObjectRemoved:*`                               = "s3:ObjectRemoved:*"
-    val `s3:ObjectRemoved:Delete`                          = "s3:ObjectRemoved:Delete"
-    val `s3:ObjectRemoved:DeleteMarkerCreated`             = "s3:ObjectRemoved:DeleteMarkerCreated"
-    val `s3:ObjectRestore:*`                               = "s3:ObjectRestore:*"
-    val `s3:ObjectRestore:Post`                            = "s3:ObjectRestore:Post"
-    val `s3:ObjectRestore:Completed`                       = "s3:ObjectRestore:Completed"
-    val `s3:Replication:*`                                 = "s3:Replication:*"
-    val `s3:Replication:OperationFailedReplication`        = "s3:Replication:OperationFailedReplication"
-    val `s3:Replication:OperationNotTracked`               = "s3:Replication:OperationNotTracked"
-    val `s3:Replication:OperationMissedThreshold`          = "s3:Replication:OperationMissedThreshold"
-    val `s3:Replication:OperationReplicatedAfterThreshold` = "s3:Replication:OperationReplicatedAfterThreshold"
+  @js.native
+  sealed trait Event extends js.Any
+  object Event extends js.Object {
+    val `s3:ReducedRedundancyLostObject`            = "s3:ReducedRedundancyLostObject".asInstanceOf[Event]
+    val `s3:ObjectCreated:*`                        = "s3:ObjectCreated:*".asInstanceOf[Event]
+    val `s3:ObjectCreated:Put`                      = "s3:ObjectCreated:Put".asInstanceOf[Event]
+    val `s3:ObjectCreated:Post`                     = "s3:ObjectCreated:Post".asInstanceOf[Event]
+    val `s3:ObjectCreated:Copy`                     = "s3:ObjectCreated:Copy".asInstanceOf[Event]
+    val `s3:ObjectCreated:CompleteMultipartUpload`  = "s3:ObjectCreated:CompleteMultipartUpload".asInstanceOf[Event]
+    val `s3:ObjectRemoved:*`                        = "s3:ObjectRemoved:*".asInstanceOf[Event]
+    val `s3:ObjectRemoved:Delete`                   = "s3:ObjectRemoved:Delete".asInstanceOf[Event]
+    val `s3:ObjectRemoved:DeleteMarkerCreated`      = "s3:ObjectRemoved:DeleteMarkerCreated".asInstanceOf[Event]
+    val `s3:ObjectRestore:*`                        = "s3:ObjectRestore:*".asInstanceOf[Event]
+    val `s3:ObjectRestore:Post`                     = "s3:ObjectRestore:Post".asInstanceOf[Event]
+    val `s3:ObjectRestore:Completed`                = "s3:ObjectRestore:Completed".asInstanceOf[Event]
+    val `s3:Replication:*`                          = "s3:Replication:*".asInstanceOf[Event]
+    val `s3:Replication:OperationFailedReplication` = "s3:Replication:OperationFailedReplication".asInstanceOf[Event]
+    val `s3:Replication:OperationNotTracked`        = "s3:Replication:OperationNotTracked".asInstanceOf[Event]
+    val `s3:Replication:OperationMissedThreshold`   = "s3:Replication:OperationMissedThreshold".asInstanceOf[Event]
+    val `s3:Replication:OperationReplicatedAfterThreshold` =
+      "s3:Replication:OperationReplicatedAfterThreshold".asInstanceOf[Event]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2480,31 +2443,35 @@ package s3 {
       __obj.asInstanceOf[ExistingObjectReplication]
     }
   }
-
-  object ExistingObjectReplicationStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
-
-    val values = js.Object.freeze(js.Array(Enabled, Disabled))
-  }
-
-  object ExpirationStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait ExistingObjectReplicationStatus extends js.Any
+  object ExistingObjectReplicationStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[ExistingObjectReplicationStatus]
+    val Disabled = "Disabled".asInstanceOf[ExistingObjectReplicationStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
+  @js.native
+  sealed trait ExpirationStatus extends js.Any
+  object ExpirationStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[ExpirationStatus]
+    val Disabled = "Disabled".asInstanceOf[ExpirationStatus]
 
-  object ExpressionTypeEnum {
-    val SQL = "SQL"
+    val values = js.Object.freeze(js.Array(Enabled, Disabled))
+  }
+  @js.native
+  sealed trait ExpressionType extends js.Any
+  object ExpressionType extends js.Object {
+    val SQL = "SQL".asInstanceOf[ExpressionType]
 
     val values = js.Object.freeze(js.Array(SQL))
   }
-
-  object FileHeaderInfoEnum {
-    val USE    = "USE"
-    val IGNORE = "IGNORE"
-    val NONE   = "NONE"
+  @js.native
+  sealed trait FileHeaderInfo extends js.Any
+  object FileHeaderInfo extends js.Object {
+    val USE    = "USE".asInstanceOf[FileHeaderInfo]
+    val IGNORE = "IGNORE".asInstanceOf[FileHeaderInfo]
+    val NONE   = "NONE".asInstanceOf[FileHeaderInfo]
 
     val values = js.Object.freeze(js.Array(USE, IGNORE, NONE))
   }
@@ -2530,10 +2497,11 @@ package s3 {
       __obj.asInstanceOf[FilterRule]
     }
   }
-
-  object FilterRuleNameEnum {
-    val prefix = "prefix"
-    val suffix = "suffix"
+  @js.native
+  sealed trait FilterRuleName extends js.Any
+  object FilterRuleName extends js.Object {
+    val prefix = "prefix".asInstanceOf[FilterRuleName]
+    val suffix = "suffix".asInstanceOf[FilterRuleName]
 
     val values = js.Object.freeze(js.Array(prefix, suffix))
   }
@@ -4095,41 +4063,45 @@ package s3 {
       __obj.asInstanceOf[InventoryFilter]
     }
   }
-
-  object InventoryFormatEnum {
-    val CSV     = "CSV"
-    val ORC     = "ORC"
-    val Parquet = "Parquet"
+  @js.native
+  sealed trait InventoryFormat extends js.Any
+  object InventoryFormat extends js.Object {
+    val CSV     = "CSV".asInstanceOf[InventoryFormat]
+    val ORC     = "ORC".asInstanceOf[InventoryFormat]
+    val Parquet = "Parquet".asInstanceOf[InventoryFormat]
 
     val values = js.Object.freeze(js.Array(CSV, ORC, Parquet))
   }
-
-  object InventoryFrequencyEnum {
-    val Daily  = "Daily"
-    val Weekly = "Weekly"
+  @js.native
+  sealed trait InventoryFrequency extends js.Any
+  object InventoryFrequency extends js.Object {
+    val Daily  = "Daily".asInstanceOf[InventoryFrequency]
+    val Weekly = "Weekly".asInstanceOf[InventoryFrequency]
 
     val values = js.Object.freeze(js.Array(Daily, Weekly))
   }
-
-  object InventoryIncludedObjectVersionsEnum {
-    val All     = "All"
-    val Current = "Current"
+  @js.native
+  sealed trait InventoryIncludedObjectVersions extends js.Any
+  object InventoryIncludedObjectVersions extends js.Object {
+    val All     = "All".asInstanceOf[InventoryIncludedObjectVersions]
+    val Current = "Current".asInstanceOf[InventoryIncludedObjectVersions]
 
     val values = js.Object.freeze(js.Array(All, Current))
   }
-
-  object InventoryOptionalFieldEnum {
-    val Size                         = "Size"
-    val LastModifiedDate             = "LastModifiedDate"
-    val StorageClass                 = "StorageClass"
-    val ETag                         = "ETag"
-    val IsMultipartUploaded          = "IsMultipartUploaded"
-    val ReplicationStatus            = "ReplicationStatus"
-    val EncryptionStatus             = "EncryptionStatus"
-    val ObjectLockRetainUntilDate    = "ObjectLockRetainUntilDate"
-    val ObjectLockMode               = "ObjectLockMode"
-    val ObjectLockLegalHoldStatus    = "ObjectLockLegalHoldStatus"
-    val IntelligentTieringAccessTier = "IntelligentTieringAccessTier"
+  @js.native
+  sealed trait InventoryOptionalField extends js.Any
+  object InventoryOptionalField extends js.Object {
+    val Size                         = "Size".asInstanceOf[InventoryOptionalField]
+    val LastModifiedDate             = "LastModifiedDate".asInstanceOf[InventoryOptionalField]
+    val StorageClass                 = "StorageClass".asInstanceOf[InventoryOptionalField]
+    val ETag                         = "ETag".asInstanceOf[InventoryOptionalField]
+    val IsMultipartUploaded          = "IsMultipartUploaded".asInstanceOf[InventoryOptionalField]
+    val ReplicationStatus            = "ReplicationStatus".asInstanceOf[InventoryOptionalField]
+    val EncryptionStatus             = "EncryptionStatus".asInstanceOf[InventoryOptionalField]
+    val ObjectLockRetainUntilDate    = "ObjectLockRetainUntilDate".asInstanceOf[InventoryOptionalField]
+    val ObjectLockMode               = "ObjectLockMode".asInstanceOf[InventoryOptionalField]
+    val ObjectLockLegalHoldStatus    = "ObjectLockLegalHoldStatus".asInstanceOf[InventoryOptionalField]
+    val IntelligentTieringAccessTier = "IntelligentTieringAccessTier".asInstanceOf[InventoryOptionalField]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4239,10 +4211,11 @@ package s3 {
       __obj.asInstanceOf[JSONOutput]
     }
   }
-
-  object JSONTypeEnum {
-    val DOCUMENT = "DOCUMENT"
-    val LINES    = "LINES"
+  @js.native
+  sealed trait JSONType extends js.Any
+  object JSONType extends js.Object {
+    val DOCUMENT = "DOCUMENT".asInstanceOf[JSONType]
+    val LINES    = "LINES".asInstanceOf[JSONType]
 
     val values = js.Object.freeze(js.Array(DOCUMENT, LINES))
   }
@@ -5041,24 +5014,27 @@ package s3 {
       __obj.asInstanceOf[LoggingEnabled]
     }
   }
-
-  object MFADeleteEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
-
-    val values = js.Object.freeze(js.Array(Enabled, Disabled))
-  }
-
-  object MFADeleteStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait MFADelete extends js.Any
+  object MFADelete extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[MFADelete]
+    val Disabled = "Disabled".asInstanceOf[MFADelete]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
+  @js.native
+  sealed trait MFADeleteStatus extends js.Any
+  object MFADeleteStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[MFADeleteStatus]
+    val Disabled = "Disabled".asInstanceOf[MFADeleteStatus]
 
-  object MetadataDirectiveEnum {
-    val COPY    = "COPY"
-    val REPLACE = "REPLACE"
+    val values = js.Object.freeze(js.Array(Enabled, Disabled))
+  }
+  @js.native
+  sealed trait MetadataDirective extends js.Any
+  object MetadataDirective extends js.Object {
+    val COPY    = "COPY".asInstanceOf[MetadataDirective]
+    val REPLACE = "REPLACE".asInstanceOf[MetadataDirective]
 
     val values = js.Object.freeze(js.Array(COPY, REPLACE))
   }
@@ -5179,10 +5155,11 @@ package s3 {
       __obj.asInstanceOf[MetricsFilter]
     }
   }
-
-  object MetricsStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait MetricsStatus extends js.Any
+  object MetricsStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[MetricsStatus]
+    val Disabled = "Disabled".asInstanceOf[MetricsStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
@@ -5365,15 +5342,16 @@ package s3 {
       __obj.asInstanceOf[Object]
     }
   }
-
-  object ObjectCannedACLEnum {
-    val `private`                   = "private"
-    val `public-read`               = "public-read"
-    val `public-read-write`         = "public-read-write"
-    val `authenticated-read`        = "authenticated-read"
-    val `aws-exec-read`             = "aws-exec-read"
-    val `bucket-owner-read`         = "bucket-owner-read"
-    val `bucket-owner-full-control` = "bucket-owner-full-control"
+  @js.native
+  sealed trait ObjectCannedACL extends js.Any
+  object ObjectCannedACL extends js.Object {
+    val `private`                   = "private".asInstanceOf[ObjectCannedACL]
+    val `public-read`               = "public-read".asInstanceOf[ObjectCannedACL]
+    val `public-read-write`         = "public-read-write".asInstanceOf[ObjectCannedACL]
+    val `authenticated-read`        = "authenticated-read".asInstanceOf[ObjectCannedACL]
+    val `aws-exec-read`             = "aws-exec-read".asInstanceOf[ObjectCannedACL]
+    val `bucket-owner-read`         = "bucket-owner-read".asInstanceOf[ObjectCannedACL]
+    val `bucket-owner-full-control` = "bucket-owner-full-control".asInstanceOf[ObjectCannedACL]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5433,9 +5411,10 @@ package s3 {
       __obj.asInstanceOf[ObjectLockConfiguration]
     }
   }
-
-  object ObjectLockEnabledEnum {
-    val Enabled = "Enabled"
+  @js.native
+  sealed trait ObjectLockEnabled extends js.Any
+  object ObjectLockEnabled extends js.Object {
+    val Enabled = "Enabled".asInstanceOf[ObjectLockEnabled]
 
     val values = js.Object.freeze(js.Array(Enabled))
   }
@@ -5458,17 +5437,19 @@ package s3 {
       __obj.asInstanceOf[ObjectLockLegalHold]
     }
   }
-
-  object ObjectLockLegalHoldStatusEnum {
-    val ON  = "ON"
-    val OFF = "OFF"
+  @js.native
+  sealed trait ObjectLockLegalHoldStatus extends js.Any
+  object ObjectLockLegalHoldStatus extends js.Object {
+    val ON  = "ON".asInstanceOf[ObjectLockLegalHoldStatus]
+    val OFF = "OFF".asInstanceOf[ObjectLockLegalHoldStatus]
 
     val values = js.Object.freeze(js.Array(ON, OFF))
   }
-
-  object ObjectLockModeEnum {
-    val GOVERNANCE = "GOVERNANCE"
-    val COMPLIANCE = "COMPLIANCE"
+  @js.native
+  sealed trait ObjectLockMode extends js.Any
+  object ObjectLockMode extends js.Object {
+    val GOVERNANCE = "GOVERNANCE".asInstanceOf[ObjectLockMode]
+    val COMPLIANCE = "COMPLIANCE".asInstanceOf[ObjectLockMode]
 
     val values = js.Object.freeze(js.Array(GOVERNANCE, COMPLIANCE))
   }
@@ -5494,10 +5475,11 @@ package s3 {
       __obj.asInstanceOf[ObjectLockRetention]
     }
   }
-
-  object ObjectLockRetentionModeEnum {
-    val GOVERNANCE = "GOVERNANCE"
-    val COMPLIANCE = "COMPLIANCE"
+  @js.native
+  sealed trait ObjectLockRetentionMode extends js.Any
+  object ObjectLockRetentionMode extends js.Object {
+    val GOVERNANCE = "GOVERNANCE".asInstanceOf[ObjectLockRetentionMode]
+    val COMPLIANCE = "COMPLIANCE".asInstanceOf[ObjectLockRetentionMode]
 
     val values = js.Object.freeze(js.Array(GOVERNANCE, COMPLIANCE))
   }
@@ -5520,15 +5502,16 @@ package s3 {
       __obj.asInstanceOf[ObjectLockRule]
     }
   }
-
-  object ObjectStorageClassEnum {
-    val STANDARD            = "STANDARD"
-    val REDUCED_REDUNDANCY  = "REDUCED_REDUNDANCY"
-    val GLACIER             = "GLACIER"
-    val STANDARD_IA         = "STANDARD_IA"
-    val ONEZONE_IA          = "ONEZONE_IA"
-    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING"
-    val DEEP_ARCHIVE        = "DEEP_ARCHIVE"
+  @js.native
+  sealed trait ObjectStorageClass extends js.Any
+  object ObjectStorageClass extends js.Object {
+    val STANDARD            = "STANDARD".asInstanceOf[ObjectStorageClass]
+    val REDUCED_REDUNDANCY  = "REDUCED_REDUNDANCY".asInstanceOf[ObjectStorageClass]
+    val GLACIER             = "GLACIER".asInstanceOf[ObjectStorageClass]
+    val STANDARD_IA         = "STANDARD_IA".asInstanceOf[ObjectStorageClass]
+    val ONEZONE_IA          = "ONEZONE_IA".asInstanceOf[ObjectStorageClass]
+    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING".asInstanceOf[ObjectStorageClass]
+    val DEEP_ARCHIVE        = "DEEP_ARCHIVE".asInstanceOf[ObjectStorageClass]
 
     val values = js.Object.freeze(
       js.Array(STANDARD, REDUCED_REDUNDANCY, GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE)
@@ -5574,9 +5557,10 @@ package s3 {
       __obj.asInstanceOf[ObjectVersion]
     }
   }
-
-  object ObjectVersionStorageClassEnum {
-    val STANDARD = "STANDARD"
+  @js.native
+  sealed trait ObjectVersionStorageClass extends js.Any
+  object ObjectVersionStorageClass extends js.Object {
+    val STANDARD = "STANDARD".asInstanceOf[ObjectVersionStorageClass]
 
     val values = js.Object.freeze(js.Array(STANDARD))
   }
@@ -5643,9 +5627,10 @@ package s3 {
       __obj.asInstanceOf[Owner]
     }
   }
-
-  object OwnerOverrideEnum {
-    val Destination = "Destination"
+  @js.native
+  sealed trait OwnerOverride extends js.Any
+  object OwnerOverride extends js.Object {
+    val Destination = "Destination".asInstanceOf[OwnerOverride]
 
     val values = js.Object.freeze(js.Array(Destination))
   }
@@ -5693,20 +5678,22 @@ package s3 {
       __obj.asInstanceOf[Part]
     }
   }
-
-  object PayerEnum {
-    val Requester   = "Requester"
-    val BucketOwner = "BucketOwner"
+  @js.native
+  sealed trait Payer extends js.Any
+  object Payer extends js.Object {
+    val Requester   = "Requester".asInstanceOf[Payer]
+    val BucketOwner = "BucketOwner".asInstanceOf[Payer]
 
     val values = js.Object.freeze(js.Array(Requester, BucketOwner))
   }
-
-  object PermissionEnum {
-    val FULL_CONTROL = "FULL_CONTROL"
-    val WRITE        = "WRITE"
-    val WRITE_ACP    = "WRITE_ACP"
-    val READ         = "READ"
-    val READ_ACP     = "READ_ACP"
+  @js.native
+  sealed trait Permission extends js.Any
+  object Permission extends js.Object {
+    val FULL_CONTROL = "FULL_CONTROL".asInstanceOf[Permission]
+    val WRITE        = "WRITE".asInstanceOf[Permission]
+    val WRITE_ACP    = "WRITE_ACP".asInstanceOf[Permission]
+    val READ         = "READ".asInstanceOf[Permission]
+    val READ_ACP     = "READ_ACP".asInstanceOf[Permission]
 
     val values = js.Object.freeze(js.Array(FULL_CONTROL, WRITE, WRITE_ACP, READ, READ_ACP))
   }
@@ -5773,10 +5760,11 @@ package s3 {
       __obj.asInstanceOf[ProgressEvent]
     }
   }
-
-  object ProtocolEnum {
-    val http  = "http"
-    val https = "https"
+  @js.native
+  sealed trait Protocol extends js.Any
+  object Protocol extends js.Object {
+    val http  = "http".asInstanceOf[Protocol]
+    val https = "https".asInstanceOf[Protocol]
 
     val values = js.Object.freeze(js.Array(http, https))
   }
@@ -6753,10 +6741,11 @@ package s3 {
       __obj.asInstanceOf[QueueConfigurationDeprecated]
     }
   }
-
-  object QuoteFieldsEnum {
-    val ALWAYS   = "ALWAYS"
-    val ASNEEDED = "ASNEEDED"
+  @js.native
+  sealed trait QuoteFields extends js.Any
+  object QuoteFields extends js.Object {
+    val ALWAYS   = "ALWAYS".asInstanceOf[QuoteFields]
+    val ASNEEDED = "ASNEEDED".asInstanceOf[QuoteFields]
 
     val values = js.Object.freeze(js.Array(ALWAYS, ASNEEDED))
   }
@@ -6955,19 +6944,21 @@ package s3 {
       __obj.asInstanceOf[ReplicationRuleFilter]
     }
   }
-
-  object ReplicationRuleStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait ReplicationRuleStatus extends js.Any
+  object ReplicationRuleStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[ReplicationRuleStatus]
+    val Disabled = "Disabled".asInstanceOf[ReplicationRuleStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
-
-  object ReplicationStatusEnum {
-    val COMPLETE = "COMPLETE"
-    val PENDING  = "PENDING"
-    val FAILED   = "FAILED"
-    val REPLICA  = "REPLICA"
+  @js.native
+  sealed trait ReplicationStatus extends js.Any
+  object ReplicationStatus extends js.Object {
+    val COMPLETE = "COMPLETE".asInstanceOf[ReplicationStatus]
+    val PENDING  = "PENDING".asInstanceOf[ReplicationStatus]
+    val FAILED   = "FAILED".asInstanceOf[ReplicationStatus]
+    val REPLICA  = "REPLICA".asInstanceOf[ReplicationStatus]
 
     val values = js.Object.freeze(js.Array(COMPLETE, PENDING, FAILED, REPLICA))
   }
@@ -6995,10 +6986,11 @@ package s3 {
       __obj.asInstanceOf[ReplicationTime]
     }
   }
-
-  object ReplicationTimeStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait ReplicationTimeStatus extends js.Any
+  object ReplicationTimeStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[ReplicationTimeStatus]
+    val Disabled = "Disabled".asInstanceOf[ReplicationTimeStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
@@ -7025,8 +7017,10 @@ package s3 {
   /**
     * If present, indicates that the requester was successfully charged for the request.
     */
-  object RequestChargedEnum {
-    val requester = "requester"
+  @js.native
+  sealed trait RequestCharged extends js.Any
+  object RequestCharged extends js.Object {
+    val requester = "requester".asInstanceOf[RequestCharged]
 
     val values = js.Object.freeze(js.Array(requester))
   }
@@ -7034,8 +7028,10 @@ package s3 {
   /**
     * Confirms that the requester knows that they will be charged for the request. Bucket owners need not specify this parameter in their requests. For information about downloading objects from requester pays buckets, see [[https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html|Downloading Objects in Requestor Pays Buckets]] in the <i>Amazon S3 Developer Guide</i>.
     */
-  object RequestPayerEnum {
-    val requester = "requester"
+  @js.native
+  sealed trait RequestPayer extends js.Any
+  object RequestPayer extends js.Object {
+    val requester = "requester".asInstanceOf[RequestPayer]
 
     val values = js.Object.freeze(js.Array(requester))
   }
@@ -7165,9 +7161,10 @@ package s3 {
       __obj.asInstanceOf[RestoreRequest]
     }
   }
-
-  object RestoreRequestTypeEnum {
-    val SELECT = "SELECT"
+  @js.native
+  sealed trait RestoreRequestType extends js.Any
+  object RestoreRequestType extends js.Object {
+    val SELECT = "SELECT".asInstanceOf[RestoreRequestType]
 
     val values = js.Object.freeze(js.Array(SELECT))
   }
@@ -7491,10 +7488,11 @@ package s3 {
       __obj.asInstanceOf[SelectParameters]
     }
   }
-
-  object ServerSideEncryptionEnum {
-    val AES256    = "AES256"
-    val `aws:kms` = "aws:kms"
+  @js.native
+  sealed trait ServerSideEncryption extends js.Any
+  object ServerSideEncryption extends js.Object {
+    val AES256    = "AES256".asInstanceOf[ServerSideEncryption]
+    val `aws:kms` = "aws:kms".asInstanceOf[ServerSideEncryption]
 
     val values = js.Object.freeze(js.Array(AES256, `aws:kms`))
   }
@@ -7604,10 +7602,11 @@ package s3 {
       __obj.asInstanceOf[SseKmsEncryptedObjects]
     }
   }
-
-  object SseKmsEncryptedObjectsStatusEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait SseKmsEncryptedObjectsStatus extends js.Any
+  object SseKmsEncryptedObjectsStatus extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[SseKmsEncryptedObjectsStatus]
+    val Disabled = "Disabled".asInstanceOf[SseKmsEncryptedObjectsStatus]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
@@ -7655,15 +7654,16 @@ package s3 {
       __obj.asInstanceOf[StatsEvent]
     }
   }
-
-  object StorageClassEnum {
-    val STANDARD            = "STANDARD"
-    val REDUCED_REDUNDANCY  = "REDUCED_REDUNDANCY"
-    val STANDARD_IA         = "STANDARD_IA"
-    val ONEZONE_IA          = "ONEZONE_IA"
-    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING"
-    val GLACIER             = "GLACIER"
-    val DEEP_ARCHIVE        = "DEEP_ARCHIVE"
+  @js.native
+  sealed trait StorageClass extends js.Any
+  object StorageClass extends js.Object {
+    val STANDARD            = "STANDARD".asInstanceOf[StorageClass]
+    val REDUCED_REDUNDANCY  = "REDUCED_REDUNDANCY".asInstanceOf[StorageClass]
+    val STANDARD_IA         = "STANDARD_IA".asInstanceOf[StorageClass]
+    val ONEZONE_IA          = "ONEZONE_IA".asInstanceOf[StorageClass]
+    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING".asInstanceOf[StorageClass]
+    val GLACIER             = "GLACIER".asInstanceOf[StorageClass]
+    val DEEP_ARCHIVE        = "DEEP_ARCHIVE".asInstanceOf[StorageClass]
 
     val values = js.Object.freeze(
       js.Array(STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE)
@@ -7712,9 +7712,10 @@ package s3 {
       __obj.asInstanceOf[StorageClassAnalysisDataExport]
     }
   }
-
-  object StorageClassAnalysisSchemaVersionEnum {
-    val V_1 = "V_1"
+  @js.native
+  sealed trait StorageClassAnalysisSchemaVersion extends js.Any
+  object StorageClassAnalysisSchemaVersion extends js.Object {
+    val V_1 = "V_1".asInstanceOf[StorageClassAnalysisSchemaVersion]
 
     val values = js.Object.freeze(js.Array(V_1))
   }
@@ -7763,10 +7764,11 @@ package s3 {
       __obj.asInstanceOf[Tagging]
     }
   }
-
-  object TaggingDirectiveEnum {
-    val COPY    = "COPY"
-    val REPLACE = "REPLACE"
+  @js.native
+  sealed trait TaggingDirective extends js.Any
+  object TaggingDirective extends js.Object {
+    val COPY    = "COPY".asInstanceOf[TaggingDirective]
+    val REPLACE = "REPLACE".asInstanceOf[TaggingDirective]
 
     val values = js.Object.freeze(js.Array(COPY, REPLACE))
   }
@@ -7792,11 +7794,12 @@ package s3 {
       __obj.asInstanceOf[TargetGrant]
     }
   }
-
-  object TierEnum {
-    val Standard  = "Standard"
-    val Bulk      = "Bulk"
-    val Expedited = "Expedited"
+  @js.native
+  sealed trait Tier extends js.Any
+  object Tier extends js.Object {
+    val Standard  = "Standard".asInstanceOf[Tier]
+    val Bulk      = "Bulk".asInstanceOf[Tier]
+    val Expedited = "Expedited".asInstanceOf[Tier]
 
     val values = js.Object.freeze(js.Array(Standard, Bulk, Expedited))
   }
@@ -7883,21 +7886,23 @@ package s3 {
       __obj.asInstanceOf[Transition]
     }
   }
-
-  object TransitionStorageClassEnum {
-    val GLACIER             = "GLACIER"
-    val STANDARD_IA         = "STANDARD_IA"
-    val ONEZONE_IA          = "ONEZONE_IA"
-    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING"
-    val DEEP_ARCHIVE        = "DEEP_ARCHIVE"
+  @js.native
+  sealed trait TransitionStorageClass extends js.Any
+  object TransitionStorageClass extends js.Object {
+    val GLACIER             = "GLACIER".asInstanceOf[TransitionStorageClass]
+    val STANDARD_IA         = "STANDARD_IA".asInstanceOf[TransitionStorageClass]
+    val ONEZONE_IA          = "ONEZONE_IA".asInstanceOf[TransitionStorageClass]
+    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING".asInstanceOf[TransitionStorageClass]
+    val DEEP_ARCHIVE        = "DEEP_ARCHIVE".asInstanceOf[TransitionStorageClass]
 
     val values = js.Object.freeze(js.Array(GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE))
   }
-
-  object TypeEnum {
-    val CanonicalUser         = "CanonicalUser"
-    val AmazonCustomerByEmail = "AmazonCustomerByEmail"
-    val Group                 = "Group"
+  @js.native
+  sealed trait Type extends js.Any
+  object Type extends js.Object {
+    val CanonicalUser         = "CanonicalUser".asInstanceOf[Type]
+    val AmazonCustomerByEmail = "AmazonCustomerByEmail".asInstanceOf[Type]
+    val Group                 = "Group".asInstanceOf[Type]
 
     val values = js.Object.freeze(js.Array(CanonicalUser, AmazonCustomerByEmail, Group))
   }

--- a/services/s3control/src/main/scala/facade/amazonaws/services/S3Control.scala
+++ b/services/s3control/src/main/scala/facade/amazonaws/services/S3Control.scala
@@ -23,14 +23,9 @@ package object s3control {
   type JobId                       = String
   type JobListDescriptorList       = js.Array[JobListDescriptor]
   type JobManifestFieldList        = js.Array[JobManifestFieldName]
-  type JobManifestFieldName        = String
-  type JobManifestFormat           = String
   type JobNumberOfTasksFailed      = Double
   type JobNumberOfTasksSucceeded   = Double
   type JobPriority                 = Int
-  type JobReportFormat             = String
-  type JobReportScope              = String
-  type JobStatus                   = String
   type JobStatusList               = js.Array[JobStatus]
   type JobStatusUpdateReason       = String
   type JobTerminationDate          = js.Date
@@ -38,30 +33,18 @@ package object s3control {
   type KmsKeyArnString             = String
   type MaxLength1024String         = String
   type MaxResults                  = Int
-  type NetworkOrigin               = String
   type NonEmptyMaxLength1024String = String
   type NonEmptyMaxLength2048String = String
   type NonEmptyMaxLength256String  = String
   type NonEmptyMaxLength64String   = String
-  type OperationName               = String
   type Policy                      = String
   type ReportPrefixString          = String
-  type RequestedJobStatus          = String
   type S3BucketArnString           = String
-  type S3CannedAccessControlList   = String
   type S3ContentLength             = Double
   type S3ExpirationInDays          = Int
-  type S3GlacierJobTier            = String
   type S3GrantList                 = js.Array[S3Grant]
-  type S3GranteeTypeIdentifier     = String
   type S3KeyArnString              = String
-  type S3MetadataDirective         = String
-  type S3ObjectLockLegalHoldStatus = String
-  type S3ObjectLockMode            = String
   type S3ObjectVersionId           = String
-  type S3Permission                = String
-  type S3SSEAlgorithm              = String
-  type S3StorageClass              = String
   type S3TagSet                    = js.Array[S3Tag]
   type S3UserMetadata              = js.Dictionary[MaxLength1024String]
   type Setting                     = Boolean
@@ -667,19 +650,21 @@ package s3control {
       __obj.asInstanceOf[JobManifest]
     }
   }
-
-  object JobManifestFieldNameEnum {
-    val Ignore    = "Ignore"
-    val Bucket    = "Bucket"
-    val Key       = "Key"
-    val VersionId = "VersionId"
+  @js.native
+  sealed trait JobManifestFieldName extends js.Any
+  object JobManifestFieldName extends js.Object {
+    val Ignore    = "Ignore".asInstanceOf[JobManifestFieldName]
+    val Bucket    = "Bucket".asInstanceOf[JobManifestFieldName]
+    val Key       = "Key".asInstanceOf[JobManifestFieldName]
+    val VersionId = "VersionId".asInstanceOf[JobManifestFieldName]
 
     val values = js.Object.freeze(js.Array(Ignore, Bucket, Key, VersionId))
   }
-
-  object JobManifestFormatEnum {
-    val S3BatchOperations_CSV_20180820 = "S3BatchOperations_CSV_20180820"
-    val S3InventoryReport_CSV_20161130 = "S3InventoryReport_CSV_20161130"
+  @js.native
+  sealed trait JobManifestFormat extends js.Any
+  object JobManifestFormat extends js.Object {
+    val S3BatchOperations_CSV_20180820 = "S3BatchOperations_CSV_20180820".asInstanceOf[JobManifestFormat]
+    val S3InventoryReport_CSV_20161130 = "S3InventoryReport_CSV_20161130".asInstanceOf[JobManifestFormat]
 
     val values = js.Object.freeze(js.Array(S3BatchOperations_CSV_20180820, S3InventoryReport_CSV_20161130))
   }
@@ -823,34 +808,37 @@ package s3control {
       __obj.asInstanceOf[JobReport]
     }
   }
-
-  object JobReportFormatEnum {
-    val Report_CSV_20180820 = "Report_CSV_20180820"
+  @js.native
+  sealed trait JobReportFormat extends js.Any
+  object JobReportFormat extends js.Object {
+    val Report_CSV_20180820 = "Report_CSV_20180820".asInstanceOf[JobReportFormat]
 
     val values = js.Object.freeze(js.Array(Report_CSV_20180820))
   }
-
-  object JobReportScopeEnum {
-    val AllTasks        = "AllTasks"
-    val FailedTasksOnly = "FailedTasksOnly"
+  @js.native
+  sealed trait JobReportScope extends js.Any
+  object JobReportScope extends js.Object {
+    val AllTasks        = "AllTasks".asInstanceOf[JobReportScope]
+    val FailedTasksOnly = "FailedTasksOnly".asInstanceOf[JobReportScope]
 
     val values = js.Object.freeze(js.Array(AllTasks, FailedTasksOnly))
   }
-
-  object JobStatusEnum {
-    val Active     = "Active"
-    val Cancelled  = "Cancelled"
-    val Cancelling = "Cancelling"
-    val Complete   = "Complete"
-    val Completing = "Completing"
-    val Failed     = "Failed"
-    val Failing    = "Failing"
-    val New        = "New"
-    val Paused     = "Paused"
-    val Pausing    = "Pausing"
-    val Preparing  = "Preparing"
-    val Ready      = "Ready"
-    val Suspended  = "Suspended"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val Active     = "Active".asInstanceOf[JobStatus]
+    val Cancelled  = "Cancelled".asInstanceOf[JobStatus]
+    val Cancelling = "Cancelling".asInstanceOf[JobStatus]
+    val Complete   = "Complete".asInstanceOf[JobStatus]
+    val Completing = "Completing".asInstanceOf[JobStatus]
+    val Failed     = "Failed".asInstanceOf[JobStatus]
+    val Failing    = "Failing".asInstanceOf[JobStatus]
+    val New        = "New".asInstanceOf[JobStatus]
+    val Paused     = "Paused".asInstanceOf[JobStatus]
+    val Pausing    = "Pausing".asInstanceOf[JobStatus]
+    val Preparing  = "Preparing".asInstanceOf[JobStatus]
+    val Ready      = "Ready".asInstanceOf[JobStatus]
+    val Suspended  = "Suspended".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -981,20 +969,22 @@ package s3control {
       __obj.asInstanceOf[ListJobsResult]
     }
   }
-
-  object NetworkOriginEnum {
-    val Internet = "Internet"
-    val VPC      = "VPC"
+  @js.native
+  sealed trait NetworkOrigin extends js.Any
+  object NetworkOrigin extends js.Object {
+    val Internet = "Internet".asInstanceOf[NetworkOrigin]
+    val VPC      = "VPC".asInstanceOf[NetworkOrigin]
 
     val values = js.Object.freeze(js.Array(Internet, VPC))
   }
-
-  object OperationNameEnum {
-    val LambdaInvoke            = "LambdaInvoke"
-    val S3PutObjectCopy         = "S3PutObjectCopy"
-    val S3PutObjectAcl          = "S3PutObjectAcl"
-    val S3PutObjectTagging      = "S3PutObjectTagging"
-    val S3InitiateRestoreObject = "S3InitiateRestoreObject"
+  @js.native
+  sealed trait OperationName extends js.Any
+  object OperationName extends js.Object {
+    val LambdaInvoke            = "LambdaInvoke".asInstanceOf[OperationName]
+    val S3PutObjectCopy         = "S3PutObjectCopy".asInstanceOf[OperationName]
+    val S3PutObjectAcl          = "S3PutObjectAcl".asInstanceOf[OperationName]
+    val S3PutObjectTagging      = "S3PutObjectTagging".asInstanceOf[OperationName]
+    val S3InitiateRestoreObject = "S3InitiateRestoreObject".asInstanceOf[OperationName]
 
     val values = js.Object.freeze(
       js.Array(LambdaInvoke, S3PutObjectCopy, S3PutObjectAcl, S3PutObjectTagging, S3InitiateRestoreObject)
@@ -1092,10 +1082,11 @@ package s3control {
       __obj.asInstanceOf[PutPublicAccessBlockRequest]
     }
   }
-
-  object RequestedJobStatusEnum {
-    val Cancelled = "Cancelled"
-    val Ready     = "Ready"
+  @js.native
+  sealed trait RequestedJobStatus extends js.Any
+  object RequestedJobStatus extends js.Object {
+    val Cancelled = "Cancelled".asInstanceOf[RequestedJobStatus]
+    val Ready     = "Ready".asInstanceOf[RequestedJobStatus]
 
     val values = js.Object.freeze(js.Array(Cancelled, Ready))
   }
@@ -1145,15 +1136,16 @@ package s3control {
       __obj.asInstanceOf[S3AccessControlPolicy]
     }
   }
-
-  object S3CannedAccessControlListEnum {
-    val `private`                   = "private"
-    val `public-read`               = "public-read"
-    val `public-read-write`         = "public-read-write"
-    val `aws-exec-read`             = "aws-exec-read"
-    val `authenticated-read`        = "authenticated-read"
-    val `bucket-owner-read`         = "bucket-owner-read"
-    val `bucket-owner-full-control` = "bucket-owner-full-control"
+  @js.native
+  sealed trait S3CannedAccessControlList extends js.Any
+  object S3CannedAccessControlList extends js.Object {
+    val `private`                   = "private".asInstanceOf[S3CannedAccessControlList]
+    val `public-read`               = "public-read".asInstanceOf[S3CannedAccessControlList]
+    val `public-read-write`         = "public-read-write".asInstanceOf[S3CannedAccessControlList]
+    val `aws-exec-read`             = "aws-exec-read".asInstanceOf[S3CannedAccessControlList]
+    val `authenticated-read`        = "authenticated-read".asInstanceOf[S3CannedAccessControlList]
+    val `bucket-owner-read`         = "bucket-owner-read".asInstanceOf[S3CannedAccessControlList]
+    val `bucket-owner-full-control` = "bucket-owner-full-control".asInstanceOf[S3CannedAccessControlList]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1237,10 +1229,11 @@ package s3control {
       __obj.asInstanceOf[S3CopyObjectOperation]
     }
   }
-
-  object S3GlacierJobTierEnum {
-    val BULK     = "BULK"
-    val STANDARD = "STANDARD"
+  @js.native
+  sealed trait S3GlacierJobTier extends js.Any
+  object S3GlacierJobTier extends js.Object {
+    val BULK     = "BULK".asInstanceOf[S3GlacierJobTier]
+    val STANDARD = "STANDARD".asInstanceOf[S3GlacierJobTier]
 
     val values = js.Object.freeze(js.Array(BULK, STANDARD))
   }
@@ -1291,11 +1284,12 @@ package s3control {
       __obj.asInstanceOf[S3Grantee]
     }
   }
-
-  object S3GranteeTypeIdentifierEnum {
-    val id           = "id"
-    val emailAddress = "emailAddress"
-    val uri          = "uri"
+  @js.native
+  sealed trait S3GranteeTypeIdentifier extends js.Any
+  object S3GranteeTypeIdentifier extends js.Object {
+    val id           = "id".asInstanceOf[S3GranteeTypeIdentifier]
+    val emailAddress = "emailAddress".asInstanceOf[S3GranteeTypeIdentifier]
+    val uri          = "uri".asInstanceOf[S3GranteeTypeIdentifier]
 
     val values = js.Object.freeze(js.Array(id, emailAddress, uri))
   }
@@ -1321,24 +1315,27 @@ package s3control {
       __obj.asInstanceOf[S3InitiateRestoreObjectOperation]
     }
   }
-
-  object S3MetadataDirectiveEnum {
-    val COPY    = "COPY"
-    val REPLACE = "REPLACE"
+  @js.native
+  sealed trait S3MetadataDirective extends js.Any
+  object S3MetadataDirective extends js.Object {
+    val COPY    = "COPY".asInstanceOf[S3MetadataDirective]
+    val REPLACE = "REPLACE".asInstanceOf[S3MetadataDirective]
 
     val values = js.Object.freeze(js.Array(COPY, REPLACE))
   }
-
-  object S3ObjectLockLegalHoldStatusEnum {
-    val OFF = "OFF"
-    val ON  = "ON"
+  @js.native
+  sealed trait S3ObjectLockLegalHoldStatus extends js.Any
+  object S3ObjectLockLegalHoldStatus extends js.Object {
+    val OFF = "OFF".asInstanceOf[S3ObjectLockLegalHoldStatus]
+    val ON  = "ON".asInstanceOf[S3ObjectLockLegalHoldStatus]
 
     val values = js.Object.freeze(js.Array(OFF, ON))
   }
-
-  object S3ObjectLockModeEnum {
-    val COMPLIANCE = "COMPLIANCE"
-    val GOVERNANCE = "GOVERNANCE"
+  @js.native
+  sealed trait S3ObjectLockMode extends js.Any
+  object S3ObjectLockMode extends js.Object {
+    val COMPLIANCE = "COMPLIANCE".asInstanceOf[S3ObjectLockMode]
+    val GOVERNANCE = "GOVERNANCE".asInstanceOf[S3ObjectLockMode]
 
     val values = js.Object.freeze(js.Array(COMPLIANCE, GOVERNANCE))
   }
@@ -1413,20 +1410,22 @@ package s3control {
       __obj.asInstanceOf[S3ObjectOwner]
     }
   }
-
-  object S3PermissionEnum {
-    val FULL_CONTROL = "FULL_CONTROL"
-    val READ         = "READ"
-    val WRITE        = "WRITE"
-    val READ_ACP     = "READ_ACP"
-    val WRITE_ACP    = "WRITE_ACP"
+  @js.native
+  sealed trait S3Permission extends js.Any
+  object S3Permission extends js.Object {
+    val FULL_CONTROL = "FULL_CONTROL".asInstanceOf[S3Permission]
+    val READ         = "READ".asInstanceOf[S3Permission]
+    val WRITE        = "WRITE".asInstanceOf[S3Permission]
+    val READ_ACP     = "READ_ACP".asInstanceOf[S3Permission]
+    val WRITE_ACP    = "WRITE_ACP".asInstanceOf[S3Permission]
 
     val values = js.Object.freeze(js.Array(FULL_CONTROL, READ, WRITE, READ_ACP, WRITE_ACP))
   }
-
-  object S3SSEAlgorithmEnum {
-    val AES256 = "AES256"
-    val KMS    = "KMS"
+  @js.native
+  sealed trait S3SSEAlgorithm extends js.Any
+  object S3SSEAlgorithm extends js.Object {
+    val AES256 = "AES256".asInstanceOf[S3SSEAlgorithm]
+    val KMS    = "KMS".asInstanceOf[S3SSEAlgorithm]
 
     val values = js.Object.freeze(js.Array(AES256, KMS))
   }
@@ -1468,14 +1467,15 @@ package s3control {
       __obj.asInstanceOf[S3SetObjectTaggingOperation]
     }
   }
-
-  object S3StorageClassEnum {
-    val STANDARD            = "STANDARD"
-    val STANDARD_IA         = "STANDARD_IA"
-    val ONEZONE_IA          = "ONEZONE_IA"
-    val GLACIER             = "GLACIER"
-    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING"
-    val DEEP_ARCHIVE        = "DEEP_ARCHIVE"
+  @js.native
+  sealed trait S3StorageClass extends js.Any
+  object S3StorageClass extends js.Object {
+    val STANDARD            = "STANDARD".asInstanceOf[S3StorageClass]
+    val STANDARD_IA         = "STANDARD_IA".asInstanceOf[S3StorageClass]
+    val ONEZONE_IA          = "ONEZONE_IA".asInstanceOf[S3StorageClass]
+    val GLACIER             = "GLACIER".asInstanceOf[S3StorageClass]
+    val INTELLIGENT_TIERING = "INTELLIGENT_TIERING".asInstanceOf[S3StorageClass]
+    val DEEP_ARCHIVE        = "DEEP_ARCHIVE".asInstanceOf[S3StorageClass]
 
     val values =
       js.Object.freeze(js.Array(STANDARD, STANDARD_IA, ONEZONE_IA, GLACIER, INTELLIGENT_TIERING, DEEP_ARCHIVE))

--- a/services/sagemaker/src/main/scala/facade/amazonaws/services/SageMaker.scala
+++ b/services/sagemaker/src/main/scala/facade/amazonaws/services/SageMaker.scala
@@ -12,55 +12,32 @@ package object sagemaker {
   type AdditionalCodeRepositoryNamesOrUrls             = js.Array[CodeRepositoryNameOrUrl]
   type AlgorithmArn                                    = String
   type AlgorithmImage                                  = String
-  type AlgorithmSortBy                                 = String
-  type AlgorithmStatus                                 = String
   type AlgorithmStatusItemList                         = js.Array[AlgorithmStatusItem]
   type AlgorithmSummaryList                            = js.Array[AlgorithmSummary]
   type AlgorithmValidationProfiles                     = js.Array[AlgorithmValidationProfile]
   type AppArn                                          = String
-  type AppInstanceType                                 = String
   type AppList                                         = js.Array[AppDetails]
   type AppName                                         = String
-  type AppSortKey                                      = String
-  type AppStatus                                       = String
-  type AppType                                         = String
   type ArnOrName                                       = String
-  type AssemblyType                                    = String
   type AttributeName                                   = String
   type AttributeNames                                  = js.Array[AttributeName]
-  type AuthMode                                        = String
   type AutoMLCandidates                                = js.Array[AutoMLCandidate]
   type AutoMLContainerDefinitions                      = js.Array[AutoMLContainerDefinition]
   type AutoMLFailureReason                             = String
   type AutoMLInputDataConfig                           = js.Array[AutoMLChannel]
   type AutoMLJobArn                                    = String
   type AutoMLJobName                                   = String
-  type AutoMLJobObjectiveType                          = String
-  type AutoMLJobSecondaryStatus                        = String
-  type AutoMLJobStatus                                 = String
   type AutoMLJobSummaries                              = js.Array[AutoMLJobSummary]
   type AutoMLMaxResults                                = Int
-  type AutoMLMetricEnum                                = String
   type AutoMLNameContains                              = String
-  type AutoMLS3DataType                                = String
-  type AutoMLSortBy                                    = String
-  type AutoMLSortOrder                                 = String
-  type AwsManagedHumanLoopRequestSource                = String
-  type BatchStrategy                                   = String
   type BillableTimeInSeconds                           = Int
-  type BooleanOperator                                 = String
   type Branch                                          = String
   type CandidateDefinitionNotebookLocation             = String
   type CandidateName                                   = String
-  type CandidateSortBy                                 = String
-  type CandidateStatus                                 = String
   type CandidateStepArn                                = String
   type CandidateStepName                               = String
-  type CandidateStepType                               = String
   type CandidateSteps                                  = js.Array[AutoMLCandidateStep]
-  type CaptureMode                                     = String
   type CaptureOptionList                               = js.Array[CaptureOption]
-  type CaptureStatus                                   = String
   type CategoricalParameterRanges                      = js.Array[CategoricalParameterRange]
   type Cents                                           = Int
   type CertifyForMarketplace                           = Boolean
@@ -72,8 +49,6 @@ package object sagemaker {
   type CodeRepositoryContains                          = String
   type CodeRepositoryNameContains                      = String
   type CodeRepositoryNameOrUrl                         = String
-  type CodeRepositorySortBy                            = String
-  type CodeRepositorySortOrder                         = String
   type CodeRepositorySummaryList                       = js.Array[CodeRepositorySummary]
   type CognitoClientId                                 = String
   type CognitoUserGroup                                = String
@@ -82,9 +57,7 @@ package object sagemaker {
   type CollectionName                                  = String
   type CollectionParameters                            = js.Dictionary[ConfigValue]
   type CompilationJobArn                               = String
-  type CompilationJobStatus                            = String
   type CompilationJobSummaries                         = js.Array[CompilationJobSummary]
-  type CompressionType                                 = String
   type CompressionTypes                                = js.Array[CompressionType]
   type ConfigKey                                       = String
   type ConfigValue                                     = String
@@ -94,8 +67,6 @@ package object sagemaker {
   type ContainerEntrypoint                             = js.Array[ContainerEntrypointString]
   type ContainerEntrypointString                       = String
   type ContainerHostname                               = String
-  type ContainerMode                                   = String
-  type ContentClassifier                               = String
   type ContentClassifiers                              = js.Array[ContentClassifier]
   type ContentType                                     = String
   type ContentTypes                                    = js.Array[ContentType]
@@ -110,9 +81,6 @@ package object sagemaker {
   type DeployedImages                                  = js.Array[DeployedImage]
   type DesiredWeightAndCapacityList                    = js.Array[DesiredWeightAndCapacity]
   type DestinationS3Uri                                = String
-  type DetailedAlgorithmStatus                         = String
-  type DetailedModelPackageStatus                      = String
-  type DirectInternetAccess                            = String
   type DirectoryPath                                   = String
   type DisassociateAdditionalCodeRepositories          = Boolean
   type DisassociateDefaultCodeRepository               = Boolean
@@ -123,7 +91,6 @@ package object sagemaker {
   type DomainId                                        = String
   type DomainList                                      = js.Array[DomainDetails]
   type DomainName                                      = String
-  type DomainStatus                                    = String
   type DoubleParameterValue                            = Double
   type EfsUid                                          = String
   type EnableCapture                                   = Boolean
@@ -131,12 +98,9 @@ package object sagemaker {
   type EndpointConfigArn                               = String
   type EndpointConfigName                              = String
   type EndpointConfigNameContains                      = String
-  type EndpointConfigSortKey                           = String
   type EndpointConfigSummaryList                       = js.Array[EndpointConfigSummary]
   type EndpointName                                    = String
   type EndpointNameContains                            = String
-  type EndpointSortKey                                 = String
-  type EndpointStatus                                  = String
   type EndpointSummaryList                             = js.Array[EndpointSummary]
   type EntityDescription                               = String
   type EntityName                                      = String
@@ -144,7 +108,6 @@ package object sagemaker {
   type EnvironmentKey                                  = String
   type EnvironmentMap                                  = js.Dictionary[EnvironmentValue]
   type EnvironmentValue                                = String
-  type ExecutionStatus                                 = String
   type ExitMessage                                     = String
   type ExperimentArn                                   = String
   type ExperimentConfigName                            = String
@@ -153,15 +116,12 @@ package object sagemaker {
   type ExperimentSourceArn                             = String
   type ExperimentSummaries                             = js.Array[ExperimentSummary]
   type FailureReason                                   = String
-  type FileSystemAccessMode                            = String
   type FileSystemId                                    = String
-  type FileSystemType                                  = String
   type FilterList                                      = js.Array[Filter]
   type FilterValue                                     = String
   type FinalMetricDataList                             = js.Array[MetricData]
   type FlowDefinitionArn                               = String
   type FlowDefinitionName                              = String
-  type FlowDefinitionStatus                            = String
   type FlowDefinitionSummaries                         = js.Array[FlowDefinitionSummary]
   type FlowDefinitionTaskAvailabilityLifetimeInSeconds = Int
   type FlowDefinitionTaskCount                         = Int
@@ -170,7 +130,6 @@ package object sagemaker {
   type FlowDefinitionTaskKeywords                      = js.Array[FlowDefinitionTaskKeyword]
   type FlowDefinitionTaskTimeLimitInSeconds            = Int
   type FlowDefinitionTaskTitle                         = String
-  type Framework                                       = String
   type GenerateCandidateDefinitionsOnly                = Boolean
   type GitConfigUrl                                    = String
   type HookParameters                                  = js.Dictionary[ConfigValue]
@@ -178,31 +137,23 @@ package object sagemaker {
   type HumanTaskUiArn                                  = String
   type HumanTaskUiName                                 = String
   type HumanTaskUiSummaries                            = js.Array[HumanTaskUiSummary]
-  type HyperParameterScalingType                       = String
   type HyperParameterSpecifications                    = js.Array[HyperParameterSpecification]
   type HyperParameterTrainingJobDefinitionName         = String
   type HyperParameterTrainingJobDefinitions            = js.Array[HyperParameterTrainingJobDefinition]
   type HyperParameterTrainingJobSummaries              = js.Array[HyperParameterTrainingJobSummary]
   type HyperParameterTuningJobArn                      = String
   type HyperParameterTuningJobName                     = String
-  type HyperParameterTuningJobObjectiveType            = String
   type HyperParameterTuningJobObjectives               = js.Array[HyperParameterTuningJobObjective]
-  type HyperParameterTuningJobSortByOptions            = String
-  type HyperParameterTuningJobStatus                   = String
-  type HyperParameterTuningJobStrategyType             = String
   type HyperParameterTuningJobSummaries                = js.Array[HyperParameterTuningJobSummary]
-  type HyperParameterTuningJobWarmStartType            = String
   type HyperParameters                                 = js.Dictionary[ParameterValue]
   type Image                                           = String
   type ImageDigest                                     = String
   type ImageUri                                        = String
   type InputDataConfig                                 = js.Array[Channel]
   type InputModes                                      = js.Array[TrainingInputMode]
-  type InstanceType                                    = String
   type IntegerParameterRanges                          = js.Array[IntegerParameterRange]
   type JobReferenceCode                                = String
   type JobReferenceCodeContains                        = String
-  type JoinSource                                      = String
   type JsonContentType                                 = String
   type JsonContentTypes                                = js.Array[JsonContentType]
   type JsonPath                                        = String
@@ -213,15 +164,11 @@ package object sagemaker {
   type LabelingJobArn                                  = String
   type LabelingJobForWorkteamSummaryList               = js.Array[LabelingJobForWorkteamSummary]
   type LabelingJobName                                 = String
-  type LabelingJobStatus                               = String
   type LabelingJobSummaryList                          = js.Array[LabelingJobSummary]
   type LambdaFunctionArn                               = String
   type LastModifiedTime                                = js.Date
-  type ListCompilationJobsSortBy                       = String
-  type ListLabelingJobsForWorkteamSortByOptions        = String
   type ListTagsMaxResults                              = Int
   type ListTrialComponentKey256                        = js.Array[TrialComponentKey256]
-  type ListWorkteamsSortByOptions                      = String
   type MaxAutoMLJobRuntimeInSeconds                    = Int
   type MaxCandidates                                   = Int
   type MaxConcurrentTaskCount                          = Int
@@ -246,16 +193,12 @@ package object sagemaker {
   type ModelNameContains                               = String
   type ModelPackageArn                                 = String
   type ModelPackageContainerDefinitionList             = js.Array[ModelPackageContainerDefinition]
-  type ModelPackageSortBy                              = String
-  type ModelPackageStatus                              = String
   type ModelPackageStatusItemList                      = js.Array[ModelPackageStatusItem]
   type ModelPackageSummaryList                         = js.Array[ModelPackageSummary]
   type ModelPackageValidationProfiles                  = js.Array[ModelPackageValidationProfile]
-  type ModelSortKey                                    = String
   type ModelSummaryList                                = js.Array[ModelSummary]
   type MonitoringContainerArguments                    = js.Array[ContainerArgument]
   type MonitoringEnvironmentMap                        = js.Dictionary[ProcessingEnvironmentValue]
-  type MonitoringExecutionSortKey                      = String
   type MonitoringExecutionSummaryList                  = js.Array[MonitoringExecutionSummary]
   type MonitoringInputs                                = js.Array[MonitoringInput]
   type MonitoringMaxRuntimeInSeconds                   = Int
@@ -263,13 +206,11 @@ package object sagemaker {
   type MonitoringS3Uri                                 = String
   type MonitoringScheduleArn                           = String
   type MonitoringScheduleName                          = String
-  type MonitoringScheduleSortKey                       = String
   type MonitoringScheduleSummaryList                   = js.Array[MonitoringScheduleSummary]
   type NameContains                                    = String
   type NestedFiltersList                               = js.Array[NestedFilters]
   type NetworkInterfaceId                              = String
   type NextToken                                       = String
-  type NotebookInstanceAcceleratorType                 = String
   type NotebookInstanceAcceleratorTypes                = js.Array[NotebookInstanceAcceleratorType]
   type NotebookInstanceArn                             = String
   type NotebookInstanceLifecycleConfigArn              = String
@@ -277,89 +218,59 @@ package object sagemaker {
   type NotebookInstanceLifecycleConfigList             = js.Array[NotebookInstanceLifecycleHook]
   type NotebookInstanceLifecycleConfigName             = String
   type NotebookInstanceLifecycleConfigNameContains     = String
-  type NotebookInstanceLifecycleConfigSortKey          = String
-  type NotebookInstanceLifecycleConfigSortOrder        = String
   type NotebookInstanceLifecycleConfigSummaryList      = js.Array[NotebookInstanceLifecycleConfigSummary]
   type NotebookInstanceName                            = String
   type NotebookInstanceNameContains                    = String
-  type NotebookInstanceSortKey                         = String
-  type NotebookInstanceSortOrder                       = String
-  type NotebookInstanceStatus                          = String
   type NotebookInstanceSummaryList                     = js.Array[NotebookInstanceSummary]
   type NotebookInstanceUrl                             = String
   type NotebookInstanceVolumeSizeInGB                  = Int
-  type NotebookOutputOption                            = String
   type NotificationTopicArn                            = String
   type NumberOfHumanWorkersPerDataObject               = Int
-  type ObjectiveStatus                                 = String
   type ObjectiveStatusCounter                          = Int
-  type Operator                                        = String
   type OptionalDouble                                  = Double
   type OptionalInteger                                 = Int
   type OptionalVolumeSizeInGB                          = Int
-  type OrderKey                                        = String
   type PaginationToken                                 = String
   type ParameterKey                                    = String
   type ParameterName                                   = String
-  type ParameterType                                   = String
   type ParameterValue                                  = String
   type ParameterValues                                 = js.Array[ParameterValue]
   type ParentHyperParameterTuningJobs                  = js.Array[ParentHyperParameterTuningJob]
   type Parents                                         = js.Array[Parent]
   type PresignedDomainUrl                              = String
-  type ProblemType                                     = String
   type ProcessingEnvironmentKey                        = String
   type ProcessingEnvironmentMap                        = js.Dictionary[ProcessingEnvironmentValue]
   type ProcessingEnvironmentValue                      = String
   type ProcessingInputs                                = js.Array[ProcessingInput]
   type ProcessingInstanceCount                         = Int
-  type ProcessingInstanceType                          = String
   type ProcessingJobArn                                = String
   type ProcessingJobName                               = String
-  type ProcessingJobStatus                             = String
   type ProcessingJobSummaries                          = js.Array[ProcessingJobSummary]
   type ProcessingLocalPath                             = String
   type ProcessingMaxRuntimeInSeconds                   = Int
   type ProcessingOutputs                               = js.Array[ProcessingOutput]
-  type ProcessingS3CompressionType                     = String
-  type ProcessingS3DataDistributionType                = String
-  type ProcessingS3DataType                            = String
-  type ProcessingS3InputMode                           = String
-  type ProcessingS3UploadMode                          = String
   type ProcessingVolumeSizeInGB                        = Int
   type ProductId                                       = String
   type ProductListings                                 = js.Array[String]
-  type ProductionVariantAcceleratorType                = String
-  type ProductionVariantInstanceType                   = String
   type ProductionVariantList                           = js.Array[ProductionVariant]
   type ProductionVariantSummaryList                    = js.Array[ProductionVariantSummary]
   type PropertyNameHint                                = String
   type PropertyNameSuggestionList                      = js.Array[PropertyNameSuggestion]
   type RealtimeInferenceInstanceTypes                  = js.Array[ProductionVariantInstanceType]
-  type RecordWrapper                                   = String
   type RenderingErrorList                              = js.Array[RenderingError]
   type ResourceArn                                     = String
   type ResourceId                                      = String
   type ResourcePropertyName                            = String
-  type ResourceType                                    = String
   type ResponseMIMEType                                = String
   type ResponseMIMETypes                               = js.Array[ResponseMIMEType]
-  type RetentionType                                   = String
   type RoleArn                                         = String
-  type RootAccess                                      = String
   type RuleConfigurationName                           = String
-  type RuleEvaluationStatus                            = String
   type RuleParameters                                  = js.Dictionary[ConfigValue]
-  type S3DataDistribution                              = String
-  type S3DataType                                      = String
   type S3Uri                                           = String
   type SamplingPercentage                              = Int
   type ScheduleExpression                              = String
-  type ScheduleStatus                                  = String
   type SearchExpressionList                            = js.Array[SearchExpression]
   type SearchResultsList                               = js.Array[SearchRecord]
-  type SearchSortOrder                                 = String
-  type SecondaryStatus                                 = String
   type SecondaryStatusTransitions                      = js.Array[SecondaryStatusTransition]
   type SecretArn                                       = String
   type SecurityGroupId                                 = String
@@ -367,14 +278,8 @@ package object sagemaker {
   type Seed                                            = Double
   type SessionExpirationDurationInSeconds              = Int
   type SingleSignOnUserIdentifier                      = String
-  type SortBy                                          = String
-  type SortExperimentsBy                               = String
-  type SortOrder                                       = String
-  type SortTrialComponentsBy                           = String
-  type SortTrialsBy                                    = String
   type SourceAlgorithmList                             = js.Array[SourceAlgorithm]
   type SourceType                                      = String
-  type SplitType                                       = String
   type StatusDetails                                   = String
   type StatusMessage                                   = String
   type String1024                                      = String
@@ -390,7 +295,6 @@ package object sagemaker {
   type TagList                                         = js.Array[Tag]
   type TagValue                                        = String
   type TargetAttributeName                             = String
-  type TargetDevice                                    = String
   type TargetObjectiveMetricValue                      = Float
   type TaskAvailabilityLifetimeInSeconds               = Int
   type TaskCount                                       = Int
@@ -405,15 +309,10 @@ package object sagemaker {
   type TemplateUrl                                     = String
   type TenthFractionsOfACent                           = Int
   type Timestamp                                       = js.Date
-  type TrainingInputMode                               = String
   type TrainingInstanceCount                           = Int
-  type TrainingInstanceType                            = String
   type TrainingInstanceTypes                           = js.Array[TrainingInstanceType]
   type TrainingJobArn                                  = String
-  type TrainingJobEarlyStoppingType                    = String
   type TrainingJobName                                 = String
-  type TrainingJobSortByOptions                        = String
-  type TrainingJobStatus                               = String
   type TrainingJobStatusCounter                        = Int
   type TrainingJobSummaries                            = js.Array[TrainingJobSummary]
   type TrainingTimeInSeconds                           = Int
@@ -421,11 +320,9 @@ package object sagemaker {
   type TransformEnvironmentMap                         = js.Dictionary[TransformEnvironmentValue]
   type TransformEnvironmentValue                       = String
   type TransformInstanceCount                          = Int
-  type TransformInstanceType                           = String
   type TransformInstanceTypes                          = js.Array[TransformInstanceType]
   type TransformJobArn                                 = String
   type TransformJobName                                = String
-  type TransformJobStatus                              = String
   type TransformJobSummaries                           = js.Array[TransformJobSummary]
   type TrialArn                                        = String
   type TrialComponentArn                               = String
@@ -435,7 +332,6 @@ package object sagemaker {
   type TrialComponentKey64                             = String
   type TrialComponentMetricSummaries                   = js.Array[TrialComponentMetricSummary]
   type TrialComponentParameters                        = js.Dictionary[TrialComponentParameterValue]
-  type TrialComponentPrimaryStatus                     = String
   type TrialComponentSimpleSummaries                   = js.Array[TrialComponentSimpleSummary]
   type TrialComponentSourceArn                         = String
   type TrialComponentStatusMessage                     = String
@@ -446,8 +342,6 @@ package object sagemaker {
   type UserProfileArn                                  = String
   type UserProfileList                                 = js.Array[UserProfileDetails]
   type UserProfileName                                 = String
-  type UserProfileSortKey                              = String
-  type UserProfileStatus                               = String
   type VariantName                                     = String
   type VariantWeight                                   = Float
   type VolumeSizeInGB                                  = Int
@@ -987,10 +881,11 @@ package sagemaker {
       __obj.asInstanceOf[AddTagsOutput]
     }
   }
-
-  object AlgorithmSortByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait AlgorithmSortBy extends js.Any
+  object AlgorithmSortBy extends js.Object {
+    val Name         = "Name".asInstanceOf[AlgorithmSortBy]
+    val CreationTime = "CreationTime".asInstanceOf[AlgorithmSortBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime))
   }
@@ -1030,13 +925,14 @@ package sagemaker {
       __obj.asInstanceOf[AlgorithmSpecification]
     }
   }
-
-  object AlgorithmStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-    val Deleting   = "Deleting"
+  @js.native
+  sealed trait AlgorithmStatus extends js.Any
+  object AlgorithmStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[AlgorithmStatus]
+    val InProgress = "InProgress".asInstanceOf[AlgorithmStatus]
+    val Completed  = "Completed".asInstanceOf[AlgorithmStatus]
+    val Failed     = "Failed".asInstanceOf[AlgorithmStatus]
+    val Deleting   = "Deleting".asInstanceOf[AlgorithmStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Completed, Failed, Deleting))
   }
@@ -1229,40 +1125,41 @@ package sagemaker {
       __obj.asInstanceOf[AppDetails]
     }
   }
-
-  object AppInstanceTypeEnum {
-    val system             = "system"
-    val `ml.t3.micro`      = "ml.t3.micro"
-    val `ml.t3.small`      = "ml.t3.small"
-    val `ml.t3.medium`     = "ml.t3.medium"
-    val `ml.t3.large`      = "ml.t3.large"
-    val `ml.t3.xlarge`     = "ml.t3.xlarge"
-    val `ml.t3.2xlarge`    = "ml.t3.2xlarge"
-    val `ml.m5.large`      = "ml.m5.large"
-    val `ml.m5.xlarge`     = "ml.m5.xlarge"
-    val `ml.m5.2xlarge`    = "ml.m5.2xlarge"
-    val `ml.m5.4xlarge`    = "ml.m5.4xlarge"
-    val `ml.m5.8xlarge`    = "ml.m5.8xlarge"
-    val `ml.m5.12xlarge`   = "ml.m5.12xlarge"
-    val `ml.m5.16xlarge`   = "ml.m5.16xlarge"
-    val `ml.m5.24xlarge`   = "ml.m5.24xlarge"
-    val `ml.c5.large`      = "ml.c5.large"
-    val `ml.c5.xlarge`     = "ml.c5.xlarge"
-    val `ml.c5.2xlarge`    = "ml.c5.2xlarge"
-    val `ml.c5.4xlarge`    = "ml.c5.4xlarge"
-    val `ml.c5.9xlarge`    = "ml.c5.9xlarge"
-    val `ml.c5.12xlarge`   = "ml.c5.12xlarge"
-    val `ml.c5.18xlarge`   = "ml.c5.18xlarge"
-    val `ml.c5.24xlarge`   = "ml.c5.24xlarge"
-    val `ml.p3.2xlarge`    = "ml.p3.2xlarge"
-    val `ml.p3.8xlarge`    = "ml.p3.8xlarge"
-    val `ml.p3.16xlarge`   = "ml.p3.16xlarge"
-    val `ml.g4dn.xlarge`   = "ml.g4dn.xlarge"
-    val `ml.g4dn.2xlarge`  = "ml.g4dn.2xlarge"
-    val `ml.g4dn.4xlarge`  = "ml.g4dn.4xlarge"
-    val `ml.g4dn.8xlarge`  = "ml.g4dn.8xlarge"
-    val `ml.g4dn.12xlarge` = "ml.g4dn.12xlarge"
-    val `ml.g4dn.16xlarge` = "ml.g4dn.16xlarge"
+  @js.native
+  sealed trait AppInstanceType extends js.Any
+  object AppInstanceType extends js.Object {
+    val system             = "system".asInstanceOf[AppInstanceType]
+    val `ml.t3.micro`      = "ml.t3.micro".asInstanceOf[AppInstanceType]
+    val `ml.t3.small`      = "ml.t3.small".asInstanceOf[AppInstanceType]
+    val `ml.t3.medium`     = "ml.t3.medium".asInstanceOf[AppInstanceType]
+    val `ml.t3.large`      = "ml.t3.large".asInstanceOf[AppInstanceType]
+    val `ml.t3.xlarge`     = "ml.t3.xlarge".asInstanceOf[AppInstanceType]
+    val `ml.t3.2xlarge`    = "ml.t3.2xlarge".asInstanceOf[AppInstanceType]
+    val `ml.m5.large`      = "ml.m5.large".asInstanceOf[AppInstanceType]
+    val `ml.m5.xlarge`     = "ml.m5.xlarge".asInstanceOf[AppInstanceType]
+    val `ml.m5.2xlarge`    = "ml.m5.2xlarge".asInstanceOf[AppInstanceType]
+    val `ml.m5.4xlarge`    = "ml.m5.4xlarge".asInstanceOf[AppInstanceType]
+    val `ml.m5.8xlarge`    = "ml.m5.8xlarge".asInstanceOf[AppInstanceType]
+    val `ml.m5.12xlarge`   = "ml.m5.12xlarge".asInstanceOf[AppInstanceType]
+    val `ml.m5.16xlarge`   = "ml.m5.16xlarge".asInstanceOf[AppInstanceType]
+    val `ml.m5.24xlarge`   = "ml.m5.24xlarge".asInstanceOf[AppInstanceType]
+    val `ml.c5.large`      = "ml.c5.large".asInstanceOf[AppInstanceType]
+    val `ml.c5.xlarge`     = "ml.c5.xlarge".asInstanceOf[AppInstanceType]
+    val `ml.c5.2xlarge`    = "ml.c5.2xlarge".asInstanceOf[AppInstanceType]
+    val `ml.c5.4xlarge`    = "ml.c5.4xlarge".asInstanceOf[AppInstanceType]
+    val `ml.c5.9xlarge`    = "ml.c5.9xlarge".asInstanceOf[AppInstanceType]
+    val `ml.c5.12xlarge`   = "ml.c5.12xlarge".asInstanceOf[AppInstanceType]
+    val `ml.c5.18xlarge`   = "ml.c5.18xlarge".asInstanceOf[AppInstanceType]
+    val `ml.c5.24xlarge`   = "ml.c5.24xlarge".asInstanceOf[AppInstanceType]
+    val `ml.p3.2xlarge`    = "ml.p3.2xlarge".asInstanceOf[AppInstanceType]
+    val `ml.p3.8xlarge`    = "ml.p3.8xlarge".asInstanceOf[AppInstanceType]
+    val `ml.p3.16xlarge`   = "ml.p3.16xlarge".asInstanceOf[AppInstanceType]
+    val `ml.g4dn.xlarge`   = "ml.g4dn.xlarge".asInstanceOf[AppInstanceType]
+    val `ml.g4dn.2xlarge`  = "ml.g4dn.2xlarge".asInstanceOf[AppInstanceType]
+    val `ml.g4dn.4xlarge`  = "ml.g4dn.4xlarge".asInstanceOf[AppInstanceType]
+    val `ml.g4dn.8xlarge`  = "ml.g4dn.8xlarge".asInstanceOf[AppInstanceType]
+    val `ml.g4dn.12xlarge` = "ml.g4dn.12xlarge".asInstanceOf[AppInstanceType]
+    val `ml.g4dn.16xlarge` = "ml.g4dn.16xlarge".asInstanceOf[AppInstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1301,9 +1198,10 @@ package sagemaker {
       )
     )
   }
-
-  object AppSortKeyEnum {
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait AppSortKey extends js.Any
+  object AppSortKey extends js.Object {
+    val CreationTime = "CreationTime".asInstanceOf[AppSortKey]
 
     val values = js.Object.freeze(js.Array(CreationTime))
   }
@@ -1334,28 +1232,31 @@ package sagemaker {
       __obj.asInstanceOf[AppSpecification]
     }
   }
-
-  object AppStatusEnum {
-    val Deleted   = "Deleted"
-    val Deleting  = "Deleting"
-    val Failed    = "Failed"
-    val InService = "InService"
-    val Pending   = "Pending"
+  @js.native
+  sealed trait AppStatus extends js.Any
+  object AppStatus extends js.Object {
+    val Deleted   = "Deleted".asInstanceOf[AppStatus]
+    val Deleting  = "Deleting".asInstanceOf[AppStatus]
+    val Failed    = "Failed".asInstanceOf[AppStatus]
+    val InService = "InService".asInstanceOf[AppStatus]
+    val Pending   = "Pending".asInstanceOf[AppStatus]
 
     val values = js.Object.freeze(js.Array(Deleted, Deleting, Failed, InService, Pending))
   }
-
-  object AppTypeEnum {
-    val JupyterServer = "JupyterServer"
-    val KernelGateway = "KernelGateway"
-    val TensorBoard   = "TensorBoard"
+  @js.native
+  sealed trait AppType extends js.Any
+  object AppType extends js.Object {
+    val JupyterServer = "JupyterServer".asInstanceOf[AppType]
+    val KernelGateway = "KernelGateway".asInstanceOf[AppType]
+    val TensorBoard   = "TensorBoard".asInstanceOf[AppType]
 
     val values = js.Object.freeze(js.Array(JupyterServer, KernelGateway, TensorBoard))
   }
-
-  object AssemblyTypeEnum {
-    val None = "None"
-    val Line = "Line"
+  @js.native
+  sealed trait AssemblyType extends js.Any
+  object AssemblyType extends js.Object {
+    val None = "None".asInstanceOf[AssemblyType]
+    val Line = "Line".asInstanceOf[AssemblyType]
 
     val values = js.Object.freeze(js.Array(None, Line))
   }
@@ -1399,10 +1300,11 @@ package sagemaker {
       __obj.asInstanceOf[AssociateTrialComponentResponse]
     }
   }
-
-  object AuthModeEnum {
-    val SSO = "SSO"
-    val IAM = "IAM"
+  @js.native
+  sealed trait AuthMode extends js.Any
+  object AuthMode extends js.Object {
+    val SSO = "SSO".asInstanceOf[AuthMode]
+    val IAM = "IAM".asInstanceOf[AuthMode]
 
     val values = js.Object.freeze(js.Array(SSO, IAM))
   }
@@ -1656,25 +1558,27 @@ package sagemaker {
       __obj.asInstanceOf[AutoMLJobObjective]
     }
   }
-
-  object AutoMLJobObjectiveTypeEnum {
-    val Maximize = "Maximize"
-    val Minimize = "Minimize"
+  @js.native
+  sealed trait AutoMLJobObjectiveType extends js.Any
+  object AutoMLJobObjectiveType extends js.Object {
+    val Maximize = "Maximize".asInstanceOf[AutoMLJobObjectiveType]
+    val Minimize = "Minimize".asInstanceOf[AutoMLJobObjectiveType]
 
     val values = js.Object.freeze(js.Array(Maximize, Minimize))
   }
-
-  object AutoMLJobSecondaryStatusEnum {
-    val Starting                      = "Starting"
-    val AnalyzingData                 = "AnalyzingData"
-    val FeatureEngineering            = "FeatureEngineering"
-    val ModelTuning                   = "ModelTuning"
-    val MaxCandidatesReached          = "MaxCandidatesReached"
-    val Failed                        = "Failed"
-    val Stopped                       = "Stopped"
-    val MaxAutoMLJobRuntimeReached    = "MaxAutoMLJobRuntimeReached"
-    val Stopping                      = "Stopping"
-    val CandidateDefinitionsGenerated = "CandidateDefinitionsGenerated"
+  @js.native
+  sealed trait AutoMLJobSecondaryStatus extends js.Any
+  object AutoMLJobSecondaryStatus extends js.Object {
+    val Starting                      = "Starting".asInstanceOf[AutoMLJobSecondaryStatus]
+    val AnalyzingData                 = "AnalyzingData".asInstanceOf[AutoMLJobSecondaryStatus]
+    val FeatureEngineering            = "FeatureEngineering".asInstanceOf[AutoMLJobSecondaryStatus]
+    val ModelTuning                   = "ModelTuning".asInstanceOf[AutoMLJobSecondaryStatus]
+    val MaxCandidatesReached          = "MaxCandidatesReached".asInstanceOf[AutoMLJobSecondaryStatus]
+    val Failed                        = "Failed".asInstanceOf[AutoMLJobSecondaryStatus]
+    val Stopped                       = "Stopped".asInstanceOf[AutoMLJobSecondaryStatus]
+    val MaxAutoMLJobRuntimeReached    = "MaxAutoMLJobRuntimeReached".asInstanceOf[AutoMLJobSecondaryStatus]
+    val Stopping                      = "Stopping".asInstanceOf[AutoMLJobSecondaryStatus]
+    val CandidateDefinitionsGenerated = "CandidateDefinitionsGenerated".asInstanceOf[AutoMLJobSecondaryStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1691,13 +1595,14 @@ package sagemaker {
       )
     )
   }
-
-  object AutoMLJobStatusEnum {
-    val Completed  = "Completed"
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Stopped    = "Stopped"
-    val Stopping   = "Stopping"
+  @js.native
+  sealed trait AutoMLJobStatus extends js.Any
+  object AutoMLJobStatus extends js.Object {
+    val Completed  = "Completed".asInstanceOf[AutoMLJobStatus]
+    val InProgress = "InProgress".asInstanceOf[AutoMLJobStatus]
+    val Failed     = "Failed".asInstanceOf[AutoMLJobStatus]
+    val Stopped    = "Stopped".asInstanceOf[AutoMLJobStatus]
+    val Stopping   = "Stopping".asInstanceOf[AutoMLJobStatus]
 
     val values = js.Object.freeze(js.Array(Completed, InProgress, Failed, Stopped, Stopping))
   }
@@ -1743,12 +1648,13 @@ package sagemaker {
       __obj.asInstanceOf[AutoMLJobSummary]
     }
   }
-
-  object AutoMLMetricEnumEnum {
-    val Accuracy = "Accuracy"
-    val MSE      = "MSE"
-    val F1       = "F1"
-    val F1macro  = "F1macro"
+  @js.native
+  sealed trait AutoMLMetricEnum extends js.Any
+  object AutoMLMetricEnum extends js.Object {
+    val Accuracy = "Accuracy".asInstanceOf[AutoMLMetricEnum]
+    val MSE      = "MSE".asInstanceOf[AutoMLMetricEnum]
+    val F1       = "F1".asInstanceOf[AutoMLMetricEnum]
+    val F1macro  = "F1macro".asInstanceOf[AutoMLMetricEnum]
 
     val values = js.Object.freeze(js.Array(Accuracy, MSE, F1, F1macro))
   }
@@ -1800,10 +1706,11 @@ package sagemaker {
       __obj.asInstanceOf[AutoMLS3DataSource]
     }
   }
-
-  object AutoMLS3DataTypeEnum {
-    val ManifestFile = "ManifestFile"
-    val S3Prefix     = "S3Prefix"
+  @js.native
+  sealed trait AutoMLS3DataType extends js.Any
+  object AutoMLS3DataType extends js.Object {
+    val ManifestFile = "ManifestFile".asInstanceOf[AutoMLS3DataType]
+    val S3Prefix     = "S3Prefix".asInstanceOf[AutoMLS3DataType]
 
     val values = js.Object.freeze(js.Array(ManifestFile, S3Prefix))
   }
@@ -1834,67 +1741,77 @@ package sagemaker {
       __obj.asInstanceOf[AutoMLSecurityConfig]
     }
   }
-
-  object AutoMLSortByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
-    val Status       = "Status"
+  @js.native
+  sealed trait AutoMLSortBy extends js.Any
+  object AutoMLSortBy extends js.Object {
+    val Name         = "Name".asInstanceOf[AutoMLSortBy]
+    val CreationTime = "CreationTime".asInstanceOf[AutoMLSortBy]
+    val Status       = "Status".asInstanceOf[AutoMLSortBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, Status))
   }
-
-  object AutoMLSortOrderEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait AutoMLSortOrder extends js.Any
+  object AutoMLSortOrder extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[AutoMLSortOrder]
+    val Descending = "Descending".asInstanceOf[AutoMLSortOrder]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }
-
-  object AwsManagedHumanLoopRequestSourceEnum {
-    val `AWS/Rekognition/DetectModerationLabels/Image/V3` = "AWS/Rekognition/DetectModerationLabels/Image/V3"
-    val `AWS/Textract/AnalyzeDocument/Forms/V1`           = "AWS/Textract/AnalyzeDocument/Forms/V1"
+  @js.native
+  sealed trait AwsManagedHumanLoopRequestSource extends js.Any
+  object AwsManagedHumanLoopRequestSource extends js.Object {
+    val `AWS/Rekognition/DetectModerationLabels/Image/V3` =
+      "AWS/Rekognition/DetectModerationLabels/Image/V3".asInstanceOf[AwsManagedHumanLoopRequestSource]
+    val `AWS/Textract/AnalyzeDocument/Forms/V1` =
+      "AWS/Textract/AnalyzeDocument/Forms/V1".asInstanceOf[AwsManagedHumanLoopRequestSource]
 
     val values = js.Object.freeze(
       js.Array(`AWS/Rekognition/DetectModerationLabels/Image/V3`, `AWS/Textract/AnalyzeDocument/Forms/V1`)
     )
   }
-
-  object BatchStrategyEnum {
-    val MultiRecord  = "MultiRecord"
-    val SingleRecord = "SingleRecord"
+  @js.native
+  sealed trait BatchStrategy extends js.Any
+  object BatchStrategy extends js.Object {
+    val MultiRecord  = "MultiRecord".asInstanceOf[BatchStrategy]
+    val SingleRecord = "SingleRecord".asInstanceOf[BatchStrategy]
 
     val values = js.Object.freeze(js.Array(MultiRecord, SingleRecord))
   }
-
-  object BooleanOperatorEnum {
-    val And = "And"
-    val Or  = "Or"
+  @js.native
+  sealed trait BooleanOperator extends js.Any
+  object BooleanOperator extends js.Object {
+    val And = "And".asInstanceOf[BooleanOperator]
+    val Or  = "Or".asInstanceOf[BooleanOperator]
 
     val values = js.Object.freeze(js.Array(And, Or))
   }
-
-  object CandidateSortByEnum {
-    val CreationTime              = "CreationTime"
-    val Status                    = "Status"
-    val FinalObjectiveMetricValue = "FinalObjectiveMetricValue"
+  @js.native
+  sealed trait CandidateSortBy extends js.Any
+  object CandidateSortBy extends js.Object {
+    val CreationTime              = "CreationTime".asInstanceOf[CandidateSortBy]
+    val Status                    = "Status".asInstanceOf[CandidateSortBy]
+    val FinalObjectiveMetricValue = "FinalObjectiveMetricValue".asInstanceOf[CandidateSortBy]
 
     val values = js.Object.freeze(js.Array(CreationTime, Status, FinalObjectiveMetricValue))
   }
-
-  object CandidateStatusEnum {
-    val Completed  = "Completed"
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Stopped    = "Stopped"
-    val Stopping   = "Stopping"
+  @js.native
+  sealed trait CandidateStatus extends js.Any
+  object CandidateStatus extends js.Object {
+    val Completed  = "Completed".asInstanceOf[CandidateStatus]
+    val InProgress = "InProgress".asInstanceOf[CandidateStatus]
+    val Failed     = "Failed".asInstanceOf[CandidateStatus]
+    val Stopped    = "Stopped".asInstanceOf[CandidateStatus]
+    val Stopping   = "Stopping".asInstanceOf[CandidateStatus]
 
     val values = js.Object.freeze(js.Array(Completed, InProgress, Failed, Stopped, Stopping))
   }
-
-  object CandidateStepTypeEnum {
-    val `AWS::SageMaker::TrainingJob`   = "AWS::SageMaker::TrainingJob"
-    val `AWS::SageMaker::TransformJob`  = "AWS::SageMaker::TransformJob"
-    val `AWS::SageMaker::ProcessingJob` = "AWS::SageMaker::ProcessingJob"
+  @js.native
+  sealed trait CandidateStepType extends js.Any
+  object CandidateStepType extends js.Object {
+    val `AWS::SageMaker::TrainingJob`   = "AWS::SageMaker::TrainingJob".asInstanceOf[CandidateStepType]
+    val `AWS::SageMaker::TransformJob`  = "AWS::SageMaker::TransformJob".asInstanceOf[CandidateStepType]
+    val `AWS::SageMaker::ProcessingJob` = "AWS::SageMaker::ProcessingJob".asInstanceOf[CandidateStepType]
 
     val values = js.Object.freeze(
       js.Array(`AWS::SageMaker::TrainingJob`, `AWS::SageMaker::TransformJob`, `AWS::SageMaker::ProcessingJob`)
@@ -1922,10 +1839,11 @@ package sagemaker {
       __obj.asInstanceOf[CaptureContentTypeHeader]
     }
   }
-
-  object CaptureModeEnum {
-    val Input  = "Input"
-    val Output = "Output"
+  @js.native
+  sealed trait CaptureMode extends js.Any
+  object CaptureMode extends js.Object {
+    val Input  = "Input".asInstanceOf[CaptureMode]
+    val Output = "Output".asInstanceOf[CaptureMode]
 
     val values = js.Object.freeze(js.Array(Input, Output))
   }
@@ -1950,10 +1868,11 @@ package sagemaker {
       __obj.asInstanceOf[CaptureOption]
     }
   }
-
-  object CaptureStatusEnum {
-    val Started = "Started"
-    val Stopped = "Stopped"
+  @js.native
+  sealed trait CaptureStatus extends js.Any
+  object CaptureStatus extends js.Object {
+    val Started = "Started".asInstanceOf[CaptureStatus]
+    val Stopped = "Stopped".asInstanceOf[CaptureStatus]
 
     val values = js.Object.freeze(js.Array(Started, Stopped))
   }
@@ -2103,18 +2022,20 @@ package sagemaker {
       __obj.asInstanceOf[CheckpointConfig]
     }
   }
-
-  object CodeRepositorySortByEnum {
-    val Name             = "Name"
-    val CreationTime     = "CreationTime"
-    val LastModifiedTime = "LastModifiedTime"
+  @js.native
+  sealed trait CodeRepositorySortBy extends js.Any
+  object CodeRepositorySortBy extends js.Object {
+    val Name             = "Name".asInstanceOf[CodeRepositorySortBy]
+    val CreationTime     = "CreationTime".asInstanceOf[CodeRepositorySortBy]
+    val LastModifiedTime = "LastModifiedTime".asInstanceOf[CodeRepositorySortBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, LastModifiedTime))
   }
-
-  object CodeRepositorySortOrderEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait CodeRepositorySortOrder extends js.Any
+  object CodeRepositorySortOrder extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[CodeRepositorySortOrder]
+    val Descending = "Descending".asInstanceOf[CodeRepositorySortOrder]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }
@@ -2200,14 +2121,15 @@ package sagemaker {
       __obj.asInstanceOf[CollectionConfiguration]
     }
   }
-
-  object CompilationJobStatusEnum {
-    val INPROGRESS = "INPROGRESS"
-    val COMPLETED  = "COMPLETED"
-    val FAILED     = "FAILED"
-    val STARTING   = "STARTING"
-    val STOPPING   = "STOPPING"
-    val STOPPED    = "STOPPED"
+  @js.native
+  sealed trait CompilationJobStatus extends js.Any
+  object CompilationJobStatus extends js.Object {
+    val INPROGRESS = "INPROGRESS".asInstanceOf[CompilationJobStatus]
+    val COMPLETED  = "COMPLETED".asInstanceOf[CompilationJobStatus]
+    val FAILED     = "FAILED".asInstanceOf[CompilationJobStatus]
+    val STARTING   = "STARTING".asInstanceOf[CompilationJobStatus]
+    val STOPPING   = "STOPPING".asInstanceOf[CompilationJobStatus]
+    val STOPPED    = "STOPPED".asInstanceOf[CompilationJobStatus]
 
     val values = js.Object.freeze(js.Array(INPROGRESS, COMPLETED, FAILED, STARTING, STOPPING, STOPPED))
   }
@@ -2253,10 +2175,11 @@ package sagemaker {
       __obj.asInstanceOf[CompilationJobSummary]
     }
   }
-
-  object CompressionTypeEnum {
-    val None = "None"
-    val Gzip = "Gzip"
+  @js.native
+  sealed trait CompressionType extends js.Any
+  object CompressionType extends js.Object {
+    val None = "None".asInstanceOf[CompressionType]
+    val Gzip = "Gzip".asInstanceOf[CompressionType]
 
     val values = js.Object.freeze(js.Array(None, Gzip))
   }
@@ -2294,17 +2217,20 @@ package sagemaker {
       __obj.asInstanceOf[ContainerDefinition]
     }
   }
-
-  object ContainerModeEnum {
-    val SingleModel = "SingleModel"
-    val MultiModel  = "MultiModel"
+  @js.native
+  sealed trait ContainerMode extends js.Any
+  object ContainerMode extends js.Object {
+    val SingleModel = "SingleModel".asInstanceOf[ContainerMode]
+    val MultiModel  = "MultiModel".asInstanceOf[ContainerMode]
 
     val values = js.Object.freeze(js.Array(SingleModel, MultiModel))
   }
-
-  object ContentClassifierEnum {
-    val FreeOfPersonallyIdentifiableInformation = "FreeOfPersonallyIdentifiableInformation"
-    val FreeOfAdultContent                      = "FreeOfAdultContent"
+  @js.native
+  sealed trait ContentClassifier extends js.Any
+  object ContentClassifier extends js.Object {
+    val FreeOfPersonallyIdentifiableInformation =
+      "FreeOfPersonallyIdentifiableInformation".asInstanceOf[ContentClassifier]
+    val FreeOfAdultContent = "FreeOfAdultContent".asInstanceOf[ContentClassifier]
 
     val values = js.Object.freeze(js.Array(FreeOfPersonallyIdentifiableInformation, FreeOfAdultContent))
   }
@@ -6335,28 +6261,31 @@ package sagemaker {
       __obj.asInstanceOf[DesiredWeightAndCapacity]
     }
   }
-
-  object DetailedAlgorithmStatusEnum {
-    val NotStarted = "NotStarted"
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-
-    val values = js.Object.freeze(js.Array(NotStarted, InProgress, Completed, Failed))
-  }
-
-  object DetailedModelPackageStatusEnum {
-    val NotStarted = "NotStarted"
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait DetailedAlgorithmStatus extends js.Any
+  object DetailedAlgorithmStatus extends js.Object {
+    val NotStarted = "NotStarted".asInstanceOf[DetailedAlgorithmStatus]
+    val InProgress = "InProgress".asInstanceOf[DetailedAlgorithmStatus]
+    val Completed  = "Completed".asInstanceOf[DetailedAlgorithmStatus]
+    val Failed     = "Failed".asInstanceOf[DetailedAlgorithmStatus]
 
     val values = js.Object.freeze(js.Array(NotStarted, InProgress, Completed, Failed))
   }
+  @js.native
+  sealed trait DetailedModelPackageStatus extends js.Any
+  object DetailedModelPackageStatus extends js.Object {
+    val NotStarted = "NotStarted".asInstanceOf[DetailedModelPackageStatus]
+    val InProgress = "InProgress".asInstanceOf[DetailedModelPackageStatus]
+    val Completed  = "Completed".asInstanceOf[DetailedModelPackageStatus]
+    val Failed     = "Failed".asInstanceOf[DetailedModelPackageStatus]
 
-  object DirectInternetAccessEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+    val values = js.Object.freeze(js.Array(NotStarted, InProgress, Completed, Failed))
+  }
+  @js.native
+  sealed trait DirectInternetAccess extends js.Any
+  object DirectInternetAccess extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[DirectInternetAccess]
+    val Disabled = "Disabled".asInstanceOf[DirectInternetAccess]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
@@ -6437,19 +6366,21 @@ package sagemaker {
       __obj.asInstanceOf[DomainDetails]
     }
   }
-
-  object DomainStatusEnum {
-    val Deleting  = "Deleting"
-    val Failed    = "Failed"
-    val InService = "InService"
-    val Pending   = "Pending"
+  @js.native
+  sealed trait DomainStatus extends js.Any
+  object DomainStatus extends js.Object {
+    val Deleting  = "Deleting".asInstanceOf[DomainStatus]
+    val Failed    = "Failed".asInstanceOf[DomainStatus]
+    val InService = "InService".asInstanceOf[DomainStatus]
+    val Pending   = "Pending".asInstanceOf[DomainStatus]
 
     val values = js.Object.freeze(js.Array(Deleting, Failed, InService, Pending))
   }
-
-  object EndpointConfigSortKeyEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait EndpointConfigSortKey extends js.Any
+  object EndpointConfigSortKey extends js.Object {
+    val Name         = "Name".asInstanceOf[EndpointConfigSortKey]
+    val CreationTime = "CreationTime".asInstanceOf[EndpointConfigSortKey]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime))
   }
@@ -6510,24 +6441,26 @@ package sagemaker {
       __obj.asInstanceOf[EndpointInput]
     }
   }
-
-  object EndpointSortKeyEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
-    val Status       = "Status"
+  @js.native
+  sealed trait EndpointSortKey extends js.Any
+  object EndpointSortKey extends js.Object {
+    val Name         = "Name".asInstanceOf[EndpointSortKey]
+    val CreationTime = "CreationTime".asInstanceOf[EndpointSortKey]
+    val Status       = "Status".asInstanceOf[EndpointSortKey]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, Status))
   }
-
-  object EndpointStatusEnum {
-    val OutOfService   = "OutOfService"
-    val Creating       = "Creating"
-    val Updating       = "Updating"
-    val SystemUpdating = "SystemUpdating"
-    val RollingBack    = "RollingBack"
-    val InService      = "InService"
-    val Deleting       = "Deleting"
-    val Failed         = "Failed"
+  @js.native
+  sealed trait EndpointStatus extends js.Any
+  object EndpointStatus extends js.Object {
+    val OutOfService   = "OutOfService".asInstanceOf[EndpointStatus]
+    val Creating       = "Creating".asInstanceOf[EndpointStatus]
+    val Updating       = "Updating".asInstanceOf[EndpointStatus]
+    val SystemUpdating = "SystemUpdating".asInstanceOf[EndpointStatus]
+    val RollingBack    = "RollingBack".asInstanceOf[EndpointStatus]
+    val InService      = "InService".asInstanceOf[EndpointStatus]
+    val Deleting       = "Deleting".asInstanceOf[EndpointStatus]
+    val Failed         = "Failed".asInstanceOf[EndpointStatus]
 
     val values = js.Object.freeze(
       js.Array(OutOfService, Creating, Updating, SystemUpdating, RollingBack, InService, Deleting, Failed)
@@ -6566,15 +6499,16 @@ package sagemaker {
       __obj.asInstanceOf[EndpointSummary]
     }
   }
-
-  object ExecutionStatusEnum {
-    val Pending                 = "Pending"
-    val Completed               = "Completed"
-    val CompletedWithViolations = "CompletedWithViolations"
-    val InProgress              = "InProgress"
-    val Failed                  = "Failed"
-    val Stopping                = "Stopping"
-    val Stopped                 = "Stopped"
+  @js.native
+  sealed trait ExecutionStatus extends js.Any
+  object ExecutionStatus extends js.Object {
+    val Pending                 = "Pending".asInstanceOf[ExecutionStatus]
+    val Completed               = "Completed".asInstanceOf[ExecutionStatus]
+    val CompletedWithViolations = "CompletedWithViolations".asInstanceOf[ExecutionStatus]
+    val InProgress              = "InProgress".asInstanceOf[ExecutionStatus]
+    val Failed                  = "Failed".asInstanceOf[ExecutionStatus]
+    val Stopping                = "Stopping".asInstanceOf[ExecutionStatus]
+    val Stopped                 = "Stopped".asInstanceOf[ExecutionStatus]
 
     val values =
       js.Object.freeze(js.Array(Pending, Completed, CompletedWithViolations, InProgress, Failed, Stopping, Stopped))
@@ -6710,10 +6644,11 @@ package sagemaker {
       __obj.asInstanceOf[ExperimentSummary]
     }
   }
-
-  object FileSystemAccessModeEnum {
-    val rw = "rw"
-    val ro = "ro"
+  @js.native
+  sealed trait FileSystemAccessMode extends js.Any
+  object FileSystemAccessMode extends js.Object {
+    val rw = "rw".asInstanceOf[FileSystemAccessMode]
+    val ro = "ro".asInstanceOf[FileSystemAccessMode]
 
     val values = js.Object.freeze(js.Array(rw, ro))
   }
@@ -6747,10 +6682,11 @@ package sagemaker {
       __obj.asInstanceOf[FileSystemDataSource]
     }
   }
-
-  object FileSystemTypeEnum {
-    val EFS       = "EFS"
-    val FSxLustre = "FSxLustre"
+  @js.native
+  sealed trait FileSystemType extends js.Any
+  object FileSystemType extends js.Object {
+    val EFS       = "EFS".asInstanceOf[FileSystemType]
+    val FSxLustre = "FSxLustre".asInstanceOf[FileSystemType]
 
     val values = js.Object.freeze(js.Array(EFS, FSxLustre))
   }
@@ -6876,13 +6812,14 @@ package sagemaker {
       __obj.asInstanceOf[FlowDefinitionOutputConfig]
     }
   }
-
-  object FlowDefinitionStatusEnum {
-    val Initializing = "Initializing"
-    val Active       = "Active"
-    val Failed       = "Failed"
-    val Deleting     = "Deleting"
-    val Deleted      = "Deleted"
+  @js.native
+  sealed trait FlowDefinitionStatus extends js.Any
+  object FlowDefinitionStatus extends js.Object {
+    val Initializing = "Initializing".asInstanceOf[FlowDefinitionStatus]
+    val Active       = "Active".asInstanceOf[FlowDefinitionStatus]
+    val Failed       = "Failed".asInstanceOf[FlowDefinitionStatus]
+    val Deleting     = "Deleting".asInstanceOf[FlowDefinitionStatus]
+    val Deleted      = "Deleted".asInstanceOf[FlowDefinitionStatus]
 
     val values = js.Object.freeze(js.Array(Initializing, Active, Failed, Deleting, Deleted))
   }
@@ -6919,14 +6856,15 @@ package sagemaker {
       __obj.asInstanceOf[FlowDefinitionSummary]
     }
   }
-
-  object FrameworkEnum {
-    val TENSORFLOW = "TENSORFLOW"
-    val KERAS      = "KERAS"
-    val MXNET      = "MXNET"
-    val ONNX       = "ONNX"
-    val PYTORCH    = "PYTORCH"
-    val XGBOOST    = "XGBOOST"
+  @js.native
+  sealed trait Framework extends js.Any
+  object Framework extends js.Object {
+    val TENSORFLOW = "TENSORFLOW".asInstanceOf[Framework]
+    val KERAS      = "KERAS".asInstanceOf[Framework]
+    val MXNET      = "MXNET".asInstanceOf[Framework]
+    val ONNX       = "ONNX".asInstanceOf[Framework]
+    val PYTORCH    = "PYTORCH".asInstanceOf[Framework]
+    val XGBOOST    = "XGBOOST".asInstanceOf[Framework]
 
     val values = js.Object.freeze(js.Array(TENSORFLOW, KERAS, MXNET, ONNX, PYTORCH, XGBOOST))
   }
@@ -7239,12 +7177,13 @@ package sagemaker {
       __obj.asInstanceOf[HyperParameterAlgorithmSpecification]
     }
   }
-
-  object HyperParameterScalingTypeEnum {
-    val Auto               = "Auto"
-    val Linear             = "Linear"
-    val Logarithmic        = "Logarithmic"
-    val ReverseLogarithmic = "ReverseLogarithmic"
+  @js.native
+  sealed trait HyperParameterScalingType extends js.Any
+  object HyperParameterScalingType extends js.Object {
+    val Auto               = "Auto".asInstanceOf[HyperParameterScalingType]
+    val Linear             = "Linear".asInstanceOf[HyperParameterScalingType]
+    val Logarithmic        = "Logarithmic".asInstanceOf[HyperParameterScalingType]
+    val ReverseLogarithmic = "ReverseLogarithmic".asInstanceOf[HyperParameterScalingType]
 
     val values = js.Object.freeze(js.Array(Auto, Linear, Logarithmic, ReverseLogarithmic))
   }
@@ -7479,28 +7418,31 @@ package sagemaker {
       __obj.asInstanceOf[HyperParameterTuningJobObjective]
     }
   }
-
-  object HyperParameterTuningJobObjectiveTypeEnum {
-    val Maximize = "Maximize"
-    val Minimize = "Minimize"
+  @js.native
+  sealed trait HyperParameterTuningJobObjectiveType extends js.Any
+  object HyperParameterTuningJobObjectiveType extends js.Object {
+    val Maximize = "Maximize".asInstanceOf[HyperParameterTuningJobObjectiveType]
+    val Minimize = "Minimize".asInstanceOf[HyperParameterTuningJobObjectiveType]
 
     val values = js.Object.freeze(js.Array(Maximize, Minimize))
   }
-
-  object HyperParameterTuningJobSortByOptionsEnum {
-    val Name         = "Name"
-    val Status       = "Status"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait HyperParameterTuningJobSortByOptions extends js.Any
+  object HyperParameterTuningJobSortByOptions extends js.Object {
+    val Name         = "Name".asInstanceOf[HyperParameterTuningJobSortByOptions]
+    val Status       = "Status".asInstanceOf[HyperParameterTuningJobSortByOptions]
+    val CreationTime = "CreationTime".asInstanceOf[HyperParameterTuningJobSortByOptions]
 
     val values = js.Object.freeze(js.Array(Name, Status, CreationTime))
   }
-
-  object HyperParameterTuningJobStatusEnum {
-    val Completed  = "Completed"
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Stopped    = "Stopped"
-    val Stopping   = "Stopping"
+  @js.native
+  sealed trait HyperParameterTuningJobStatus extends js.Any
+  object HyperParameterTuningJobStatus extends js.Object {
+    val Completed  = "Completed".asInstanceOf[HyperParameterTuningJobStatus]
+    val InProgress = "InProgress".asInstanceOf[HyperParameterTuningJobStatus]
+    val Failed     = "Failed".asInstanceOf[HyperParameterTuningJobStatus]
+    val Stopped    = "Stopped".asInstanceOf[HyperParameterTuningJobStatus]
+    val Stopping   = "Stopping".asInstanceOf[HyperParameterTuningJobStatus]
 
     val values = js.Object.freeze(js.Array(Completed, InProgress, Failed, Stopped, Stopping))
   }
@@ -7508,9 +7450,11 @@ package sagemaker {
   /**
     * The strategy hyperparameter tuning uses to find the best combination of hyperparameters for your model. Currently, the only supported value is <code>Bayesian</code>.
     */
-  object HyperParameterTuningJobStrategyTypeEnum {
-    val Bayesian = "Bayesian"
-    val Random   = "Random"
+  @js.native
+  sealed trait HyperParameterTuningJobStrategyType extends js.Any
+  object HyperParameterTuningJobStrategyType extends js.Object {
+    val Bayesian = "Bayesian".asInstanceOf[HyperParameterTuningJobStrategyType]
+    val Random   = "Random".asInstanceOf[HyperParameterTuningJobStrategyType]
 
     val values = js.Object.freeze(js.Array(Bayesian, Random))
   }
@@ -7591,10 +7535,11 @@ package sagemaker {
       __obj.asInstanceOf[HyperParameterTuningJobWarmStartConfig]
     }
   }
-
-  object HyperParameterTuningJobWarmStartTypeEnum {
-    val IdenticalDataAndAlgorithm = "IdenticalDataAndAlgorithm"
-    val TransferLearning          = "TransferLearning"
+  @js.native
+  sealed trait HyperParameterTuningJobWarmStartType extends js.Any
+  object HyperParameterTuningJobWarmStartType extends js.Object {
+    val IdenticalDataAndAlgorithm = "IdenticalDataAndAlgorithm".asInstanceOf[HyperParameterTuningJobWarmStartType]
+    val TransferLearning          = "TransferLearning".asInstanceOf[HyperParameterTuningJobWarmStartType]
 
     val values = js.Object.freeze(js.Array(IdenticalDataAndAlgorithm, TransferLearning))
   }
@@ -7658,46 +7603,47 @@ package sagemaker {
       __obj.asInstanceOf[InputConfig]
     }
   }
-
-  object InstanceTypeEnum {
-    val `ml.t2.medium`    = "ml.t2.medium"
-    val `ml.t2.large`     = "ml.t2.large"
-    val `ml.t2.xlarge`    = "ml.t2.xlarge"
-    val `ml.t2.2xlarge`   = "ml.t2.2xlarge"
-    val `ml.t3.medium`    = "ml.t3.medium"
-    val `ml.t3.large`     = "ml.t3.large"
-    val `ml.t3.xlarge`    = "ml.t3.xlarge"
-    val `ml.t3.2xlarge`   = "ml.t3.2xlarge"
-    val `ml.m4.xlarge`    = "ml.m4.xlarge"
-    val `ml.m4.2xlarge`   = "ml.m4.2xlarge"
-    val `ml.m4.4xlarge`   = "ml.m4.4xlarge"
-    val `ml.m4.10xlarge`  = "ml.m4.10xlarge"
-    val `ml.m4.16xlarge`  = "ml.m4.16xlarge"
-    val `ml.m5.xlarge`    = "ml.m5.xlarge"
-    val `ml.m5.2xlarge`   = "ml.m5.2xlarge"
-    val `ml.m5.4xlarge`   = "ml.m5.4xlarge"
-    val `ml.m5.12xlarge`  = "ml.m5.12xlarge"
-    val `ml.m5.24xlarge`  = "ml.m5.24xlarge"
-    val `ml.c4.xlarge`    = "ml.c4.xlarge"
-    val `ml.c4.2xlarge`   = "ml.c4.2xlarge"
-    val `ml.c4.4xlarge`   = "ml.c4.4xlarge"
-    val `ml.c4.8xlarge`   = "ml.c4.8xlarge"
-    val `ml.c5.xlarge`    = "ml.c5.xlarge"
-    val `ml.c5.2xlarge`   = "ml.c5.2xlarge"
-    val `ml.c5.4xlarge`   = "ml.c5.4xlarge"
-    val `ml.c5.9xlarge`   = "ml.c5.9xlarge"
-    val `ml.c5.18xlarge`  = "ml.c5.18xlarge"
-    val `ml.c5d.xlarge`   = "ml.c5d.xlarge"
-    val `ml.c5d.2xlarge`  = "ml.c5d.2xlarge"
-    val `ml.c5d.4xlarge`  = "ml.c5d.4xlarge"
-    val `ml.c5d.9xlarge`  = "ml.c5d.9xlarge"
-    val `ml.c5d.18xlarge` = "ml.c5d.18xlarge"
-    val `ml.p2.xlarge`    = "ml.p2.xlarge"
-    val `ml.p2.8xlarge`   = "ml.p2.8xlarge"
-    val `ml.p2.16xlarge`  = "ml.p2.16xlarge"
-    val `ml.p3.2xlarge`   = "ml.p3.2xlarge"
-    val `ml.p3.8xlarge`   = "ml.p3.8xlarge"
-    val `ml.p3.16xlarge`  = "ml.p3.16xlarge"
+  @js.native
+  sealed trait InstanceType extends js.Any
+  object InstanceType extends js.Object {
+    val `ml.t2.medium`    = "ml.t2.medium".asInstanceOf[InstanceType]
+    val `ml.t2.large`     = "ml.t2.large".asInstanceOf[InstanceType]
+    val `ml.t2.xlarge`    = "ml.t2.xlarge".asInstanceOf[InstanceType]
+    val `ml.t2.2xlarge`   = "ml.t2.2xlarge".asInstanceOf[InstanceType]
+    val `ml.t3.medium`    = "ml.t3.medium".asInstanceOf[InstanceType]
+    val `ml.t3.large`     = "ml.t3.large".asInstanceOf[InstanceType]
+    val `ml.t3.xlarge`    = "ml.t3.xlarge".asInstanceOf[InstanceType]
+    val `ml.t3.2xlarge`   = "ml.t3.2xlarge".asInstanceOf[InstanceType]
+    val `ml.m4.xlarge`    = "ml.m4.xlarge".asInstanceOf[InstanceType]
+    val `ml.m4.2xlarge`   = "ml.m4.2xlarge".asInstanceOf[InstanceType]
+    val `ml.m4.4xlarge`   = "ml.m4.4xlarge".asInstanceOf[InstanceType]
+    val `ml.m4.10xlarge`  = "ml.m4.10xlarge".asInstanceOf[InstanceType]
+    val `ml.m4.16xlarge`  = "ml.m4.16xlarge".asInstanceOf[InstanceType]
+    val `ml.m5.xlarge`    = "ml.m5.xlarge".asInstanceOf[InstanceType]
+    val `ml.m5.2xlarge`   = "ml.m5.2xlarge".asInstanceOf[InstanceType]
+    val `ml.m5.4xlarge`   = "ml.m5.4xlarge".asInstanceOf[InstanceType]
+    val `ml.m5.12xlarge`  = "ml.m5.12xlarge".asInstanceOf[InstanceType]
+    val `ml.m5.24xlarge`  = "ml.m5.24xlarge".asInstanceOf[InstanceType]
+    val `ml.c4.xlarge`    = "ml.c4.xlarge".asInstanceOf[InstanceType]
+    val `ml.c4.2xlarge`   = "ml.c4.2xlarge".asInstanceOf[InstanceType]
+    val `ml.c4.4xlarge`   = "ml.c4.4xlarge".asInstanceOf[InstanceType]
+    val `ml.c4.8xlarge`   = "ml.c4.8xlarge".asInstanceOf[InstanceType]
+    val `ml.c5.xlarge`    = "ml.c5.xlarge".asInstanceOf[InstanceType]
+    val `ml.c5.2xlarge`   = "ml.c5.2xlarge".asInstanceOf[InstanceType]
+    val `ml.c5.4xlarge`   = "ml.c5.4xlarge".asInstanceOf[InstanceType]
+    val `ml.c5.9xlarge`   = "ml.c5.9xlarge".asInstanceOf[InstanceType]
+    val `ml.c5.18xlarge`  = "ml.c5.18xlarge".asInstanceOf[InstanceType]
+    val `ml.c5d.xlarge`   = "ml.c5d.xlarge".asInstanceOf[InstanceType]
+    val `ml.c5d.2xlarge`  = "ml.c5d.2xlarge".asInstanceOf[InstanceType]
+    val `ml.c5d.4xlarge`  = "ml.c5d.4xlarge".asInstanceOf[InstanceType]
+    val `ml.c5d.9xlarge`  = "ml.c5d.9xlarge".asInstanceOf[InstanceType]
+    val `ml.c5d.18xlarge` = "ml.c5d.18xlarge".asInstanceOf[InstanceType]
+    val `ml.p2.xlarge`    = "ml.p2.xlarge".asInstanceOf[InstanceType]
+    val `ml.p2.8xlarge`   = "ml.p2.8xlarge".asInstanceOf[InstanceType]
+    val `ml.p2.16xlarge`  = "ml.p2.16xlarge".asInstanceOf[InstanceType]
+    val `ml.p3.2xlarge`   = "ml.p3.2xlarge".asInstanceOf[InstanceType]
+    val `ml.p3.8xlarge`   = "ml.p3.8xlarge".asInstanceOf[InstanceType]
+    val `ml.p3.16xlarge`  = "ml.p3.16xlarge".asInstanceOf[InstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -7796,10 +7742,11 @@ package sagemaker {
       __obj.asInstanceOf[IntegerParameterRangeSpecification]
     }
   }
-
-  object JoinSourceEnum {
-    val Input = "Input"
-    val None  = "None"
+  @js.native
+  sealed trait JoinSource extends js.Any
+  object JoinSource extends js.Object {
+    val Input = "Input".asInstanceOf[JoinSource]
+    val None  = "None".asInstanceOf[JoinSource]
 
     val values = js.Object.freeze(js.Array(Input, None))
   }
@@ -8120,13 +8067,14 @@ package sagemaker {
       __obj.asInstanceOf[LabelingJobS3DataSource]
     }
   }
-
-  object LabelingJobStatusEnum {
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-    val Stopping   = "Stopping"
-    val Stopped    = "Stopped"
+  @js.native
+  sealed trait LabelingJobStatus extends js.Any
+  object LabelingJobStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[LabelingJobStatus]
+    val Completed  = "Completed".asInstanceOf[LabelingJobStatus]
+    val Failed     = "Failed".asInstanceOf[LabelingJobStatus]
+    val Stopping   = "Stopping".asInstanceOf[LabelingJobStatus]
+    val Stopped    = "Stopped".asInstanceOf[LabelingJobStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Completed, Failed, Stopping, Stopped))
   }
@@ -8565,11 +8513,12 @@ package sagemaker {
       __obj.asInstanceOf[ListCompilationJobsResponse]
     }
   }
-
-  object ListCompilationJobsSortByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
-    val Status       = "Status"
+  @js.native
+  sealed trait ListCompilationJobsSortBy extends js.Any
+  object ListCompilationJobsSortBy extends js.Object {
+    val Name         = "Name".asInstanceOf[ListCompilationJobsSortBy]
+    val CreationTime = "CreationTime".asInstanceOf[ListCompilationJobsSortBy]
+    val Status       = "Status".asInstanceOf[ListCompilationJobsSortBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, Status))
   }
@@ -9002,9 +8951,10 @@ package sagemaker {
       __obj.asInstanceOf[ListLabelingJobsForWorkteamResponse]
     }
   }
-
-  object ListLabelingJobsForWorkteamSortByOptionsEnum {
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait ListLabelingJobsForWorkteamSortByOptions extends js.Any
+  object ListLabelingJobsForWorkteamSortByOptions extends js.Object {
+    val CreationTime = "CreationTime".asInstanceOf[ListLabelingJobsForWorkteamSortByOptions]
 
     val values = js.Object.freeze(js.Array(CreationTime))
   }
@@ -10001,10 +9951,11 @@ package sagemaker {
       __obj.asInstanceOf[ListWorkteamsResponse]
     }
   }
-
-  object ListWorkteamsSortByOptionsEnum {
-    val Name       = "Name"
-    val CreateDate = "CreateDate"
+  @js.native
+  sealed trait ListWorkteamsSortByOptions extends js.Any
+  object ListWorkteamsSortByOptions extends js.Object {
+    val Name       = "Name".asInstanceOf[ListWorkteamsSortByOptions]
+    val CreateDate = "CreateDate".asInstanceOf[ListWorkteamsSortByOptions]
 
     val values = js.Object.freeze(js.Array(Name, CreateDate))
   }
@@ -10130,20 +10081,22 @@ package sagemaker {
       __obj.asInstanceOf[ModelPackageContainerDefinition]
     }
   }
-
-  object ModelPackageSortByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait ModelPackageSortBy extends js.Any
+  object ModelPackageSortBy extends js.Object {
+    val Name         = "Name".asInstanceOf[ModelPackageSortBy]
+    val CreationTime = "CreationTime".asInstanceOf[ModelPackageSortBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime))
   }
-
-  object ModelPackageStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-    val Deleting   = "Deleting"
+  @js.native
+  sealed trait ModelPackageStatus extends js.Any
+  object ModelPackageStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[ModelPackageStatus]
+    val InProgress = "InProgress".asInstanceOf[ModelPackageStatus]
+    val Completed  = "Completed".asInstanceOf[ModelPackageStatus]
+    val Failed     = "Failed".asInstanceOf[ModelPackageStatus]
+    val Deleting   = "Deleting".asInstanceOf[ModelPackageStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Completed, Failed, Deleting))
   }
@@ -10280,10 +10233,11 @@ package sagemaker {
       __obj.asInstanceOf[ModelPackageValidationSpecification]
     }
   }
-
-  object ModelSortKeyEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait ModelSortKey extends js.Any
+  object ModelSortKey extends js.Object {
+    val Name         = "Name".asInstanceOf[ModelSortKey]
+    val CreationTime = "CreationTime".asInstanceOf[ModelSortKey]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime))
   }
@@ -10422,11 +10376,12 @@ package sagemaker {
       __obj.asInstanceOf[MonitoringConstraintsResource]
     }
   }
-
-  object MonitoringExecutionSortKeyEnum {
-    val CreationTime  = "CreationTime"
-    val ScheduledTime = "ScheduledTime"
-    val Status        = "Status"
+  @js.native
+  sealed trait MonitoringExecutionSortKey extends js.Any
+  object MonitoringExecutionSortKey extends js.Object {
+    val CreationTime  = "CreationTime".asInstanceOf[MonitoringExecutionSortKey]
+    val ScheduledTime = "ScheduledTime".asInstanceOf[MonitoringExecutionSortKey]
+    val Status        = "Status".asInstanceOf[MonitoringExecutionSortKey]
 
     val values = js.Object.freeze(js.Array(CreationTime, ScheduledTime, Status))
   }
@@ -10655,11 +10610,12 @@ package sagemaker {
       __obj.asInstanceOf[MonitoringScheduleConfig]
     }
   }
-
-  object MonitoringScheduleSortKeyEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
-    val Status       = "Status"
+  @js.native
+  sealed trait MonitoringScheduleSortKey extends js.Any
+  object MonitoringScheduleSortKey extends js.Object {
+    val Name         = "Name".asInstanceOf[MonitoringScheduleSortKey]
+    val CreationTime = "CreationTime".asInstanceOf[MonitoringScheduleSortKey]
+    val Status       = "Status".asInstanceOf[MonitoringScheduleSortKey]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, Status))
   }
@@ -10789,31 +10745,34 @@ package sagemaker {
       __obj.asInstanceOf[NetworkConfig]
     }
   }
-
-  object NotebookInstanceAcceleratorTypeEnum {
-    val `ml.eia1.medium` = "ml.eia1.medium"
-    val `ml.eia1.large`  = "ml.eia1.large"
-    val `ml.eia1.xlarge` = "ml.eia1.xlarge"
-    val `ml.eia2.medium` = "ml.eia2.medium"
-    val `ml.eia2.large`  = "ml.eia2.large"
-    val `ml.eia2.xlarge` = "ml.eia2.xlarge"
+  @js.native
+  sealed trait NotebookInstanceAcceleratorType extends js.Any
+  object NotebookInstanceAcceleratorType extends js.Object {
+    val `ml.eia1.medium` = "ml.eia1.medium".asInstanceOf[NotebookInstanceAcceleratorType]
+    val `ml.eia1.large`  = "ml.eia1.large".asInstanceOf[NotebookInstanceAcceleratorType]
+    val `ml.eia1.xlarge` = "ml.eia1.xlarge".asInstanceOf[NotebookInstanceAcceleratorType]
+    val `ml.eia2.medium` = "ml.eia2.medium".asInstanceOf[NotebookInstanceAcceleratorType]
+    val `ml.eia2.large`  = "ml.eia2.large".asInstanceOf[NotebookInstanceAcceleratorType]
+    val `ml.eia2.xlarge` = "ml.eia2.xlarge".asInstanceOf[NotebookInstanceAcceleratorType]
 
     val values = js.Object.freeze(
       js.Array(`ml.eia1.medium`, `ml.eia1.large`, `ml.eia1.xlarge`, `ml.eia2.medium`, `ml.eia2.large`, `ml.eia2.xlarge`)
     )
   }
-
-  object NotebookInstanceLifecycleConfigSortKeyEnum {
-    val Name             = "Name"
-    val CreationTime     = "CreationTime"
-    val LastModifiedTime = "LastModifiedTime"
+  @js.native
+  sealed trait NotebookInstanceLifecycleConfigSortKey extends js.Any
+  object NotebookInstanceLifecycleConfigSortKey extends js.Object {
+    val Name             = "Name".asInstanceOf[NotebookInstanceLifecycleConfigSortKey]
+    val CreationTime     = "CreationTime".asInstanceOf[NotebookInstanceLifecycleConfigSortKey]
+    val LastModifiedTime = "LastModifiedTime".asInstanceOf[NotebookInstanceLifecycleConfigSortKey]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, LastModifiedTime))
   }
-
-  object NotebookInstanceLifecycleConfigSortOrderEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait NotebookInstanceLifecycleConfigSortOrder extends js.Any
+  object NotebookInstanceLifecycleConfigSortOrder extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[NotebookInstanceLifecycleConfigSortOrder]
+    val Descending = "Descending".asInstanceOf[NotebookInstanceLifecycleConfigSortOrder]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }
@@ -10871,30 +10830,33 @@ package sagemaker {
       __obj.asInstanceOf[NotebookInstanceLifecycleHook]
     }
   }
-
-  object NotebookInstanceSortKeyEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
-    val Status       = "Status"
+  @js.native
+  sealed trait NotebookInstanceSortKey extends js.Any
+  object NotebookInstanceSortKey extends js.Object {
+    val Name         = "Name".asInstanceOf[NotebookInstanceSortKey]
+    val CreationTime = "CreationTime".asInstanceOf[NotebookInstanceSortKey]
+    val Status       = "Status".asInstanceOf[NotebookInstanceSortKey]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, Status))
   }
-
-  object NotebookInstanceSortOrderEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait NotebookInstanceSortOrder extends js.Any
+  object NotebookInstanceSortOrder extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[NotebookInstanceSortOrder]
+    val Descending = "Descending".asInstanceOf[NotebookInstanceSortOrder]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }
-
-  object NotebookInstanceStatusEnum {
-    val Pending   = "Pending"
-    val InService = "InService"
-    val Stopping  = "Stopping"
-    val Stopped   = "Stopped"
-    val Failed    = "Failed"
-    val Deleting  = "Deleting"
-    val Updating  = "Updating"
+  @js.native
+  sealed trait NotebookInstanceStatus extends js.Any
+  object NotebookInstanceStatus extends js.Object {
+    val Pending   = "Pending".asInstanceOf[NotebookInstanceStatus]
+    val InService = "InService".asInstanceOf[NotebookInstanceStatus]
+    val Stopping  = "Stopping".asInstanceOf[NotebookInstanceStatus]
+    val Stopped   = "Stopped".asInstanceOf[NotebookInstanceStatus]
+    val Failed    = "Failed".asInstanceOf[NotebookInstanceStatus]
+    val Deleting  = "Deleting".asInstanceOf[NotebookInstanceStatus]
+    val Updating  = "Updating".asInstanceOf[NotebookInstanceStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InService, Stopping, Stopped, Failed, Deleting, Updating))
   }
@@ -10950,10 +10912,11 @@ package sagemaker {
       __obj.asInstanceOf[NotebookInstanceSummary]
     }
   }
-
-  object NotebookOutputOptionEnum {
-    val Allowed  = "Allowed"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait NotebookOutputOption extends js.Any
+  object NotebookOutputOption extends js.Object {
+    val Allowed  = "Allowed".asInstanceOf[NotebookOutputOption]
+    val Disabled = "Disabled".asInstanceOf[NotebookOutputOption]
 
     val values = js.Object.freeze(js.Array(Allowed, Disabled))
   }
@@ -10976,11 +10939,12 @@ package sagemaker {
       __obj.asInstanceOf[NotificationConfiguration]
     }
   }
-
-  object ObjectiveStatusEnum {
-    val Succeeded = "Succeeded"
-    val Pending   = "Pending"
-    val Failed    = "Failed"
+  @js.native
+  sealed trait ObjectiveStatus extends js.Any
+  object ObjectiveStatus extends js.Object {
+    val Succeeded = "Succeeded".asInstanceOf[ObjectiveStatus]
+    val Pending   = "Pending".asInstanceOf[ObjectiveStatus]
+    val Failed    = "Failed".asInstanceOf[ObjectiveStatus]
 
     val values = js.Object.freeze(js.Array(Succeeded, Pending, Failed))
   }
@@ -11009,17 +10973,18 @@ package sagemaker {
       __obj.asInstanceOf[ObjectiveStatusCounters]
     }
   }
-
-  object OperatorEnum {
-    val Equals               = "Equals"
-    val NotEquals            = "NotEquals"
-    val GreaterThan          = "GreaterThan"
-    val GreaterThanOrEqualTo = "GreaterThanOrEqualTo"
-    val LessThan             = "LessThan"
-    val LessThanOrEqualTo    = "LessThanOrEqualTo"
-    val Contains             = "Contains"
-    val Exists               = "Exists"
-    val NotExists            = "NotExists"
+  @js.native
+  sealed trait Operator extends js.Any
+  object Operator extends js.Object {
+    val Equals               = "Equals".asInstanceOf[Operator]
+    val NotEquals            = "NotEquals".asInstanceOf[Operator]
+    val GreaterThan          = "GreaterThan".asInstanceOf[Operator]
+    val GreaterThanOrEqualTo = "GreaterThanOrEqualTo".asInstanceOf[Operator]
+    val LessThan             = "LessThan".asInstanceOf[Operator]
+    val LessThanOrEqualTo    = "LessThanOrEqualTo".asInstanceOf[Operator]
+    val Contains             = "Contains".asInstanceOf[Operator]
+    val Exists               = "Exists".asInstanceOf[Operator]
+    val NotExists            = "NotExists".asInstanceOf[Operator]
 
     val values = js.Object.freeze(
       js.Array(
@@ -11035,10 +11000,11 @@ package sagemaker {
       )
     )
   }
-
-  object OrderKeyEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait OrderKey extends js.Any
+  object OrderKey extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[OrderKey]
+    val Descending = "Descending".asInstanceOf[OrderKey]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }
@@ -11152,12 +11118,13 @@ package sagemaker {
       __obj.asInstanceOf[ParameterRanges]
     }
   }
-
-  object ParameterTypeEnum {
-    val Integer     = "Integer"
-    val Continuous  = "Continuous"
-    val Categorical = "Categorical"
-    val FreeText    = "FreeText"
+  @js.native
+  sealed trait ParameterType extends js.Any
+  object ParameterType extends js.Object {
+    val Integer     = "Integer".asInstanceOf[ParameterType]
+    val Continuous  = "Continuous".asInstanceOf[ParameterType]
+    val Categorical = "Categorical".asInstanceOf[ParameterType]
+    val FreeText    = "FreeText".asInstanceOf[ParameterType]
 
     val values = js.Object.freeze(js.Array(Integer, Continuous, Categorical, FreeText))
   }
@@ -11204,11 +11171,12 @@ package sagemaker {
       __obj.asInstanceOf[ParentHyperParameterTuningJob]
     }
   }
-
-  object ProblemTypeEnum {
-    val BinaryClassification     = "BinaryClassification"
-    val MulticlassClassification = "MulticlassClassification"
-    val Regression               = "Regression"
+  @js.native
+  sealed trait ProblemType extends js.Any
+  object ProblemType extends js.Object {
+    val BinaryClassification     = "BinaryClassification".asInstanceOf[ProblemType]
+    val MulticlassClassification = "MulticlassClassification".asInstanceOf[ProblemType]
+    val Regression               = "Regression".asInstanceOf[ProblemType]
 
     val values = js.Object.freeze(js.Array(BinaryClassification, MulticlassClassification, Regression))
   }
@@ -11266,46 +11234,47 @@ package sagemaker {
       __obj.asInstanceOf[ProcessingInput]
     }
   }
-
-  object ProcessingInstanceTypeEnum {
-    val `ml.t3.medium`   = "ml.t3.medium"
-    val `ml.t3.large`    = "ml.t3.large"
-    val `ml.t3.xlarge`   = "ml.t3.xlarge"
-    val `ml.t3.2xlarge`  = "ml.t3.2xlarge"
-    val `ml.m4.xlarge`   = "ml.m4.xlarge"
-    val `ml.m4.2xlarge`  = "ml.m4.2xlarge"
-    val `ml.m4.4xlarge`  = "ml.m4.4xlarge"
-    val `ml.m4.10xlarge` = "ml.m4.10xlarge"
-    val `ml.m4.16xlarge` = "ml.m4.16xlarge"
-    val `ml.c4.xlarge`   = "ml.c4.xlarge"
-    val `ml.c4.2xlarge`  = "ml.c4.2xlarge"
-    val `ml.c4.4xlarge`  = "ml.c4.4xlarge"
-    val `ml.c4.8xlarge`  = "ml.c4.8xlarge"
-    val `ml.p2.xlarge`   = "ml.p2.xlarge"
-    val `ml.p2.8xlarge`  = "ml.p2.8xlarge"
-    val `ml.p2.16xlarge` = "ml.p2.16xlarge"
-    val `ml.p3.2xlarge`  = "ml.p3.2xlarge"
-    val `ml.p3.8xlarge`  = "ml.p3.8xlarge"
-    val `ml.p3.16xlarge` = "ml.p3.16xlarge"
-    val `ml.c5.xlarge`   = "ml.c5.xlarge"
-    val `ml.c5.2xlarge`  = "ml.c5.2xlarge"
-    val `ml.c5.4xlarge`  = "ml.c5.4xlarge"
-    val `ml.c5.9xlarge`  = "ml.c5.9xlarge"
-    val `ml.c5.18xlarge` = "ml.c5.18xlarge"
-    val `ml.m5.large`    = "ml.m5.large"
-    val `ml.m5.xlarge`   = "ml.m5.xlarge"
-    val `ml.m5.2xlarge`  = "ml.m5.2xlarge"
-    val `ml.m5.4xlarge`  = "ml.m5.4xlarge"
-    val `ml.m5.12xlarge` = "ml.m5.12xlarge"
-    val `ml.m5.24xlarge` = "ml.m5.24xlarge"
-    val `ml.r5.large`    = "ml.r5.large"
-    val `ml.r5.xlarge`   = "ml.r5.xlarge"
-    val `ml.r5.2xlarge`  = "ml.r5.2xlarge"
-    val `ml.r5.4xlarge`  = "ml.r5.4xlarge"
-    val `ml.r5.8xlarge`  = "ml.r5.8xlarge"
-    val `ml.r5.12xlarge` = "ml.r5.12xlarge"
-    val `ml.r5.16xlarge` = "ml.r5.16xlarge"
-    val `ml.r5.24xlarge` = "ml.r5.24xlarge"
+  @js.native
+  sealed trait ProcessingInstanceType extends js.Any
+  object ProcessingInstanceType extends js.Object {
+    val `ml.t3.medium`   = "ml.t3.medium".asInstanceOf[ProcessingInstanceType]
+    val `ml.t3.large`    = "ml.t3.large".asInstanceOf[ProcessingInstanceType]
+    val `ml.t3.xlarge`   = "ml.t3.xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.t3.2xlarge`  = "ml.t3.2xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m4.xlarge`   = "ml.m4.xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m4.2xlarge`  = "ml.m4.2xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m4.4xlarge`  = "ml.m4.4xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m4.10xlarge` = "ml.m4.10xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m4.16xlarge` = "ml.m4.16xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c4.xlarge`   = "ml.c4.xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c4.2xlarge`  = "ml.c4.2xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c4.4xlarge`  = "ml.c4.4xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c4.8xlarge`  = "ml.c4.8xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.p2.xlarge`   = "ml.p2.xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.p2.8xlarge`  = "ml.p2.8xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.p2.16xlarge` = "ml.p2.16xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.p3.2xlarge`  = "ml.p3.2xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.p3.8xlarge`  = "ml.p3.8xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.p3.16xlarge` = "ml.p3.16xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c5.xlarge`   = "ml.c5.xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c5.2xlarge`  = "ml.c5.2xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c5.4xlarge`  = "ml.c5.4xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c5.9xlarge`  = "ml.c5.9xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.c5.18xlarge` = "ml.c5.18xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m5.large`    = "ml.m5.large".asInstanceOf[ProcessingInstanceType]
+    val `ml.m5.xlarge`   = "ml.m5.xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m5.2xlarge`  = "ml.m5.2xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m5.4xlarge`  = "ml.m5.4xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m5.12xlarge` = "ml.m5.12xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.m5.24xlarge` = "ml.m5.24xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.large`    = "ml.r5.large".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.xlarge`   = "ml.r5.xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.2xlarge`  = "ml.r5.2xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.4xlarge`  = "ml.r5.4xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.8xlarge`  = "ml.r5.8xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.12xlarge` = "ml.r5.12xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.16xlarge` = "ml.r5.16xlarge".asInstanceOf[ProcessingInstanceType]
+    val `ml.r5.24xlarge` = "ml.r5.24xlarge".asInstanceOf[ProcessingInstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -11350,13 +11319,14 @@ package sagemaker {
       )
     )
   }
-
-  object ProcessingJobStatusEnum {
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-    val Stopping   = "Stopping"
-    val Stopped    = "Stopped"
+  @js.native
+  sealed trait ProcessingJobStatus extends js.Any
+  object ProcessingJobStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[ProcessingJobStatus]
+    val Completed  = "Completed".asInstanceOf[ProcessingJobStatus]
+    val Failed     = "Failed".asInstanceOf[ProcessingJobStatus]
+    val Stopping   = "Stopping".asInstanceOf[ProcessingJobStatus]
+    val Stopped    = "Stopped".asInstanceOf[ProcessingJobStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Completed, Failed, Stopping, Stopped))
   }
@@ -11471,24 +11441,27 @@ package sagemaker {
       __obj.asInstanceOf[ProcessingResources]
     }
   }
-
-  object ProcessingS3CompressionTypeEnum {
-    val None = "None"
-    val Gzip = "Gzip"
+  @js.native
+  sealed trait ProcessingS3CompressionType extends js.Any
+  object ProcessingS3CompressionType extends js.Object {
+    val None = "None".asInstanceOf[ProcessingS3CompressionType]
+    val Gzip = "Gzip".asInstanceOf[ProcessingS3CompressionType]
 
     val values = js.Object.freeze(js.Array(None, Gzip))
   }
-
-  object ProcessingS3DataDistributionTypeEnum {
-    val FullyReplicated = "FullyReplicated"
-    val ShardedByS3Key  = "ShardedByS3Key"
+  @js.native
+  sealed trait ProcessingS3DataDistributionType extends js.Any
+  object ProcessingS3DataDistributionType extends js.Object {
+    val FullyReplicated = "FullyReplicated".asInstanceOf[ProcessingS3DataDistributionType]
+    val ShardedByS3Key  = "ShardedByS3Key".asInstanceOf[ProcessingS3DataDistributionType]
 
     val values = js.Object.freeze(js.Array(FullyReplicated, ShardedByS3Key))
   }
-
-  object ProcessingS3DataTypeEnum {
-    val ManifestFile = "ManifestFile"
-    val S3Prefix     = "S3Prefix"
+  @js.native
+  sealed trait ProcessingS3DataType extends js.Any
+  object ProcessingS3DataType extends js.Object {
+    val ManifestFile = "ManifestFile".asInstanceOf[ProcessingS3DataType]
+    val S3Prefix     = "S3Prefix".asInstanceOf[ProcessingS3DataType]
 
     val values = js.Object.freeze(js.Array(ManifestFile, S3Prefix))
   }
@@ -11528,10 +11501,11 @@ package sagemaker {
       __obj.asInstanceOf[ProcessingS3Input]
     }
   }
-
-  object ProcessingS3InputModeEnum {
-    val Pipe = "Pipe"
-    val File = "File"
+  @js.native
+  sealed trait ProcessingS3InputMode extends js.Any
+  object ProcessingS3InputMode extends js.Object {
+    val Pipe = "Pipe".asInstanceOf[ProcessingS3InputMode]
+    val File = "File".asInstanceOf[ProcessingS3InputMode]
 
     val values = js.Object.freeze(js.Array(Pipe, File))
   }
@@ -11562,10 +11536,11 @@ package sagemaker {
       __obj.asInstanceOf[ProcessingS3Output]
     }
   }
-
-  object ProcessingS3UploadModeEnum {
-    val Continuous = "Continuous"
-    val EndOfJob   = "EndOfJob"
+  @js.native
+  sealed trait ProcessingS3UploadMode extends js.Any
+  object ProcessingS3UploadMode extends js.Object {
+    val Continuous = "Continuous".asInstanceOf[ProcessingS3UploadMode]
+    val EndOfJob   = "EndOfJob".asInstanceOf[ProcessingS3UploadMode]
 
     val values = js.Object.freeze(js.Array(Continuous, EndOfJob))
   }
@@ -11626,87 +11601,89 @@ package sagemaker {
       __obj.asInstanceOf[ProductionVariant]
     }
   }
-
-  object ProductionVariantAcceleratorTypeEnum {
-    val `ml.eia1.medium` = "ml.eia1.medium"
-    val `ml.eia1.large`  = "ml.eia1.large"
-    val `ml.eia1.xlarge` = "ml.eia1.xlarge"
-    val `ml.eia2.medium` = "ml.eia2.medium"
-    val `ml.eia2.large`  = "ml.eia2.large"
-    val `ml.eia2.xlarge` = "ml.eia2.xlarge"
+  @js.native
+  sealed trait ProductionVariantAcceleratorType extends js.Any
+  object ProductionVariantAcceleratorType extends js.Object {
+    val `ml.eia1.medium` = "ml.eia1.medium".asInstanceOf[ProductionVariantAcceleratorType]
+    val `ml.eia1.large`  = "ml.eia1.large".asInstanceOf[ProductionVariantAcceleratorType]
+    val `ml.eia1.xlarge` = "ml.eia1.xlarge".asInstanceOf[ProductionVariantAcceleratorType]
+    val `ml.eia2.medium` = "ml.eia2.medium".asInstanceOf[ProductionVariantAcceleratorType]
+    val `ml.eia2.large`  = "ml.eia2.large".asInstanceOf[ProductionVariantAcceleratorType]
+    val `ml.eia2.xlarge` = "ml.eia2.xlarge".asInstanceOf[ProductionVariantAcceleratorType]
 
     val values = js.Object.freeze(
       js.Array(`ml.eia1.medium`, `ml.eia1.large`, `ml.eia1.xlarge`, `ml.eia2.medium`, `ml.eia2.large`, `ml.eia2.xlarge`)
     )
   }
-
-  object ProductionVariantInstanceTypeEnum {
-    val `ml.t2.medium`     = "ml.t2.medium"
-    val `ml.t2.large`      = "ml.t2.large"
-    val `ml.t2.xlarge`     = "ml.t2.xlarge"
-    val `ml.t2.2xlarge`    = "ml.t2.2xlarge"
-    val `ml.m4.xlarge`     = "ml.m4.xlarge"
-    val `ml.m4.2xlarge`    = "ml.m4.2xlarge"
-    val `ml.m4.4xlarge`    = "ml.m4.4xlarge"
-    val `ml.m4.10xlarge`   = "ml.m4.10xlarge"
-    val `ml.m4.16xlarge`   = "ml.m4.16xlarge"
-    val `ml.m5.large`      = "ml.m5.large"
-    val `ml.m5.xlarge`     = "ml.m5.xlarge"
-    val `ml.m5.2xlarge`    = "ml.m5.2xlarge"
-    val `ml.m5.4xlarge`    = "ml.m5.4xlarge"
-    val `ml.m5.12xlarge`   = "ml.m5.12xlarge"
-    val `ml.m5.24xlarge`   = "ml.m5.24xlarge"
-    val `ml.m5d.large`     = "ml.m5d.large"
-    val `ml.m5d.xlarge`    = "ml.m5d.xlarge"
-    val `ml.m5d.2xlarge`   = "ml.m5d.2xlarge"
-    val `ml.m5d.4xlarge`   = "ml.m5d.4xlarge"
-    val `ml.m5d.12xlarge`  = "ml.m5d.12xlarge"
-    val `ml.m5d.24xlarge`  = "ml.m5d.24xlarge"
-    val `ml.c4.large`      = "ml.c4.large"
-    val `ml.c4.xlarge`     = "ml.c4.xlarge"
-    val `ml.c4.2xlarge`    = "ml.c4.2xlarge"
-    val `ml.c4.4xlarge`    = "ml.c4.4xlarge"
-    val `ml.c4.8xlarge`    = "ml.c4.8xlarge"
-    val `ml.p2.xlarge`     = "ml.p2.xlarge"
-    val `ml.p2.8xlarge`    = "ml.p2.8xlarge"
-    val `ml.p2.16xlarge`   = "ml.p2.16xlarge"
-    val `ml.p3.2xlarge`    = "ml.p3.2xlarge"
-    val `ml.p3.8xlarge`    = "ml.p3.8xlarge"
-    val `ml.p3.16xlarge`   = "ml.p3.16xlarge"
-    val `ml.c5.large`      = "ml.c5.large"
-    val `ml.c5.xlarge`     = "ml.c5.xlarge"
-    val `ml.c5.2xlarge`    = "ml.c5.2xlarge"
-    val `ml.c5.4xlarge`    = "ml.c5.4xlarge"
-    val `ml.c5.9xlarge`    = "ml.c5.9xlarge"
-    val `ml.c5.18xlarge`   = "ml.c5.18xlarge"
-    val `ml.c5d.large`     = "ml.c5d.large"
-    val `ml.c5d.xlarge`    = "ml.c5d.xlarge"
-    val `ml.c5d.2xlarge`   = "ml.c5d.2xlarge"
-    val `ml.c5d.4xlarge`   = "ml.c5d.4xlarge"
-    val `ml.c5d.9xlarge`   = "ml.c5d.9xlarge"
-    val `ml.c5d.18xlarge`  = "ml.c5d.18xlarge"
-    val `ml.g4dn.xlarge`   = "ml.g4dn.xlarge"
-    val `ml.g4dn.2xlarge`  = "ml.g4dn.2xlarge"
-    val `ml.g4dn.4xlarge`  = "ml.g4dn.4xlarge"
-    val `ml.g4dn.8xlarge`  = "ml.g4dn.8xlarge"
-    val `ml.g4dn.12xlarge` = "ml.g4dn.12xlarge"
-    val `ml.g4dn.16xlarge` = "ml.g4dn.16xlarge"
-    val `ml.r5.large`      = "ml.r5.large"
-    val `ml.r5.xlarge`     = "ml.r5.xlarge"
-    val `ml.r5.2xlarge`    = "ml.r5.2xlarge"
-    val `ml.r5.4xlarge`    = "ml.r5.4xlarge"
-    val `ml.r5.12xlarge`   = "ml.r5.12xlarge"
-    val `ml.r5.24xlarge`   = "ml.r5.24xlarge"
-    val `ml.r5d.large`     = "ml.r5d.large"
-    val `ml.r5d.xlarge`    = "ml.r5d.xlarge"
-    val `ml.r5d.2xlarge`   = "ml.r5d.2xlarge"
-    val `ml.r5d.4xlarge`   = "ml.r5d.4xlarge"
-    val `ml.r5d.12xlarge`  = "ml.r5d.12xlarge"
-    val `ml.r5d.24xlarge`  = "ml.r5d.24xlarge"
-    val `ml.inf1.xlarge`   = "ml.inf1.xlarge"
-    val `ml.inf1.2xlarge`  = "ml.inf1.2xlarge"
-    val `ml.inf1.6xlarge`  = "ml.inf1.6xlarge"
-    val `ml.inf1.24xlarge` = "ml.inf1.24xlarge"
+  @js.native
+  sealed trait ProductionVariantInstanceType extends js.Any
+  object ProductionVariantInstanceType extends js.Object {
+    val `ml.t2.medium`     = "ml.t2.medium".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.t2.large`      = "ml.t2.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.t2.xlarge`     = "ml.t2.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.t2.2xlarge`    = "ml.t2.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m4.xlarge`     = "ml.m4.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m4.2xlarge`    = "ml.m4.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m4.4xlarge`    = "ml.m4.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m4.10xlarge`   = "ml.m4.10xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m4.16xlarge`   = "ml.m4.16xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5.large`      = "ml.m5.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5.xlarge`     = "ml.m5.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5.2xlarge`    = "ml.m5.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5.4xlarge`    = "ml.m5.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5.12xlarge`   = "ml.m5.12xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5.24xlarge`   = "ml.m5.24xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5d.large`     = "ml.m5d.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5d.xlarge`    = "ml.m5d.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5d.2xlarge`   = "ml.m5d.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5d.4xlarge`   = "ml.m5d.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5d.12xlarge`  = "ml.m5d.12xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.m5d.24xlarge`  = "ml.m5d.24xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c4.large`      = "ml.c4.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c4.xlarge`     = "ml.c4.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c4.2xlarge`    = "ml.c4.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c4.4xlarge`    = "ml.c4.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c4.8xlarge`    = "ml.c4.8xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.p2.xlarge`     = "ml.p2.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.p2.8xlarge`    = "ml.p2.8xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.p2.16xlarge`   = "ml.p2.16xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.p3.2xlarge`    = "ml.p3.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.p3.8xlarge`    = "ml.p3.8xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.p3.16xlarge`   = "ml.p3.16xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5.large`      = "ml.c5.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5.xlarge`     = "ml.c5.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5.2xlarge`    = "ml.c5.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5.4xlarge`    = "ml.c5.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5.9xlarge`    = "ml.c5.9xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5.18xlarge`   = "ml.c5.18xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5d.large`     = "ml.c5d.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5d.xlarge`    = "ml.c5d.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5d.2xlarge`   = "ml.c5d.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5d.4xlarge`   = "ml.c5d.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5d.9xlarge`   = "ml.c5d.9xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.c5d.18xlarge`  = "ml.c5d.18xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.g4dn.xlarge`   = "ml.g4dn.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.g4dn.2xlarge`  = "ml.g4dn.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.g4dn.4xlarge`  = "ml.g4dn.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.g4dn.8xlarge`  = "ml.g4dn.8xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.g4dn.12xlarge` = "ml.g4dn.12xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.g4dn.16xlarge` = "ml.g4dn.16xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5.large`      = "ml.r5.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5.xlarge`     = "ml.r5.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5.2xlarge`    = "ml.r5.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5.4xlarge`    = "ml.r5.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5.12xlarge`   = "ml.r5.12xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5.24xlarge`   = "ml.r5.24xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5d.large`     = "ml.r5d.large".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5d.xlarge`    = "ml.r5d.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5d.2xlarge`   = "ml.r5d.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5d.4xlarge`   = "ml.r5d.4xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5d.12xlarge`  = "ml.r5d.12xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.r5d.24xlarge`  = "ml.r5d.24xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.inf1.xlarge`   = "ml.inf1.xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.inf1.2xlarge`  = "ml.inf1.2xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.inf1.6xlarge`  = "ml.inf1.6xlarge".asInstanceOf[ProductionVariantInstanceType]
+    val `ml.inf1.24xlarge` = "ml.inf1.24xlarge".asInstanceOf[ProductionVariantInstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -11972,10 +11949,11 @@ package sagemaker {
       __obj.asInstanceOf[PublicWorkforceTaskPrice]
     }
   }
-
-  object RecordWrapperEnum {
-    val None     = "None"
-    val RecordIO = "RecordIO"
+  @js.native
+  sealed trait RecordWrapper extends js.Any
+  object RecordWrapper extends js.Object {
+    val None     = "None".asInstanceOf[RecordWrapper]
+    val RecordIO = "RecordIO".asInstanceOf[RecordWrapper]
 
     val values = js.Object.freeze(js.Array(None, RecordIO))
   }
@@ -12170,12 +12148,13 @@ package sagemaker {
       __obj.asInstanceOf[ResourceSpec]
     }
   }
-
-  object ResourceTypeEnum {
-    val TrainingJob              = "TrainingJob"
-    val Experiment               = "Experiment"
-    val ExperimentTrial          = "ExperimentTrial"
-    val ExperimentTrialComponent = "ExperimentTrialComponent"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val TrainingJob              = "TrainingJob".asInstanceOf[ResourceType]
+    val Experiment               = "Experiment".asInstanceOf[ResourceType]
+    val ExperimentTrial          = "ExperimentTrial".asInstanceOf[ResourceType]
+    val ExperimentTrialComponent = "ExperimentTrialComponent".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(TrainingJob, Experiment, ExperimentTrial, ExperimentTrialComponent))
   }
@@ -12198,35 +12177,39 @@ package sagemaker {
       __obj.asInstanceOf[RetentionPolicy]
     }
   }
-
-  object RetentionTypeEnum {
-    val Retain = "Retain"
-    val Delete = "Delete"
+  @js.native
+  sealed trait RetentionType extends js.Any
+  object RetentionType extends js.Object {
+    val Retain = "Retain".asInstanceOf[RetentionType]
+    val Delete = "Delete".asInstanceOf[RetentionType]
 
     val values = js.Object.freeze(js.Array(Retain, Delete))
   }
-
-  object RootAccessEnum {
-    val Enabled  = "Enabled"
-    val Disabled = "Disabled"
+  @js.native
+  sealed trait RootAccess extends js.Any
+  object RootAccess extends js.Object {
+    val Enabled  = "Enabled".asInstanceOf[RootAccess]
+    val Disabled = "Disabled".asInstanceOf[RootAccess]
 
     val values = js.Object.freeze(js.Array(Enabled, Disabled))
   }
-
-  object RuleEvaluationStatusEnum {
-    val InProgress    = "InProgress"
-    val NoIssuesFound = "NoIssuesFound"
-    val IssuesFound   = "IssuesFound"
-    val Error         = "Error"
-    val Stopping      = "Stopping"
-    val Stopped       = "Stopped"
+  @js.native
+  sealed trait RuleEvaluationStatus extends js.Any
+  object RuleEvaluationStatus extends js.Object {
+    val InProgress    = "InProgress".asInstanceOf[RuleEvaluationStatus]
+    val NoIssuesFound = "NoIssuesFound".asInstanceOf[RuleEvaluationStatus]
+    val IssuesFound   = "IssuesFound".asInstanceOf[RuleEvaluationStatus]
+    val Error         = "Error".asInstanceOf[RuleEvaluationStatus]
+    val Stopping      = "Stopping".asInstanceOf[RuleEvaluationStatus]
+    val Stopped       = "Stopped".asInstanceOf[RuleEvaluationStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, NoIssuesFound, IssuesFound, Error, Stopping, Stopped))
   }
-
-  object S3DataDistributionEnum {
-    val FullyReplicated = "FullyReplicated"
-    val ShardedByS3Key  = "ShardedByS3Key"
+  @js.native
+  sealed trait S3DataDistribution extends js.Any
+  object S3DataDistribution extends js.Object {
+    val FullyReplicated = "FullyReplicated".asInstanceOf[S3DataDistribution]
+    val ShardedByS3Key  = "ShardedByS3Key".asInstanceOf[S3DataDistribution]
 
     val values = js.Object.freeze(js.Array(FullyReplicated, ShardedByS3Key))
   }
@@ -12260,11 +12243,12 @@ package sagemaker {
       __obj.asInstanceOf[S3DataSource]
     }
   }
-
-  object S3DataTypeEnum {
-    val ManifestFile          = "ManifestFile"
-    val S3Prefix              = "S3Prefix"
-    val AugmentedManifestFile = "AugmentedManifestFile"
+  @js.native
+  sealed trait S3DataType extends js.Any
+  object S3DataType extends js.Object {
+    val ManifestFile          = "ManifestFile".asInstanceOf[S3DataType]
+    val S3Prefix              = "S3Prefix".asInstanceOf[S3DataType]
+    val AugmentedManifestFile = "AugmentedManifestFile".asInstanceOf[S3DataType]
 
     val values = js.Object.freeze(js.Array(ManifestFile, S3Prefix, AugmentedManifestFile))
   }
@@ -12289,12 +12273,13 @@ package sagemaker {
       __obj.asInstanceOf[ScheduleConfig]
     }
   }
-
-  object ScheduleStatusEnum {
-    val Pending   = "Pending"
-    val Failed    = "Failed"
-    val Scheduled = "Scheduled"
-    val Stopped   = "Stopped"
+  @js.native
+  sealed trait ScheduleStatus extends js.Any
+  object ScheduleStatus extends js.Object {
+    val Pending   = "Pending".asInstanceOf[ScheduleStatus]
+    val Failed    = "Failed".asInstanceOf[ScheduleStatus]
+    val Scheduled = "Scheduled".asInstanceOf[ScheduleStatus]
+    val Stopped   = "Stopped".asInstanceOf[ScheduleStatus]
 
     val values = js.Object.freeze(js.Array(Pending, Failed, Scheduled, Stopped))
   }
@@ -12411,29 +12396,31 @@ package sagemaker {
       __obj.asInstanceOf[SearchResponse]
     }
   }
-
-  object SearchSortOrderEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait SearchSortOrder extends js.Any
+  object SearchSortOrder extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[SearchSortOrder]
+    val Descending = "Descending".asInstanceOf[SearchSortOrder]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }
-
-  object SecondaryStatusEnum {
-    val Starting                 = "Starting"
-    val LaunchingMLInstances     = "LaunchingMLInstances"
-    val PreparingTrainingStack   = "PreparingTrainingStack"
-    val Downloading              = "Downloading"
-    val DownloadingTrainingImage = "DownloadingTrainingImage"
-    val Training                 = "Training"
-    val Uploading                = "Uploading"
-    val Stopping                 = "Stopping"
-    val Stopped                  = "Stopped"
-    val MaxRuntimeExceeded       = "MaxRuntimeExceeded"
-    val Completed                = "Completed"
-    val Failed                   = "Failed"
-    val Interrupted              = "Interrupted"
-    val MaxWaitTimeExceeded      = "MaxWaitTimeExceeded"
+  @js.native
+  sealed trait SecondaryStatus extends js.Any
+  object SecondaryStatus extends js.Object {
+    val Starting                 = "Starting".asInstanceOf[SecondaryStatus]
+    val LaunchingMLInstances     = "LaunchingMLInstances".asInstanceOf[SecondaryStatus]
+    val PreparingTrainingStack   = "PreparingTrainingStack".asInstanceOf[SecondaryStatus]
+    val Downloading              = "Downloading".asInstanceOf[SecondaryStatus]
+    val DownloadingTrainingImage = "DownloadingTrainingImage".asInstanceOf[SecondaryStatus]
+    val Training                 = "Training".asInstanceOf[SecondaryStatus]
+    val Uploading                = "Uploading".asInstanceOf[SecondaryStatus]
+    val Stopping                 = "Stopping".asInstanceOf[SecondaryStatus]
+    val Stopped                  = "Stopped".asInstanceOf[SecondaryStatus]
+    val MaxRuntimeExceeded       = "MaxRuntimeExceeded".asInstanceOf[SecondaryStatus]
+    val Completed                = "Completed".asInstanceOf[SecondaryStatus]
+    val Failed                   = "Failed".asInstanceOf[SecondaryStatus]
+    val Interrupted              = "Interrupted".asInstanceOf[SecondaryStatus]
+    val MaxWaitTimeExceeded      = "MaxWaitTimeExceeded".asInstanceOf[SecondaryStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -12532,39 +12519,44 @@ package sagemaker {
       __obj.asInstanceOf[ShuffleConfig]
     }
   }
-
-  object SortByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
-    val Status       = "Status"
+  @js.native
+  sealed trait SortBy extends js.Any
+  object SortBy extends js.Object {
+    val Name         = "Name".asInstanceOf[SortBy]
+    val CreationTime = "CreationTime".asInstanceOf[SortBy]
+    val Status       = "Status".asInstanceOf[SortBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, Status))
   }
-
-  object SortExperimentsByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait SortExperimentsBy extends js.Any
+  object SortExperimentsBy extends js.Object {
+    val Name         = "Name".asInstanceOf[SortExperimentsBy]
+    val CreationTime = "CreationTime".asInstanceOf[SortExperimentsBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime))
   }
-
-  object SortOrderEnum {
-    val Ascending  = "Ascending"
-    val Descending = "Descending"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val Ascending  = "Ascending".asInstanceOf[SortOrder]
+    val Descending = "Descending".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(Ascending, Descending))
   }
-
-  object SortTrialComponentsByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait SortTrialComponentsBy extends js.Any
+  object SortTrialComponentsBy extends js.Object {
+    val Name         = "Name".asInstanceOf[SortTrialComponentsBy]
+    val CreationTime = "CreationTime".asInstanceOf[SortTrialComponentsBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime))
   }
-
-  object SortTrialsByEnum {
-    val Name         = "Name"
-    val CreationTime = "CreationTime"
+  @js.native
+  sealed trait SortTrialsBy extends js.Any
+  object SortTrialsBy extends js.Object {
+    val Name         = "Name".asInstanceOf[SortTrialsBy]
+    val CreationTime = "CreationTime".asInstanceOf[SortTrialsBy]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime))
   }
@@ -12634,12 +12626,13 @@ package sagemaker {
       __obj.asInstanceOf[SourceIpConfig]
     }
   }
-
-  object SplitTypeEnum {
-    val None     = "None"
-    val Line     = "Line"
-    val RecordIO = "RecordIO"
-    val TFRecord = "TFRecord"
+  @js.native
+  sealed trait SplitType extends js.Any
+  object SplitType extends js.Object {
+    val None     = "None".asInstanceOf[SplitType]
+    val Line     = "Line".asInstanceOf[SplitType]
+    val RecordIO = "RecordIO".asInstanceOf[SplitType]
+    val TFRecord = "TFRecord".asInstanceOf[SplitType]
 
     val values = js.Object.freeze(js.Array(None, Line, RecordIO, TFRecord))
   }
@@ -12943,27 +12936,28 @@ package sagemaker {
       __obj.asInstanceOf[Tag]
     }
   }
-
-  object TargetDeviceEnum {
-    val lambda      = "lambda"
-    val ml_m4       = "ml_m4"
-    val ml_m5       = "ml_m5"
-    val ml_c4       = "ml_c4"
-    val ml_c5       = "ml_c5"
-    val ml_p2       = "ml_p2"
-    val ml_p3       = "ml_p3"
-    val ml_inf1     = "ml_inf1"
-    val jetson_tx1  = "jetson_tx1"
-    val jetson_tx2  = "jetson_tx2"
-    val jetson_nano = "jetson_nano"
-    val rasp3b      = "rasp3b"
-    val deeplens    = "deeplens"
-    val rk3399      = "rk3399"
-    val rk3288      = "rk3288"
-    val aisage      = "aisage"
-    val sbe_c       = "sbe_c"
-    val qcs605      = "qcs605"
-    val qcs603      = "qcs603"
+  @js.native
+  sealed trait TargetDevice extends js.Any
+  object TargetDevice extends js.Object {
+    val lambda      = "lambda".asInstanceOf[TargetDevice]
+    val ml_m4       = "ml_m4".asInstanceOf[TargetDevice]
+    val ml_m5       = "ml_m5".asInstanceOf[TargetDevice]
+    val ml_c4       = "ml_c4".asInstanceOf[TargetDevice]
+    val ml_c5       = "ml_c5".asInstanceOf[TargetDevice]
+    val ml_p2       = "ml_p2".asInstanceOf[TargetDevice]
+    val ml_p3       = "ml_p3".asInstanceOf[TargetDevice]
+    val ml_inf1     = "ml_inf1".asInstanceOf[TargetDevice]
+    val jetson_tx1  = "jetson_tx1".asInstanceOf[TargetDevice]
+    val jetson_tx2  = "jetson_tx2".asInstanceOf[TargetDevice]
+    val jetson_nano = "jetson_nano".asInstanceOf[TargetDevice]
+    val rasp3b      = "rasp3b".asInstanceOf[TargetDevice]
+    val deeplens    = "deeplens".asInstanceOf[TargetDevice]
+    val rk3399      = "rk3399".asInstanceOf[TargetDevice]
+    val rk3288      = "rk3288".asInstanceOf[TargetDevice]
+    val aisage      = "aisage".asInstanceOf[TargetDevice]
+    val sbe_c       = "sbe_c".asInstanceOf[TargetDevice]
+    val qcs605      = "qcs605".asInstanceOf[TargetDevice]
+    val qcs603      = "qcs603".asInstanceOf[TargetDevice]
 
     val values = js.Object.freeze(
       js.Array(
@@ -13032,48 +13026,50 @@ package sagemaker {
       __obj.asInstanceOf[TensorBoardOutputConfig]
     }
   }
-
-  object TrainingInputModeEnum {
-    val Pipe = "Pipe"
-    val File = "File"
+  @js.native
+  sealed trait TrainingInputMode extends js.Any
+  object TrainingInputMode extends js.Object {
+    val Pipe = "Pipe".asInstanceOf[TrainingInputMode]
+    val File = "File".asInstanceOf[TrainingInputMode]
 
     val values = js.Object.freeze(js.Array(Pipe, File))
   }
-
-  object TrainingInstanceTypeEnum {
-    val `ml.m4.xlarge`     = "ml.m4.xlarge"
-    val `ml.m4.2xlarge`    = "ml.m4.2xlarge"
-    val `ml.m4.4xlarge`    = "ml.m4.4xlarge"
-    val `ml.m4.10xlarge`   = "ml.m4.10xlarge"
-    val `ml.m4.16xlarge`   = "ml.m4.16xlarge"
-    val `ml.g4dn.xlarge`   = "ml.g4dn.xlarge"
-    val `ml.g4dn.2xlarge`  = "ml.g4dn.2xlarge"
-    val `ml.g4dn.4xlarge`  = "ml.g4dn.4xlarge"
-    val `ml.g4dn.8xlarge`  = "ml.g4dn.8xlarge"
-    val `ml.g4dn.12xlarge` = "ml.g4dn.12xlarge"
-    val `ml.g4dn.16xlarge` = "ml.g4dn.16xlarge"
-    val `ml.m5.large`      = "ml.m5.large"
-    val `ml.m5.xlarge`     = "ml.m5.xlarge"
-    val `ml.m5.2xlarge`    = "ml.m5.2xlarge"
-    val `ml.m5.4xlarge`    = "ml.m5.4xlarge"
-    val `ml.m5.12xlarge`   = "ml.m5.12xlarge"
-    val `ml.m5.24xlarge`   = "ml.m5.24xlarge"
-    val `ml.c4.xlarge`     = "ml.c4.xlarge"
-    val `ml.c4.2xlarge`    = "ml.c4.2xlarge"
-    val `ml.c4.4xlarge`    = "ml.c4.4xlarge"
-    val `ml.c4.8xlarge`    = "ml.c4.8xlarge"
-    val `ml.p2.xlarge`     = "ml.p2.xlarge"
-    val `ml.p2.8xlarge`    = "ml.p2.8xlarge"
-    val `ml.p2.16xlarge`   = "ml.p2.16xlarge"
-    val `ml.p3.2xlarge`    = "ml.p3.2xlarge"
-    val `ml.p3.8xlarge`    = "ml.p3.8xlarge"
-    val `ml.p3.16xlarge`   = "ml.p3.16xlarge"
-    val `ml.p3dn.24xlarge` = "ml.p3dn.24xlarge"
-    val `ml.c5.xlarge`     = "ml.c5.xlarge"
-    val `ml.c5.2xlarge`    = "ml.c5.2xlarge"
-    val `ml.c5.4xlarge`    = "ml.c5.4xlarge"
-    val `ml.c5.9xlarge`    = "ml.c5.9xlarge"
-    val `ml.c5.18xlarge`   = "ml.c5.18xlarge"
+  @js.native
+  sealed trait TrainingInstanceType extends js.Any
+  object TrainingInstanceType extends js.Object {
+    val `ml.m4.xlarge`     = "ml.m4.xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m4.2xlarge`    = "ml.m4.2xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m4.4xlarge`    = "ml.m4.4xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m4.10xlarge`   = "ml.m4.10xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m4.16xlarge`   = "ml.m4.16xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.g4dn.xlarge`   = "ml.g4dn.xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.g4dn.2xlarge`  = "ml.g4dn.2xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.g4dn.4xlarge`  = "ml.g4dn.4xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.g4dn.8xlarge`  = "ml.g4dn.8xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.g4dn.12xlarge` = "ml.g4dn.12xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.g4dn.16xlarge` = "ml.g4dn.16xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m5.large`      = "ml.m5.large".asInstanceOf[TrainingInstanceType]
+    val `ml.m5.xlarge`     = "ml.m5.xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m5.2xlarge`    = "ml.m5.2xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m5.4xlarge`    = "ml.m5.4xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m5.12xlarge`   = "ml.m5.12xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.m5.24xlarge`   = "ml.m5.24xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c4.xlarge`     = "ml.c4.xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c4.2xlarge`    = "ml.c4.2xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c4.4xlarge`    = "ml.c4.4xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c4.8xlarge`    = "ml.c4.8xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.p2.xlarge`     = "ml.p2.xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.p2.8xlarge`    = "ml.p2.8xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.p2.16xlarge`   = "ml.p2.16xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.p3.2xlarge`    = "ml.p3.2xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.p3.8xlarge`    = "ml.p3.8xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.p3.16xlarge`   = "ml.p3.16xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.p3dn.24xlarge` = "ml.p3dn.24xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c5.xlarge`     = "ml.c5.xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c5.2xlarge`    = "ml.c5.2xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c5.4xlarge`    = "ml.c5.4xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c5.9xlarge`    = "ml.c5.9xlarge".asInstanceOf[TrainingInstanceType]
+    val `ml.c5.18xlarge`   = "ml.c5.18xlarge".asInstanceOf[TrainingInstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -13278,29 +13274,32 @@ package sagemaker {
       __obj.asInstanceOf[TrainingJobDefinition]
     }
   }
-
-  object TrainingJobEarlyStoppingTypeEnum {
-    val Off  = "Off"
-    val Auto = "Auto"
+  @js.native
+  sealed trait TrainingJobEarlyStoppingType extends js.Any
+  object TrainingJobEarlyStoppingType extends js.Object {
+    val Off  = "Off".asInstanceOf[TrainingJobEarlyStoppingType]
+    val Auto = "Auto".asInstanceOf[TrainingJobEarlyStoppingType]
 
     val values = js.Object.freeze(js.Array(Off, Auto))
   }
-
-  object TrainingJobSortByOptionsEnum {
-    val Name                      = "Name"
-    val CreationTime              = "CreationTime"
-    val Status                    = "Status"
-    val FinalObjectiveMetricValue = "FinalObjectiveMetricValue"
+  @js.native
+  sealed trait TrainingJobSortByOptions extends js.Any
+  object TrainingJobSortByOptions extends js.Object {
+    val Name                      = "Name".asInstanceOf[TrainingJobSortByOptions]
+    val CreationTime              = "CreationTime".asInstanceOf[TrainingJobSortByOptions]
+    val Status                    = "Status".asInstanceOf[TrainingJobSortByOptions]
+    val FinalObjectiveMetricValue = "FinalObjectiveMetricValue".asInstanceOf[TrainingJobSortByOptions]
 
     val values = js.Object.freeze(js.Array(Name, CreationTime, Status, FinalObjectiveMetricValue))
   }
-
-  object TrainingJobStatusEnum {
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-    val Stopping   = "Stopping"
-    val Stopped    = "Stopped"
+  @js.native
+  sealed trait TrainingJobStatus extends js.Any
+  object TrainingJobStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[TrainingJobStatus]
+    val Completed  = "Completed".asInstanceOf[TrainingJobStatus]
+    val Failed     = "Failed".asInstanceOf[TrainingJobStatus]
+    val Stopping   = "Stopping".asInstanceOf[TrainingJobStatus]
+    val Stopped    = "Stopped".asInstanceOf[TrainingJobStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Completed, Failed, Stopping, Stopped))
   }
@@ -13468,34 +13467,35 @@ package sagemaker {
       __obj.asInstanceOf[TransformInput]
     }
   }
-
-  object TransformInstanceTypeEnum {
-    val `ml.m4.xlarge`   = "ml.m4.xlarge"
-    val `ml.m4.2xlarge`  = "ml.m4.2xlarge"
-    val `ml.m4.4xlarge`  = "ml.m4.4xlarge"
-    val `ml.m4.10xlarge` = "ml.m4.10xlarge"
-    val `ml.m4.16xlarge` = "ml.m4.16xlarge"
-    val `ml.c4.xlarge`   = "ml.c4.xlarge"
-    val `ml.c4.2xlarge`  = "ml.c4.2xlarge"
-    val `ml.c4.4xlarge`  = "ml.c4.4xlarge"
-    val `ml.c4.8xlarge`  = "ml.c4.8xlarge"
-    val `ml.p2.xlarge`   = "ml.p2.xlarge"
-    val `ml.p2.8xlarge`  = "ml.p2.8xlarge"
-    val `ml.p2.16xlarge` = "ml.p2.16xlarge"
-    val `ml.p3.2xlarge`  = "ml.p3.2xlarge"
-    val `ml.p3.8xlarge`  = "ml.p3.8xlarge"
-    val `ml.p3.16xlarge` = "ml.p3.16xlarge"
-    val `ml.c5.xlarge`   = "ml.c5.xlarge"
-    val `ml.c5.2xlarge`  = "ml.c5.2xlarge"
-    val `ml.c5.4xlarge`  = "ml.c5.4xlarge"
-    val `ml.c5.9xlarge`  = "ml.c5.9xlarge"
-    val `ml.c5.18xlarge` = "ml.c5.18xlarge"
-    val `ml.m5.large`    = "ml.m5.large"
-    val `ml.m5.xlarge`   = "ml.m5.xlarge"
-    val `ml.m5.2xlarge`  = "ml.m5.2xlarge"
-    val `ml.m5.4xlarge`  = "ml.m5.4xlarge"
-    val `ml.m5.12xlarge` = "ml.m5.12xlarge"
-    val `ml.m5.24xlarge` = "ml.m5.24xlarge"
+  @js.native
+  sealed trait TransformInstanceType extends js.Any
+  object TransformInstanceType extends js.Object {
+    val `ml.m4.xlarge`   = "ml.m4.xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m4.2xlarge`  = "ml.m4.2xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m4.4xlarge`  = "ml.m4.4xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m4.10xlarge` = "ml.m4.10xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m4.16xlarge` = "ml.m4.16xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c4.xlarge`   = "ml.c4.xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c4.2xlarge`  = "ml.c4.2xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c4.4xlarge`  = "ml.c4.4xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c4.8xlarge`  = "ml.c4.8xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.p2.xlarge`   = "ml.p2.xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.p2.8xlarge`  = "ml.p2.8xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.p2.16xlarge` = "ml.p2.16xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.p3.2xlarge`  = "ml.p3.2xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.p3.8xlarge`  = "ml.p3.8xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.p3.16xlarge` = "ml.p3.16xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c5.xlarge`   = "ml.c5.xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c5.2xlarge`  = "ml.c5.2xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c5.4xlarge`  = "ml.c5.4xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c5.9xlarge`  = "ml.c5.9xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.c5.18xlarge` = "ml.c5.18xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m5.large`    = "ml.m5.large".asInstanceOf[TransformInstanceType]
+    val `ml.m5.xlarge`   = "ml.m5.xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m5.2xlarge`  = "ml.m5.2xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m5.4xlarge`  = "ml.m5.4xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m5.12xlarge` = "ml.m5.12xlarge".asInstanceOf[TransformInstanceType]
+    val `ml.m5.24xlarge` = "ml.m5.24xlarge".asInstanceOf[TransformInstanceType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -13567,13 +13567,14 @@ package sagemaker {
       __obj.asInstanceOf[TransformJobDefinition]
     }
   }
-
-  object TransformJobStatusEnum {
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
-    val Stopping   = "Stopping"
-    val Stopped    = "Stopped"
+  @js.native
+  sealed trait TransformJobStatus extends js.Any
+  object TransformJobStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[TransformJobStatus]
+    val Completed  = "Completed".asInstanceOf[TransformJobStatus]
+    val Failed     = "Failed".asInstanceOf[TransformJobStatus]
+    val Stopping   = "Stopping".asInstanceOf[TransformJobStatus]
+    val Stopped    = "Stopped".asInstanceOf[TransformJobStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Completed, Failed, Stopping, Stopped))
   }
@@ -13907,11 +13908,12 @@ package sagemaker {
       __obj.asInstanceOf[TrialComponentParameterValue]
     }
   }
-
-  object TrialComponentPrimaryStatusEnum {
-    val InProgress = "InProgress"
-    val Completed  = "Completed"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait TrialComponentPrimaryStatus extends js.Any
+  object TrialComponentPrimaryStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[TrialComponentPrimaryStatus]
+    val Completed  = "Completed".asInstanceOf[TrialComponentPrimaryStatus]
+    val Failed     = "Failed".asInstanceOf[TrialComponentPrimaryStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Completed, Failed))
   }
@@ -14861,19 +14863,21 @@ package sagemaker {
       __obj.asInstanceOf[UserProfileDetails]
     }
   }
-
-  object UserProfileSortKeyEnum {
-    val CreationTime     = "CreationTime"
-    val LastModifiedTime = "LastModifiedTime"
+  @js.native
+  sealed trait UserProfileSortKey extends js.Any
+  object UserProfileSortKey extends js.Object {
+    val CreationTime     = "CreationTime".asInstanceOf[UserProfileSortKey]
+    val LastModifiedTime = "LastModifiedTime".asInstanceOf[UserProfileSortKey]
 
     val values = js.Object.freeze(js.Array(CreationTime, LastModifiedTime))
   }
-
-  object UserProfileStatusEnum {
-    val Deleting  = "Deleting"
-    val Failed    = "Failed"
-    val InService = "InService"
-    val Pending   = "Pending"
+  @js.native
+  sealed trait UserProfileStatus extends js.Any
+  object UserProfileStatus extends js.Object {
+    val Deleting  = "Deleting".asInstanceOf[UserProfileStatus]
+    val Failed    = "Failed".asInstanceOf[UserProfileStatus]
+    val InService = "InService".asInstanceOf[UserProfileStatus]
+    val Pending   = "Pending".asInstanceOf[UserProfileStatus]
 
     val values = js.Object.freeze(js.Array(Deleting, Failed, InService, Pending))
   }

--- a/services/savingsplans/src/main/scala/facade/amazonaws/services/SavingsPlans.scala
+++ b/services/savingsplans/src/main/scala/facade/amazonaws/services/SavingsPlans.scala
@@ -9,7 +9,6 @@ import facade.amazonaws._
 package object savingsplans {
   type Amount                              = String
   type ClientToken                         = String
-  type CurrencyCode                        = String
   type CurrencyList                        = js.Array[CurrencyCode]
   type DurationsList                       = js.Array[SavingsPlansDuration]
   type EC2InstanceFamily                   = String
@@ -28,10 +27,8 @@ package object savingsplans {
   type SavingsPlanId                       = String
   type SavingsPlanIdList                   = js.Array[SavingsPlanId]
   type SavingsPlanList                     = js.Array[SavingsPlan]
-  type SavingsPlanOfferingFilterAttribute  = String
   type SavingsPlanOfferingFiltersList      = js.Array[SavingsPlanOfferingFilterElement]
   type SavingsPlanOfferingId               = String
-  type SavingsPlanOfferingPropertyKey      = String
   type SavingsPlanOfferingPropertyList     = js.Array[SavingsPlanOfferingProperty]
   type SavingsPlanOfferingRateFiltersList  = js.Array[SavingsPlanOfferingRateFilterElement]
   type SavingsPlanOfferingRatePropertyList = js.Array[SavingsPlanOfferingRateProperty]
@@ -39,34 +36,24 @@ package object savingsplans {
   type SavingsPlanOfferingsList            = js.Array[SavingsPlanOffering]
   type SavingsPlanOperation                = String
   type SavingsPlanOperationList            = js.Array[SavingsPlanOperation]
-  type SavingsPlanPaymentOption            = String
   type SavingsPlanPaymentOptionList        = js.Array[SavingsPlanPaymentOption]
-  type SavingsPlanProductType              = String
   type SavingsPlanProductTypeList          = js.Array[SavingsPlanProductType]
-  type SavingsPlanRateFilterAttribute      = String
   type SavingsPlanRateFilterList           = js.Array[SavingsPlanRateFilter]
-  type SavingsPlanRateFilterName           = String
   type SavingsPlanRateList                 = js.Array[SavingsPlanRate]
   type SavingsPlanRateOperation            = String
   type SavingsPlanRateOperationList        = js.Array[SavingsPlanRateOperation]
   type SavingsPlanRatePricePerUnit         = String
-  type SavingsPlanRatePropertyKey          = String
   type SavingsPlanRatePropertyList         = js.Array[SavingsPlanRateProperty]
-  type SavingsPlanRateServiceCode          = String
   type SavingsPlanRateServiceCodeList      = js.Array[SavingsPlanRateServiceCode]
-  type SavingsPlanRateUnit                 = String
   type SavingsPlanRateUsageType            = String
   type SavingsPlanRateUsageTypeList        = js.Array[SavingsPlanRateUsageType]
   type SavingsPlanServiceCode              = String
   type SavingsPlanServiceCodeList          = js.Array[SavingsPlanServiceCode]
-  type SavingsPlanState                    = String
   type SavingsPlanStateList                = js.Array[SavingsPlanState]
-  type SavingsPlanType                     = String
   type SavingsPlanTypeList                 = js.Array[SavingsPlanType]
   type SavingsPlanUsageType                = String
   type SavingsPlanUsageTypeList            = js.Array[SavingsPlanUsageType]
   type SavingsPlansDuration                = Double
-  type SavingsPlansFilterName              = String
   type TagKey                              = String
   type TagKeyList                          = js.Array[TagKey]
   type TagMap                              = js.Dictionary[TagValue]
@@ -166,10 +153,11 @@ package savingsplans {
       __obj.asInstanceOf[CreateSavingsPlanResponse]
     }
   }
-
-  object CurrencyCodeEnum {
-    val CNY = "CNY"
-    val USD = "USD"
+  @js.native
+  sealed trait CurrencyCode extends js.Any
+  object CurrencyCode extends js.Object {
+    val CNY = "CNY".asInstanceOf[CurrencyCode]
+    val USD = "USD".asInstanceOf[CurrencyCode]
 
     val values = js.Object.freeze(js.Array(CNY, USD))
   }
@@ -616,10 +604,11 @@ package savingsplans {
       __obj.asInstanceOf[SavingsPlanOffering]
     }
   }
-
-  object SavingsPlanOfferingFilterAttributeEnum {
-    val region         = "region"
-    val instanceFamily = "instanceFamily"
+  @js.native
+  sealed trait SavingsPlanOfferingFilterAttribute extends js.Any
+  object SavingsPlanOfferingFilterAttribute extends js.Object {
+    val region         = "region".asInstanceOf[SavingsPlanOfferingFilterAttribute]
+    val instanceFamily = "instanceFamily".asInstanceOf[SavingsPlanOfferingFilterAttribute]
 
     val values = js.Object.freeze(js.Array(region, instanceFamily))
   }
@@ -667,10 +656,11 @@ package savingsplans {
       __obj.asInstanceOf[SavingsPlanOfferingProperty]
     }
   }
-
-  object SavingsPlanOfferingPropertyKeyEnum {
-    val region         = "region"
-    val instanceFamily = "instanceFamily"
+  @js.native
+  sealed trait SavingsPlanOfferingPropertyKey extends js.Any
+  object SavingsPlanOfferingPropertyKey extends js.Object {
+    val region         = "region".asInstanceOf[SavingsPlanOfferingPropertyKey]
+    val instanceFamily = "instanceFamily".asInstanceOf[SavingsPlanOfferingPropertyKey]
 
     val values = js.Object.freeze(js.Array(region, instanceFamily))
   }
@@ -758,19 +748,21 @@ package savingsplans {
       __obj.asInstanceOf[SavingsPlanOfferingRateProperty]
     }
   }
-
-  object SavingsPlanPaymentOptionEnum {
-    val `All Upfront`     = "All Upfront"
-    val `Partial Upfront` = "Partial Upfront"
-    val `No Upfront`      = "No Upfront"
+  @js.native
+  sealed trait SavingsPlanPaymentOption extends js.Any
+  object SavingsPlanPaymentOption extends js.Object {
+    val `All Upfront`     = "All Upfront".asInstanceOf[SavingsPlanPaymentOption]
+    val `Partial Upfront` = "Partial Upfront".asInstanceOf[SavingsPlanPaymentOption]
+    val `No Upfront`      = "No Upfront".asInstanceOf[SavingsPlanPaymentOption]
 
     val values = js.Object.freeze(js.Array(`All Upfront`, `Partial Upfront`, `No Upfront`))
   }
-
-  object SavingsPlanProductTypeEnum {
-    val EC2     = "EC2"
-    val Fargate = "Fargate"
-    val Lambda  = "Lambda"
+  @js.native
+  sealed trait SavingsPlanProductType extends js.Any
+  object SavingsPlanProductType extends js.Object {
+    val EC2     = "EC2".asInstanceOf[SavingsPlanProductType]
+    val Fargate = "Fargate".asInstanceOf[SavingsPlanProductType]
+    val Lambda  = "Lambda".asInstanceOf[SavingsPlanProductType]
 
     val values = js.Object.freeze(js.Array(EC2, Fargate, Lambda))
   }
@@ -836,28 +828,30 @@ package savingsplans {
       __obj.asInstanceOf[SavingsPlanRateFilter]
     }
   }
-
-  object SavingsPlanRateFilterAttributeEnum {
-    val region             = "region"
-    val instanceFamily     = "instanceFamily"
-    val instanceType       = "instanceType"
-    val productDescription = "productDescription"
-    val tenancy            = "tenancy"
-    val productId          = "productId"
+  @js.native
+  sealed trait SavingsPlanRateFilterAttribute extends js.Any
+  object SavingsPlanRateFilterAttribute extends js.Object {
+    val region             = "region".asInstanceOf[SavingsPlanRateFilterAttribute]
+    val instanceFamily     = "instanceFamily".asInstanceOf[SavingsPlanRateFilterAttribute]
+    val instanceType       = "instanceType".asInstanceOf[SavingsPlanRateFilterAttribute]
+    val productDescription = "productDescription".asInstanceOf[SavingsPlanRateFilterAttribute]
+    val tenancy            = "tenancy".asInstanceOf[SavingsPlanRateFilterAttribute]
+    val productId          = "productId".asInstanceOf[SavingsPlanRateFilterAttribute]
 
     val values =
       js.Object.freeze(js.Array(region, instanceFamily, instanceType, productDescription, tenancy, productId))
   }
-
-  object SavingsPlanRateFilterNameEnum {
-    val region             = "region"
-    val instanceType       = "instanceType"
-    val productDescription = "productDescription"
-    val tenancy            = "tenancy"
-    val productType        = "productType"
-    val serviceCode        = "serviceCode"
-    val usageType          = "usageType"
-    val operation          = "operation"
+  @js.native
+  sealed trait SavingsPlanRateFilterName extends js.Any
+  object SavingsPlanRateFilterName extends js.Object {
+    val region             = "region".asInstanceOf[SavingsPlanRateFilterName]
+    val instanceType       = "instanceType".asInstanceOf[SavingsPlanRateFilterName]
+    val productDescription = "productDescription".asInstanceOf[SavingsPlanRateFilterName]
+    val tenancy            = "tenancy".asInstanceOf[SavingsPlanRateFilterName]
+    val productType        = "productType".asInstanceOf[SavingsPlanRateFilterName]
+    val serviceCode        = "serviceCode".asInstanceOf[SavingsPlanRateFilterName]
+    val usageType          = "usageType".asInstanceOf[SavingsPlanRateFilterName]
+    val operation          = "operation".asInstanceOf[SavingsPlanRateFilterName]
 
     val values = js.Object.freeze(
       js.Array(region, instanceType, productDescription, tenancy, productType, serviceCode, usageType, operation)
@@ -885,59 +879,65 @@ package savingsplans {
       __obj.asInstanceOf[SavingsPlanRateProperty]
     }
   }
-
-  object SavingsPlanRatePropertyKeyEnum {
-    val region             = "region"
-    val instanceType       = "instanceType"
-    val instanceFamily     = "instanceFamily"
-    val productDescription = "productDescription"
-    val tenancy            = "tenancy"
+  @js.native
+  sealed trait SavingsPlanRatePropertyKey extends js.Any
+  object SavingsPlanRatePropertyKey extends js.Object {
+    val region             = "region".asInstanceOf[SavingsPlanRatePropertyKey]
+    val instanceType       = "instanceType".asInstanceOf[SavingsPlanRatePropertyKey]
+    val instanceFamily     = "instanceFamily".asInstanceOf[SavingsPlanRatePropertyKey]
+    val productDescription = "productDescription".asInstanceOf[SavingsPlanRatePropertyKey]
+    val tenancy            = "tenancy".asInstanceOf[SavingsPlanRatePropertyKey]
 
     val values = js.Object.freeze(js.Array(region, instanceType, instanceFamily, productDescription, tenancy))
   }
-
-  object SavingsPlanRateServiceCodeEnum {
-    val AmazonEC2 = "AmazonEC2"
-    val AmazonECS = "AmazonECS"
-    val AWSLambda = "AWSLambda"
+  @js.native
+  sealed trait SavingsPlanRateServiceCode extends js.Any
+  object SavingsPlanRateServiceCode extends js.Object {
+    val AmazonEC2 = "AmazonEC2".asInstanceOf[SavingsPlanRateServiceCode]
+    val AmazonECS = "AmazonECS".asInstanceOf[SavingsPlanRateServiceCode]
+    val AWSLambda = "AWSLambda".asInstanceOf[SavingsPlanRateServiceCode]
 
     val values = js.Object.freeze(js.Array(AmazonEC2, AmazonECS, AWSLambda))
   }
-
-  object SavingsPlanRateUnitEnum {
-    val Hrs                = "Hrs"
-    val `Lambda-GB-Second` = "Lambda-GB-Second"
-    val Request            = "Request"
+  @js.native
+  sealed trait SavingsPlanRateUnit extends js.Any
+  object SavingsPlanRateUnit extends js.Object {
+    val Hrs                = "Hrs".asInstanceOf[SavingsPlanRateUnit]
+    val `Lambda-GB-Second` = "Lambda-GB-Second".asInstanceOf[SavingsPlanRateUnit]
+    val Request            = "Request".asInstanceOf[SavingsPlanRateUnit]
 
     val values = js.Object.freeze(js.Array(Hrs, `Lambda-GB-Second`, Request))
   }
-
-  object SavingsPlanStateEnum {
-    val `payment-pending` = "payment-pending"
-    val `payment-failed`  = "payment-failed"
-    val active            = "active"
-    val retired           = "retired"
+  @js.native
+  sealed trait SavingsPlanState extends js.Any
+  object SavingsPlanState extends js.Object {
+    val `payment-pending` = "payment-pending".asInstanceOf[SavingsPlanState]
+    val `payment-failed`  = "payment-failed".asInstanceOf[SavingsPlanState]
+    val active            = "active".asInstanceOf[SavingsPlanState]
+    val retired           = "retired".asInstanceOf[SavingsPlanState]
 
     val values = js.Object.freeze(js.Array(`payment-pending`, `payment-failed`, active, retired))
   }
-
-  object SavingsPlanTypeEnum {
-    val Compute     = "Compute"
-    val EC2Instance = "EC2Instance"
+  @js.native
+  sealed trait SavingsPlanType extends js.Any
+  object SavingsPlanType extends js.Object {
+    val Compute     = "Compute".asInstanceOf[SavingsPlanType]
+    val EC2Instance = "EC2Instance".asInstanceOf[SavingsPlanType]
 
     val values = js.Object.freeze(js.Array(Compute, EC2Instance))
   }
-
-  object SavingsPlansFilterNameEnum {
-    val region                = "region"
-    val `ec2-instance-family` = "ec2-instance-family"
-    val commitment            = "commitment"
-    val upfront               = "upfront"
-    val term                  = "term"
-    val `savings-plan-type`   = "savings-plan-type"
-    val `payment-option`      = "payment-option"
-    val start                 = "start"
-    val end                   = "end"
+  @js.native
+  sealed trait SavingsPlansFilterName extends js.Any
+  object SavingsPlansFilterName extends js.Object {
+    val region                = "region".asInstanceOf[SavingsPlansFilterName]
+    val `ec2-instance-family` = "ec2-instance-family".asInstanceOf[SavingsPlansFilterName]
+    val commitment            = "commitment".asInstanceOf[SavingsPlansFilterName]
+    val upfront               = "upfront".asInstanceOf[SavingsPlansFilterName]
+    val term                  = "term".asInstanceOf[SavingsPlansFilterName]
+    val `savings-plan-type`   = "savings-plan-type".asInstanceOf[SavingsPlansFilterName]
+    val `payment-option`      = "payment-option".asInstanceOf[SavingsPlansFilterName]
+    val start                 = "start".asInstanceOf[SavingsPlansFilterName]
+    val end                   = "end".asInstanceOf[SavingsPlansFilterName]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/schemas/src/main/scala/facade/amazonaws/services/Schemas.scala
+++ b/services/schemas/src/main/scala/facade/amazonaws/services/Schemas.scala
@@ -8,11 +8,8 @@ import facade.amazonaws._
 
 package object schemas {
   type Body                                        = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type CodeGenerationStatus                        = String
-  type DiscovererState                             = String
   type GetDiscoveredSchemaVersionItemInput         = String
   type Tags                                        = js.Dictionary[__string]
-  type Type                                        = String
   type __boolean                                   = Boolean
   type __integer                                   = Int
   type __integerMin1Max29000                       = Int
@@ -135,11 +132,12 @@ package schemas {
     def updateRegistry(params: UpdateRegistryRequest): Request[UpdateRegistryResponse]       = js.native
     def updateSchema(params: UpdateSchemaRequest): Request[UpdateSchemaResponse]             = js.native
   }
-
-  object CodeGenerationStatusEnum {
-    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS"
-    val CREATE_COMPLETE    = "CREATE_COMPLETE"
-    val CREATE_FAILED      = "CREATE_FAILED"
+  @js.native
+  sealed trait CodeGenerationStatus extends js.Any
+  object CodeGenerationStatus extends js.Object {
+    val CREATE_IN_PROGRESS = "CREATE_IN_PROGRESS".asInstanceOf[CodeGenerationStatus]
+    val CREATE_COMPLETE    = "CREATE_COMPLETE".asInstanceOf[CodeGenerationStatus]
+    val CREATE_FAILED      = "CREATE_FAILED".asInstanceOf[CodeGenerationStatus]
 
     val values = js.Object.freeze(js.Array(CREATE_IN_PROGRESS, CREATE_COMPLETE, CREATE_FAILED))
   }
@@ -606,10 +604,11 @@ package schemas {
       __obj.asInstanceOf[DescribeSchemaResponse]
     }
   }
-
-  object DiscovererStateEnum {
-    val STARTED = "STARTED"
-    val STOPPED = "STOPPED"
+  @js.native
+  sealed trait DiscovererState extends js.Any
+  object DiscovererState extends js.Object {
+    val STARTED = "STARTED".asInstanceOf[DiscovererState]
+    val STOPPED = "STOPPED".asInstanceOf[DiscovererState]
 
     val values = js.Object.freeze(js.Array(STARTED, STOPPED))
   }
@@ -1292,9 +1291,10 @@ package schemas {
       __obj.asInstanceOf[TagResourceRequest]
     }
   }
-
-  object TypeEnum {
-    val OpenApi3 = "OpenApi3"
+  @js.native
+  sealed trait Type extends js.Any
+  object Type extends js.Object {
+    val OpenApi3 = "OpenApi3".asInstanceOf[Type]
 
     val values = js.Object.freeze(js.Array(OpenApi3))
   }

--- a/services/securityhub/src/main/scala/facade/amazonaws/services/SecurityHub.scala
+++ b/services/securityhub/src/main/scala/facade/amazonaws/services/SecurityHub.scala
@@ -20,7 +20,6 @@ package object securityhub {
   type AwsEc2SecurityGroupIpv6RangeList        = js.Array[AwsEc2SecurityGroupIpv6Range]
   type AwsEc2SecurityGroupPrefixListIdList     = js.Array[AwsEc2SecurityGroupPrefixListId]
   type AwsEc2SecurityGroupUserIdGroupPairList  = js.Array[AwsEc2SecurityGroupUserIdGroupPair]
-  type AwsIamAccessKeyStatus                   = String
   type AwsIamRoleAssumeRolePolicyDocument      = String
   type AwsLambdaFunctionLayerList              = js.Array[AwsLambdaFunctionLayer]
   type AwsLambdaLayerVersionNumber             = Double
@@ -30,10 +29,7 @@ package object securityhub {
   type AwsSnsTopicSubscriptionList             = js.Array[AwsSnsTopicSubscription]
   type AwsWafWebAclRuleList                    = js.Array[AwsWafWebAclRule]
   type CategoryList                            = js.Array[NonEmptyString]
-  type ComplianceStatus                        = String
-  type ControlStatus                           = String
   type DateFilterList                          = js.Array[DateFilter]
-  type DateRangeUnit                           = String
   type FieldMap                                = js.Dictionary[NonEmptyString]
   type ImportFindingsErrorList                 = js.Array[ImportFindingsError]
   type InsightList                             = js.Array[Insight]
@@ -42,52 +38,38 @@ package object securityhub {
   type IpFilterList                            = js.Array[IpFilter]
   type KeywordFilterList                       = js.Array[KeywordFilter]
   type MalwareList                             = js.Array[Malware]
-  type MalwareState                            = String
-  type MalwareType                             = String
-  type MapFilterComparison                     = String
   type MapFilterList                           = js.Array[MapFilter]
   type MaxResults                              = Int
   type MemberList                              = js.Array[Member]
-  type NetworkDirection                        = String
   type NextToken                               = String
   type NonEmptyString                          = String
   type NonEmptyStringList                      = js.Array[NonEmptyString]
   type NumberFilterList                        = js.Array[NumberFilter]
-  type Partition                               = String
   type ProductSubscriptionArnList              = js.Array[NonEmptyString]
   type ProductsList                            = js.Array[Product]
-  type RecordState                             = String
   type RelatedFindingList                      = js.Array[RelatedFinding]
   type RelatedRequirementsList                 = js.Array[NonEmptyString]
   type ResourceArn                             = String
   type ResourceList                            = js.Array[Resource]
   type ResultList                              = js.Array[Result]
   type SecurityGroups                          = js.Array[NonEmptyString]
-  type SeverityRating                          = String
   type SortCriteria                            = js.Array[SortCriterion]
-  type SortOrder                               = String
   type Standards                               = js.Array[Standard]
   type StandardsControls                       = js.Array[StandardsControl]
   type StandardsInputParameterMap              = js.Dictionary[NonEmptyString]
-  type StandardsStatus                         = String
   type StandardsSubscriptionArns               = js.Array[NonEmptyString]
   type StandardsSubscriptionRequests           = js.Array[StandardsSubscriptionRequest]
   type StandardsSubscriptions                  = js.Array[StandardsSubscription]
-  type StringFilterComparison                  = String
   type StringFilterList                        = js.Array[StringFilter]
   type StringList                              = js.Array[NonEmptyString]
   type TagKey                                  = String
   type TagKeyList                              = js.Array[TagKey]
   type TagMap                                  = js.Dictionary[TagValue]
   type TagValue                                = String
-  type ThreatIntelIndicatorCategory            = String
   type ThreatIntelIndicatorList                = js.Array[ThreatIntelIndicator]
-  type ThreatIntelIndicatorType                = String
   type Timestamp                               = js.Date
   type TypeList                                = js.Array[NonEmptyString]
-  type VerificationState                       = String
   type WafExcludedRuleList                     = js.Array[WafExcludedRule]
-  type WorkflowState                           = String
 
   implicit final class SecurityHubOps(private val service: SecurityHub) extends AnyVal {
 
@@ -1106,10 +1088,11 @@ package securityhub {
       __obj.asInstanceOf[AwsIamAccessKeyDetails]
     }
   }
-
-  object AwsIamAccessKeyStatusEnum {
-    val Active   = "Active"
-    val Inactive = "Inactive"
+  @js.native
+  sealed trait AwsIamAccessKeyStatus extends js.Any
+  object AwsIamAccessKeyStatus extends js.Object {
+    val Active   = "Active".asInstanceOf[AwsIamAccessKeyStatus]
+    val Inactive = "Inactive".asInstanceOf[AwsIamAccessKeyStatus]
 
     val values = js.Object.freeze(js.Array(Active, Inactive))
   }
@@ -2302,12 +2285,13 @@ package securityhub {
       __obj.asInstanceOf[Compliance]
     }
   }
-
-  object ComplianceStatusEnum {
-    val PASSED        = "PASSED"
-    val WARNING       = "WARNING"
-    val FAILED        = "FAILED"
-    val NOT_AVAILABLE = "NOT_AVAILABLE"
+  @js.native
+  sealed trait ComplianceStatus extends js.Any
+  object ComplianceStatus extends js.Object {
+    val PASSED        = "PASSED".asInstanceOf[ComplianceStatus]
+    val WARNING       = "WARNING".asInstanceOf[ComplianceStatus]
+    val FAILED        = "FAILED".asInstanceOf[ComplianceStatus]
+    val NOT_AVAILABLE = "NOT_AVAILABLE".asInstanceOf[ComplianceStatus]
 
     val values = js.Object.freeze(js.Array(PASSED, WARNING, FAILED, NOT_AVAILABLE))
   }
@@ -2339,10 +2323,11 @@ package securityhub {
       __obj.asInstanceOf[ContainerDetails]
     }
   }
-
-  object ControlStatusEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait ControlStatus extends js.Any
+  object ControlStatus extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[ControlStatus]
+    val DISABLED = "DISABLED".asInstanceOf[ControlStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -2509,9 +2494,10 @@ package securityhub {
       __obj.asInstanceOf[DateRange]
     }
   }
-
-  object DateRangeUnitEnum {
-    val DAYS = "DAYS"
+  @js.native
+  sealed trait DateRangeUnit extends js.Any
+  object DateRangeUnit extends js.Object {
+    val DAYS = "DAYS".asInstanceOf[DateRangeUnit]
 
     val values = js.Object.freeze(js.Array(DAYS))
   }
@@ -3733,31 +3719,33 @@ package securityhub {
       __obj.asInstanceOf[Malware]
     }
   }
-
-  object MalwareStateEnum {
-    val OBSERVED       = "OBSERVED"
-    val REMOVAL_FAILED = "REMOVAL_FAILED"
-    val REMOVED        = "REMOVED"
+  @js.native
+  sealed trait MalwareState extends js.Any
+  object MalwareState extends js.Object {
+    val OBSERVED       = "OBSERVED".asInstanceOf[MalwareState]
+    val REMOVAL_FAILED = "REMOVAL_FAILED".asInstanceOf[MalwareState]
+    val REMOVED        = "REMOVED".asInstanceOf[MalwareState]
 
     val values = js.Object.freeze(js.Array(OBSERVED, REMOVAL_FAILED, REMOVED))
   }
-
-  object MalwareTypeEnum {
-    val ADWARE               = "ADWARE"
-    val BLENDED_THREAT       = "BLENDED_THREAT"
-    val BOTNET_AGENT         = "BOTNET_AGENT"
-    val COIN_MINER           = "COIN_MINER"
-    val EXPLOIT_KIT          = "EXPLOIT_KIT"
-    val KEYLOGGER            = "KEYLOGGER"
-    val MACRO                = "MACRO"
-    val POTENTIALLY_UNWANTED = "POTENTIALLY_UNWANTED"
-    val SPYWARE              = "SPYWARE"
-    val RANSOMWARE           = "RANSOMWARE"
-    val REMOTE_ACCESS        = "REMOTE_ACCESS"
-    val ROOTKIT              = "ROOTKIT"
-    val TROJAN               = "TROJAN"
-    val VIRUS                = "VIRUS"
-    val WORM                 = "WORM"
+  @js.native
+  sealed trait MalwareType extends js.Any
+  object MalwareType extends js.Object {
+    val ADWARE               = "ADWARE".asInstanceOf[MalwareType]
+    val BLENDED_THREAT       = "BLENDED_THREAT".asInstanceOf[MalwareType]
+    val BOTNET_AGENT         = "BOTNET_AGENT".asInstanceOf[MalwareType]
+    val COIN_MINER           = "COIN_MINER".asInstanceOf[MalwareType]
+    val EXPLOIT_KIT          = "EXPLOIT_KIT".asInstanceOf[MalwareType]
+    val KEYLOGGER            = "KEYLOGGER".asInstanceOf[MalwareType]
+    val MACRO                = "MACRO".asInstanceOf[MalwareType]
+    val POTENTIALLY_UNWANTED = "POTENTIALLY_UNWANTED".asInstanceOf[MalwareType]
+    val SPYWARE              = "SPYWARE".asInstanceOf[MalwareType]
+    val RANSOMWARE           = "RANSOMWARE".asInstanceOf[MalwareType]
+    val REMOTE_ACCESS        = "REMOTE_ACCESS".asInstanceOf[MalwareType]
+    val ROOTKIT              = "ROOTKIT".asInstanceOf[MalwareType]
+    val TROJAN               = "TROJAN".asInstanceOf[MalwareType]
+    val VIRUS                = "VIRUS".asInstanceOf[MalwareType]
+    val WORM                 = "WORM".asInstanceOf[MalwareType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3804,9 +3792,10 @@ package securityhub {
       __obj.asInstanceOf[MapFilter]
     }
   }
-
-  object MapFilterComparisonEnum {
-    val EQUALS = "EQUALS"
+  @js.native
+  sealed trait MapFilterComparison extends js.Any
+  object MapFilterComparison extends js.Object {
+    val EQUALS = "EQUALS".asInstanceOf[MapFilterComparison]
 
     val values = js.Object.freeze(js.Array(EQUALS))
   }
@@ -3893,10 +3882,11 @@ package securityhub {
       __obj.asInstanceOf[Network]
     }
   }
-
-  object NetworkDirectionEnum {
-    val IN  = "IN"
-    val OUT = "OUT"
+  @js.native
+  sealed trait NetworkDirection extends js.Any
+  object NetworkDirection extends js.Object {
+    val IN  = "IN".asInstanceOf[NetworkDirection]
+    val OUT = "OUT".asInstanceOf[NetworkDirection]
 
     val values = js.Object.freeze(js.Array(IN, OUT))
   }
@@ -3976,11 +3966,12 @@ package securityhub {
       __obj.asInstanceOf[NumberFilter]
     }
   }
-
-  object PartitionEnum {
-    val aws          = "aws"
-    val `aws-cn`     = "aws-cn"
-    val `aws-us-gov` = "aws-us-gov"
+  @js.native
+  sealed trait Partition extends js.Any
+  object Partition extends js.Object {
+    val aws          = "aws".asInstanceOf[Partition]
+    val `aws-cn`     = "aws-cn".asInstanceOf[Partition]
+    val `aws-us-gov` = "aws-us-gov".asInstanceOf[Partition]
 
     val values = js.Object.freeze(js.Array(aws, `aws-cn`, `aws-us-gov`))
   }
@@ -4084,10 +4075,11 @@ package securityhub {
       __obj.asInstanceOf[Recommendation]
     }
   }
-
-  object RecordStateEnum {
-    val ACTIVE   = "ACTIVE"
-    val ARCHIVED = "ARCHIVED"
+  @js.native
+  sealed trait RecordState extends js.Any
+  object RecordState extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[RecordState]
+    val ARCHIVED = "ARCHIVED".asInstanceOf[RecordState]
 
     val values = js.Object.freeze(js.Array(ACTIVE, ARCHIVED))
   }
@@ -4294,12 +4286,13 @@ package securityhub {
       __obj.asInstanceOf[Severity]
     }
   }
-
-  object SeverityRatingEnum {
-    val LOW      = "LOW"
-    val MEDIUM   = "MEDIUM"
-    val HIGH     = "HIGH"
-    val CRITICAL = "CRITICAL"
+  @js.native
+  sealed trait SeverityRating extends js.Any
+  object SeverityRating extends js.Object {
+    val LOW      = "LOW".asInstanceOf[SeverityRating]
+    val MEDIUM   = "MEDIUM".asInstanceOf[SeverityRating]
+    val HIGH     = "HIGH".asInstanceOf[SeverityRating]
+    val CRITICAL = "CRITICAL".asInstanceOf[SeverityRating]
 
     val values = js.Object.freeze(js.Array(LOW, MEDIUM, HIGH, CRITICAL))
   }
@@ -4325,10 +4318,11 @@ package securityhub {
       __obj.asInstanceOf[SortCriterion]
     }
   }
-
-  object SortOrderEnum {
-    val asc  = "asc"
-    val desc = "desc"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val asc  = "asc".asInstanceOf[SortOrder]
+    val desc = "desc".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(asc, desc))
   }
@@ -4403,13 +4397,14 @@ package securityhub {
       __obj.asInstanceOf[StandardsControl]
     }
   }
-
-  object StandardsStatusEnum {
-    val PENDING    = "PENDING"
-    val READY      = "READY"
-    val FAILED     = "FAILED"
-    val DELETING   = "DELETING"
-    val INCOMPLETE = "INCOMPLETE"
+  @js.native
+  sealed trait StandardsStatus extends js.Any
+  object StandardsStatus extends js.Object {
+    val PENDING    = "PENDING".asInstanceOf[StandardsStatus]
+    val READY      = "READY".asInstanceOf[StandardsStatus]
+    val FAILED     = "FAILED".asInstanceOf[StandardsStatus]
+    val DELETING   = "DELETING".asInstanceOf[StandardsStatus]
+    val INCOMPLETE = "INCOMPLETE".asInstanceOf[StandardsStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, READY, FAILED, DELETING, INCOMPLETE))
   }
@@ -4489,10 +4484,11 @@ package securityhub {
       __obj.asInstanceOf[StringFilter]
     }
   }
-
-  object StringFilterComparisonEnum {
-    val EQUALS = "EQUALS"
-    val PREFIX = "PREFIX"
+  @js.native
+  sealed trait StringFilterComparison extends js.Any
+  object StringFilterComparison extends js.Object {
+    val EQUALS = "EQUALS".asInstanceOf[StringFilterComparison]
+    val PREFIX = "PREFIX".asInstanceOf[StringFilterComparison]
 
     val values = js.Object.freeze(js.Array(EQUALS, PREFIX))
   }
@@ -4564,31 +4560,33 @@ package securityhub {
       __obj.asInstanceOf[ThreatIntelIndicator]
     }
   }
-
-  object ThreatIntelIndicatorCategoryEnum {
-    val BACKDOOR            = "BACKDOOR"
-    val CARD_STEALER        = "CARD_STEALER"
-    val COMMAND_AND_CONTROL = "COMMAND_AND_CONTROL"
-    val DROP_SITE           = "DROP_SITE"
-    val EXPLOIT_SITE        = "EXPLOIT_SITE"
-    val KEYLOGGER           = "KEYLOGGER"
+  @js.native
+  sealed trait ThreatIntelIndicatorCategory extends js.Any
+  object ThreatIntelIndicatorCategory extends js.Object {
+    val BACKDOOR            = "BACKDOOR".asInstanceOf[ThreatIntelIndicatorCategory]
+    val CARD_STEALER        = "CARD_STEALER".asInstanceOf[ThreatIntelIndicatorCategory]
+    val COMMAND_AND_CONTROL = "COMMAND_AND_CONTROL".asInstanceOf[ThreatIntelIndicatorCategory]
+    val DROP_SITE           = "DROP_SITE".asInstanceOf[ThreatIntelIndicatorCategory]
+    val EXPLOIT_SITE        = "EXPLOIT_SITE".asInstanceOf[ThreatIntelIndicatorCategory]
+    val KEYLOGGER           = "KEYLOGGER".asInstanceOf[ThreatIntelIndicatorCategory]
 
     val values =
       js.Object.freeze(js.Array(BACKDOOR, CARD_STEALER, COMMAND_AND_CONTROL, DROP_SITE, EXPLOIT_SITE, KEYLOGGER))
   }
-
-  object ThreatIntelIndicatorTypeEnum {
-    val DOMAIN        = "DOMAIN"
-    val EMAIL_ADDRESS = "EMAIL_ADDRESS"
-    val HASH_MD5      = "HASH_MD5"
-    val HASH_SHA1     = "HASH_SHA1"
-    val HASH_SHA256   = "HASH_SHA256"
-    val HASH_SHA512   = "HASH_SHA512"
-    val IPV4_ADDRESS  = "IPV4_ADDRESS"
-    val IPV6_ADDRESS  = "IPV6_ADDRESS"
-    val MUTEX         = "MUTEX"
-    val PROCESS       = "PROCESS"
-    val URL           = "URL"
+  @js.native
+  sealed trait ThreatIntelIndicatorType extends js.Any
+  object ThreatIntelIndicatorType extends js.Object {
+    val DOMAIN        = "DOMAIN".asInstanceOf[ThreatIntelIndicatorType]
+    val EMAIL_ADDRESS = "EMAIL_ADDRESS".asInstanceOf[ThreatIntelIndicatorType]
+    val HASH_MD5      = "HASH_MD5".asInstanceOf[ThreatIntelIndicatorType]
+    val HASH_SHA1     = "HASH_SHA1".asInstanceOf[ThreatIntelIndicatorType]
+    val HASH_SHA256   = "HASH_SHA256".asInstanceOf[ThreatIntelIndicatorType]
+    val HASH_SHA512   = "HASH_SHA512".asInstanceOf[ThreatIntelIndicatorType]
+    val IPV4_ADDRESS  = "IPV4_ADDRESS".asInstanceOf[ThreatIntelIndicatorType]
+    val IPV6_ADDRESS  = "IPV6_ADDRESS".asInstanceOf[ThreatIntelIndicatorType]
+    val MUTEX         = "MUTEX".asInstanceOf[ThreatIntelIndicatorType]
+    val PROCESS       = "PROCESS".asInstanceOf[ThreatIntelIndicatorType]
+    val URL           = "URL".asInstanceOf[ThreatIntelIndicatorType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4791,12 +4789,13 @@ package securityhub {
       __obj.asInstanceOf[UpdateStandardsControlResponse]
     }
   }
-
-  object VerificationStateEnum {
-    val UNKNOWN         = "UNKNOWN"
-    val TRUE_POSITIVE   = "TRUE_POSITIVE"
-    val FALSE_POSITIVE  = "FALSE_POSITIVE"
-    val BENIGN_POSITIVE = "BENIGN_POSITIVE"
+  @js.native
+  sealed trait VerificationState extends js.Any
+  object VerificationState extends js.Object {
+    val UNKNOWN         = "UNKNOWN".asInstanceOf[VerificationState]
+    val TRUE_POSITIVE   = "TRUE_POSITIVE".asInstanceOf[VerificationState]
+    val FALSE_POSITIVE  = "FALSE_POSITIVE".asInstanceOf[VerificationState]
+    val BENIGN_POSITIVE = "BENIGN_POSITIVE".asInstanceOf[VerificationState]
 
     val values = js.Object.freeze(js.Array(UNKNOWN, TRUE_POSITIVE, FALSE_POSITIVE, BENIGN_POSITIVE))
   }
@@ -4857,13 +4856,14 @@ package securityhub {
       __obj.asInstanceOf[WafOverrideAction]
     }
   }
-
-  object WorkflowStateEnum {
-    val NEW         = "NEW"
-    val ASSIGNED    = "ASSIGNED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val DEFERRED    = "DEFERRED"
-    val RESOLVED    = "RESOLVED"
+  @js.native
+  sealed trait WorkflowState extends js.Any
+  object WorkflowState extends js.Object {
+    val NEW         = "NEW".asInstanceOf[WorkflowState]
+    val ASSIGNED    = "ASSIGNED".asInstanceOf[WorkflowState]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[WorkflowState]
+    val DEFERRED    = "DEFERRED".asInstanceOf[WorkflowState]
+    val RESOLVED    = "RESOLVED".asInstanceOf[WorkflowState]
 
     val values = js.Object.freeze(js.Array(NEW, ASSIGNED, IN_PROGRESS, DEFERRED, RESOLVED))
   }

--- a/services/serverlessapplicationrepository/src/main/scala/facade/amazonaws/services/ServerlessApplicationRepository.scala
+++ b/services/serverlessapplicationrepository/src/main/scala/facade/amazonaws/services/ServerlessApplicationRepository.scala
@@ -7,9 +7,7 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object serverlessapplicationrepository {
-  type Capability                           = String
   type MaxItems                             = Int
-  type Status                               = String
   type __boolean                            = Boolean
   type __integer                            = Int
   type __listOfApplicationDependencySummary = js.Array[ApplicationDependencySummary]
@@ -189,11 +187,13 @@ package serverlessapplicationrepository {
   /**
     * Values that must be specified in order to deploy some applications.
     */
-  object CapabilityEnum {
-    val CAPABILITY_IAM             = "CAPABILITY_IAM"
-    val CAPABILITY_NAMED_IAM       = "CAPABILITY_NAMED_IAM"
-    val CAPABILITY_AUTO_EXPAND     = "CAPABILITY_AUTO_EXPAND"
-    val CAPABILITY_RESOURCE_POLICY = "CAPABILITY_RESOURCE_POLICY"
+  @js.native
+  sealed trait Capability extends js.Any
+  object Capability extends js.Object {
+    val CAPABILITY_IAM             = "CAPABILITY_IAM".asInstanceOf[Capability]
+    val CAPABILITY_NAMED_IAM       = "CAPABILITY_NAMED_IAM".asInstanceOf[Capability]
+    val CAPABILITY_AUTO_EXPAND     = "CAPABILITY_AUTO_EXPAND".asInstanceOf[Capability]
+    val CAPABILITY_RESOURCE_POLICY = "CAPABILITY_RESOURCE_POLICY".asInstanceOf[Capability]
 
     val values = js.Object.freeze(
       js.Array(CAPABILITY_IAM, CAPABILITY_NAMED_IAM, CAPABILITY_AUTO_EXPAND, CAPABILITY_RESOURCE_POLICY)
@@ -991,11 +991,12 @@ package serverlessapplicationrepository {
       __obj.asInstanceOf[RollbackTrigger]
     }
   }
-
-  object StatusEnum {
-    val PREPARING = "PREPARING"
-    val ACTIVE    = "ACTIVE"
-    val EXPIRED   = "EXPIRED"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val PREPARING = "PREPARING".asInstanceOf[Status]
+    val ACTIVE    = "ACTIVE".asInstanceOf[Status]
+    val EXPIRED   = "EXPIRED".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(PREPARING, ACTIVE, EXPIRED))
   }

--- a/services/servicecatalog/src/main/scala/facade/amazonaws/services/ServiceCatalog.scala
+++ b/services/servicecatalog/src/main/scala/facade/amazonaws/services/ServiceCatalog.scala
@@ -8,9 +8,7 @@ import facade.amazonaws._
 
 package object servicecatalog {
   type AcceptLanguage                          = String
-  type AccessLevelFilterKey                    = String
   type AccessLevelFilterValue                  = String
-  type AccessStatus                            = String
   type AccountId                               = String
   type AccountIds                              = js.Array[AccountId]
   type AddTags                                 = js.Array[Tag]
@@ -21,7 +19,6 @@ package object servicecatalog {
   type BudgetName                              = String
   type Budgets                                 = js.Array[BudgetDetail]
   type CausingEntity                           = String
-  type ChangeAction                            = String
   type CloudWatchDashboardName                 = String
   type CloudWatchDashboards                    = js.Array[CloudWatchDashboard]
   type ConstraintDescription                   = String
@@ -29,9 +26,7 @@ package object servicecatalog {
   type ConstraintParameters                    = String
   type ConstraintSummaries                     = js.Array[ConstraintSummary]
   type ConstraintType                          = String
-  type CopyOption                              = String
   type CopyOptions                             = js.Array[CopyOption]
-  type CopyProductStatus                       = String
   type CreatedTime                             = js.Date
   type CreationTime                            = js.Date
   type DefaultValue                            = String
@@ -40,7 +35,6 @@ package object servicecatalog {
   type Error                                   = String
   type ErrorCode                               = String
   type ErrorDescription                        = String
-  type EvaluationType                          = String
   type ExecutionParameterKey                   = String
   type ExecutionParameterMap                   = js.Dictionary[ExecutionParameterValueList]
   type ExecutionParameterType                  = String
@@ -62,7 +56,6 @@ package object servicecatalog {
   type NoEcho                                  = Boolean
   type NotificationArn                         = String
   type NotificationArns                        = js.Array[NotificationArn]
-  type OrganizationNodeType                    = String
   type OrganizationNodeValue                   = String
   type OrganizationNodes                       = js.Array[OrganizationNode]
   type OutputKey                               = String
@@ -79,28 +72,21 @@ package object servicecatalog {
   type PortfolioDetails                        = js.Array[PortfolioDetail]
   type PortfolioDisplayName                    = String
   type PortfolioName                           = String
-  type PortfolioShareType                      = String
   type PrincipalARN                            = String
-  type PrincipalType                           = String
   type Principals                              = js.Array[Principal]
   type ProductArn                              = String
-  type ProductSource                           = String
-  type ProductType                             = String
   type ProductViewAggregationType              = String
   type ProductViewAggregationValues            = js.Array[ProductViewAggregationValue]
   type ProductViewAggregations                 = js.Dictionary[ProductViewAggregationValues]
   type ProductViewDetails                      = js.Array[ProductViewDetail]
   type ProductViewDistributor                  = String
-  type ProductViewFilterBy                     = String
   type ProductViewFilterValue                  = String
   type ProductViewFilterValues                 = js.Array[ProductViewFilterValue]
   type ProductViewFilters                      = js.Dictionary[ProductViewFilterValues]
   type ProductViewName                         = String
   type ProductViewOwner                        = String
   type ProductViewShortDescription             = String
-  type ProductViewSortBy                       = String
   type ProductViewSummaries                    = js.Array[ProductViewSummary]
-  type PropertyKey                             = String
   type PropertyName                            = String
   type PropertyValue                           = String
   type ProviderName                            = String
@@ -111,46 +97,35 @@ package object servicecatalog {
   type ProvisionedProductName                  = String
   type ProvisionedProductNameOrArn             = String
   type ProvisionedProductPlanName              = String
-  type ProvisionedProductPlanStatus            = String
-  type ProvisionedProductPlanType              = String
   type ProvisionedProductPlans                 = js.Array[ProvisionedProductPlanSummary]
   type ProvisionedProductProperties            = js.Dictionary[PropertyValue]
-  type ProvisionedProductStatus                = String
   type ProvisionedProductStatusMessage         = String
   type ProvisionedProductType                  = String
-  type ProvisionedProductViewFilterBy          = String
   type ProvisionedProductViewFilterValue       = String
   type ProvisionedProductViewFilterValues      = js.Array[ProvisionedProductViewFilterValue]
   type ProvisioningArtifactActive              = Boolean
   type ProvisioningArtifactCreatedTime         = js.Date
   type ProvisioningArtifactDescription         = String
   type ProvisioningArtifactDetails             = js.Array[ProvisioningArtifactDetail]
-  type ProvisioningArtifactGuidance            = String
   type ProvisioningArtifactInfo                = js.Dictionary[ProvisioningArtifactInfoValue]
   type ProvisioningArtifactInfoKey             = String
   type ProvisioningArtifactInfoValue           = String
   type ProvisioningArtifactName                = String
   type ProvisioningArtifactParameters          = js.Array[ProvisioningArtifactParameter]
-  type ProvisioningArtifactPropertyName        = String
   type ProvisioningArtifactPropertyValue       = String
   type ProvisioningArtifactSummaries           = js.Array[ProvisioningArtifactSummary]
-  type ProvisioningArtifactType                = String
   type ProvisioningArtifactViews               = js.Array[ProvisioningArtifactView]
   type ProvisioningArtifacts                   = js.Array[ProvisioningArtifact]
   type ProvisioningParameters                  = js.Array[ProvisioningParameter]
   type RecordDetails                           = js.Array[RecordDetail]
   type RecordErrors                            = js.Array[RecordError]
   type RecordOutputs                           = js.Array[RecordOutput]
-  type RecordStatus                            = String
   type RecordTagKey                            = String
   type RecordTagValue                          = String
   type RecordTags                              = js.Array[RecordTag]
   type RecordType                              = String
   type Region                                  = String
-  type Replacement                             = String
-  type RequiresRecreation                      = String
   type ResourceARN                             = String
-  type ResourceAttribute                       = String
   type ResourceChangeDetails                   = js.Array[ResourceChangeDetail]
   type ResourceChanges                         = js.Array[ResourceChange]
   type ResourceDetailARN                       = String
@@ -165,32 +140,24 @@ package object servicecatalog {
   type SearchFilterKey                         = String
   type SearchFilterValue                       = String
   type SearchProvisionedProductsPageSize       = Int
-  type ServiceActionAssociationErrorCode       = String
   type ServiceActionAssociationErrorMessage    = String
   type ServiceActionAssociations               = js.Array[ServiceActionAssociation]
-  type ServiceActionDefinitionKey              = String
   type ServiceActionDefinitionMap              = js.Dictionary[ServiceActionDefinitionValue]
-  type ServiceActionDefinitionType             = String
   type ServiceActionDefinitionValue            = String
   type ServiceActionDescription                = String
   type ServiceActionName                       = String
   type ServiceActionSummaries                  = js.Array[ServiceActionSummary]
   type ShareErrors                             = js.Array[ShareError]
-  type ShareStatus                             = String
   type SortField                               = String
-  type SortOrder                               = String
   type SourceProvisioningArtifactProperties    = js.Array[SourceProvisioningArtifactPropertiesMap]
   type SourceProvisioningArtifactPropertiesMap = js.Dictionary[ProvisioningArtifactPropertyValue]
-  type StackInstanceStatus                     = String
   type StackInstances                          = js.Array[StackInstance]
   type StackSetAccounts                        = js.Array[AccountId]
   type StackSetFailureToleranceCount           = Int
   type StackSetFailureTolerancePercentage      = Int
   type StackSetMaxConcurrencyCount             = Int
   type StackSetMaxConcurrencyPercentage        = Int
-  type StackSetOperationType                   = String
   type StackSetRegions                         = js.Array[Region]
-  type Status                                  = String
   type StatusDetail                            = String
   type StatusMessage                           = String
   type SuccessfulShares                        = js.Array[AccountId]
@@ -675,19 +642,21 @@ package servicecatalog {
       __obj.asInstanceOf[AccessLevelFilter]
     }
   }
-
-  object AccessLevelFilterKeyEnum {
-    val Account = "Account"
-    val Role    = "Role"
-    val User    = "User"
+  @js.native
+  sealed trait AccessLevelFilterKey extends js.Any
+  object AccessLevelFilterKey extends js.Object {
+    val Account = "Account".asInstanceOf[AccessLevelFilterKey]
+    val Role    = "Role".asInstanceOf[AccessLevelFilterKey]
+    val User    = "User".asInstanceOf[AccessLevelFilterKey]
 
     val values = js.Object.freeze(js.Array(Account, Role, User))
   }
-
-  object AccessStatusEnum {
-    val ENABLED      = "ENABLED"
-    val UNDER_CHANGE = "UNDER_CHANGE"
-    val DISABLED     = "DISABLED"
+  @js.native
+  sealed trait AccessStatus extends js.Any
+  object AccessStatus extends js.Object {
+    val ENABLED      = "ENABLED".asInstanceOf[AccessStatus]
+    val UNDER_CHANGE = "UNDER_CHANGE".asInstanceOf[AccessStatus]
+    val DISABLED     = "DISABLED".asInstanceOf[AccessStatus]
 
     val values = js.Object.freeze(js.Array(ENABLED, UNDER_CHANGE, DISABLED))
   }
@@ -976,11 +945,12 @@ package servicecatalog {
       __obj.asInstanceOf[BudgetDetail]
     }
   }
-
-  object ChangeActionEnum {
-    val ADD    = "ADD"
-    val MODIFY = "MODIFY"
-    val REMOVE = "REMOVE"
+  @js.native
+  sealed trait ChangeAction extends js.Any
+  object ChangeAction extends js.Object {
+    val ADD    = "ADD".asInstanceOf[ChangeAction]
+    val MODIFY = "MODIFY".asInstanceOf[ChangeAction]
+    val REMOVE = "REMOVE".asInstanceOf[ChangeAction]
 
     val values = js.Object.freeze(js.Array(ADD, MODIFY, REMOVE))
   }
@@ -1053,9 +1023,10 @@ package servicecatalog {
       __obj.asInstanceOf[ConstraintSummary]
     }
   }
-
-  object CopyOptionEnum {
-    val CopyTags = "CopyTags"
+  @js.native
+  sealed trait CopyOption extends js.Any
+  object CopyOption extends js.Object {
+    val CopyTags = "CopyTags".asInstanceOf[CopyOption]
 
     val values = js.Object.freeze(js.Array(CopyTags))
   }
@@ -1113,11 +1084,12 @@ package servicecatalog {
       __obj.asInstanceOf[CopyProductOutput]
     }
   }
-
-  object CopyProductStatusEnum {
-    val SUCCEEDED   = "SUCCEEDED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val FAILED      = "FAILED"
+  @js.native
+  sealed trait CopyProductStatus extends js.Any
+  object CopyProductStatus extends js.Object {
+    val SUCCEEDED   = "SUCCEEDED".asInstanceOf[CopyProductStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[CopyProductStatus]
+    val FAILED      = "FAILED".asInstanceOf[CopyProductStatus]
 
     val values = js.Object.freeze(js.Array(SUCCEEDED, IN_PROGRESS, FAILED))
   }
@@ -2753,10 +2725,11 @@ package servicecatalog {
       __obj.asInstanceOf[EnableAWSOrganizationsAccessOutput]
     }
   }
-
-  object EvaluationTypeEnum {
-    val STATIC  = "STATIC"
-    val DYNAMIC = "DYNAMIC"
+  @js.native
+  sealed trait EvaluationType extends js.Any
+  object EvaluationType extends js.Object {
+    val STATIC  = "STATIC".asInstanceOf[EvaluationType]
+    val DYNAMIC = "DYNAMIC".asInstanceOf[EvaluationType]
 
     val values = js.Object.freeze(js.Array(STATIC, DYNAMIC))
   }
@@ -3851,11 +3824,12 @@ package servicecatalog {
       __obj.asInstanceOf[OrganizationNode]
     }
   }
-
-  object OrganizationNodeTypeEnum {
-    val ORGANIZATION        = "ORGANIZATION"
-    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT"
-    val ACCOUNT             = "ACCOUNT"
+  @js.native
+  sealed trait OrganizationNodeType extends js.Any
+  object OrganizationNodeType extends js.Object {
+    val ORGANIZATION        = "ORGANIZATION".asInstanceOf[OrganizationNodeType]
+    val ORGANIZATIONAL_UNIT = "ORGANIZATIONAL_UNIT".asInstanceOf[OrganizationNodeType]
+    val ACCOUNT             = "ACCOUNT".asInstanceOf[OrganizationNodeType]
 
     val values = js.Object.freeze(js.Array(ORGANIZATION, ORGANIZATIONAL_UNIT, ACCOUNT))
   }
@@ -3912,11 +3886,12 @@ package servicecatalog {
       __obj.asInstanceOf[PortfolioDetail]
     }
   }
-
-  object PortfolioShareTypeEnum {
-    val IMPORTED           = "IMPORTED"
-    val AWS_SERVICECATALOG = "AWS_SERVICECATALOG"
-    val AWS_ORGANIZATIONS  = "AWS_ORGANIZATIONS"
+  @js.native
+  sealed trait PortfolioShareType extends js.Any
+  object PortfolioShareType extends js.Object {
+    val IMPORTED           = "IMPORTED".asInstanceOf[PortfolioShareType]
+    val AWS_SERVICECATALOG = "AWS_SERVICECATALOG".asInstanceOf[PortfolioShareType]
+    val AWS_ORGANIZATIONS  = "AWS_ORGANIZATIONS".asInstanceOf[PortfolioShareType]
 
     val values = js.Object.freeze(js.Array(IMPORTED, AWS_SERVICECATALOG, AWS_ORGANIZATIONS))
   }
@@ -3942,22 +3917,25 @@ package servicecatalog {
       __obj.asInstanceOf[Principal]
     }
   }
-
-  object PrincipalTypeEnum {
-    val IAM = "IAM"
+  @js.native
+  sealed trait PrincipalType extends js.Any
+  object PrincipalType extends js.Object {
+    val IAM = "IAM".asInstanceOf[PrincipalType]
 
     val values = js.Object.freeze(js.Array(IAM))
   }
-
-  object ProductSourceEnum {
-    val ACCOUNT = "ACCOUNT"
+  @js.native
+  sealed trait ProductSource extends js.Any
+  object ProductSource extends js.Object {
+    val ACCOUNT = "ACCOUNT".asInstanceOf[ProductSource]
 
     val values = js.Object.freeze(js.Array(ACCOUNT))
   }
-
-  object ProductTypeEnum {
-    val CLOUD_FORMATION_TEMPLATE = "CLOUD_FORMATION_TEMPLATE"
-    val MARKETPLACE              = "MARKETPLACE"
+  @js.native
+  sealed trait ProductType extends js.Any
+  object ProductType extends js.Object {
+    val CLOUD_FORMATION_TEMPLATE = "CLOUD_FORMATION_TEMPLATE".asInstanceOf[ProductType]
+    val MARKETPLACE              = "MARKETPLACE".asInstanceOf[ProductType]
 
     val values = js.Object.freeze(js.Array(CLOUD_FORMATION_TEMPLATE, MARKETPLACE))
   }
@@ -4011,20 +3989,22 @@ package servicecatalog {
       __obj.asInstanceOf[ProductViewDetail]
     }
   }
-
-  object ProductViewFilterByEnum {
-    val FullTextSearch  = "FullTextSearch"
-    val Owner           = "Owner"
-    val ProductType     = "ProductType"
-    val SourceProductId = "SourceProductId"
+  @js.native
+  sealed trait ProductViewFilterBy extends js.Any
+  object ProductViewFilterBy extends js.Object {
+    val FullTextSearch  = "FullTextSearch".asInstanceOf[ProductViewFilterBy]
+    val Owner           = "Owner".asInstanceOf[ProductViewFilterBy]
+    val ProductType     = "ProductType".asInstanceOf[ProductViewFilterBy]
+    val SourceProductId = "SourceProductId".asInstanceOf[ProductViewFilterBy]
 
     val values = js.Object.freeze(js.Array(FullTextSearch, Owner, ProductType, SourceProductId))
   }
-
-  object ProductViewSortByEnum {
-    val Title        = "Title"
-    val VersionCount = "VersionCount"
-    val CreationDate = "CreationDate"
+  @js.native
+  sealed trait ProductViewSortBy extends js.Any
+  object ProductViewSortBy extends js.Object {
+    val Title        = "Title".asInstanceOf[ProductViewSortBy]
+    val VersionCount = "VersionCount".asInstanceOf[ProductViewSortBy]
+    val CreationDate = "CreationDate".asInstanceOf[ProductViewSortBy]
 
     val values = js.Object.freeze(js.Array(Title, VersionCount, CreationDate))
   }
@@ -4077,9 +4057,10 @@ package servicecatalog {
       __obj.asInstanceOf[ProductViewSummary]
     }
   }
-
-  object PropertyKeyEnum {
-    val OWNER = "OWNER"
+  @js.native
+  sealed trait PropertyKey extends js.Any
+  object PropertyKey extends js.Object {
+    val OWNER = "OWNER".asInstanceOf[PropertyKey]
 
     val values = js.Object.freeze(js.Array(OWNER))
   }
@@ -4315,14 +4296,15 @@ package servicecatalog {
       __obj.asInstanceOf[ProvisionedProductPlanDetails]
     }
   }
-
-  object ProvisionedProductPlanStatusEnum {
-    val CREATE_IN_PROGRESS  = "CREATE_IN_PROGRESS"
-    val CREATE_SUCCESS      = "CREATE_SUCCESS"
-    val CREATE_FAILED       = "CREATE_FAILED"
-    val EXECUTE_IN_PROGRESS = "EXECUTE_IN_PROGRESS"
-    val EXECUTE_SUCCESS     = "EXECUTE_SUCCESS"
-    val EXECUTE_FAILED      = "EXECUTE_FAILED"
+  @js.native
+  sealed trait ProvisionedProductPlanStatus extends js.Any
+  object ProvisionedProductPlanStatus extends js.Object {
+    val CREATE_IN_PROGRESS  = "CREATE_IN_PROGRESS".asInstanceOf[ProvisionedProductPlanStatus]
+    val CREATE_SUCCESS      = "CREATE_SUCCESS".asInstanceOf[ProvisionedProductPlanStatus]
+    val CREATE_FAILED       = "CREATE_FAILED".asInstanceOf[ProvisionedProductPlanStatus]
+    val EXECUTE_IN_PROGRESS = "EXECUTE_IN_PROGRESS".asInstanceOf[ProvisionedProductPlanStatus]
+    val EXECUTE_SUCCESS     = "EXECUTE_SUCCESS".asInstanceOf[ProvisionedProductPlanStatus]
+    val EXECUTE_FAILED      = "EXECUTE_FAILED".asInstanceOf[ProvisionedProductPlanStatus]
 
     val values = js.Object.freeze(
       js.Array(CREATE_IN_PROGRESS, CREATE_SUCCESS, CREATE_FAILED, EXECUTE_IN_PROGRESS, EXECUTE_SUCCESS, EXECUTE_FAILED)
@@ -4362,25 +4344,28 @@ package servicecatalog {
       __obj.asInstanceOf[ProvisionedProductPlanSummary]
     }
   }
-
-  object ProvisionedProductPlanTypeEnum {
-    val CLOUDFORMATION = "CLOUDFORMATION"
+  @js.native
+  sealed trait ProvisionedProductPlanType extends js.Any
+  object ProvisionedProductPlanType extends js.Object {
+    val CLOUDFORMATION = "CLOUDFORMATION".asInstanceOf[ProvisionedProductPlanType]
 
     val values = js.Object.freeze(js.Array(CLOUDFORMATION))
   }
-
-  object ProvisionedProductStatusEnum {
-    val AVAILABLE        = "AVAILABLE"
-    val UNDER_CHANGE     = "UNDER_CHANGE"
-    val TAINTED          = "TAINTED"
-    val ERROR            = "ERROR"
-    val PLAN_IN_PROGRESS = "PLAN_IN_PROGRESS"
+  @js.native
+  sealed trait ProvisionedProductStatus extends js.Any
+  object ProvisionedProductStatus extends js.Object {
+    val AVAILABLE        = "AVAILABLE".asInstanceOf[ProvisionedProductStatus]
+    val UNDER_CHANGE     = "UNDER_CHANGE".asInstanceOf[ProvisionedProductStatus]
+    val TAINTED          = "TAINTED".asInstanceOf[ProvisionedProductStatus]
+    val ERROR            = "ERROR".asInstanceOf[ProvisionedProductStatus]
+    val PLAN_IN_PROGRESS = "PLAN_IN_PROGRESS".asInstanceOf[ProvisionedProductStatus]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, UNDER_CHANGE, TAINTED, ERROR, PLAN_IN_PROGRESS))
   }
-
-  object ProvisionedProductViewFilterByEnum {
-    val SearchQuery = "SearchQuery"
+  @js.native
+  sealed trait ProvisionedProductViewFilterBy extends js.Any
+  object ProvisionedProductViewFilterBy extends js.Object {
+    val SearchQuery = "SearchQuery".asInstanceOf[ProvisionedProductViewFilterBy]
 
     val values = js.Object.freeze(js.Array(SearchQuery))
   }
@@ -4452,10 +4437,11 @@ package servicecatalog {
       __obj.asInstanceOf[ProvisioningArtifactDetail]
     }
   }
-
-  object ProvisioningArtifactGuidanceEnum {
-    val DEFAULT    = "DEFAULT"
-    val DEPRECATED = "DEPRECATED"
+  @js.native
+  sealed trait ProvisioningArtifactGuidance extends js.Any
+  object ProvisioningArtifactGuidance extends js.Object {
+    val DEFAULT    = "DEFAULT".asInstanceOf[ProvisioningArtifactGuidance]
+    val DEPRECATED = "DEPRECATED".asInstanceOf[ProvisioningArtifactGuidance]
 
     val values = js.Object.freeze(js.Array(DEFAULT, DEPRECATED))
   }
@@ -4551,9 +4537,10 @@ package servicecatalog {
       __obj.asInstanceOf[ProvisioningArtifactProperties]
     }
   }
-
-  object ProvisioningArtifactPropertyNameEnum {
-    val Id = "Id"
+  @js.native
+  sealed trait ProvisioningArtifactPropertyName extends js.Any
+  object ProvisioningArtifactPropertyName extends js.Object {
+    val Id = "Id".asInstanceOf[ProvisioningArtifactPropertyName]
 
     val values = js.Object.freeze(js.Array(Id))
   }
@@ -4590,11 +4577,12 @@ package servicecatalog {
       __obj.asInstanceOf[ProvisioningArtifactSummary]
     }
   }
-
-  object ProvisioningArtifactTypeEnum {
-    val CLOUD_FORMATION_TEMPLATE = "CLOUD_FORMATION_TEMPLATE"
-    val MARKETPLACE_AMI          = "MARKETPLACE_AMI"
-    val MARKETPLACE_CAR          = "MARKETPLACE_CAR"
+  @js.native
+  sealed trait ProvisioningArtifactType extends js.Any
+  object ProvisioningArtifactType extends js.Object {
+    val CLOUD_FORMATION_TEMPLATE = "CLOUD_FORMATION_TEMPLATE".asInstanceOf[ProvisioningArtifactType]
+    val MARKETPLACE_AMI          = "MARKETPLACE_AMI".asInstanceOf[ProvisioningArtifactType]
+    val MARKETPLACE_CAR          = "MARKETPLACE_CAR".asInstanceOf[ProvisioningArtifactType]
 
     val values = js.Object.freeze(js.Array(CLOUD_FORMATION_TEMPLATE, MARKETPLACE_AMI, MARKETPLACE_CAR))
   }
@@ -4786,13 +4774,14 @@ package servicecatalog {
       __obj.asInstanceOf[RecordOutput]
     }
   }
-
-  object RecordStatusEnum {
-    val CREATED              = "CREATED"
-    val IN_PROGRESS          = "IN_PROGRESS"
-    val IN_PROGRESS_IN_ERROR = "IN_PROGRESS_IN_ERROR"
-    val SUCCEEDED            = "SUCCEEDED"
-    val FAILED               = "FAILED"
+  @js.native
+  sealed trait RecordStatus extends js.Any
+  object RecordStatus extends js.Object {
+    val CREATED              = "CREATED".asInstanceOf[RecordStatus]
+    val IN_PROGRESS          = "IN_PROGRESS".asInstanceOf[RecordStatus]
+    val IN_PROGRESS_IN_ERROR = "IN_PROGRESS_IN_ERROR".asInstanceOf[RecordStatus]
+    val SUCCEEDED            = "SUCCEEDED".asInstanceOf[RecordStatus]
+    val FAILED               = "FAILED".asInstanceOf[RecordStatus]
 
     val values = js.Object.freeze(js.Array(CREATED, IN_PROGRESS, IN_PROGRESS_IN_ERROR, SUCCEEDED, FAILED))
   }
@@ -4855,30 +4844,33 @@ package servicecatalog {
       __obj.asInstanceOf[RejectPortfolioShareOutput]
     }
   }
-
-  object ReplacementEnum {
-    val TRUE        = "TRUE"
-    val FALSE       = "FALSE"
-    val CONDITIONAL = "CONDITIONAL"
+  @js.native
+  sealed trait Replacement extends js.Any
+  object Replacement extends js.Object {
+    val TRUE        = "TRUE".asInstanceOf[Replacement]
+    val FALSE       = "FALSE".asInstanceOf[Replacement]
+    val CONDITIONAL = "CONDITIONAL".asInstanceOf[Replacement]
 
     val values = js.Object.freeze(js.Array(TRUE, FALSE, CONDITIONAL))
   }
-
-  object RequiresRecreationEnum {
-    val NEVER         = "NEVER"
-    val CONDITIONALLY = "CONDITIONALLY"
-    val ALWAYS        = "ALWAYS"
+  @js.native
+  sealed trait RequiresRecreation extends js.Any
+  object RequiresRecreation extends js.Object {
+    val NEVER         = "NEVER".asInstanceOf[RequiresRecreation]
+    val CONDITIONALLY = "CONDITIONALLY".asInstanceOf[RequiresRecreation]
+    val ALWAYS        = "ALWAYS".asInstanceOf[RequiresRecreation]
 
     val values = js.Object.freeze(js.Array(NEVER, CONDITIONALLY, ALWAYS))
   }
-
-  object ResourceAttributeEnum {
-    val PROPERTIES     = "PROPERTIES"
-    val METADATA       = "METADATA"
-    val CREATIONPOLICY = "CREATIONPOLICY"
-    val UPDATEPOLICY   = "UPDATEPOLICY"
-    val DELETIONPOLICY = "DELETIONPOLICY"
-    val TAGS           = "TAGS"
+  @js.native
+  sealed trait ResourceAttribute extends js.Any
+  object ResourceAttribute extends js.Object {
+    val PROPERTIES     = "PROPERTIES".asInstanceOf[ResourceAttribute]
+    val METADATA       = "METADATA".asInstanceOf[ResourceAttribute]
+    val CREATIONPOLICY = "CREATIONPOLICY".asInstanceOf[ResourceAttribute]
+    val UPDATEPOLICY   = "UPDATEPOLICY".asInstanceOf[ResourceAttribute]
+    val DELETIONPOLICY = "DELETIONPOLICY".asInstanceOf[ResourceAttribute]
+    val TAGS           = "TAGS".asInstanceOf[ResourceAttribute]
 
     val values = js.Object.freeze(js.Array(PROPERTIES, METADATA, CREATIONPOLICY, UPDATEPOLICY, DELETIONPOLICY, TAGS))
   }
@@ -5236,29 +5228,32 @@ package servicecatalog {
       __obj.asInstanceOf[ServiceActionAssociation]
     }
   }
-
-  object ServiceActionAssociationErrorCodeEnum {
-    val DUPLICATE_RESOURCE = "DUPLICATE_RESOURCE"
-    val INTERNAL_FAILURE   = "INTERNAL_FAILURE"
-    val LIMIT_EXCEEDED     = "LIMIT_EXCEEDED"
-    val RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND"
-    val THROTTLING         = "THROTTLING"
+  @js.native
+  sealed trait ServiceActionAssociationErrorCode extends js.Any
+  object ServiceActionAssociationErrorCode extends js.Object {
+    val DUPLICATE_RESOURCE = "DUPLICATE_RESOURCE".asInstanceOf[ServiceActionAssociationErrorCode]
+    val INTERNAL_FAILURE   = "INTERNAL_FAILURE".asInstanceOf[ServiceActionAssociationErrorCode]
+    val LIMIT_EXCEEDED     = "LIMIT_EXCEEDED".asInstanceOf[ServiceActionAssociationErrorCode]
+    val RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND".asInstanceOf[ServiceActionAssociationErrorCode]
+    val THROTTLING         = "THROTTLING".asInstanceOf[ServiceActionAssociationErrorCode]
 
     val values =
       js.Object.freeze(js.Array(DUPLICATE_RESOURCE, INTERNAL_FAILURE, LIMIT_EXCEEDED, RESOURCE_NOT_FOUND, THROTTLING))
   }
-
-  object ServiceActionDefinitionKeyEnum {
-    val Name       = "Name"
-    val Version    = "Version"
-    val AssumeRole = "AssumeRole"
-    val Parameters = "Parameters"
+  @js.native
+  sealed trait ServiceActionDefinitionKey extends js.Any
+  object ServiceActionDefinitionKey extends js.Object {
+    val Name       = "Name".asInstanceOf[ServiceActionDefinitionKey]
+    val Version    = "Version".asInstanceOf[ServiceActionDefinitionKey]
+    val AssumeRole = "AssumeRole".asInstanceOf[ServiceActionDefinitionKey]
+    val Parameters = "Parameters".asInstanceOf[ServiceActionDefinitionKey]
 
     val values = js.Object.freeze(js.Array(Name, Version, AssumeRole, Parameters))
   }
-
-  object ServiceActionDefinitionTypeEnum {
-    val SSM_AUTOMATION = "SSM_AUTOMATION"
+  @js.native
+  sealed trait ServiceActionDefinitionType extends js.Any
+  object ServiceActionDefinitionType extends js.Object {
+    val SSM_AUTOMATION = "SSM_AUTOMATION".asInstanceOf[ServiceActionDefinitionType]
 
     val values = js.Object.freeze(js.Array(SSM_AUTOMATION))
   }
@@ -5359,20 +5354,22 @@ package servicecatalog {
       __obj.asInstanceOf[ShareError]
     }
   }
-
-  object ShareStatusEnum {
-    val NOT_STARTED           = "NOT_STARTED"
-    val IN_PROGRESS           = "IN_PROGRESS"
-    val COMPLETED             = "COMPLETED"
-    val COMPLETED_WITH_ERRORS = "COMPLETED_WITH_ERRORS"
-    val ERROR                 = "ERROR"
+  @js.native
+  sealed trait ShareStatus extends js.Any
+  object ShareStatus extends js.Object {
+    val NOT_STARTED           = "NOT_STARTED".asInstanceOf[ShareStatus]
+    val IN_PROGRESS           = "IN_PROGRESS".asInstanceOf[ShareStatus]
+    val COMPLETED             = "COMPLETED".asInstanceOf[ShareStatus]
+    val COMPLETED_WITH_ERRORS = "COMPLETED_WITH_ERRORS".asInstanceOf[ShareStatus]
+    val ERROR                 = "ERROR".asInstanceOf[ShareStatus]
 
     val values = js.Object.freeze(js.Array(NOT_STARTED, IN_PROGRESS, COMPLETED, COMPLETED_WITH_ERRORS, ERROR))
   }
-
-  object SortOrderEnum {
-    val ASCENDING  = "ASCENDING"
-    val DESCENDING = "DESCENDING"
+  @js.native
+  sealed trait SortOrder extends js.Any
+  object SortOrder extends js.Object {
+    val ASCENDING  = "ASCENDING".asInstanceOf[SortOrder]
+    val DESCENDING = "DESCENDING".asInstanceOf[SortOrder]
 
     val values = js.Object.freeze(js.Array(ASCENDING, DESCENDING))
   }
@@ -5401,27 +5398,30 @@ package servicecatalog {
       __obj.asInstanceOf[StackInstance]
     }
   }
-
-  object StackInstanceStatusEnum {
-    val CURRENT    = "CURRENT"
-    val OUTDATED   = "OUTDATED"
-    val INOPERABLE = "INOPERABLE"
+  @js.native
+  sealed trait StackInstanceStatus extends js.Any
+  object StackInstanceStatus extends js.Object {
+    val CURRENT    = "CURRENT".asInstanceOf[StackInstanceStatus]
+    val OUTDATED   = "OUTDATED".asInstanceOf[StackInstanceStatus]
+    val INOPERABLE = "INOPERABLE".asInstanceOf[StackInstanceStatus]
 
     val values = js.Object.freeze(js.Array(CURRENT, OUTDATED, INOPERABLE))
   }
-
-  object StackSetOperationTypeEnum {
-    val CREATE = "CREATE"
-    val UPDATE = "UPDATE"
-    val DELETE = "DELETE"
+  @js.native
+  sealed trait StackSetOperationType extends js.Any
+  object StackSetOperationType extends js.Object {
+    val CREATE = "CREATE".asInstanceOf[StackSetOperationType]
+    val UPDATE = "UPDATE".asInstanceOf[StackSetOperationType]
+    val DELETE = "DELETE".asInstanceOf[StackSetOperationType]
 
     val values = js.Object.freeze(js.Array(CREATE, UPDATE, DELETE))
   }
-
-  object StatusEnum {
-    val AVAILABLE = "AVAILABLE"
-    val CREATING  = "CREATING"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait Status extends js.Any
+  object Status extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[Status]
+    val CREATING  = "CREATING".asInstanceOf[Status]
+    val FAILED    = "FAILED".asInstanceOf[Status]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, CREATING, FAILED))
   }

--- a/services/servicediscovery/src/main/scala/facade/amazonaws/services/ServiceDiscovery.scala
+++ b/services/servicediscovery/src/main/scala/facade/amazonaws/services/ServiceDiscovery.scala
@@ -12,43 +12,29 @@ package object servicediscovery {
   type AttrValue               = String
   type Attributes              = js.Dictionary[AttrValue]
   type Code                    = String
-  type CustomHealthStatus      = String
   type DnsRecordList           = js.Array[DnsRecord]
   type FailureThreshold        = Int
-  type FilterCondition         = String
   type FilterValue             = String
   type FilterValues            = js.Array[FilterValue]
-  type HealthCheckType         = String
-  type HealthStatus            = String
-  type HealthStatusFilter      = String
   type HttpInstanceSummaryList = js.Array[HttpInstanceSummary]
   type InstanceHealthStatusMap = js.Dictionary[HealthStatus]
   type InstanceIdList          = js.Array[ResourceId]
   type InstanceSummaryList     = js.Array[InstanceSummary]
   type MaxResults              = Int
   type Message                 = String
-  type NamespaceFilterName     = String
   type NamespaceFilters        = js.Array[NamespaceFilter]
   type NamespaceName           = String
   type NamespaceSummariesList  = js.Array[NamespaceSummary]
-  type NamespaceType           = String
   type NextToken               = String
-  type OperationFilterName     = String
   type OperationFilters        = js.Array[OperationFilter]
   type OperationId             = String
-  type OperationStatus         = String
   type OperationSummaryList    = js.Array[OperationSummary]
-  type OperationTargetType     = String
   type OperationTargetsMap     = js.Dictionary[ResourceId]
-  type OperationType           = String
   type RecordTTL               = Double
-  type RecordType              = String
   type ResourceCount           = Int
   type ResourceDescription     = String
   type ResourceId              = String
   type ResourcePath            = String
-  type RoutingPolicy           = String
-  type ServiceFilterName       = String
   type ServiceFilters          = js.Array[ServiceFilter]
   type ServiceName             = String
   type ServiceSummariesList    = js.Array[ServiceSummary]
@@ -310,10 +296,11 @@ package servicediscovery {
       __obj.asInstanceOf[CreateServiceResponse]
     }
   }
-
-  object CustomHealthStatusEnum {
-    val HEALTHY   = "HEALTHY"
-    val UNHEALTHY = "UNHEALTHY"
+  @js.native
+  sealed trait CustomHealthStatus extends js.Any
+  object CustomHealthStatus extends js.Object {
+    val HEALTHY   = "HEALTHY".asInstanceOf[CustomHealthStatus]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[CustomHealthStatus]
 
     val values = js.Object.freeze(js.Array(HEALTHY, UNHEALTHY))
   }
@@ -556,11 +543,12 @@ package servicediscovery {
       __obj.asInstanceOf[DnsRecord]
     }
   }
-
-  object FilterConditionEnum {
-    val EQ      = "EQ"
-    val IN      = "IN"
-    val BETWEEN = "BETWEEN"
+  @js.native
+  sealed trait FilterCondition extends js.Any
+  object FilterCondition extends js.Object {
+    val EQ      = "EQ".asInstanceOf[FilterCondition]
+    val IN      = "IN".asInstanceOf[FilterCondition]
+    val BETWEEN = "BETWEEN".asInstanceOf[FilterCondition]
 
     val values = js.Object.freeze(js.Array(EQ, IN, BETWEEN))
   }
@@ -828,27 +816,30 @@ package servicediscovery {
       __obj.asInstanceOf[HealthCheckCustomConfig]
     }
   }
-
-  object HealthCheckTypeEnum {
-    val HTTP  = "HTTP"
-    val HTTPS = "HTTPS"
-    val TCP   = "TCP"
+  @js.native
+  sealed trait HealthCheckType extends js.Any
+  object HealthCheckType extends js.Object {
+    val HTTP  = "HTTP".asInstanceOf[HealthCheckType]
+    val HTTPS = "HTTPS".asInstanceOf[HealthCheckType]
+    val TCP   = "TCP".asInstanceOf[HealthCheckType]
 
     val values = js.Object.freeze(js.Array(HTTP, HTTPS, TCP))
   }
-
-  object HealthStatusEnum {
-    val HEALTHY   = "HEALTHY"
-    val UNHEALTHY = "UNHEALTHY"
-    val UNKNOWN   = "UNKNOWN"
+  @js.native
+  sealed trait HealthStatus extends js.Any
+  object HealthStatus extends js.Object {
+    val HEALTHY   = "HEALTHY".asInstanceOf[HealthStatus]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[HealthStatus]
+    val UNKNOWN   = "UNKNOWN".asInstanceOf[HealthStatus]
 
     val values = js.Object.freeze(js.Array(HEALTHY, UNHEALTHY, UNKNOWN))
   }
-
-  object HealthStatusFilterEnum {
-    val HEALTHY   = "HEALTHY"
-    val UNHEALTHY = "UNHEALTHY"
-    val ALL       = "ALL"
+  @js.native
+  sealed trait HealthStatusFilter extends js.Any
+  object HealthStatusFilter extends js.Object {
+    val HEALTHY   = "HEALTHY".asInstanceOf[HealthStatusFilter]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[HealthStatusFilter]
+    val ALL       = "ALL".asInstanceOf[HealthStatusFilter]
 
     val values = js.Object.freeze(js.Array(HEALTHY, UNHEALTHY, ALL))
   }
@@ -1187,9 +1178,10 @@ package servicediscovery {
       __obj.asInstanceOf[NamespaceFilter]
     }
   }
-
-  object NamespaceFilterNameEnum {
-    val TYPE = "TYPE"
+  @js.native
+  sealed trait NamespaceFilterName extends js.Any
+  object NamespaceFilterName extends js.Object {
+    val TYPE = "TYPE".asInstanceOf[NamespaceFilterName]
 
     val values = js.Object.freeze(js.Array(TYPE))
   }
@@ -1255,11 +1247,12 @@ package servicediscovery {
       __obj.asInstanceOf[NamespaceSummary]
     }
   }
-
-  object NamespaceTypeEnum {
-    val DNS_PUBLIC  = "DNS_PUBLIC"
-    val DNS_PRIVATE = "DNS_PRIVATE"
-    val HTTP        = "HTTP"
+  @js.native
+  sealed trait NamespaceType extends js.Any
+  object NamespaceType extends js.Object {
+    val DNS_PUBLIC  = "DNS_PUBLIC".asInstanceOf[NamespaceType]
+    val DNS_PRIVATE = "DNS_PRIVATE".asInstanceOf[NamespaceType]
+    val HTTP        = "HTTP".asInstanceOf[NamespaceType]
 
     val values = js.Object.freeze(js.Array(DNS_PUBLIC, DNS_PRIVATE, HTTP))
   }
@@ -1330,22 +1323,24 @@ package servicediscovery {
       __obj.asInstanceOf[OperationFilter]
     }
   }
-
-  object OperationFilterNameEnum {
-    val NAMESPACE_ID = "NAMESPACE_ID"
-    val SERVICE_ID   = "SERVICE_ID"
-    val STATUS       = "STATUS"
-    val TYPE         = "TYPE"
-    val UPDATE_DATE  = "UPDATE_DATE"
+  @js.native
+  sealed trait OperationFilterName extends js.Any
+  object OperationFilterName extends js.Object {
+    val NAMESPACE_ID = "NAMESPACE_ID".asInstanceOf[OperationFilterName]
+    val SERVICE_ID   = "SERVICE_ID".asInstanceOf[OperationFilterName]
+    val STATUS       = "STATUS".asInstanceOf[OperationFilterName]
+    val TYPE         = "TYPE".asInstanceOf[OperationFilterName]
+    val UPDATE_DATE  = "UPDATE_DATE".asInstanceOf[OperationFilterName]
 
     val values = js.Object.freeze(js.Array(NAMESPACE_ID, SERVICE_ID, STATUS, TYPE, UPDATE_DATE))
   }
-
-  object OperationStatusEnum {
-    val SUBMITTED = "SUBMITTED"
-    val PENDING   = "PENDING"
-    val SUCCESS   = "SUCCESS"
-    val FAIL      = "FAIL"
+  @js.native
+  sealed trait OperationStatus extends js.Any
+  object OperationStatus extends js.Object {
+    val SUBMITTED = "SUBMITTED".asInstanceOf[OperationStatus]
+    val PENDING   = "PENDING".asInstanceOf[OperationStatus]
+    val SUCCESS   = "SUCCESS".asInstanceOf[OperationStatus]
+    val FAIL      = "FAIL".asInstanceOf[OperationStatus]
 
     val values = js.Object.freeze(js.Array(SUBMITTED, PENDING, SUCCESS, FAIL))
   }
@@ -1371,32 +1366,35 @@ package servicediscovery {
       __obj.asInstanceOf[OperationSummary]
     }
   }
-
-  object OperationTargetTypeEnum {
-    val NAMESPACE = "NAMESPACE"
-    val SERVICE   = "SERVICE"
-    val INSTANCE  = "INSTANCE"
+  @js.native
+  sealed trait OperationTargetType extends js.Any
+  object OperationTargetType extends js.Object {
+    val NAMESPACE = "NAMESPACE".asInstanceOf[OperationTargetType]
+    val SERVICE   = "SERVICE".asInstanceOf[OperationTargetType]
+    val INSTANCE  = "INSTANCE".asInstanceOf[OperationTargetType]
 
     val values = js.Object.freeze(js.Array(NAMESPACE, SERVICE, INSTANCE))
   }
-
-  object OperationTypeEnum {
-    val CREATE_NAMESPACE    = "CREATE_NAMESPACE"
-    val DELETE_NAMESPACE    = "DELETE_NAMESPACE"
-    val UPDATE_SERVICE      = "UPDATE_SERVICE"
-    val REGISTER_INSTANCE   = "REGISTER_INSTANCE"
-    val DEREGISTER_INSTANCE = "DEREGISTER_INSTANCE"
+  @js.native
+  sealed trait OperationType extends js.Any
+  object OperationType extends js.Object {
+    val CREATE_NAMESPACE    = "CREATE_NAMESPACE".asInstanceOf[OperationType]
+    val DELETE_NAMESPACE    = "DELETE_NAMESPACE".asInstanceOf[OperationType]
+    val UPDATE_SERVICE      = "UPDATE_SERVICE".asInstanceOf[OperationType]
+    val REGISTER_INSTANCE   = "REGISTER_INSTANCE".asInstanceOf[OperationType]
+    val DEREGISTER_INSTANCE = "DEREGISTER_INSTANCE".asInstanceOf[OperationType]
 
     val values = js.Object.freeze(
       js.Array(CREATE_NAMESPACE, DELETE_NAMESPACE, UPDATE_SERVICE, REGISTER_INSTANCE, DEREGISTER_INSTANCE)
     )
   }
-
-  object RecordTypeEnum {
-    val SRV   = "SRV"
-    val A     = "A"
-    val AAAA  = "AAAA"
-    val CNAME = "CNAME"
+  @js.native
+  sealed trait RecordType extends js.Any
+  object RecordType extends js.Object {
+    val SRV   = "SRV".asInstanceOf[RecordType]
+    val A     = "A".asInstanceOf[RecordType]
+    val AAAA  = "AAAA".asInstanceOf[RecordType]
+    val CNAME = "CNAME".asInstanceOf[RecordType]
 
     val values = js.Object.freeze(js.Array(SRV, A, AAAA, CNAME))
   }
@@ -1443,10 +1441,11 @@ package servicediscovery {
       __obj.asInstanceOf[RegisterInstanceResponse]
     }
   }
-
-  object RoutingPolicyEnum {
-    val MULTIVALUE = "MULTIVALUE"
-    val WEIGHTED   = "WEIGHTED"
+  @js.native
+  sealed trait RoutingPolicy extends js.Any
+  object RoutingPolicy extends js.Object {
+    val MULTIVALUE = "MULTIVALUE".asInstanceOf[RoutingPolicy]
+    val WEIGHTED   = "WEIGHTED".asInstanceOf[RoutingPolicy]
 
     val values = js.Object.freeze(js.Array(MULTIVALUE, WEIGHTED))
   }
@@ -1553,9 +1552,10 @@ package servicediscovery {
       __obj.asInstanceOf[ServiceFilter]
     }
   }
-
-  object ServiceFilterNameEnum {
-    val NAMESPACE_ID = "NAMESPACE_ID"
+  @js.native
+  sealed trait ServiceFilterName extends js.Any
+  object ServiceFilterName extends js.Object {
+    val NAMESPACE_ID = "NAMESPACE_ID".asInstanceOf[ServiceFilterName]
 
     val values = js.Object.freeze(js.Array(NAMESPACE_ID))
   }

--- a/services/servicequotas/src/main/scala/facade/amazonaws/services/ServiceQuotas.scala
+++ b/services/servicequotas/src/main/scala/facade/amazonaws/services/ServiceQuotas.scala
@@ -10,7 +10,6 @@ package object servicequotas {
   type AwsRegion                                        = String
   type CustomerServiceEngagementId                      = String
   type DateTime                                         = js.Date
-  type ErrorCode                                        = String
   type ErrorMessage                                     = String
   type GlobalQuota                                      = Boolean
   type MaxResults                                       = Int
@@ -18,7 +17,6 @@ package object servicequotas {
   type MetricDimensionValue                             = String
   type MetricDimensionsMapDefinition                    = js.Dictionary[MetricDimensionValue]
   type NextToken                                        = String
-  type PeriodUnit                                       = String
   type PeriodValue                                      = Int
   type QuotaAdjustable                                  = Boolean
   type QuotaArn                                         = String
@@ -29,7 +27,6 @@ package object servicequotas {
   type QuotaUnit                                        = String
   type QuotaValue                                       = Double
   type RequestId                                        = String
-  type RequestStatus                                    = String
   type RequestedServiceQuotaChangeHistoryListDefinition = js.Array[RequestedServiceQuotaChange]
   type Requester                                        = String
   type ServiceCode                                      = String
@@ -37,7 +34,6 @@ package object servicequotas {
   type ServiceName                                      = String
   type ServiceQuotaIncreaseRequestInTemplateList        = js.Array[ServiceQuotaIncreaseRequestInTemplate]
   type ServiceQuotaListDefinition                       = js.Array[ServiceQuota]
-  type ServiceQuotaTemplateAssociationStatus            = String
   type Statistic                                        = String
 
   implicit final class ServiceQuotasOps(private val service: ServiceQuotas) extends AnyVal {
@@ -236,12 +232,13 @@ package servicequotas {
       __obj.asInstanceOf[DisassociateServiceQuotaTemplateResponse]
     }
   }
-
-  object ErrorCodeEnum {
-    val DEPENDENCY_ACCESS_DENIED_ERROR    = "DEPENDENCY_ACCESS_DENIED_ERROR"
-    val DEPENDENCY_THROTTLING_ERROR       = "DEPENDENCY_THROTTLING_ERROR"
-    val DEPENDENCY_SERVICE_ERROR          = "DEPENDENCY_SERVICE_ERROR"
-    val SERVICE_QUOTA_NOT_AVAILABLE_ERROR = "SERVICE_QUOTA_NOT_AVAILABLE_ERROR"
+  @js.native
+  sealed trait ErrorCode extends js.Any
+  object ErrorCode extends js.Object {
+    val DEPENDENCY_ACCESS_DENIED_ERROR    = "DEPENDENCY_ACCESS_DENIED_ERROR".asInstanceOf[ErrorCode]
+    val DEPENDENCY_THROTTLING_ERROR       = "DEPENDENCY_THROTTLING_ERROR".asInstanceOf[ErrorCode]
+    val DEPENDENCY_SERVICE_ERROR          = "DEPENDENCY_SERVICE_ERROR".asInstanceOf[ErrorCode]
+    val SERVICE_QUOTA_NOT_AVAILABLE_ERROR = "SERVICE_QUOTA_NOT_AVAILABLE_ERROR".asInstanceOf[ErrorCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -748,15 +745,16 @@ package servicequotas {
       __obj.asInstanceOf[MetricInfo]
     }
   }
-
-  object PeriodUnitEnum {
-    val MICROSECOND = "MICROSECOND"
-    val MILLISECOND = "MILLISECOND"
-    val SECOND      = "SECOND"
-    val MINUTE      = "MINUTE"
-    val HOUR        = "HOUR"
-    val DAY         = "DAY"
-    val WEEK        = "WEEK"
+  @js.native
+  sealed trait PeriodUnit extends js.Any
+  object PeriodUnit extends js.Object {
+    val MICROSECOND = "MICROSECOND".asInstanceOf[PeriodUnit]
+    val MILLISECOND = "MILLISECOND".asInstanceOf[PeriodUnit]
+    val SECOND      = "SECOND".asInstanceOf[PeriodUnit]
+    val MINUTE      = "MINUTE".asInstanceOf[PeriodUnit]
+    val HOUR        = "HOUR".asInstanceOf[PeriodUnit]
+    val DAY         = "DAY".asInstanceOf[PeriodUnit]
+    val WEEK        = "WEEK".asInstanceOf[PeriodUnit]
 
     val values = js.Object.freeze(js.Array(MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK))
   }
@@ -867,13 +865,14 @@ package servicequotas {
       __obj.asInstanceOf[RequestServiceQuotaIncreaseResponse]
     }
   }
-
-  object RequestStatusEnum {
-    val PENDING     = "PENDING"
-    val CASE_OPENED = "CASE_OPENED"
-    val APPROVED    = "APPROVED"
-    val DENIED      = "DENIED"
-    val CASE_CLOSED = "CASE_CLOSED"
+  @js.native
+  sealed trait RequestStatus extends js.Any
+  object RequestStatus extends js.Object {
+    val PENDING     = "PENDING".asInstanceOf[RequestStatus]
+    val CASE_OPENED = "CASE_OPENED".asInstanceOf[RequestStatus]
+    val APPROVED    = "APPROVED".asInstanceOf[RequestStatus]
+    val DENIED      = "DENIED".asInstanceOf[RequestStatus]
+    val CASE_CLOSED = "CASE_CLOSED".asInstanceOf[RequestStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, CASE_OPENED, APPROVED, DENIED, CASE_CLOSED))
   }
@@ -1049,10 +1048,11 @@ package servicequotas {
       __obj.asInstanceOf[ServiceQuotaIncreaseRequestInTemplate]
     }
   }
-
-  object ServiceQuotaTemplateAssociationStatusEnum {
-    val ASSOCIATED    = "ASSOCIATED"
-    val DISASSOCIATED = "DISASSOCIATED"
+  @js.native
+  sealed trait ServiceQuotaTemplateAssociationStatus extends js.Any
+  object ServiceQuotaTemplateAssociationStatus extends js.Object {
+    val ASSOCIATED    = "ASSOCIATED".asInstanceOf[ServiceQuotaTemplateAssociationStatus]
+    val DISASSOCIATED = "DISASSOCIATED".asInstanceOf[ServiceQuotaTemplateAssociationStatus]
 
     val values = js.Object.freeze(js.Array(ASSOCIATED, DISASSOCIATED))
   }

--- a/services/ses/src/main/scala/facade/amazonaws/services/SES.scala
+++ b/services/ses/src/main/scala/facade/amazonaws/services/SES.scala
@@ -11,39 +11,31 @@ package object ses {
   type AddressList                       = js.Array[Address]
   type AmazonResourceName                = String
   type ArrivalDate                       = js.Date
-  type BehaviorOnMXFailure               = String
   type BounceMessage                     = String
   type BounceSmtpReplyCode               = String
   type BounceStatusCode                  = String
-  type BounceType                        = String
   type BouncedRecipientInfoList          = js.Array[BouncedRecipientInfo]
   type BulkEmailDestinationList          = js.Array[BulkEmailDestination]
   type BulkEmailDestinationStatusList    = js.Array[BulkEmailDestinationStatus]
-  type BulkEmailStatus                   = String
   type Charset                           = String
   type Cidr                              = String
   type CloudWatchDimensionConfigurations = js.Array[CloudWatchDimensionConfiguration]
-  type ConfigurationSetAttribute         = String
   type ConfigurationSetAttributeList     = js.Array[ConfigurationSetAttribute]
   type ConfigurationSetName              = String
   type ConfigurationSets                 = js.Array[ConfigurationSet]
   type Counter                           = Double
-  type CustomMailFromStatus              = String
   type CustomRedirectDomain              = String
   type CustomVerificationEmailTemplates  = js.Array[CustomVerificationEmailTemplate]
   type DefaultDimensionValue             = String
   type DiagnosticCode                    = String
   type DimensionName                     = String
-  type DimensionValueSource              = String
   type DkimAttributes                    = js.Dictionary[IdentityDkimAttributes]
   type Domain                            = String
-  type DsnAction                         = String
   type DsnStatus                         = String
   type Enabled                           = Boolean
   type Error                             = String
   type EventDestinationName              = String
   type EventDestinations                 = js.Array[EventDestination]
-  type EventType                         = String
   type EventTypes                        = js.Array[EventType]
   type Explanation                       = String
   type ExtensionFieldList                = js.Array[ExtensionField]
@@ -56,8 +48,6 @@ package object ses {
   type HtmlPart                          = String
   type Identity                          = String
   type IdentityList                      = js.Array[Identity]
-  type IdentityType                      = String
-  type InvocationType                    = String
   type LastAttemptDate                   = js.Date
   type LastFreshStart                    = js.Date
   type MailFromDomainAttributes          = js.Dictionary[IdentityMailFromDomainAttributes]
@@ -74,7 +64,6 @@ package object ses {
   type NextToken                         = String
   type NotificationAttributes            = js.Dictionary[IdentityNotificationAttributes]
   type NotificationTopic                 = String
-  type NotificationType                  = String
   type Policy                            = String
   type PolicyMap                         = js.Dictionary[Policy]
   type PolicyName                        = String
@@ -83,7 +72,6 @@ package object ses {
   type ReceiptActionsList                = js.Array[ReceiptAction]
   type ReceiptFilterList                 = js.Array[ReceiptFilter]
   type ReceiptFilterName                 = String
-  type ReceiptFilterPolicy               = String
   type ReceiptRuleName                   = String
   type ReceiptRuleNamesList              = js.Array[ReceiptRuleName]
   type ReceiptRuleSetName                = String
@@ -96,10 +84,8 @@ package object ses {
   type ReportingMta                      = String
   type S3BucketName                      = String
   type S3KeyPrefix                       = String
-  type SNSActionEncoding                 = String
   type SendDataPointList                 = js.Array[SendDataPoint]
   type SentLast24Hours                   = Double
-  type StopScope                         = String
   type Subject                           = String
   type SubjectPart                       = String
   type SuccessRedirectionURL             = String
@@ -109,9 +95,7 @@ package object ses {
   type TemplateName                      = String
   type TextPart                          = String
   type Timestamp                         = js.Date
-  type TlsPolicy                         = String
   type VerificationAttributes            = js.Dictionary[IdentityVerificationAttributes]
-  type VerificationStatus                = String
   type VerificationToken                 = String
   type VerificationTokenList             = js.Array[VerificationToken]
 
@@ -467,10 +451,11 @@ package ses {
       __obj.asInstanceOf[AddHeaderAction]
     }
   }
-
-  object BehaviorOnMXFailureEnum {
-    val UseDefaultValue = "UseDefaultValue"
-    val RejectMessage   = "RejectMessage"
+  @js.native
+  sealed trait BehaviorOnMXFailure extends js.Any
+  object BehaviorOnMXFailure extends js.Object {
+    val UseDefaultValue = "UseDefaultValue".asInstanceOf[BehaviorOnMXFailure]
+    val RejectMessage   = "RejectMessage".asInstanceOf[BehaviorOnMXFailure]
 
     val values = js.Object.freeze(js.Array(UseDefaultValue, RejectMessage))
   }
@@ -530,14 +515,15 @@ package ses {
       __obj.asInstanceOf[BounceAction]
     }
   }
-
-  object BounceTypeEnum {
-    val DoesNotExist     = "DoesNotExist"
-    val MessageTooLarge  = "MessageTooLarge"
-    val ExceededQuota    = "ExceededQuota"
-    val ContentRejected  = "ContentRejected"
-    val Undefined        = "Undefined"
-    val TemporaryFailure = "TemporaryFailure"
+  @js.native
+  sealed trait BounceType extends js.Any
+  object BounceType extends js.Object {
+    val DoesNotExist     = "DoesNotExist".asInstanceOf[BounceType]
+    val MessageTooLarge  = "MessageTooLarge".asInstanceOf[BounceType]
+    val ExceededQuota    = "ExceededQuota".asInstanceOf[BounceType]
+    val ContentRejected  = "ContentRejected".asInstanceOf[BounceType]
+    val Undefined        = "Undefined".asInstanceOf[BounceType]
+    val TemporaryFailure = "TemporaryFailure".asInstanceOf[BounceType]
 
     val values = js.Object.freeze(
       js.Array(DoesNotExist, MessageTooLarge, ExceededQuota, ContentRejected, Undefined, TemporaryFailure)
@@ -626,22 +612,23 @@ package ses {
       __obj.asInstanceOf[BulkEmailDestinationStatus]
     }
   }
-
-  object BulkEmailStatusEnum {
-    val Success                       = "Success"
-    val MessageRejected               = "MessageRejected"
-    val MailFromDomainNotVerified     = "MailFromDomainNotVerified"
-    val ConfigurationSetDoesNotExist  = "ConfigurationSetDoesNotExist"
-    val TemplateDoesNotExist          = "TemplateDoesNotExist"
-    val AccountSuspended              = "AccountSuspended"
-    val AccountThrottled              = "AccountThrottled"
-    val AccountDailyQuotaExceeded     = "AccountDailyQuotaExceeded"
-    val InvalidSendingPoolName        = "InvalidSendingPoolName"
-    val AccountSendingPaused          = "AccountSendingPaused"
-    val ConfigurationSetSendingPaused = "ConfigurationSetSendingPaused"
-    val InvalidParameterValue         = "InvalidParameterValue"
-    val TransientFailure              = "TransientFailure"
-    val Failed                        = "Failed"
+  @js.native
+  sealed trait BulkEmailStatus extends js.Any
+  object BulkEmailStatus extends js.Object {
+    val Success                       = "Success".asInstanceOf[BulkEmailStatus]
+    val MessageRejected               = "MessageRejected".asInstanceOf[BulkEmailStatus]
+    val MailFromDomainNotVerified     = "MailFromDomainNotVerified".asInstanceOf[BulkEmailStatus]
+    val ConfigurationSetDoesNotExist  = "ConfigurationSetDoesNotExist".asInstanceOf[BulkEmailStatus]
+    val TemplateDoesNotExist          = "TemplateDoesNotExist".asInstanceOf[BulkEmailStatus]
+    val AccountSuspended              = "AccountSuspended".asInstanceOf[BulkEmailStatus]
+    val AccountThrottled              = "AccountThrottled".asInstanceOf[BulkEmailStatus]
+    val AccountDailyQuotaExceeded     = "AccountDailyQuotaExceeded".asInstanceOf[BulkEmailStatus]
+    val InvalidSendingPoolName        = "InvalidSendingPoolName".asInstanceOf[BulkEmailStatus]
+    val AccountSendingPaused          = "AccountSendingPaused".asInstanceOf[BulkEmailStatus]
+    val ConfigurationSetSendingPaused = "ConfigurationSetSendingPaused".asInstanceOf[BulkEmailStatus]
+    val InvalidParameterValue         = "InvalidParameterValue".asInstanceOf[BulkEmailStatus]
+    val TransientFailure              = "TransientFailure".asInstanceOf[BulkEmailStatus]
+    val Failed                        = "Failed".asInstanceOf[BulkEmailStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -774,12 +761,13 @@ package ses {
       __obj.asInstanceOf[ConfigurationSet]
     }
   }
-
-  object ConfigurationSetAttributeEnum {
-    val eventDestinations = "eventDestinations"
-    val trackingOptions   = "trackingOptions"
-    val deliveryOptions   = "deliveryOptions"
-    val reputationOptions = "reputationOptions"
+  @js.native
+  sealed trait ConfigurationSetAttribute extends js.Any
+  object ConfigurationSetAttribute extends js.Object {
+    val eventDestinations = "eventDestinations".asInstanceOf[ConfigurationSetAttribute]
+    val trackingOptions   = "trackingOptions".asInstanceOf[ConfigurationSetAttribute]
+    val deliveryOptions   = "deliveryOptions".asInstanceOf[ConfigurationSetAttribute]
+    val reputationOptions = "reputationOptions".asInstanceOf[ConfigurationSetAttribute]
 
     val values = js.Object.freeze(js.Array(eventDestinations, trackingOptions, deliveryOptions, reputationOptions))
   }
@@ -1112,12 +1100,13 @@ package ses {
       __obj.asInstanceOf[CreateTemplateResponse]
     }
   }
-
-  object CustomMailFromStatusEnum {
-    val Pending          = "Pending"
-    val Success          = "Success"
-    val Failed           = "Failed"
-    val TemporaryFailure = "TemporaryFailure"
+  @js.native
+  sealed trait CustomMailFromStatus extends js.Any
+  object CustomMailFromStatus extends js.Object {
+    val Pending          = "Pending".asInstanceOf[CustomMailFromStatus]
+    val Success          = "Success".asInstanceOf[CustomMailFromStatus]
+    val Failed           = "Failed".asInstanceOf[CustomMailFromStatus]
+    val TemporaryFailure = "TemporaryFailure".asInstanceOf[CustomMailFromStatus]
 
     val values = js.Object.freeze(js.Array(Pending, Success, Failed, TemporaryFailure))
   }
@@ -1760,21 +1749,23 @@ package ses {
       __obj.asInstanceOf[Destination]
     }
   }
-
-  object DimensionValueSourceEnum {
-    val messageTag  = "messageTag"
-    val emailHeader = "emailHeader"
-    val linkTag     = "linkTag"
+  @js.native
+  sealed trait DimensionValueSource extends js.Any
+  object DimensionValueSource extends js.Object {
+    val messageTag  = "messageTag".asInstanceOf[DimensionValueSource]
+    val emailHeader = "emailHeader".asInstanceOf[DimensionValueSource]
+    val linkTag     = "linkTag".asInstanceOf[DimensionValueSource]
 
     val values = js.Object.freeze(js.Array(messageTag, emailHeader, linkTag))
   }
-
-  object DsnActionEnum {
-    val failed    = "failed"
-    val delayed   = "delayed"
-    val delivered = "delivered"
-    val relayed   = "relayed"
-    val expanded  = "expanded"
+  @js.native
+  sealed trait DsnAction extends js.Any
+  object DsnAction extends js.Object {
+    val failed    = "failed".asInstanceOf[DsnAction]
+    val delayed   = "delayed".asInstanceOf[DsnAction]
+    val delivered = "delivered".asInstanceOf[DsnAction]
+    val relayed   = "relayed".asInstanceOf[DsnAction]
+    val expanded  = "expanded".asInstanceOf[DsnAction]
 
     val values = js.Object.freeze(js.Array(failed, delayed, delivered, relayed, expanded))
   }
@@ -1819,16 +1810,17 @@ package ses {
       __obj.asInstanceOf[EventDestination]
     }
   }
-
-  object EventTypeEnum {
-    val send             = "send"
-    val reject           = "reject"
-    val bounce           = "bounce"
-    val complaint        = "complaint"
-    val delivery         = "delivery"
-    val open             = "open"
-    val click            = "click"
-    val renderingFailure = "renderingFailure"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val send             = "send".asInstanceOf[EventType]
+    val reject           = "reject".asInstanceOf[EventType]
+    val bounce           = "bounce".asInstanceOf[EventType]
+    val complaint        = "complaint".asInstanceOf[EventType]
+    val delivery         = "delivery".asInstanceOf[EventType]
+    val open             = "open".asInstanceOf[EventType]
+    val click            = "click".asInstanceOf[EventType]
+    val renderingFailure = "renderingFailure".asInstanceOf[EventType]
 
     val values = js.Object.freeze(js.Array(send, reject, bounce, complaint, delivery, open, click, renderingFailure))
   }
@@ -2321,10 +2313,11 @@ package ses {
       __obj.asInstanceOf[IdentityNotificationAttributes]
     }
   }
-
-  object IdentityTypeEnum {
-    val EmailAddress = "EmailAddress"
-    val Domain       = "Domain"
+  @js.native
+  sealed trait IdentityType extends js.Any
+  object IdentityType extends js.Object {
+    val EmailAddress = "EmailAddress".asInstanceOf[IdentityType]
+    val Domain       = "Domain".asInstanceOf[IdentityType]
 
     val values = js.Object.freeze(js.Array(EmailAddress, Domain))
   }
@@ -2352,10 +2345,11 @@ package ses {
       __obj.asInstanceOf[IdentityVerificationAttributes]
     }
   }
-
-  object InvocationTypeEnum {
-    val Event           = "Event"
-    val RequestResponse = "RequestResponse"
+  @js.native
+  sealed trait InvocationType extends js.Any
+  object InvocationType extends js.Object {
+    val Event           = "Event".asInstanceOf[InvocationType]
+    val RequestResponse = "RequestResponse".asInstanceOf[InvocationType]
 
     val values = js.Object.freeze(js.Array(Event, RequestResponse))
   }
@@ -2805,11 +2799,12 @@ package ses {
       __obj.asInstanceOf[MessageTag]
     }
   }
-
-  object NotificationTypeEnum {
-    val Bounce    = "Bounce"
-    val Complaint = "Complaint"
-    val Delivery  = "Delivery"
+  @js.native
+  sealed trait NotificationType extends js.Any
+  object NotificationType extends js.Object {
+    val Bounce    = "Bounce".asInstanceOf[NotificationType]
+    val Complaint = "Complaint".asInstanceOf[NotificationType]
+    val Delivery  = "Delivery".asInstanceOf[NotificationType]
 
     val values = js.Object.freeze(js.Array(Bounce, Complaint, Delivery))
   }
@@ -2980,10 +2975,11 @@ package ses {
       __obj.asInstanceOf[ReceiptFilter]
     }
   }
-
-  object ReceiptFilterPolicyEnum {
-    val Block = "Block"
-    val Allow = "Allow"
+  @js.native
+  sealed trait ReceiptFilterPolicy extends js.Any
+  object ReceiptFilterPolicy extends js.Object {
+    val Block = "Block".asInstanceOf[ReceiptFilterPolicy]
+    val Allow = "Allow".asInstanceOf[ReceiptFilterPolicy]
 
     val values = js.Object.freeze(js.Array(Block, Allow))
   }
@@ -3240,10 +3236,11 @@ package ses {
       __obj.asInstanceOf[SNSAction]
     }
   }
-
-  object SNSActionEncodingEnum {
-    val `UTF-8` = "UTF-8"
-    val Base64  = "Base64"
+  @js.native
+  sealed trait SNSActionEncoding extends js.Any
+  object SNSActionEncoding extends js.Object {
+    val `UTF-8` = "UTF-8".asInstanceOf[SNSActionEncoding]
+    val Base64  = "Base64".asInstanceOf[SNSActionEncoding]
 
     val values = js.Object.freeze(js.Array(`UTF-8`, Base64))
   }
@@ -3980,9 +3977,10 @@ package ses {
       __obj.asInstanceOf[StopAction]
     }
   }
-
-  object StopScopeEnum {
-    val RuleSet = "RuleSet"
+  @js.native
+  sealed trait StopScope extends js.Any
+  object StopScope extends js.Object {
+    val RuleSet = "RuleSet".asInstanceOf[StopScope]
 
     val values = js.Object.freeze(js.Array(RuleSet))
   }
@@ -4075,10 +4073,11 @@ package ses {
       __obj.asInstanceOf[TestRenderTemplateResponse]
     }
   }
-
-  object TlsPolicyEnum {
-    val Require  = "Require"
-    val Optional = "Optional"
+  @js.native
+  sealed trait TlsPolicy extends js.Any
+  object TlsPolicy extends js.Object {
+    val Require  = "Require".asInstanceOf[TlsPolicy]
+    val Optional = "Optional".asInstanceOf[TlsPolicy]
 
     val values = js.Object.freeze(js.Array(Require, Optional))
   }
@@ -4356,13 +4355,14 @@ package ses {
       __obj.asInstanceOf[UpdateTemplateResponse]
     }
   }
-
-  object VerificationStatusEnum {
-    val Pending          = "Pending"
-    val Success          = "Success"
-    val Failed           = "Failed"
-    val TemporaryFailure = "TemporaryFailure"
-    val NotStarted       = "NotStarted"
+  @js.native
+  sealed trait VerificationStatus extends js.Any
+  object VerificationStatus extends js.Object {
+    val Pending          = "Pending".asInstanceOf[VerificationStatus]
+    val Success          = "Success".asInstanceOf[VerificationStatus]
+    val Failed           = "Failed".asInstanceOf[VerificationStatus]
+    val TemporaryFailure = "TemporaryFailure".asInstanceOf[VerificationStatus]
+    val NotStarted       = "NotStarted".asInstanceOf[VerificationStatus]
 
     val values = js.Object.freeze(js.Array(Pending, Success, Failed, TemporaryFailure, NotStarted))
   }

--- a/services/sesv2/src/main/scala/facade/amazonaws/services/SESv2.scala
+++ b/services/sesv2/src/main/scala/facade/amazonaws/services/SESv2.scala
@@ -7,95 +7,83 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object sesv2 {
-  type AmazonResourceName                   = String
-  type BehaviorOnMxFailure                  = String
-  type BlacklistEntries                     = js.Array[BlacklistEntry]
-  type BlacklistItemName                    = String
-  type BlacklistItemNames                   = js.Array[BlacklistItemName]
-  type BlacklistReport                      = js.Dictionary[BlacklistEntries]
-  type BlacklistingDescription              = String
-  type CampaignId                           = String
-  type Charset                              = String
-  type CloudWatchDimensionConfigurations    = js.Array[CloudWatchDimensionConfiguration]
-  type ConfigurationSetName                 = String
-  type ConfigurationSetNameList             = js.Array[ConfigurationSetName]
-  type CustomRedirectDomain                 = String
-  type DailyVolumes                         = js.Array[DailyVolume]
-  type DedicatedIpList                      = js.Array[DedicatedIp]
-  type DefaultDimensionValue                = String
-  type DeliverabilityDashboardAccountStatus = String
-  type DeliverabilityTestReports            = js.Array[DeliverabilityTestReport]
-  type DeliverabilityTestStatus             = String
-  type DeliverabilityTestSubject            = String
-  type DimensionName                        = String
-  type DimensionValueSource                 = String
-  type DkimSigningAttributesOrigin          = String
-  type DkimStatus                           = String
-  type DnsToken                             = String
-  type DnsTokenList                         = js.Array[DnsToken]
-  type Domain                               = String
-  type DomainDeliverabilityCampaignList     = js.Array[DomainDeliverabilityCampaign]
-  type DomainDeliverabilityTrackingOptions  = js.Array[DomainDeliverabilityTrackingOption]
-  type DomainIspPlacements                  = js.Array[DomainIspPlacement]
-  type EmailAddress                         = String
-  type EmailAddressList                     = js.Array[EmailAddress]
-  type Enabled                              = Boolean
-  type Esp                                  = String
-  type Esps                                 = js.Array[Esp]
-  type EventDestinationName                 = String
-  type EventDestinations                    = js.Array[EventDestination]
-  type EventType                            = String
-  type EventTypes                           = js.Array[EventType]
-  type FeedbackId                           = String
-  type GeneralEnforcementStatus             = String
-  type Identity                             = String
-  type IdentityInfoList                     = js.Array[IdentityInfo]
-  type IdentityType                         = String
-  type ImageUrl                             = String
-  type Ip                                   = String
-  type IpList                               = js.Array[Ip]
-  type IspName                              = String
-  type IspNameList                          = js.Array[IspName]
-  type IspPlacements                        = js.Array[IspPlacement]
-  type LastFreshStart                       = js.Date
-  type ListOfDedicatedIpPools               = js.Array[PoolName]
-  type MailFromDomainName                   = String
-  type MailFromDomainStatus                 = String
-  type Max24HourSend                        = Double
-  type MaxItems                             = Int
-  type MaxSendRate                          = Double
-  type MessageContent                       = String
-  type MessageData                          = String
-  type MessageTagList                       = js.Array[MessageTag]
-  type MessageTagName                       = String
-  type MessageTagValue                      = String
-  type NextToken                            = String
-  type OutboundMessageId                    = String
-  type Percentage                           = Double
-  type Percentage100Wrapper                 = Int
-  type PoolName                             = String
-  type PrivateKey                           = String
-  type RawMessageData                       = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type RblName                              = String
-  type ReportId                             = String
-  type ReportName                           = String
-  type Selector                             = String
-  type SendingPoolName                      = String
-  type SentLast24Hours                      = Double
-  type Subject                              = String
-  type SuppressedDestinationSummaries       = js.Array[SuppressedDestinationSummary]
-  type SuppressionListReason                = String
-  type SuppressionListReasons               = js.Array[SuppressionListReason]
-  type TagKey                               = String
-  type TagKeyList                           = js.Array[TagKey]
-  type TagList                              = js.Array[Tag]
-  type TagValue                             = String
-  type TemplateArn                          = String
-  type TemplateData                         = String
-  type Timestamp                            = js.Date
-  type TlsPolicy                            = String
-  type Volume                               = Double
-  type WarmupStatus                         = String
+  type AmazonResourceName                  = String
+  type BlacklistEntries                    = js.Array[BlacklistEntry]
+  type BlacklistItemName                   = String
+  type BlacklistItemNames                  = js.Array[BlacklistItemName]
+  type BlacklistReport                     = js.Dictionary[BlacklistEntries]
+  type BlacklistingDescription             = String
+  type CampaignId                          = String
+  type Charset                             = String
+  type CloudWatchDimensionConfigurations   = js.Array[CloudWatchDimensionConfiguration]
+  type ConfigurationSetName                = String
+  type ConfigurationSetNameList            = js.Array[ConfigurationSetName]
+  type CustomRedirectDomain                = String
+  type DailyVolumes                        = js.Array[DailyVolume]
+  type DedicatedIpList                     = js.Array[DedicatedIp]
+  type DefaultDimensionValue               = String
+  type DeliverabilityTestReports           = js.Array[DeliverabilityTestReport]
+  type DeliverabilityTestSubject           = String
+  type DimensionName                       = String
+  type DnsToken                            = String
+  type DnsTokenList                        = js.Array[DnsToken]
+  type Domain                              = String
+  type DomainDeliverabilityCampaignList    = js.Array[DomainDeliverabilityCampaign]
+  type DomainDeliverabilityTrackingOptions = js.Array[DomainDeliverabilityTrackingOption]
+  type DomainIspPlacements                 = js.Array[DomainIspPlacement]
+  type EmailAddress                        = String
+  type EmailAddressList                    = js.Array[EmailAddress]
+  type Enabled                             = Boolean
+  type Esp                                 = String
+  type Esps                                = js.Array[Esp]
+  type EventDestinationName                = String
+  type EventDestinations                   = js.Array[EventDestination]
+  type EventTypes                          = js.Array[EventType]
+  type FeedbackId                          = String
+  type GeneralEnforcementStatus            = String
+  type Identity                            = String
+  type IdentityInfoList                    = js.Array[IdentityInfo]
+  type ImageUrl                            = String
+  type Ip                                  = String
+  type IpList                              = js.Array[Ip]
+  type IspName                             = String
+  type IspNameList                         = js.Array[IspName]
+  type IspPlacements                       = js.Array[IspPlacement]
+  type LastFreshStart                      = js.Date
+  type ListOfDedicatedIpPools              = js.Array[PoolName]
+  type MailFromDomainName                  = String
+  type Max24HourSend                       = Double
+  type MaxItems                            = Int
+  type MaxSendRate                         = Double
+  type MessageContent                      = String
+  type MessageData                         = String
+  type MessageTagList                      = js.Array[MessageTag]
+  type MessageTagName                      = String
+  type MessageTagValue                     = String
+  type NextToken                           = String
+  type OutboundMessageId                   = String
+  type Percentage                          = Double
+  type Percentage100Wrapper                = Int
+  type PoolName                            = String
+  type PrivateKey                          = String
+  type RawMessageData                      = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type RblName                             = String
+  type ReportId                            = String
+  type ReportName                          = String
+  type Selector                            = String
+  type SendingPoolName                     = String
+  type SentLast24Hours                     = Double
+  type Subject                             = String
+  type SuppressedDestinationSummaries      = js.Array[SuppressedDestinationSummary]
+  type SuppressionListReasons              = js.Array[SuppressionListReason]
+  type TagKey                              = String
+  type TagKeyList                          = js.Array[TagKey]
+  type TagList                             = js.Array[Tag]
+  type TagValue                            = String
+  type TemplateArn                         = String
+  type TemplateData                        = String
+  type Timestamp                           = js.Date
+  type Volume                              = Double
 
   implicit final class SESv2Ops(private val service: SESv2) extends AnyVal {
 
@@ -371,9 +359,11 @@ package sesv2 {
     * The action that you want to take if the required MX record can't be found when you send an email. When you set this value to <code>UseDefaultValue</code>, the mail is sent using <i>amazonses.com</i> as the MAIL FROM domain. When you set this value to <code>RejectMessage</code>, the Amazon SES API v2 returns a <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the email.
     *  These behaviors are taken when the custom MAIL FROM domain configuration is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.
     */
-  object BehaviorOnMxFailureEnum {
-    val USE_DEFAULT_VALUE = "USE_DEFAULT_VALUE"
-    val REJECT_MESSAGE    = "REJECT_MESSAGE"
+  @js.native
+  sealed trait BehaviorOnMxFailure extends js.Any
+  object BehaviorOnMxFailure extends js.Object {
+    val USE_DEFAULT_VALUE = "USE_DEFAULT_VALUE".asInstanceOf[BehaviorOnMxFailure]
+    val REJECT_MESSAGE    = "REJECT_MESSAGE".asInstanceOf[BehaviorOnMxFailure]
 
     val values = js.Object.freeze(js.Array(USE_DEFAULT_VALUE, REJECT_MESSAGE))
   }
@@ -989,10 +979,12 @@ package sesv2 {
   /**
     * The current status of your Deliverability dashboard subscription. If this value is <code>PENDING_EXPIRATION</code>, your subscription is scheduled to expire at the end of the current calendar month.
     */
-  object DeliverabilityDashboardAccountStatusEnum {
-    val ACTIVE             = "ACTIVE"
-    val PENDING_EXPIRATION = "PENDING_EXPIRATION"
-    val DISABLED           = "DISABLED"
+  @js.native
+  sealed trait DeliverabilityDashboardAccountStatus extends js.Any
+  object DeliverabilityDashboardAccountStatus extends js.Object {
+    val ACTIVE             = "ACTIVE".asInstanceOf[DeliverabilityDashboardAccountStatus]
+    val PENDING_EXPIRATION = "PENDING_EXPIRATION".asInstanceOf[DeliverabilityDashboardAccountStatus]
+    val DISABLED           = "DISABLED".asInstanceOf[DeliverabilityDashboardAccountStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, PENDING_EXPIRATION, DISABLED))
   }
@@ -1034,9 +1026,11 @@ package sesv2 {
   /**
     * The status of a predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.
     */
-  object DeliverabilityTestStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val COMPLETED   = "COMPLETED"
+  @js.native
+  sealed trait DeliverabilityTestStatus extends js.Any
+  object DeliverabilityTestStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[DeliverabilityTestStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[DeliverabilityTestStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, COMPLETED))
   }
@@ -1091,10 +1085,12 @@ package sesv2 {
   /**
     * The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. If you want to use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or a parameter to the <code>SendEmail</code> or <code>SendRawEmail</code> API, choose <code>messageTag</code>. If you want to use your own email headers, choose <code>emailHeader</code>. If you want to use link tags, choose <code>linkTags</code>.
     */
-  object DimensionValueSourceEnum {
-    val MESSAGE_TAG  = "MESSAGE_TAG"
-    val EMAIL_HEADER = "EMAIL_HEADER"
-    val LINK_TAG     = "LINK_TAG"
+  @js.native
+  sealed trait DimensionValueSource extends js.Any
+  object DimensionValueSource extends js.Object {
+    val MESSAGE_TAG  = "MESSAGE_TAG".asInstanceOf[DimensionValueSource]
+    val EMAIL_HEADER = "EMAIL_HEADER".asInstanceOf[DimensionValueSource]
+    val LINK_TAG     = "LINK_TAG".asInstanceOf[DimensionValueSource]
 
     val values = js.Object.freeze(js.Array(MESSAGE_TAG, EMAIL_HEADER, LINK_TAG))
   }
@@ -1151,10 +1147,11 @@ package sesv2 {
       __obj.asInstanceOf[DkimSigningAttributes]
     }
   }
-
-  object DkimSigningAttributesOriginEnum {
-    val AWS_SES  = "AWS_SES"
-    val EXTERNAL = "EXTERNAL"
+  @js.native
+  sealed trait DkimSigningAttributesOrigin extends js.Any
+  object DkimSigningAttributesOrigin extends js.Object {
+    val AWS_SES  = "AWS_SES".asInstanceOf[DkimSigningAttributesOrigin]
+    val EXTERNAL = "EXTERNAL".asInstanceOf[DkimSigningAttributesOrigin]
 
     val values = js.Object.freeze(js.Array(AWS_SES, EXTERNAL))
   }
@@ -1167,12 +1164,14 @@ package sesv2 {
     *  * <code>TEMPORARY_FAILURE</code> – A temporary issue is preventing Amazon SES from determining the DKIM authentication status of the domain.
     *  * <code>NOT_STARTED</code> – The DKIM verification process hasn't been initiated for the domain.
     */
-  object DkimStatusEnum {
-    val PENDING           = "PENDING"
-    val SUCCESS           = "SUCCESS"
-    val FAILED            = "FAILED"
-    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE"
-    val NOT_STARTED       = "NOT_STARTED"
+  @js.native
+  sealed trait DkimStatus extends js.Any
+  object DkimStatus extends js.Object {
+    val PENDING           = "PENDING".asInstanceOf[DkimStatus]
+    val SUCCESS           = "SUCCESS".asInstanceOf[DkimStatus]
+    val FAILED            = "FAILED".asInstanceOf[DkimStatus]
+    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE".asInstanceOf[DkimStatus]
+    val NOT_STARTED       = "NOT_STARTED".asInstanceOf[DkimStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, SUCCESS, FAILED, TEMPORARY_FAILURE, NOT_STARTED))
   }
@@ -1398,15 +1397,17 @@ package sesv2 {
   /**
     * An email sending event type. For example, email sends, opens, and bounces are all email events.
     */
-  object EventTypeEnum {
-    val SEND              = "SEND"
-    val REJECT            = "REJECT"
-    val BOUNCE            = "BOUNCE"
-    val COMPLAINT         = "COMPLAINT"
-    val DELIVERY          = "DELIVERY"
-    val OPEN              = "OPEN"
-    val CLICK             = "CLICK"
-    val RENDERING_FAILURE = "RENDERING_FAILURE"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val SEND              = "SEND".asInstanceOf[EventType]
+    val REJECT            = "REJECT".asInstanceOf[EventType]
+    val BOUNCE            = "BOUNCE".asInstanceOf[EventType]
+    val COMPLAINT         = "COMPLAINT".asInstanceOf[EventType]
+    val DELIVERY          = "DELIVERY".asInstanceOf[EventType]
+    val OPEN              = "OPEN".asInstanceOf[EventType]
+    val CLICK             = "CLICK".asInstanceOf[EventType]
+    val RENDERING_FAILURE = "RENDERING_FAILURE".asInstanceOf[EventType]
 
     val values = js.Object.freeze(js.Array(SEND, REJECT, BOUNCE, COMPLAINT, DELIVERY, OPEN, CLICK, RENDERING_FAILURE))
   }
@@ -2016,10 +2017,12 @@ package sesv2 {
     * * <code>EMAIL_ADDRESS</code> – The identity is an email address.
     *  * <code>DOMAIN</code> – The identity is a domain.
     */
-  object IdentityTypeEnum {
-    val EMAIL_ADDRESS  = "EMAIL_ADDRESS"
-    val DOMAIN         = "DOMAIN"
-    val MANAGED_DOMAIN = "MANAGED_DOMAIN"
+  @js.native
+  sealed trait IdentityType extends js.Any
+  object IdentityType extends js.Object {
+    val EMAIL_ADDRESS  = "EMAIL_ADDRESS".asInstanceOf[IdentityType]
+    val DOMAIN         = "DOMAIN".asInstanceOf[IdentityType]
+    val MANAGED_DOMAIN = "MANAGED_DOMAIN".asInstanceOf[IdentityType]
 
     val values = js.Object.freeze(js.Array(EMAIL_ADDRESS, DOMAIN, MANAGED_DOMAIN))
   }
@@ -2452,11 +2455,13 @@ package sesv2 {
     *  * <code>FAILED</code> – Amazon SES can't find the required MX record, or the record no longer exists.
     *  * <code>TEMPORARY_FAILURE</code> – A temporary issue occurred, which prevented Amazon SES from determining the status of the MAIL FROM domain.
     */
-  object MailFromDomainStatusEnum {
-    val PENDING           = "PENDING"
-    val SUCCESS           = "SUCCESS"
-    val FAILED            = "FAILED"
-    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE"
+  @js.native
+  sealed trait MailFromDomainStatus extends js.Any
+  object MailFromDomainStatus extends js.Object {
+    val PENDING           = "PENDING".asInstanceOf[MailFromDomainStatus]
+    val SUCCESS           = "SUCCESS".asInstanceOf[MailFromDomainStatus]
+    val FAILED            = "FAILED".asInstanceOf[MailFromDomainStatus]
+    val TEMPORARY_FAILURE = "TEMPORARY_FAILURE".asInstanceOf[MailFromDomainStatus]
 
     val values = js.Object.freeze(js.Array(PENDING, SUCCESS, FAILED, TEMPORARY_FAILURE))
   }
@@ -3497,9 +3502,11 @@ package sesv2 {
     * * <code>COMPLAINT</code> – Amazon SES added an email address to the suppression list for your account because a message sent to that address results in a complaint.
     *  * <code>BOUNCE</code> – Amazon SES added an email address to the suppression list for your account because a message sent to that address results in a hard bounce.
     */
-  object SuppressionListReasonEnum {
-    val BOUNCE    = "BOUNCE"
-    val COMPLAINT = "COMPLAINT"
+  @js.native
+  sealed trait SuppressionListReason extends js.Any
+  object SuppressionListReason extends js.Object {
+    val BOUNCE    = "BOUNCE".asInstanceOf[SuppressionListReason]
+    val COMPLAINT = "COMPLAINT".asInstanceOf[SuppressionListReason]
 
     val values = js.Object.freeze(js.Array(BOUNCE, COMPLAINT))
   }
@@ -3611,9 +3618,11 @@ package sesv2 {
   /**
     * Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only delivered if a TLS connection can be established. If the value is <code>Optional</code>, messages can be delivered in plain text if a TLS connection can't be established.
     */
-  object TlsPolicyEnum {
-    val REQUIRE  = "REQUIRE"
-    val OPTIONAL = "OPTIONAL"
+  @js.native
+  sealed trait TlsPolicy extends js.Any
+  object TlsPolicy extends js.Object {
+    val REQUIRE  = "REQUIRE".asInstanceOf[TlsPolicy]
+    val OPTIONAL = "OPTIONAL".asInstanceOf[TlsPolicy]
 
     val values = js.Object.freeze(js.Array(REQUIRE, OPTIONAL))
   }
@@ -3748,9 +3757,11 @@ package sesv2 {
   /**
     * The warmup status of a dedicated IP.
     */
-  object WarmupStatusEnum {
-    val IN_PROGRESS = "IN_PROGRESS"
-    val DONE        = "DONE"
+  @js.native
+  sealed trait WarmupStatus extends js.Any
+  object WarmupStatus extends js.Object {
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[WarmupStatus]
+    val DONE        = "DONE".asInstanceOf[WarmupStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, DONE))
   }

--- a/services/shield/src/main/scala/facade/amazonaws/services/Shield.scala
+++ b/services/shield/src/main/scala/facade/amazonaws/services/Shield.scala
@@ -8,13 +8,10 @@ import facade.amazonaws._
 
 package object shield {
   type AttackId                    = String
-  type AttackLayer                 = String
   type AttackProperties            = js.Array[AttackProperty]
-  type AttackPropertyIdentifier    = String
   type AttackSummaries             = js.Array[AttackSummary]
   type AttackTimestamp             = js.Date
   type AttackVectorDescriptionList = js.Array[AttackVectorDescription]
-  type AutoRenew                   = String
   type DurationInSeconds           = Double
   type EmailAddress                = String
   type EmergencyContactList        = js.Array[EmergencyContact]
@@ -33,14 +30,11 @@ package object shield {
   type ResourceArnFilterList       = js.Array[ResourceArn]
   type RoleArn                     = String
   type SubResourceSummaryList      = js.Array[SubResourceSummary]
-  type SubResourceType             = String
-  type SubscriptionState           = String
   type SummarizedAttackVectorList  = js.Array[SummarizedAttackVector]
   type SummarizedCounterList       = js.Array[SummarizedCounter]
   type Timestamp                   = js.Date
   type Token                       = String
   type TopContributors             = js.Array[Contributor]
-  type Unit                        = String
 
   implicit final class ShieldOps(private val service: Shield) extends AnyVal {
 
@@ -262,10 +256,11 @@ package shield {
       __obj.asInstanceOf[AttackDetail]
     }
   }
-
-  object AttackLayerEnum {
-    val NETWORK     = "NETWORK"
-    val APPLICATION = "APPLICATION"
+  @js.native
+  sealed trait AttackLayer extends js.Any
+  object AttackLayer extends js.Object {
+    val NETWORK     = "NETWORK".asInstanceOf[AttackLayer]
+    val APPLICATION = "APPLICATION".asInstanceOf[AttackLayer]
 
     val values = js.Object.freeze(js.Array(NETWORK, APPLICATION))
   }
@@ -300,16 +295,17 @@ package shield {
       __obj.asInstanceOf[AttackProperty]
     }
   }
-
-  object AttackPropertyIdentifierEnum {
-    val DESTINATION_URL              = "DESTINATION_URL"
-    val REFERRER                     = "REFERRER"
-    val SOURCE_ASN                   = "SOURCE_ASN"
-    val SOURCE_COUNTRY               = "SOURCE_COUNTRY"
-    val SOURCE_IP_ADDRESS            = "SOURCE_IP_ADDRESS"
-    val SOURCE_USER_AGENT            = "SOURCE_USER_AGENT"
-    val WORDPRESS_PINGBACK_REFLECTOR = "WORDPRESS_PINGBACK_REFLECTOR"
-    val WORDPRESS_PINGBACK_SOURCE    = "WORDPRESS_PINGBACK_SOURCE"
+  @js.native
+  sealed trait AttackPropertyIdentifier extends js.Any
+  object AttackPropertyIdentifier extends js.Object {
+    val DESTINATION_URL              = "DESTINATION_URL".asInstanceOf[AttackPropertyIdentifier]
+    val REFERRER                     = "REFERRER".asInstanceOf[AttackPropertyIdentifier]
+    val SOURCE_ASN                   = "SOURCE_ASN".asInstanceOf[AttackPropertyIdentifier]
+    val SOURCE_COUNTRY               = "SOURCE_COUNTRY".asInstanceOf[AttackPropertyIdentifier]
+    val SOURCE_IP_ADDRESS            = "SOURCE_IP_ADDRESS".asInstanceOf[AttackPropertyIdentifier]
+    val SOURCE_USER_AGENT            = "SOURCE_USER_AGENT".asInstanceOf[AttackPropertyIdentifier]
+    val WORDPRESS_PINGBACK_REFLECTOR = "WORDPRESS_PINGBACK_REFLECTOR".asInstanceOf[AttackPropertyIdentifier]
+    val WORDPRESS_PINGBACK_SOURCE    = "WORDPRESS_PINGBACK_SOURCE".asInstanceOf[AttackPropertyIdentifier]
 
     val values = js.Object.freeze(
       js.Array(
@@ -376,10 +372,11 @@ package shield {
       __obj.asInstanceOf[AttackVectorDescription]
     }
   }
-
-  object AutoRenewEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait AutoRenew extends js.Any
+  object AutoRenew extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[AutoRenew]
+    val DISABLED = "DISABLED".asInstanceOf[AutoRenew]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -1011,10 +1008,11 @@ package shield {
       __obj.asInstanceOf[SubResourceSummary]
     }
   }
-
-  object SubResourceTypeEnum {
-    val IP  = "IP"
-    val URL = "URL"
+  @js.native
+  sealed trait SubResourceType extends js.Any
+  object SubResourceType extends js.Object {
+    val IP  = "IP".asInstanceOf[SubResourceType]
+    val URL = "URL".asInstanceOf[SubResourceType]
 
     val values = js.Object.freeze(js.Array(IP, URL))
   }
@@ -1049,10 +1047,11 @@ package shield {
       __obj.asInstanceOf[Subscription]
     }
   }
-
-  object SubscriptionStateEnum {
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
+  @js.native
+  sealed trait SubscriptionState extends js.Any
+  object SubscriptionState extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[SubscriptionState]
+    val INACTIVE = "INACTIVE".asInstanceOf[SubscriptionState]
 
     val values = js.Object.freeze(js.Array(ACTIVE, INACTIVE))
   }
@@ -1136,12 +1135,13 @@ package shield {
       __obj.asInstanceOf[TimeRange]
     }
   }
-
-  object UnitEnum {
-    val BITS     = "BITS"
-    val BYTES    = "BYTES"
-    val PACKETS  = "PACKETS"
-    val REQUESTS = "REQUESTS"
+  @js.native
+  sealed trait Unit extends js.Any
+  object Unit extends js.Object {
+    val BITS     = "BITS".asInstanceOf[Unit]
+    val BYTES    = "BYTES".asInstanceOf[Unit]
+    val PACKETS  = "PACKETS".asInstanceOf[Unit]
+    val REQUESTS = "REQUESTS".asInstanceOf[Unit]
 
     val values = js.Object.freeze(js.Array(BITS, BYTES, PACKETS, REQUESTS))
   }

--- a/services/signer/src/main/scala/facade/amazonaws/services/Signer.scala
+++ b/services/signer/src/main/scala/facade/amazonaws/services/Signer.scala
@@ -8,17 +8,13 @@ import facade.amazonaws._
 
 package object signer {
   type BucketName            = String
-  type Category              = String
   type CertificateArn        = String
   type ClientRequestToken    = String
   type CompletedAt           = js.Date
   type CreatedAt             = js.Date
   type DisplayName           = String
-  type EncryptionAlgorithm   = String
   type EncryptionAlgorithms  = js.Array[EncryptionAlgorithm]
-  type HashAlgorithm         = String
   type HashAlgorithms        = js.Array[HashAlgorithm]
-  type ImageFormat           = String
   type ImageFormats          = js.Array[ImageFormat]
   type JobId                 = String
   type Key                   = String
@@ -34,9 +30,7 @@ package object signer {
   type SigningParameterValue = String
   type SigningParameters     = js.Dictionary[SigningParameterValue]
   type SigningPlatforms      = js.Array[SigningPlatform]
-  type SigningProfileStatus  = String
   type SigningProfiles       = js.Array[SigningProfile]
-  type SigningStatus         = String
   type StatusReason          = String
   type TagKey                = String
   type TagKeyList            = js.Array[TagKey]
@@ -111,9 +105,10 @@ package signer {
       __obj.asInstanceOf[CancelSigningProfileRequest]
     }
   }
-
-  object CategoryEnum {
-    val AWSIoT = "AWSIoT"
+  @js.native
+  sealed trait Category extends js.Any
+  object Category extends js.Object {
+    val AWSIoT = "AWSIoT".asInstanceOf[Category]
 
     val values = js.Object.freeze(js.Array(AWSIoT))
   }
@@ -206,10 +201,11 @@ package signer {
       __obj.asInstanceOf[Destination]
     }
   }
-
-  object EncryptionAlgorithmEnum {
-    val RSA   = "RSA"
-    val ECDSA = "ECDSA"
+  @js.native
+  sealed trait EncryptionAlgorithm extends js.Any
+  object EncryptionAlgorithm extends js.Object {
+    val RSA   = "RSA".asInstanceOf[EncryptionAlgorithm]
+    val ECDSA = "ECDSA".asInstanceOf[EncryptionAlgorithm]
 
     val values = js.Object.freeze(js.Array(RSA, ECDSA))
   }
@@ -347,10 +343,11 @@ package signer {
       __obj.asInstanceOf[GetSigningProfileResponse]
     }
   }
-
-  object HashAlgorithmEnum {
-    val SHA1   = "SHA1"
-    val SHA256 = "SHA256"
+  @js.native
+  sealed trait HashAlgorithm extends js.Any
+  object HashAlgorithm extends js.Object {
+    val SHA1   = "SHA1".asInstanceOf[HashAlgorithm]
+    val SHA256 = "SHA256".asInstanceOf[HashAlgorithm]
 
     val values = js.Object.freeze(js.Array(SHA1, SHA256))
   }
@@ -378,9 +375,10 @@ package signer {
       __obj.asInstanceOf[HashAlgorithmOptions]
     }
   }
-
-  object ImageFormatEnum {
-    val JSON = "JSON"
+  @js.native
+  sealed trait ImageFormat extends js.Any
+  object ImageFormat extends js.Object {
+    val JSON = "JSON".asInstanceOf[ImageFormat]
 
     val values = js.Object.freeze(js.Array(JSON))
   }
@@ -913,18 +911,20 @@ package signer {
       __obj.asInstanceOf[SigningProfile]
     }
   }
-
-  object SigningProfileStatusEnum {
-    val Active   = "Active"
-    val Canceled = "Canceled"
+  @js.native
+  sealed trait SigningProfileStatus extends js.Any
+  object SigningProfileStatus extends js.Object {
+    val Active   = "Active".asInstanceOf[SigningProfileStatus]
+    val Canceled = "Canceled".asInstanceOf[SigningProfileStatus]
 
     val values = js.Object.freeze(js.Array(Active, Canceled))
   }
-
-  object SigningStatusEnum {
-    val InProgress = "InProgress"
-    val Failed     = "Failed"
-    val Succeeded  = "Succeeded"
+  @js.native
+  sealed trait SigningStatus extends js.Any
+  object SigningStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[SigningStatus]
+    val Failed     = "Failed".asInstanceOf[SigningStatus]
+    val Succeeded  = "Succeeded".asInstanceOf[SigningStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Failed, Succeeded))
   }

--- a/services/sms/src/main/scala/facade/amazonaws/services/SMS.scala
+++ b/services/sms/src/main/scala/facade/amazonaws/services/SMS.scala
@@ -11,22 +11,17 @@ package object sms {
   type AppDescription                       = String
   type AppId                                = String
   type AppIds                               = js.Array[AppId]
-  type AppLaunchStatus                      = String
   type AppLaunchStatusMessage               = String
   type AppName                              = String
-  type AppReplicationStatus                 = String
   type AppReplicationStatusMessage          = String
-  type AppStatus                            = String
   type AppStatusMessage                     = String
   type Apps                                 = js.Array[AppSummary]
   type AssociatePublicIpAddress             = Boolean
   type BucketName                           = String
   type ClientToken                          = String
-  type ConnectorCapability                  = String
   type ConnectorCapabilityList              = js.Array[ConnectorCapability]
   type ConnectorId                          = String
   type ConnectorList                        = js.Array[Connector]
-  type ConnectorStatus                      = String
   type ConnectorVersion                     = String
   type Description                          = String
   type EC2KeyName                           = String
@@ -39,29 +34,23 @@ package object sms {
   type KeyName                              = String
   type KmsKeyId                             = String
   type LaunchOrder                          = Int
-  type LicenseType                          = String
   type LogicalId                            = String
   type MacAddress                           = String
   type MaxResults                           = Int
   type NextToken                            = String
   type NumberOfRecentAmisToKeep             = Int
-  type OutputFormat                         = String
   type ReplicationJobId                     = String
   type ReplicationJobList                   = js.Array[ReplicationJob]
-  type ReplicationJobState                  = String
   type ReplicationJobStatusMessage          = String
   type ReplicationJobTerminated             = Boolean
   type ReplicationRunId                     = String
   type ReplicationRunList                   = js.Array[ReplicationRun]
   type ReplicationRunStage                  = String
   type ReplicationRunStageProgress          = String
-  type ReplicationRunState                  = String
   type ReplicationRunStatusMessage          = String
-  type ReplicationRunType                   = String
   type RoleName                             = String
   type RunOnce                              = Boolean
   type SecurityGroup                        = String
-  type ServerCatalogStatus                  = String
   type ServerGroupId                        = String
   type ServerGroupLaunchConfigurations      = js.Array[ServerGroupLaunchConfiguration]
   type ServerGroupName                      = String
@@ -71,7 +60,6 @@ package object sms {
   type ServerLaunchConfigurations           = js.Array[ServerLaunchConfiguration]
   type ServerList                           = js.Array[Server]
   type ServerReplicationConfigurations      = js.Array[ServerReplicationConfiguration]
-  type ServerType                           = String
   type StackId                              = String
   type StackName                            = String
   type Subnet                               = String
@@ -85,7 +73,6 @@ package object sms {
   type VmId                                 = String
   type VmManagerId                          = String
   type VmManagerName                        = String
-  type VmManagerType                        = String
   type VmName                               = String
   type VmPath                               = String
   type VmServerAddressList                  = js.Array[VmServerAddress]
@@ -208,22 +195,23 @@ package sms {
     def updateApp(params: UpdateAppRequest): Request[UpdateAppResponse]                                  = js.native
     def updateReplicationJob(params: UpdateReplicationJobRequest): Request[UpdateReplicationJobResponse] = js.native
   }
-
-  object AppLaunchStatusEnum {
-    val READY_FOR_CONFIGURATION   = "READY_FOR_CONFIGURATION"
-    val CONFIGURATION_IN_PROGRESS = "CONFIGURATION_IN_PROGRESS"
-    val CONFIGURATION_INVALID     = "CONFIGURATION_INVALID"
-    val READY_FOR_LAUNCH          = "READY_FOR_LAUNCH"
-    val VALIDATION_IN_PROGRESS    = "VALIDATION_IN_PROGRESS"
-    val LAUNCH_PENDING            = "LAUNCH_PENDING"
-    val LAUNCH_IN_PROGRESS        = "LAUNCH_IN_PROGRESS"
-    val LAUNCHED                  = "LAUNCHED"
-    val DELTA_LAUNCH_IN_PROGRESS  = "DELTA_LAUNCH_IN_PROGRESS"
-    val DELTA_LAUNCH_FAILED       = "DELTA_LAUNCH_FAILED"
-    val LAUNCH_FAILED             = "LAUNCH_FAILED"
-    val TERMINATE_IN_PROGRESS     = "TERMINATE_IN_PROGRESS"
-    val TERMINATE_FAILED          = "TERMINATE_FAILED"
-    val TERMINATED                = "TERMINATED"
+  @js.native
+  sealed trait AppLaunchStatus extends js.Any
+  object AppLaunchStatus extends js.Object {
+    val READY_FOR_CONFIGURATION   = "READY_FOR_CONFIGURATION".asInstanceOf[AppLaunchStatus]
+    val CONFIGURATION_IN_PROGRESS = "CONFIGURATION_IN_PROGRESS".asInstanceOf[AppLaunchStatus]
+    val CONFIGURATION_INVALID     = "CONFIGURATION_INVALID".asInstanceOf[AppLaunchStatus]
+    val READY_FOR_LAUNCH          = "READY_FOR_LAUNCH".asInstanceOf[AppLaunchStatus]
+    val VALIDATION_IN_PROGRESS    = "VALIDATION_IN_PROGRESS".asInstanceOf[AppLaunchStatus]
+    val LAUNCH_PENDING            = "LAUNCH_PENDING".asInstanceOf[AppLaunchStatus]
+    val LAUNCH_IN_PROGRESS        = "LAUNCH_IN_PROGRESS".asInstanceOf[AppLaunchStatus]
+    val LAUNCHED                  = "LAUNCHED".asInstanceOf[AppLaunchStatus]
+    val DELTA_LAUNCH_IN_PROGRESS  = "DELTA_LAUNCH_IN_PROGRESS".asInstanceOf[AppLaunchStatus]
+    val DELTA_LAUNCH_FAILED       = "DELTA_LAUNCH_FAILED".asInstanceOf[AppLaunchStatus]
+    val LAUNCH_FAILED             = "LAUNCH_FAILED".asInstanceOf[AppLaunchStatus]
+    val TERMINATE_IN_PROGRESS     = "TERMINATE_IN_PROGRESS".asInstanceOf[AppLaunchStatus]
+    val TERMINATE_FAILED          = "TERMINATE_FAILED".asInstanceOf[AppLaunchStatus]
+    val TERMINATED                = "TERMINATED".asInstanceOf[AppLaunchStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -244,23 +232,24 @@ package sms {
       )
     )
   }
-
-  object AppReplicationStatusEnum {
-    val READY_FOR_CONFIGURATION       = "READY_FOR_CONFIGURATION"
-    val CONFIGURATION_IN_PROGRESS     = "CONFIGURATION_IN_PROGRESS"
-    val CONFIGURATION_INVALID         = "CONFIGURATION_INVALID"
-    val READY_FOR_REPLICATION         = "READY_FOR_REPLICATION"
-    val VALIDATION_IN_PROGRESS        = "VALIDATION_IN_PROGRESS"
-    val REPLICATION_PENDING           = "REPLICATION_PENDING"
-    val REPLICATION_IN_PROGRESS       = "REPLICATION_IN_PROGRESS"
-    val REPLICATED                    = "REPLICATED"
-    val DELTA_REPLICATION_IN_PROGRESS = "DELTA_REPLICATION_IN_PROGRESS"
-    val DELTA_REPLICATED              = "DELTA_REPLICATED"
-    val DELTA_REPLICATION_FAILED      = "DELTA_REPLICATION_FAILED"
-    val REPLICATION_FAILED            = "REPLICATION_FAILED"
-    val REPLICATION_STOPPING          = "REPLICATION_STOPPING"
-    val REPLICATION_STOP_FAILED       = "REPLICATION_STOP_FAILED"
-    val REPLICATION_STOPPED           = "REPLICATION_STOPPED"
+  @js.native
+  sealed trait AppReplicationStatus extends js.Any
+  object AppReplicationStatus extends js.Object {
+    val READY_FOR_CONFIGURATION       = "READY_FOR_CONFIGURATION".asInstanceOf[AppReplicationStatus]
+    val CONFIGURATION_IN_PROGRESS     = "CONFIGURATION_IN_PROGRESS".asInstanceOf[AppReplicationStatus]
+    val CONFIGURATION_INVALID         = "CONFIGURATION_INVALID".asInstanceOf[AppReplicationStatus]
+    val READY_FOR_REPLICATION         = "READY_FOR_REPLICATION".asInstanceOf[AppReplicationStatus]
+    val VALIDATION_IN_PROGRESS        = "VALIDATION_IN_PROGRESS".asInstanceOf[AppReplicationStatus]
+    val REPLICATION_PENDING           = "REPLICATION_PENDING".asInstanceOf[AppReplicationStatus]
+    val REPLICATION_IN_PROGRESS       = "REPLICATION_IN_PROGRESS".asInstanceOf[AppReplicationStatus]
+    val REPLICATED                    = "REPLICATED".asInstanceOf[AppReplicationStatus]
+    val DELTA_REPLICATION_IN_PROGRESS = "DELTA_REPLICATION_IN_PROGRESS".asInstanceOf[AppReplicationStatus]
+    val DELTA_REPLICATED              = "DELTA_REPLICATED".asInstanceOf[AppReplicationStatus]
+    val DELTA_REPLICATION_FAILED      = "DELTA_REPLICATION_FAILED".asInstanceOf[AppReplicationStatus]
+    val REPLICATION_FAILED            = "REPLICATION_FAILED".asInstanceOf[AppReplicationStatus]
+    val REPLICATION_STOPPING          = "REPLICATION_STOPPING".asInstanceOf[AppReplicationStatus]
+    val REPLICATION_STOP_FAILED       = "REPLICATION_STOP_FAILED".asInstanceOf[AppReplicationStatus]
+    val REPLICATION_STOPPED           = "REPLICATION_STOPPED".asInstanceOf[AppReplicationStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -282,14 +271,15 @@ package sms {
       )
     )
   }
-
-  object AppStatusEnum {
-    val CREATING      = "CREATING"
-    val ACTIVE        = "ACTIVE"
-    val UPDATING      = "UPDATING"
-    val DELETING      = "DELETING"
-    val DELETED       = "DELETED"
-    val DELETE_FAILED = "DELETE_FAILED"
+  @js.native
+  sealed trait AppStatus extends js.Any
+  object AppStatus extends js.Object {
+    val CREATING      = "CREATING".asInstanceOf[AppStatus]
+    val ACTIVE        = "ACTIVE".asInstanceOf[AppStatus]
+    val UPDATING      = "UPDATING".asInstanceOf[AppStatus]
+    val DELETING      = "DELETING".asInstanceOf[AppStatus]
+    val DELETED       = "DELETED".asInstanceOf[AppStatus]
+    val DELETE_FAILED = "DELETE_FAILED".asInstanceOf[AppStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, UPDATING, DELETING, DELETED, DELETE_FAILED))
   }
@@ -403,19 +393,21 @@ package sms {
       __obj.asInstanceOf[Connector]
     }
   }
-
-  object ConnectorCapabilityEnum {
-    val VSPHERE           = "VSPHERE"
-    val SCVMM             = "SCVMM"
-    val `HYPERV-MANAGER`  = "HYPERV-MANAGER"
-    val SNAPSHOT_BATCHING = "SNAPSHOT_BATCHING"
+  @js.native
+  sealed trait ConnectorCapability extends js.Any
+  object ConnectorCapability extends js.Object {
+    val VSPHERE           = "VSPHERE".asInstanceOf[ConnectorCapability]
+    val SCVMM             = "SCVMM".asInstanceOf[ConnectorCapability]
+    val `HYPERV-MANAGER`  = "HYPERV-MANAGER".asInstanceOf[ConnectorCapability]
+    val SNAPSHOT_BATCHING = "SNAPSHOT_BATCHING".asInstanceOf[ConnectorCapability]
 
     val values = js.Object.freeze(js.Array(VSPHERE, SCVMM, `HYPERV-MANAGER`, SNAPSHOT_BATCHING))
   }
-
-  object ConnectorStatusEnum {
-    val HEALTHY   = "HEALTHY"
-    val UNHEALTHY = "UNHEALTHY"
+  @js.native
+  sealed trait ConnectorStatus extends js.Any
+  object ConnectorStatus extends js.Object {
+    val HEALTHY   = "HEALTHY".asInstanceOf[ConnectorStatus]
+    val UNHEALTHY = "UNHEALTHY".asInstanceOf[ConnectorStatus]
 
     val values = js.Object.freeze(js.Array(HEALTHY, UNHEALTHY))
   }
@@ -1148,10 +1140,11 @@ package sms {
       __obj.asInstanceOf[LaunchDetails]
     }
   }
-
-  object LicenseTypeEnum {
-    val AWS  = "AWS"
-    val BYOL = "BYOL"
+  @js.native
+  sealed trait LicenseType extends js.Any
+  object LicenseType extends js.Object {
+    val AWS  = "AWS".asInstanceOf[LicenseType]
+    val BYOL = "BYOL".asInstanceOf[LicenseType]
 
     val values = js.Object.freeze(js.Array(AWS, BYOL))
   }
@@ -1196,10 +1189,11 @@ package sms {
       __obj.asInstanceOf[ListAppsResponse]
     }
   }
-
-  object OutputFormatEnum {
-    val JSON = "JSON"
-    val YAML = "YAML"
+  @js.native
+  sealed trait OutputFormat extends js.Any
+  object OutputFormat extends js.Object {
+    val JSON = "JSON".asInstanceOf[OutputFormat]
+    val YAML = "YAML".asInstanceOf[OutputFormat]
 
     val values = js.Object.freeze(js.Array(JSON, YAML))
   }
@@ -1346,16 +1340,17 @@ package sms {
       __obj.asInstanceOf[ReplicationJob]
     }
   }
-
-  object ReplicationJobStateEnum {
-    val PENDING           = "PENDING"
-    val ACTIVE            = "ACTIVE"
-    val FAILED            = "FAILED"
-    val DELETING          = "DELETING"
-    val DELETED           = "DELETED"
-    val COMPLETED         = "COMPLETED"
-    val PAUSED_ON_FAILURE = "PAUSED_ON_FAILURE"
-    val FAILING           = "FAILING"
+  @js.native
+  sealed trait ReplicationJobState extends js.Any
+  object ReplicationJobState extends js.Object {
+    val PENDING           = "PENDING".asInstanceOf[ReplicationJobState]
+    val ACTIVE            = "ACTIVE".asInstanceOf[ReplicationJobState]
+    val FAILED            = "FAILED".asInstanceOf[ReplicationJobState]
+    val DELETING          = "DELETING".asInstanceOf[ReplicationJobState]
+    val DELETED           = "DELETED".asInstanceOf[ReplicationJobState]
+    val COMPLETED         = "COMPLETED".asInstanceOf[ReplicationJobState]
+    val PAUSED_ON_FAILURE = "PAUSED_ON_FAILURE".asInstanceOf[ReplicationJobState]
+    val FAILING           = "FAILING".asInstanceOf[ReplicationJobState]
 
     val values =
       js.Object.freeze(js.Array(PENDING, ACTIVE, FAILED, DELETING, DELETED, COMPLETED, PAUSED_ON_FAILURE, FAILING))
@@ -1431,22 +1426,24 @@ package sms {
       __obj.asInstanceOf[ReplicationRunStageDetails]
     }
   }
-
-  object ReplicationRunStateEnum {
-    val PENDING   = "PENDING"
-    val MISSED    = "MISSED"
-    val ACTIVE    = "ACTIVE"
-    val FAILED    = "FAILED"
-    val COMPLETED = "COMPLETED"
-    val DELETING  = "DELETING"
-    val DELETED   = "DELETED"
+  @js.native
+  sealed trait ReplicationRunState extends js.Any
+  object ReplicationRunState extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[ReplicationRunState]
+    val MISSED    = "MISSED".asInstanceOf[ReplicationRunState]
+    val ACTIVE    = "ACTIVE".asInstanceOf[ReplicationRunState]
+    val FAILED    = "FAILED".asInstanceOf[ReplicationRunState]
+    val COMPLETED = "COMPLETED".asInstanceOf[ReplicationRunState]
+    val DELETING  = "DELETING".asInstanceOf[ReplicationRunState]
+    val DELETED   = "DELETED".asInstanceOf[ReplicationRunState]
 
     val values = js.Object.freeze(js.Array(PENDING, MISSED, ACTIVE, FAILED, COMPLETED, DELETING, DELETED))
   }
-
-  object ReplicationRunTypeEnum {
-    val ON_DEMAND = "ON_DEMAND"
-    val AUTOMATIC = "AUTOMATIC"
+  @js.native
+  sealed trait ReplicationRunType extends js.Any
+  object ReplicationRunType extends js.Object {
+    val ON_DEMAND = "ON_DEMAND".asInstanceOf[ReplicationRunType]
+    val AUTOMATIC = "AUTOMATIC".asInstanceOf[ReplicationRunType]
 
     val values = js.Object.freeze(js.Array(ON_DEMAND, AUTOMATIC))
   }
@@ -1503,13 +1500,14 @@ package sms {
       __obj.asInstanceOf[Server]
     }
   }
-
-  object ServerCatalogStatusEnum {
-    val NOT_IMPORTED = "NOT_IMPORTED"
-    val IMPORTING    = "IMPORTING"
-    val AVAILABLE    = "AVAILABLE"
-    val DELETED      = "DELETED"
-    val EXPIRED      = "EXPIRED"
+  @js.native
+  sealed trait ServerCatalogStatus extends js.Any
+  object ServerCatalogStatus extends js.Object {
+    val NOT_IMPORTED = "NOT_IMPORTED".asInstanceOf[ServerCatalogStatus]
+    val IMPORTING    = "IMPORTING".asInstanceOf[ServerCatalogStatus]
+    val AVAILABLE    = "AVAILABLE".asInstanceOf[ServerCatalogStatus]
+    val DELETED      = "DELETED".asInstanceOf[ServerCatalogStatus]
+    val EXPIRED      = "EXPIRED".asInstanceOf[ServerCatalogStatus]
 
     val values = js.Object.freeze(js.Array(NOT_IMPORTED, IMPORTING, AVAILABLE, DELETED, EXPIRED))
   }
@@ -1693,9 +1691,10 @@ package sms {
       __obj.asInstanceOf[ServerReplicationParameters]
     }
   }
-
-  object ServerTypeEnum {
-    val VIRTUAL_MACHINE = "VIRTUAL_MACHINE"
+  @js.native
+  sealed trait ServerType extends js.Any
+  object ServerType extends js.Object {
+    val VIRTUAL_MACHINE = "VIRTUAL_MACHINE".asInstanceOf[ServerType]
 
     val values = js.Object.freeze(js.Array(VIRTUAL_MACHINE))
   }
@@ -1974,11 +1973,12 @@ package sms {
       __obj.asInstanceOf[UserData]
     }
   }
-
-  object VmManagerTypeEnum {
-    val VSPHERE          = "VSPHERE"
-    val SCVMM            = "SCVMM"
-    val `HYPERV-MANAGER` = "HYPERV-MANAGER"
+  @js.native
+  sealed trait VmManagerType extends js.Any
+  object VmManagerType extends js.Object {
+    val VSPHERE          = "VSPHERE".asInstanceOf[VmManagerType]
+    val SCVMM            = "SCVMM".asInstanceOf[VmManagerType]
+    val `HYPERV-MANAGER` = "HYPERV-MANAGER".asInstanceOf[VmManagerType]
 
     val values = js.Object.freeze(js.Array(VSPHERE, SCVMM, `HYPERV-MANAGER`))
   }

--- a/services/snowball/src/main/scala/facade/amazonaws/services/Snowball.scala
+++ b/services/snowball/src/main/scala/facade/amazonaws/services/Snowball.scala
@@ -12,25 +12,19 @@ package object snowball {
   type AmiId                      = String
   type ClusterId                  = String
   type ClusterListEntryList       = js.Array[ClusterListEntry]
-  type ClusterState               = String
   type CompatibleImageList        = js.Array[CompatibleImage]
   type Ec2AmiResourceList         = js.Array[Ec2AmiResource]
   type EventTriggerDefinitionList = js.Array[EventTriggerDefinition]
   type JobId                      = String
   type JobListEntryList           = js.Array[JobListEntry]
   type JobMetadataList            = js.Array[JobMetadata]
-  type JobState                   = String
   type JobStateList               = js.Array[JobState]
-  type JobType                    = String
   type KmsKeyARN                  = String
   type LambdaResourceList         = js.Array[LambdaResource]
   type ListLimit                  = Int
   type ResourceARN                = String
   type RoleARN                    = String
   type S3ResourceList             = js.Array[S3Resource]
-  type ShippingOption             = String
-  type SnowballCapacity           = String
-  type SnowballType               = String
   type SnsTopicARN                = String
   type Timestamp                  = js.Date
 
@@ -306,13 +300,14 @@ package snowball {
       __obj.asInstanceOf[ClusterMetadata]
     }
   }
-
-  object ClusterStateEnum {
-    val AwaitingQuorum = "AwaitingQuorum"
-    val Pending        = "Pending"
-    val InUse          = "InUse"
-    val Complete       = "Complete"
-    val Cancelled      = "Cancelled"
+  @js.native
+  sealed trait ClusterState extends js.Any
+  object ClusterState extends js.Object {
+    val AwaitingQuorum = "AwaitingQuorum".asInstanceOf[ClusterState]
+    val Pending        = "Pending".asInstanceOf[ClusterState]
+    val InUse          = "InUse".asInstanceOf[ClusterState]
+    val Complete       = "Complete".asInstanceOf[ClusterState]
+    val Cancelled      = "Cancelled".asInstanceOf[ClusterState]
 
     val values = js.Object.freeze(js.Array(AwaitingQuorum, Pending, InUse, Complete, Cancelled))
   }
@@ -1007,21 +1002,22 @@ package snowball {
       __obj.asInstanceOf[JobResource]
     }
   }
-
-  object JobStateEnum {
-    val New                    = "New"
-    val PreparingAppliance     = "PreparingAppliance"
-    val PreparingShipment      = "PreparingShipment"
-    val InTransitToCustomer    = "InTransitToCustomer"
-    val WithCustomer           = "WithCustomer"
-    val InTransitToAWS         = "InTransitToAWS"
-    val WithAWSSortingFacility = "WithAWSSortingFacility"
-    val WithAWS                = "WithAWS"
-    val InProgress             = "InProgress"
-    val Complete               = "Complete"
-    val Cancelled              = "Cancelled"
-    val Listing                = "Listing"
-    val Pending                = "Pending"
+  @js.native
+  sealed trait JobState extends js.Any
+  object JobState extends js.Object {
+    val New                    = "New".asInstanceOf[JobState]
+    val PreparingAppliance     = "PreparingAppliance".asInstanceOf[JobState]
+    val PreparingShipment      = "PreparingShipment".asInstanceOf[JobState]
+    val InTransitToCustomer    = "InTransitToCustomer".asInstanceOf[JobState]
+    val WithCustomer           = "WithCustomer".asInstanceOf[JobState]
+    val InTransitToAWS         = "InTransitToAWS".asInstanceOf[JobState]
+    val WithAWSSortingFacility = "WithAWSSortingFacility".asInstanceOf[JobState]
+    val WithAWS                = "WithAWS".asInstanceOf[JobState]
+    val InProgress             = "InProgress".asInstanceOf[JobState]
+    val Complete               = "Complete".asInstanceOf[JobState]
+    val Cancelled              = "Cancelled".asInstanceOf[JobState]
+    val Listing                = "Listing".asInstanceOf[JobState]
+    val Pending                = "Pending".asInstanceOf[JobState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1041,11 +1037,12 @@ package snowball {
       )
     )
   }
-
-  object JobTypeEnum {
-    val IMPORT    = "IMPORT"
-    val EXPORT    = "EXPORT"
-    val LOCAL_USE = "LOCAL_USE"
+  @js.native
+  sealed trait JobType extends js.Any
+  object JobType extends js.Object {
+    val IMPORT    = "IMPORT".asInstanceOf[JobType]
+    val EXPORT    = "EXPORT".asInstanceOf[JobType]
+    val LOCAL_USE = "LOCAL_USE".asInstanceOf[JobType]
 
     val values = js.Object.freeze(js.Array(IMPORT, EXPORT, LOCAL_USE))
   }
@@ -1345,31 +1342,34 @@ package snowball {
       __obj.asInstanceOf[ShippingDetails]
     }
   }
-
-  object ShippingOptionEnum {
-    val SECOND_DAY = "SECOND_DAY"
-    val NEXT_DAY   = "NEXT_DAY"
-    val EXPRESS    = "EXPRESS"
-    val STANDARD   = "STANDARD"
+  @js.native
+  sealed trait ShippingOption extends js.Any
+  object ShippingOption extends js.Object {
+    val SECOND_DAY = "SECOND_DAY".asInstanceOf[ShippingOption]
+    val NEXT_DAY   = "NEXT_DAY".asInstanceOf[ShippingOption]
+    val EXPRESS    = "EXPRESS".asInstanceOf[ShippingOption]
+    val STANDARD   = "STANDARD".asInstanceOf[ShippingOption]
 
     val values = js.Object.freeze(js.Array(SECOND_DAY, NEXT_DAY, EXPRESS, STANDARD))
   }
-
-  object SnowballCapacityEnum {
-    val T50          = "T50"
-    val T80          = "T80"
-    val T100         = "T100"
-    val T42          = "T42"
-    val NoPreference = "NoPreference"
+  @js.native
+  sealed trait SnowballCapacity extends js.Any
+  object SnowballCapacity extends js.Object {
+    val T50          = "T50".asInstanceOf[SnowballCapacity]
+    val T80          = "T80".asInstanceOf[SnowballCapacity]
+    val T100         = "T100".asInstanceOf[SnowballCapacity]
+    val T42          = "T42".asInstanceOf[SnowballCapacity]
+    val NoPreference = "NoPreference".asInstanceOf[SnowballCapacity]
 
     val values = js.Object.freeze(js.Array(T50, T80, T100, T42, NoPreference))
   }
-
-  object SnowballTypeEnum {
-    val STANDARD = "STANDARD"
-    val EDGE     = "EDGE"
-    val EDGE_C   = "EDGE_C"
-    val EDGE_CG  = "EDGE_CG"
+  @js.native
+  sealed trait SnowballType extends js.Any
+  object SnowballType extends js.Object {
+    val STANDARD = "STANDARD".asInstanceOf[SnowballType]
+    val EDGE     = "EDGE".asInstanceOf[SnowballType]
+    val EDGE_C   = "EDGE_C".asInstanceOf[SnowballType]
+    val EDGE_CG  = "EDGE_CG".asInstanceOf[SnowballType]
 
     val values = js.Object.freeze(js.Array(STANDARD, EDGE, EDGE_C, EDGE_CG))
   }

--- a/services/sqs/src/main/scala/facade/amazonaws/services/SQS.scala
+++ b/services/sqs/src/main/scala/facade/amazonaws/services/SQS.scala
@@ -23,10 +23,7 @@ package object sqs {
   type MessageBodySystemAttributeMap                = js.Dictionary[MessageSystemAttributeValue]
   type MessageList                                  = js.Array[Message]
   type MessageSystemAttributeMap                    = js.Dictionary[String]
-  type MessageSystemAttributeName                   = String
-  type MessageSystemAttributeNameForSends           = String
   type QueueAttributeMap                            = js.Dictionary[String]
-  type QueueAttributeName                           = String
   type QueueUrlList                                 = js.Array[String]
   type SendMessageBatchRequestEntryList             = js.Array[SendMessageBatchRequestEntry]
   type SendMessageBatchResultEntryList              = js.Array[SendMessageBatchResultEntry]
@@ -752,16 +749,17 @@ package sqs {
       __obj.asInstanceOf[MessageAttributeValue]
     }
   }
-
-  object MessageSystemAttributeNameEnum {
-    val SenderId                         = "SenderId"
-    val SentTimestamp                    = "SentTimestamp"
-    val ApproximateReceiveCount          = "ApproximateReceiveCount"
-    val ApproximateFirstReceiveTimestamp = "ApproximateFirstReceiveTimestamp"
-    val SequenceNumber                   = "SequenceNumber"
-    val MessageDeduplicationId           = "MessageDeduplicationId"
-    val MessageGroupId                   = "MessageGroupId"
-    val AWSTraceHeader                   = "AWSTraceHeader"
+  @js.native
+  sealed trait MessageSystemAttributeName extends js.Any
+  object MessageSystemAttributeName extends js.Object {
+    val SenderId                         = "SenderId".asInstanceOf[MessageSystemAttributeName]
+    val SentTimestamp                    = "SentTimestamp".asInstanceOf[MessageSystemAttributeName]
+    val ApproximateReceiveCount          = "ApproximateReceiveCount".asInstanceOf[MessageSystemAttributeName]
+    val ApproximateFirstReceiveTimestamp = "ApproximateFirstReceiveTimestamp".asInstanceOf[MessageSystemAttributeName]
+    val SequenceNumber                   = "SequenceNumber".asInstanceOf[MessageSystemAttributeName]
+    val MessageDeduplicationId           = "MessageDeduplicationId".asInstanceOf[MessageSystemAttributeName]
+    val MessageGroupId                   = "MessageGroupId".asInstanceOf[MessageSystemAttributeName]
+    val AWSTraceHeader                   = "AWSTraceHeader".asInstanceOf[MessageSystemAttributeName]
 
     val values = js.Object.freeze(
       js.Array(
@@ -776,9 +774,10 @@ package sqs {
       )
     )
   }
-
-  object MessageSystemAttributeNameForSendsEnum {
-    val AWSTraceHeader = "AWSTraceHeader"
+  @js.native
+  sealed trait MessageSystemAttributeNameForSends extends js.Any
+  object MessageSystemAttributeNameForSends extends js.Object {
+    val AWSTraceHeader = "AWSTraceHeader".asInstanceOf[MessageSystemAttributeNameForSends]
 
     val values = js.Object.freeze(js.Array(AWSTraceHeader))
   }
@@ -837,26 +836,27 @@ package sqs {
       __obj.asInstanceOf[PurgeQueueRequest]
     }
   }
-
-  object QueueAttributeNameEnum {
-    val All                                   = "All"
-    val Policy                                = "Policy"
-    val VisibilityTimeout                     = "VisibilityTimeout"
-    val MaximumMessageSize                    = "MaximumMessageSize"
-    val MessageRetentionPeriod                = "MessageRetentionPeriod"
-    val ApproximateNumberOfMessages           = "ApproximateNumberOfMessages"
-    val ApproximateNumberOfMessagesNotVisible = "ApproximateNumberOfMessagesNotVisible"
-    val CreatedTimestamp                      = "CreatedTimestamp"
-    val LastModifiedTimestamp                 = "LastModifiedTimestamp"
-    val QueueArn                              = "QueueArn"
-    val ApproximateNumberOfMessagesDelayed    = "ApproximateNumberOfMessagesDelayed"
-    val DelaySeconds                          = "DelaySeconds"
-    val ReceiveMessageWaitTimeSeconds         = "ReceiveMessageWaitTimeSeconds"
-    val RedrivePolicy                         = "RedrivePolicy"
-    val FifoQueue                             = "FifoQueue"
-    val ContentBasedDeduplication             = "ContentBasedDeduplication"
-    val KmsMasterKeyId                        = "KmsMasterKeyId"
-    val KmsDataKeyReusePeriodSeconds          = "KmsDataKeyReusePeriodSeconds"
+  @js.native
+  sealed trait QueueAttributeName extends js.Any
+  object QueueAttributeName extends js.Object {
+    val All                                   = "All".asInstanceOf[QueueAttributeName]
+    val Policy                                = "Policy".asInstanceOf[QueueAttributeName]
+    val VisibilityTimeout                     = "VisibilityTimeout".asInstanceOf[QueueAttributeName]
+    val MaximumMessageSize                    = "MaximumMessageSize".asInstanceOf[QueueAttributeName]
+    val MessageRetentionPeriod                = "MessageRetentionPeriod".asInstanceOf[QueueAttributeName]
+    val ApproximateNumberOfMessages           = "ApproximateNumberOfMessages".asInstanceOf[QueueAttributeName]
+    val ApproximateNumberOfMessagesNotVisible = "ApproximateNumberOfMessagesNotVisible".asInstanceOf[QueueAttributeName]
+    val CreatedTimestamp                      = "CreatedTimestamp".asInstanceOf[QueueAttributeName]
+    val LastModifiedTimestamp                 = "LastModifiedTimestamp".asInstanceOf[QueueAttributeName]
+    val QueueArn                              = "QueueArn".asInstanceOf[QueueAttributeName]
+    val ApproximateNumberOfMessagesDelayed    = "ApproximateNumberOfMessagesDelayed".asInstanceOf[QueueAttributeName]
+    val DelaySeconds                          = "DelaySeconds".asInstanceOf[QueueAttributeName]
+    val ReceiveMessageWaitTimeSeconds         = "ReceiveMessageWaitTimeSeconds".asInstanceOf[QueueAttributeName]
+    val RedrivePolicy                         = "RedrivePolicy".asInstanceOf[QueueAttributeName]
+    val FifoQueue                             = "FifoQueue".asInstanceOf[QueueAttributeName]
+    val ContentBasedDeduplication             = "ContentBasedDeduplication".asInstanceOf[QueueAttributeName]
+    val KmsMasterKeyId                        = "KmsMasterKeyId".asInstanceOf[QueueAttributeName]
+    val KmsDataKeyReusePeriodSeconds          = "KmsDataKeyReusePeriodSeconds".asInstanceOf[QueueAttributeName]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/ssm/src/main/scala/facade/amazonaws/services/SSM.scala
+++ b/services/ssm/src/main/scala/facade/amazonaws/services/SSM.scala
@@ -20,20 +20,15 @@ package object ssm {
   type AggregatorSchemaOnly                                 = Boolean
   type AllowedPattern                                       = String
   type ApproveAfterDays                                     = Int
-  type AssociationComplianceSeverity                        = String
   type AssociationDescriptionList                           = js.Array[AssociationDescription]
-  type AssociationExecutionFilterKey                        = String
   type AssociationExecutionFilterList                       = js.Array[AssociationExecutionFilter]
   type AssociationExecutionFilterValue                      = String
   type AssociationExecutionId                               = String
-  type AssociationExecutionTargetsFilterKey                 = String
   type AssociationExecutionTargetsFilterList                = js.Array[AssociationExecutionTargetsFilter]
   type AssociationExecutionTargetsFilterValue               = String
   type AssociationExecutionTargetsList                      = js.Array[AssociationExecutionTarget]
   type AssociationExecutionsList                            = js.Array[AssociationExecution]
-  type AssociationFilterKey                                 = String
   type AssociationFilterList                                = js.Array[AssociationFilter]
-  type AssociationFilterOperatorType                        = String
   type AssociationFilterValue                               = String
   type AssociationId                                        = String
   type AssociationIdList                                    = js.Array[AssociationId]
@@ -42,59 +37,48 @@ package object ssm {
   type AssociationResourceId                                = String
   type AssociationResourceType                              = String
   type AssociationStatusAggregatedCount                     = js.Dictionary[InstanceCount]
-  type AssociationStatusName                                = String
   type AssociationVersion                                   = String
   type AssociationVersionList                               = js.Array[AssociationVersionInfo]
   type AttachmentContentList                                = js.Array[AttachmentContent]
   type AttachmentHash                                       = String
-  type AttachmentHashType                                   = String
   type AttachmentIdentifier                                 = String
   type AttachmentInformationList                            = js.Array[AttachmentInformation]
   type AttachmentName                                       = String
   type AttachmentUrl                                        = String
-  type AttachmentsSourceKey                                 = String
   type AttachmentsSourceList                                = js.Array[AttachmentsSource]
   type AttachmentsSourceValue                               = String
   type AttachmentsSourceValues                              = js.Array[AttachmentsSourceValue]
   type AttributeName                                        = String
   type AttributeValue                                       = String
   type AutomationActionName                                 = String
-  type AutomationExecutionFilterKey                         = String
   type AutomationExecutionFilterList                        = js.Array[AutomationExecutionFilter]
   type AutomationExecutionFilterValue                       = String
   type AutomationExecutionFilterValueList                   = js.Array[AutomationExecutionFilterValue]
   type AutomationExecutionId                                = String
   type AutomationExecutionMetadataList                      = js.Array[AutomationExecutionMetadata]
-  type AutomationExecutionStatus                            = String
   type AutomationParameterKey                               = String
   type AutomationParameterMap                               = js.Dictionary[AutomationParameterValueList]
   type AutomationParameterValue                             = String
   type AutomationParameterValueList                         = js.Array[AutomationParameterValue]
   type AutomationTargetParameterName                        = String
-  type AutomationType                                       = String
   type BaselineDescription                                  = String
   type BaselineId                                           = String
   type BaselineName                                         = String
   type BatchErrorMessage                                    = String
   type CalendarNameOrARN                                    = String
   type CalendarNameOrARNList                                = js.Array[CalendarNameOrARN]
-  type CalendarState                                        = String
   type ClientToken                                          = String
   type CloudWatchLogGroupName                               = String
   type CloudWatchOutputEnabled                              = Boolean
-  type CommandFilterKey                                     = String
   type CommandFilterList                                    = js.Array[CommandFilter]
   type CommandFilterValue                                   = String
   type CommandId                                            = String
   type CommandInvocationList                                = js.Array[CommandInvocation]
-  type CommandInvocationStatus                              = String
   type CommandList                                          = js.Array[Command]
   type CommandMaxResults                                    = Int
   type CommandPluginList                                    = js.Array[CommandPlugin]
   type CommandPluginName                                    = String
   type CommandPluginOutput                                  = String
-  type CommandPluginStatus                                  = String
-  type CommandStatus                                        = String
   type Comment                                              = String
   type CompletedCount                                       = Int
   type ComplianceExecutionId                                = String
@@ -106,13 +90,10 @@ package object ssm {
   type ComplianceItemId                                     = String
   type ComplianceItemList                                   = js.Array[ComplianceItem]
   type ComplianceItemTitle                                  = String
-  type ComplianceQueryOperatorType                          = String
   type ComplianceResourceId                                 = String
   type ComplianceResourceIdList                             = js.Array[ComplianceResourceId]
   type ComplianceResourceType                               = String
   type ComplianceResourceTypeList                           = js.Array[ComplianceResourceType]
-  type ComplianceSeverity                                   = String
-  type ComplianceStatus                                     = String
   type ComplianceStringFilterKey                            = String
   type ComplianceStringFilterList                           = js.Array[ComplianceStringFilter]
   type ComplianceStringFilterValueList                      = js.Array[ComplianceFilterValue]
@@ -120,7 +101,6 @@ package object ssm {
   type ComplianceSummaryItemList                            = js.Array[ComplianceSummaryItem]
   type ComplianceTypeName                                   = String
   type ComputerName                                         = String
-  type ConnectionStatus                                     = String
   type ContentLength                                        = Double
   type CreateAssociationBatchRequestEntries                 = js.Array[CreateAssociationBatchRequestEntry]
   type CreatedDate                                          = js.Date
@@ -128,17 +108,13 @@ package object ssm {
   type DefaultBaseline                                      = Boolean
   type DefaultInstanceName                                  = String
   type DeliveryTimedOutCount                                = Int
-  type DescribeActivationsFilterKeys                        = String
   type DescribeActivationsFilterList                        = js.Array[DescribeActivationsFilter]
   type DescriptionInDocument                                = String
   type DocumentARN                                          = String
   type DocumentContent                                      = String
-  type DocumentFilterKey                                    = String
   type DocumentFilterList                                   = js.Array[DocumentFilter]
   type DocumentFilterValue                                  = String
-  type DocumentFormat                                       = String
   type DocumentHash                                         = String
-  type DocumentHashType                                     = String
   type DocumentIdentifierList                               = js.Array[DocumentIdentifier]
   type DocumentKeyValuesFilterKey                           = String
   type DocumentKeyValuesFilterList                          = js.Array[DocumentKeyValuesFilter]
@@ -150,14 +126,10 @@ package object ssm {
   type DocumentParameterDescrption                          = String
   type DocumentParameterList                                = js.Array[DocumentParameter]
   type DocumentParameterName                                = String
-  type DocumentParameterType                                = String
-  type DocumentPermissionType                               = String
   type DocumentRequiresList                                 = js.Array[DocumentRequires]
   type DocumentSchemaVersion                                = String
   type DocumentSha1                                         = String
-  type DocumentStatus                                       = String
   type DocumentStatusInformation                            = String
-  type DocumentType                                         = String
   type DocumentVersion                                      = String
   type DocumentVersionList                                  = js.Array[DocumentVersionInfo]
   type DocumentVersionName                                  = String
@@ -166,11 +138,9 @@ package object ssm {
   type EffectiveInstanceAssociationMaxResults               = Int
   type EffectivePatchList                                   = js.Array[EffectivePatch]
   type ErrorCount                                           = Int
-  type ExecutionMode                                        = String
   type ExecutionRoleName                                    = String
   type ExpirationDate                                       = js.Date
   type FailedCreateAssociationList                          = js.Array[FailedCreateAssociation]
-  type Fault                                                = String
   type GetInventorySchemaMaxResults                         = Int
   type GetParametersByPathMaxResults                        = Int
   type IPAddress                                            = String
@@ -185,7 +155,6 @@ package object ssm {
   type InstanceCount                                        = Int
   type InstanceId                                           = String
   type InstanceIdList                                       = js.Array[InstanceId]
-  type InstanceInformationFilterKey                         = String
   type InstanceInformationFilterList                        = js.Array[InstanceInformationFilter]
   type InstanceInformationFilterValue                       = String
   type InstanceInformationFilterValueSet                    = js.Array[InstanceInformationFilterValue]
@@ -197,18 +166,15 @@ package object ssm {
   type InstancePatchStateFilterValue                        = String
   type InstancePatchStateFilterValues                       = js.Array[InstancePatchStateFilterValue]
   type InstancePatchStateList                               = js.Array[InstancePatchState]
-  type InstancePatchStateOperatorType                       = String
   type InstancePatchStatesList                              = js.Array[InstancePatchState]
   type InstanceTagName                                      = String
   type InstancesCount                                       = Int
   type InventoryAggregatorExpression                        = String
   type InventoryAggregatorList                              = js.Array[InventoryAggregator]
-  type InventoryAttributeDataType                           = String
   type InventoryDeletionId                                  = String
   type InventoryDeletionLastStatusMessage                   = String
   type InventoryDeletionLastStatusUpdateTime                = js.Date
   type InventoryDeletionStartTime                           = js.Date
-  type InventoryDeletionStatus                              = String
   type InventoryDeletionSummaryItems                        = js.Array[InventoryDeletionSummaryItem]
   type InventoryDeletionsList                               = js.Array[InventoryDeletionStatusItem]
   type InventoryFilterKey                                   = String
@@ -229,18 +195,15 @@ package object ssm {
   type InventoryItemSchemaVersion                           = String
   type InventoryItemTypeName                                = String
   type InventoryItemTypeNameFilter                          = String
-  type InventoryQueryOperatorType                           = String
   type InventoryResultEntityId                              = String
   type InventoryResultEntityList                            = js.Array[InventoryResultEntity]
   type InventoryResultItemKey                               = String
   type InventoryResultItemMap                               = js.Dictionary[InventoryResultItem]
-  type InventorySchemaDeleteOption                          = String
   type InventoryTypeDisplayName                             = String
   type InvocationTraceOutput                                = String
   type IsSubTypeSchema                                      = Boolean
   type KeyList                                              = js.Array[TagKey]
   type LastResourceDataSyncMessage                          = String
-  type LastResourceDataSyncStatus                           = String
   type LastResourceDataSyncTime                             = js.Date
   type LastSuccessfulResourceDataSyncTime                   = js.Date
   type MaintenanceWindowAllowUnassociatedTargets            = Boolean
@@ -250,7 +213,6 @@ package object ssm {
   type MaintenanceWindowEnabled                             = Boolean
   type MaintenanceWindowExecutionId                         = String
   type MaintenanceWindowExecutionList                       = js.Array[MaintenanceWindowExecution]
-  type MaintenanceWindowExecutionStatus                     = String
   type MaintenanceWindowExecutionStatusDetails              = String
   type MaintenanceWindowExecutionTaskExecutionId            = String
   type MaintenanceWindowExecutionTaskId                     = String
@@ -270,7 +232,6 @@ package object ssm {
   type MaintenanceWindowLambdaQualifier                     = String
   type MaintenanceWindowMaxResults                          = Int
   type MaintenanceWindowName                                = String
-  type MaintenanceWindowResourceType                        = String
   type MaintenanceWindowSchedule                            = String
   type MaintenanceWindowSearchMaxResults                    = Int
   type MaintenanceWindowStepFunctionsInput                  = String
@@ -288,7 +249,6 @@ package object ssm {
   type MaintenanceWindowTaskParametersList                  = js.Array[MaintenanceWindowTaskParameters]
   type MaintenanceWindowTaskPriority                        = Int
   type MaintenanceWindowTaskTargetId                        = String
-  type MaintenanceWindowTaskType                            = String
   type MaintenanceWindowTimezone                            = String
   type MaintenanceWindowsForTargetList                      = js.Array[MaintenanceWindowIdentityForTarget]
   type ManagedInstanceId                                    = String
@@ -299,10 +259,7 @@ package object ssm {
   type NextToken                                            = String
   type NormalStringMap                                      = js.Dictionary[String]
   type NotificationArn                                      = String
-  type NotificationEvent                                    = String
   type NotificationEventList                                = js.Array[NotificationEvent]
-  type NotificationType                                     = String
-  type OperatingSystem                                      = String
   type OpsAggregatorList                                    = js.Array[OpsAggregator]
   type OpsAggregatorType                                    = String
   type OpsAggregatorValue                                   = String
@@ -319,16 +276,12 @@ package object ssm {
   type OpsEntityList                                        = js.Array[OpsEntity]
   type OpsFilterKey                                         = String
   type OpsFilterList                                        = js.Array[OpsFilter]
-  type OpsFilterOperatorType                                = String
   type OpsFilterValue                                       = String
   type OpsFilterValueList                                   = js.Array[OpsFilterValue]
   type OpsItemCategory                                      = String
   type OpsItemDataKey                                       = String
-  type OpsItemDataType                                      = String
   type OpsItemDataValueString                               = String
   type OpsItemDescription                                   = String
-  type OpsItemFilterKey                                     = String
-  type OpsItemFilterOperator                                = String
   type OpsItemFilterValue                                   = String
   type OpsItemFilterValues                                  = js.Array[OpsItemFilterValue]
   type OpsItemFilters                                       = js.Array[OpsItemFilter]
@@ -340,7 +293,6 @@ package object ssm {
   type OpsItemPriority                                      = Int
   type OpsItemSeverity                                      = String
   type OpsItemSource                                        = String
-  type OpsItemStatus                                        = String
   type OpsItemSummaries                                     = js.Array[OpsItemSummary]
   type OpsItemTitle                                         = String
   type OpsResultAttributeList                               = js.Array[OpsResultAttribute]
@@ -367,28 +319,20 @@ package object ssm {
   type ParameterStringFilterValue                           = String
   type ParameterStringFilterValueList                       = js.Array[ParameterStringFilterValue]
   type ParameterStringQueryOption                           = String
-  type ParameterTier                                        = String
-  type ParameterType                                        = String
   type ParameterValue                                       = String
   type ParameterValueList                                   = js.Array[ParameterValue]
   type Parameters                                           = js.Dictionary[ParameterValueList]
-  type ParametersFilterKey                                  = String
   type ParametersFilterList                                 = js.Array[ParametersFilter]
   type ParametersFilterValue                                = String
   type ParametersFilterValueList                            = js.Array[ParametersFilterValue]
-  type PatchAction                                          = String
   type PatchBaselineIdentityList                            = js.Array[PatchBaselineIdentity]
   type PatchBaselineMaxResults                              = Int
   type PatchClassification                                  = String
   type PatchComplianceDataList                              = js.Array[PatchComplianceData]
-  type PatchComplianceDataState                             = String
-  type PatchComplianceLevel                                 = String
   type PatchComplianceMaxResults                            = Int
   type PatchContentUrl                                      = String
-  type PatchDeploymentStatus                                = String
   type PatchDescription                                     = String
   type PatchFailedCount                                     = Int
-  type PatchFilterKey                                       = String
   type PatchFilterList                                      = js.Array[PatchFilter]
   type PatchFilterValue                                     = String
   type PatchFilterValueList                                 = js.Array[PatchFilterValue]
@@ -408,7 +352,6 @@ package object ssm {
   type PatchMsrcNumber                                      = String
   type PatchMsrcSeverity                                    = String
   type PatchNotApplicableCount                              = Int
-  type PatchOperationType                                   = String
   type PatchOrchestratorFilterKey                           = String
   type PatchOrchestratorFilterList                          = js.Array[PatchOrchestratorFilter]
   type PatchOrchestratorFilterValue                         = String
@@ -416,10 +359,8 @@ package object ssm {
   type PatchProduct                                         = String
   type PatchProductFamily                                   = String
   type PatchPropertiesList                                  = js.Array[PatchPropertyEntry]
-  type PatchProperty                                        = String
   type PatchPropertyEntry                                   = js.Dictionary[AttributeValue]
   type PatchRuleList                                        = js.Array[PatchRule]
-  type PatchSet                                             = String
   type PatchSeverity                                        = String
   type PatchSourceConfiguration                             = String
   type PatchSourceList                                      = js.Array[PatchSource]
@@ -430,12 +371,9 @@ package object ssm {
   type PatchTitle                                           = String
   type PatchUnreportedNotApplicableCount                    = Int
   type PatchVendor                                          = String
-  type PingStatus                                           = String
-  type PlatformType                                         = String
   type PlatformTypeList                                     = js.Array[PlatformType]
   type Product                                              = String
   type PutInventoryMessage                                  = String
-  type RebootOption                                         = String
   type Region                                               = String
   type Regions                                              = js.Array[Region]
   type RegistrationLimit                                    = Int
@@ -455,7 +393,6 @@ package object ssm {
   type ResourceDataSyncOrganizationalUnitId                 = String
   type ResourceDataSyncOrganizationalUnitList               = js.Array[ResourceDataSyncOrganizationalUnit]
   type ResourceDataSyncS3BucketName                         = String
-  type ResourceDataSyncS3Format                             = String
   type ResourceDataSyncS3Prefix                             = String
   type ResourceDataSyncS3Region                             = String
   type ResourceDataSyncSourceRegion                         = String
@@ -464,8 +401,6 @@ package object ssm {
   type ResourceDataSyncState                                = String
   type ResourceDataSyncType                                 = String
   type ResourceId                                           = String
-  type ResourceType                                         = String
-  type ResourceTypeForTagging                               = String
   type ResponseCode                                         = Int
   type ResultAttributeList                                  = js.Array[ResultAttribute]
   type S3BucketName                                         = String
@@ -477,7 +412,6 @@ package object ssm {
   type ServiceSettingId                                     = String
   type ServiceSettingValue                                  = String
   type SessionDetails                                       = String
-  type SessionFilterKey                                     = String
   type SessionFilterList                                    = js.Array[SessionFilter]
   type SessionFilterValue                                   = String
   type SessionId                                            = String
@@ -490,11 +424,8 @@ package object ssm {
   type SessionManagerS3OutputUrl                            = String
   type SessionMaxResults                                    = Int
   type SessionOwner                                         = String
-  type SessionState                                         = String
-  type SessionStatus                                        = String
   type SessionTarget                                        = String
   type SharedDocumentVersion                                = String
-  type SignalType                                           = String
   type SnapshotDownloadUrl                                  = String
   type SnapshotId                                           = String
   type StandardErrorContent                                 = String
@@ -503,12 +434,10 @@ package object ssm {
   type StatusDetails                                        = String
   type StatusMessage                                        = String
   type StatusName                                           = String
-  type StepExecutionFilterKey                               = String
   type StepExecutionFilterList                              = js.Array[StepExecutionFilter]
   type StepExecutionFilterValue                             = String
   type StepExecutionFilterValueList                         = js.Array[StepExecutionFilterValue]
   type StepExecutionList                                    = js.Array[StepExecution]
-  type StopType                                             = String
   type StreamUrl                                            = String
   type StringDateTime                                       = String
   type StringList                                           = js.Array[String]
@@ -1240,13 +1169,14 @@ package ssm {
       __obj.asInstanceOf[Association]
     }
   }
-
-  object AssociationComplianceSeverityEnum {
-    val CRITICAL    = "CRITICAL"
-    val HIGH        = "HIGH"
-    val MEDIUM      = "MEDIUM"
-    val LOW         = "LOW"
-    val UNSPECIFIED = "UNSPECIFIED"
+  @js.native
+  sealed trait AssociationComplianceSeverity extends js.Any
+  object AssociationComplianceSeverity extends js.Object {
+    val CRITICAL    = "CRITICAL".asInstanceOf[AssociationComplianceSeverity]
+    val HIGH        = "HIGH".asInstanceOf[AssociationComplianceSeverity]
+    val MEDIUM      = "MEDIUM".asInstanceOf[AssociationComplianceSeverity]
+    val LOW         = "LOW".asInstanceOf[AssociationComplianceSeverity]
+    val UNSPECIFIED = "UNSPECIFIED".asInstanceOf[AssociationComplianceSeverity]
 
     val values = js.Object.freeze(js.Array(CRITICAL, HIGH, MEDIUM, LOW, UNSPECIFIED))
   }
@@ -1399,11 +1329,12 @@ package ssm {
       __obj.asInstanceOf[AssociationExecutionFilter]
     }
   }
-
-  object AssociationExecutionFilterKeyEnum {
-    val ExecutionId = "ExecutionId"
-    val Status      = "Status"
-    val CreatedTime = "CreatedTime"
+  @js.native
+  sealed trait AssociationExecutionFilterKey extends js.Any
+  object AssociationExecutionFilterKey extends js.Object {
+    val ExecutionId = "ExecutionId".asInstanceOf[AssociationExecutionFilterKey]
+    val Status      = "Status".asInstanceOf[AssociationExecutionFilterKey]
+    val CreatedTime = "CreatedTime".asInstanceOf[AssociationExecutionFilterKey]
 
     val values = js.Object.freeze(js.Array(ExecutionId, Status, CreatedTime))
   }
@@ -1474,11 +1405,12 @@ package ssm {
       __obj.asInstanceOf[AssociationExecutionTargetsFilter]
     }
   }
-
-  object AssociationExecutionTargetsFilterKeyEnum {
-    val Status       = "Status"
-    val ResourceId   = "ResourceId"
-    val ResourceType = "ResourceType"
+  @js.native
+  sealed trait AssociationExecutionTargetsFilterKey extends js.Any
+  object AssociationExecutionTargetsFilterKey extends js.Object {
+    val Status       = "Status".asInstanceOf[AssociationExecutionTargetsFilterKey]
+    val ResourceId   = "ResourceId".asInstanceOf[AssociationExecutionTargetsFilterKey]
+    val ResourceType = "ResourceType".asInstanceOf[AssociationExecutionTargetsFilterKey]
 
     val values = js.Object.freeze(js.Array(Status, ResourceId, ResourceType))
   }
@@ -1506,15 +1438,16 @@ package ssm {
       __obj.asInstanceOf[AssociationFilter]
     }
   }
-
-  object AssociationFilterKeyEnum {
-    val InstanceId            = "InstanceId"
-    val Name                  = "Name"
-    val AssociationId         = "AssociationId"
-    val AssociationStatusName = "AssociationStatusName"
-    val LastExecutedBefore    = "LastExecutedBefore"
-    val LastExecutedAfter     = "LastExecutedAfter"
-    val AssociationName       = "AssociationName"
+  @js.native
+  sealed trait AssociationFilterKey extends js.Any
+  object AssociationFilterKey extends js.Object {
+    val InstanceId            = "InstanceId".asInstanceOf[AssociationFilterKey]
+    val Name                  = "Name".asInstanceOf[AssociationFilterKey]
+    val AssociationId         = "AssociationId".asInstanceOf[AssociationFilterKey]
+    val AssociationStatusName = "AssociationStatusName".asInstanceOf[AssociationFilterKey]
+    val LastExecutedBefore    = "LastExecutedBefore".asInstanceOf[AssociationFilterKey]
+    val LastExecutedAfter     = "LastExecutedAfter".asInstanceOf[AssociationFilterKey]
+    val AssociationName       = "AssociationName".asInstanceOf[AssociationFilterKey]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1528,11 +1461,12 @@ package ssm {
       )
     )
   }
-
-  object AssociationFilterOperatorTypeEnum {
-    val EQUAL        = "EQUAL"
-    val LESS_THAN    = "LESS_THAN"
-    val GREATER_THAN = "GREATER_THAN"
+  @js.native
+  sealed trait AssociationFilterOperatorType extends js.Any
+  object AssociationFilterOperatorType extends js.Object {
+    val EQUAL        = "EQUAL".asInstanceOf[AssociationFilterOperatorType]
+    val LESS_THAN    = "LESS_THAN".asInstanceOf[AssociationFilterOperatorType]
+    val GREATER_THAN = "GREATER_THAN".asInstanceOf[AssociationFilterOperatorType]
 
     val values = js.Object.freeze(js.Array(EQUAL, LESS_THAN, GREATER_THAN))
   }
@@ -1593,11 +1527,12 @@ package ssm {
       __obj.asInstanceOf[AssociationStatus]
     }
   }
-
-  object AssociationStatusNameEnum {
-    val Pending = "Pending"
-    val Success = "Success"
-    val Failed  = "Failed"
+  @js.native
+  sealed trait AssociationStatusName extends js.Any
+  object AssociationStatusName extends js.Object {
+    val Pending = "Pending".asInstanceOf[AssociationStatusName]
+    val Success = "Success".asInstanceOf[AssociationStatusName]
+    val Failed  = "Failed".asInstanceOf[AssociationStatusName]
 
     val values = js.Object.freeze(js.Array(Pending, Success, Failed))
   }
@@ -1687,9 +1622,10 @@ package ssm {
       __obj.asInstanceOf[AttachmentContent]
     }
   }
-
-  object AttachmentHashTypeEnum {
-    val Sha256 = "Sha256"
+  @js.native
+  sealed trait AttachmentHashType extends js.Any
+  object AttachmentHashType extends js.Object {
+    val Sha256 = "Sha256".asInstanceOf[AttachmentHashType]
 
     val values = js.Object.freeze(js.Array(Sha256))
   }
@@ -1737,11 +1673,12 @@ package ssm {
       __obj.asInstanceOf[AttachmentsSource]
     }
   }
-
-  object AttachmentsSourceKeyEnum {
-    val SourceUrl           = "SourceUrl"
-    val S3FileUrl           = "S3FileUrl"
-    val AttachmentReference = "AttachmentReference"
+  @js.native
+  sealed trait AttachmentsSourceKey extends js.Any
+  object AttachmentsSourceKey extends js.Object {
+    val SourceUrl           = "SourceUrl".asInstanceOf[AttachmentsSourceKey]
+    val S3FileUrl           = "S3FileUrl".asInstanceOf[AttachmentsSourceKey]
+    val AttachmentReference = "AttachmentReference".asInstanceOf[AttachmentsSourceKey]
 
     val values = js.Object.freeze(js.Array(SourceUrl, S3FileUrl, AttachmentReference))
   }
@@ -1864,17 +1801,18 @@ package ssm {
       __obj.asInstanceOf[AutomationExecutionFilter]
     }
   }
-
-  object AutomationExecutionFilterKeyEnum {
-    val DocumentNamePrefix = "DocumentNamePrefix"
-    val ExecutionStatus    = "ExecutionStatus"
-    val ExecutionId        = "ExecutionId"
-    val ParentExecutionId  = "ParentExecutionId"
-    val CurrentAction      = "CurrentAction"
-    val StartTimeBefore    = "StartTimeBefore"
-    val StartTimeAfter     = "StartTimeAfter"
-    val AutomationType     = "AutomationType"
-    val TagKey             = "TagKey"
+  @js.native
+  sealed trait AutomationExecutionFilterKey extends js.Any
+  object AutomationExecutionFilterKey extends js.Object {
+    val DocumentNamePrefix = "DocumentNamePrefix".asInstanceOf[AutomationExecutionFilterKey]
+    val ExecutionStatus    = "ExecutionStatus".asInstanceOf[AutomationExecutionFilterKey]
+    val ExecutionId        = "ExecutionId".asInstanceOf[AutomationExecutionFilterKey]
+    val ParentExecutionId  = "ParentExecutionId".asInstanceOf[AutomationExecutionFilterKey]
+    val CurrentAction      = "CurrentAction".asInstanceOf[AutomationExecutionFilterKey]
+    val StartTimeBefore    = "StartTimeBefore".asInstanceOf[AutomationExecutionFilterKey]
+    val StartTimeAfter     = "StartTimeAfter".asInstanceOf[AutomationExecutionFilterKey]
+    val AutomationType     = "AutomationType".asInstanceOf[AutomationExecutionFilterKey]
+    val TagKey             = "TagKey".asInstanceOf[AutomationExecutionFilterKey]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1976,31 +1914,34 @@ package ssm {
       __obj.asInstanceOf[AutomationExecutionMetadata]
     }
   }
-
-  object AutomationExecutionStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Waiting    = "Waiting"
-    val Success    = "Success"
-    val TimedOut   = "TimedOut"
-    val Cancelling = "Cancelling"
-    val Cancelled  = "Cancelled"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait AutomationExecutionStatus extends js.Any
+  object AutomationExecutionStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[AutomationExecutionStatus]
+    val InProgress = "InProgress".asInstanceOf[AutomationExecutionStatus]
+    val Waiting    = "Waiting".asInstanceOf[AutomationExecutionStatus]
+    val Success    = "Success".asInstanceOf[AutomationExecutionStatus]
+    val TimedOut   = "TimedOut".asInstanceOf[AutomationExecutionStatus]
+    val Cancelling = "Cancelling".asInstanceOf[AutomationExecutionStatus]
+    val Cancelled  = "Cancelled".asInstanceOf[AutomationExecutionStatus]
+    val Failed     = "Failed".asInstanceOf[AutomationExecutionStatus]
 
     val values =
       js.Object.freeze(js.Array(Pending, InProgress, Waiting, Success, TimedOut, Cancelling, Cancelled, Failed))
   }
-
-  object AutomationTypeEnum {
-    val CrossAccount = "CrossAccount"
-    val Local        = "Local"
+  @js.native
+  sealed trait AutomationType extends js.Any
+  object AutomationType extends js.Object {
+    val CrossAccount = "CrossAccount".asInstanceOf[AutomationType]
+    val Local        = "Local".asInstanceOf[AutomationType]
 
     val values = js.Object.freeze(js.Array(CrossAccount, Local))
   }
-
-  object CalendarStateEnum {
-    val OPEN   = "OPEN"
-    val CLOSED = "CLOSED"
+  @js.native
+  sealed trait CalendarState extends js.Any
+  object CalendarState extends js.Object {
+    val OPEN   = "OPEN".asInstanceOf[CalendarState]
+    val CLOSED = "CLOSED".asInstanceOf[CalendarState]
 
     val values = js.Object.freeze(js.Array(OPEN, CLOSED))
   }
@@ -2209,13 +2150,14 @@ package ssm {
       __obj.asInstanceOf[CommandFilter]
     }
   }
-
-  object CommandFilterKeyEnum {
-    val InvokedAfter   = "InvokedAfter"
-    val InvokedBefore  = "InvokedBefore"
-    val Status         = "Status"
-    val ExecutionStage = "ExecutionStage"
-    val DocumentName   = "DocumentName"
+  @js.native
+  sealed trait CommandFilterKey extends js.Any
+  object CommandFilterKey extends js.Object {
+    val InvokedAfter   = "InvokedAfter".asInstanceOf[CommandFilterKey]
+    val InvokedBefore  = "InvokedBefore".asInstanceOf[CommandFilterKey]
+    val Status         = "Status".asInstanceOf[CommandFilterKey]
+    val ExecutionStage = "ExecutionStage".asInstanceOf[CommandFilterKey]
+    val DocumentName   = "DocumentName".asInstanceOf[CommandFilterKey]
 
     val values = js.Object.freeze(js.Array(InvokedAfter, InvokedBefore, Status, ExecutionStage, DocumentName))
   }
@@ -2283,16 +2225,17 @@ package ssm {
       __obj.asInstanceOf[CommandInvocation]
     }
   }
-
-  object CommandInvocationStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Delayed    = "Delayed"
-    val Success    = "Success"
-    val Cancelled  = "Cancelled"
-    val TimedOut   = "TimedOut"
-    val Failed     = "Failed"
-    val Cancelling = "Cancelling"
+  @js.native
+  sealed trait CommandInvocationStatus extends js.Any
+  object CommandInvocationStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[CommandInvocationStatus]
+    val InProgress = "InProgress".asInstanceOf[CommandInvocationStatus]
+    val Delayed    = "Delayed".asInstanceOf[CommandInvocationStatus]
+    val Success    = "Success".asInstanceOf[CommandInvocationStatus]
+    val Cancelled  = "Cancelled".asInstanceOf[CommandInvocationStatus]
+    val TimedOut   = "TimedOut".asInstanceOf[CommandInvocationStatus]
+    val Failed     = "Failed".asInstanceOf[CommandInvocationStatus]
+    val Cancelling = "Cancelling".asInstanceOf[CommandInvocationStatus]
 
     val values =
       js.Object.freeze(js.Array(Pending, InProgress, Delayed, Success, Cancelled, TimedOut, Failed, Cancelling))
@@ -2349,26 +2292,28 @@ package ssm {
       __obj.asInstanceOf[CommandPlugin]
     }
   }
-
-  object CommandPluginStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Success    = "Success"
-    val TimedOut   = "TimedOut"
-    val Cancelled  = "Cancelled"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait CommandPluginStatus extends js.Any
+  object CommandPluginStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[CommandPluginStatus]
+    val InProgress = "InProgress".asInstanceOf[CommandPluginStatus]
+    val Success    = "Success".asInstanceOf[CommandPluginStatus]
+    val TimedOut   = "TimedOut".asInstanceOf[CommandPluginStatus]
+    val Cancelled  = "Cancelled".asInstanceOf[CommandPluginStatus]
+    val Failed     = "Failed".asInstanceOf[CommandPluginStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Success, TimedOut, Cancelled, Failed))
   }
-
-  object CommandStatusEnum {
-    val Pending    = "Pending"
-    val InProgress = "InProgress"
-    val Success    = "Success"
-    val Cancelled  = "Cancelled"
-    val Failed     = "Failed"
-    val TimedOut   = "TimedOut"
-    val Cancelling = "Cancelling"
+  @js.native
+  sealed trait CommandStatus extends js.Any
+  object CommandStatus extends js.Object {
+    val Pending    = "Pending".asInstanceOf[CommandStatus]
+    val InProgress = "InProgress".asInstanceOf[CommandStatus]
+    val Success    = "Success".asInstanceOf[CommandStatus]
+    val Cancelled  = "Cancelled".asInstanceOf[CommandStatus]
+    val Failed     = "Failed".asInstanceOf[CommandStatus]
+    val TimedOut   = "TimedOut".asInstanceOf[CommandStatus]
+    val Cancelling = "Cancelling".asInstanceOf[CommandStatus]
 
     val values = js.Object.freeze(js.Array(Pending, InProgress, Success, Cancelled, Failed, TimedOut, Cancelling))
   }
@@ -2475,31 +2420,34 @@ package ssm {
       __obj.asInstanceOf[ComplianceItemEntry]
     }
   }
-
-  object ComplianceQueryOperatorTypeEnum {
-    val EQUAL        = "EQUAL"
-    val NOT_EQUAL    = "NOT_EQUAL"
-    val BEGIN_WITH   = "BEGIN_WITH"
-    val LESS_THAN    = "LESS_THAN"
-    val GREATER_THAN = "GREATER_THAN"
+  @js.native
+  sealed trait ComplianceQueryOperatorType extends js.Any
+  object ComplianceQueryOperatorType extends js.Object {
+    val EQUAL        = "EQUAL".asInstanceOf[ComplianceQueryOperatorType]
+    val NOT_EQUAL    = "NOT_EQUAL".asInstanceOf[ComplianceQueryOperatorType]
+    val BEGIN_WITH   = "BEGIN_WITH".asInstanceOf[ComplianceQueryOperatorType]
+    val LESS_THAN    = "LESS_THAN".asInstanceOf[ComplianceQueryOperatorType]
+    val GREATER_THAN = "GREATER_THAN".asInstanceOf[ComplianceQueryOperatorType]
 
     val values = js.Object.freeze(js.Array(EQUAL, NOT_EQUAL, BEGIN_WITH, LESS_THAN, GREATER_THAN))
   }
-
-  object ComplianceSeverityEnum {
-    val CRITICAL      = "CRITICAL"
-    val HIGH          = "HIGH"
-    val MEDIUM        = "MEDIUM"
-    val LOW           = "LOW"
-    val INFORMATIONAL = "INFORMATIONAL"
-    val UNSPECIFIED   = "UNSPECIFIED"
+  @js.native
+  sealed trait ComplianceSeverity extends js.Any
+  object ComplianceSeverity extends js.Object {
+    val CRITICAL      = "CRITICAL".asInstanceOf[ComplianceSeverity]
+    val HIGH          = "HIGH".asInstanceOf[ComplianceSeverity]
+    val MEDIUM        = "MEDIUM".asInstanceOf[ComplianceSeverity]
+    val LOW           = "LOW".asInstanceOf[ComplianceSeverity]
+    val INFORMATIONAL = "INFORMATIONAL".asInstanceOf[ComplianceSeverity]
+    val UNSPECIFIED   = "UNSPECIFIED".asInstanceOf[ComplianceSeverity]
 
     val values = js.Object.freeze(js.Array(CRITICAL, HIGH, MEDIUM, LOW, INFORMATIONAL, UNSPECIFIED))
   }
-
-  object ComplianceStatusEnum {
-    val COMPLIANT     = "COMPLIANT"
-    val NON_COMPLIANT = "NON_COMPLIANT"
+  @js.native
+  sealed trait ComplianceStatus extends js.Any
+  object ComplianceStatus extends js.Object {
+    val COMPLIANT     = "COMPLIANT".asInstanceOf[ComplianceStatus]
+    val NON_COMPLIANT = "NON_COMPLIANT".asInstanceOf[ComplianceStatus]
 
     val values = js.Object.freeze(js.Array(COMPLIANT, NON_COMPLIANT))
   }
@@ -2575,10 +2523,11 @@ package ssm {
       __obj.asInstanceOf[CompliantSummary]
     }
   }
-
-  object ConnectionStatusEnum {
-    val Connected    = "Connected"
-    val NotConnected = "NotConnected"
+  @js.native
+  sealed trait ConnectionStatus extends js.Any
+  object ConnectionStatus extends js.Object {
+    val Connected    = "Connected".asInstanceOf[ConnectionStatus]
+    val NotConnected = "NotConnected".asInstanceOf[ConnectionStatus]
 
     val values = js.Object.freeze(js.Array(Connected, NotConnected))
   }
@@ -3594,11 +3543,12 @@ package ssm {
       __obj.asInstanceOf[DescribeActivationsFilter]
     }
   }
-
-  object DescribeActivationsFilterKeysEnum {
-    val ActivationIds       = "ActivationIds"
-    val DefaultInstanceName = "DefaultInstanceName"
-    val IamRole             = "IamRole"
+  @js.native
+  sealed trait DescribeActivationsFilterKeys extends js.Any
+  object DescribeActivationsFilterKeys extends js.Object {
+    val ActivationIds       = "ActivationIds".asInstanceOf[DescribeActivationsFilterKeys]
+    val DefaultInstanceName = "DefaultInstanceName".asInstanceOf[DescribeActivationsFilterKeys]
+    val IamRole             = "IamRole".asInstanceOf[DescribeActivationsFilterKeys]
 
     val values = js.Object.freeze(js.Array(ActivationIds, DefaultInstanceName, IamRole))
   }
@@ -5191,27 +5141,30 @@ package ssm {
       __obj.asInstanceOf[DocumentFilter]
     }
   }
-
-  object DocumentFilterKeyEnum {
-    val Name          = "Name"
-    val Owner         = "Owner"
-    val PlatformTypes = "PlatformTypes"
-    val DocumentType  = "DocumentType"
+  @js.native
+  sealed trait DocumentFilterKey extends js.Any
+  object DocumentFilterKey extends js.Object {
+    val Name          = "Name".asInstanceOf[DocumentFilterKey]
+    val Owner         = "Owner".asInstanceOf[DocumentFilterKey]
+    val PlatformTypes = "PlatformTypes".asInstanceOf[DocumentFilterKey]
+    val DocumentType  = "DocumentType".asInstanceOf[DocumentFilterKey]
 
     val values = js.Object.freeze(js.Array(Name, Owner, PlatformTypes, DocumentType))
   }
-
-  object DocumentFormatEnum {
-    val YAML = "YAML"
-    val JSON = "JSON"
-    val TEXT = "TEXT"
+  @js.native
+  sealed trait DocumentFormat extends js.Any
+  object DocumentFormat extends js.Object {
+    val YAML = "YAML".asInstanceOf[DocumentFormat]
+    val JSON = "JSON".asInstanceOf[DocumentFormat]
+    val TEXT = "TEXT".asInstanceOf[DocumentFormat]
 
     val values = js.Object.freeze(js.Array(YAML, JSON, TEXT))
   }
-
-  object DocumentHashTypeEnum {
-    val Sha256 = "Sha256"
-    val Sha1   = "Sha1"
+  @js.native
+  sealed trait DocumentHashType extends js.Any
+  object DocumentHashType extends js.Object {
+    val Sha256 = "Sha256".asInstanceOf[DocumentHashType]
+    val Sha1   = "Sha1".asInstanceOf[DocumentHashType]
 
     val values = js.Object.freeze(js.Array(Sha256, Sha1))
   }
@@ -5323,16 +5276,18 @@ package ssm {
       __obj.asInstanceOf[DocumentParameter]
     }
   }
-
-  object DocumentParameterTypeEnum {
-    val String     = "String"
-    val StringList = "StringList"
+  @js.native
+  sealed trait DocumentParameterType extends js.Any
+  object DocumentParameterType extends js.Object {
+    val String     = "String".asInstanceOf[DocumentParameterType]
+    val StringList = "StringList".asInstanceOf[DocumentParameterType]
 
     val values = js.Object.freeze(js.Array(String, StringList))
   }
-
-  object DocumentPermissionTypeEnum {
-    val Share = "Share"
+  @js.native
+  sealed trait DocumentPermissionType extends js.Any
+  object DocumentPermissionType extends js.Object {
+    val Share = "Share".asInstanceOf[DocumentPermissionType]
 
     val values = js.Object.freeze(js.Array(Share))
   }
@@ -5364,26 +5319,29 @@ package ssm {
   /**
     * The status of a document.
     */
-  object DocumentStatusEnum {
-    val Creating = "Creating"
-    val Active   = "Active"
-    val Updating = "Updating"
-    val Deleting = "Deleting"
-    val Failed   = "Failed"
+  @js.native
+  sealed trait DocumentStatus extends js.Any
+  object DocumentStatus extends js.Object {
+    val Creating = "Creating".asInstanceOf[DocumentStatus]
+    val Active   = "Active".asInstanceOf[DocumentStatus]
+    val Updating = "Updating".asInstanceOf[DocumentStatus]
+    val Deleting = "Deleting".asInstanceOf[DocumentStatus]
+    val Failed   = "Failed".asInstanceOf[DocumentStatus]
 
     val values = js.Object.freeze(js.Array(Creating, Active, Updating, Deleting, Failed))
   }
-
-  object DocumentTypeEnum {
-    val Command                        = "Command"
-    val Policy                         = "Policy"
-    val Automation                     = "Automation"
-    val Session                        = "Session"
-    val Package                        = "Package"
-    val ApplicationConfiguration       = "ApplicationConfiguration"
-    val ApplicationConfigurationSchema = "ApplicationConfigurationSchema"
-    val DeploymentStrategy             = "DeploymentStrategy"
-    val ChangeCalendar                 = "ChangeCalendar"
+  @js.native
+  sealed trait DocumentType extends js.Any
+  object DocumentType extends js.Object {
+    val Command                        = "Command".asInstanceOf[DocumentType]
+    val Policy                         = "Policy".asInstanceOf[DocumentType]
+    val Automation                     = "Automation".asInstanceOf[DocumentType]
+    val Session                        = "Session".asInstanceOf[DocumentType]
+    val Package                        = "Package".asInstanceOf[DocumentType]
+    val ApplicationConfiguration       = "ApplicationConfiguration".asInstanceOf[DocumentType]
+    val ApplicationConfigurationSchema = "ApplicationConfigurationSchema".asInstanceOf[DocumentType]
+    val DeploymentStrategy             = "DeploymentStrategy".asInstanceOf[DocumentType]
+    val ChangeCalendar                 = "ChangeCalendar".asInstanceOf[DocumentType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -5461,10 +5419,11 @@ package ssm {
       __obj.asInstanceOf[EffectivePatch]
     }
   }
-
-  object ExecutionModeEnum {
-    val Auto        = "Auto"
-    val Interactive = "Interactive"
+  @js.native
+  sealed trait ExecutionMode extends js.Any
+  object ExecutionMode extends js.Object {
+    val Auto        = "Auto".asInstanceOf[ExecutionMode]
+    val Interactive = "Interactive".asInstanceOf[ExecutionMode]
 
     val values = js.Object.freeze(js.Array(Auto, Interactive))
   }
@@ -5518,11 +5477,12 @@ package ssm {
       __obj.asInstanceOf[FailureDetails]
     }
   }
-
-  object FaultEnum {
-    val Client  = "Client"
-    val Server  = "Server"
-    val Unknown = "Unknown"
+  @js.native
+  sealed trait Fault extends js.Any
+  object Fault extends js.Object {
+    val Client  = "Client".asInstanceOf[Fault]
+    val Server  = "Server".asInstanceOf[Fault]
+    val Unknown = "Unknown".asInstanceOf[Fault]
 
     val values = js.Object.freeze(js.Array(Client, Server, Unknown))
   }
@@ -6983,16 +6943,17 @@ package ssm {
       __obj.asInstanceOf[InstanceInformationFilter]
     }
   }
-
-  object InstanceInformationFilterKeyEnum {
-    val InstanceIds       = "InstanceIds"
-    val AgentVersion      = "AgentVersion"
-    val PingStatus        = "PingStatus"
-    val PlatformTypes     = "PlatformTypes"
-    val ActivationIds     = "ActivationIds"
-    val IamRole           = "IamRole"
-    val ResourceType      = "ResourceType"
-    val AssociationStatus = "AssociationStatus"
+  @js.native
+  sealed trait InstanceInformationFilterKey extends js.Any
+  object InstanceInformationFilterKey extends js.Object {
+    val InstanceIds       = "InstanceIds".asInstanceOf[InstanceInformationFilterKey]
+    val AgentVersion      = "AgentVersion".asInstanceOf[InstanceInformationFilterKey]
+    val PingStatus        = "PingStatus".asInstanceOf[InstanceInformationFilterKey]
+    val PlatformTypes     = "PlatformTypes".asInstanceOf[InstanceInformationFilterKey]
+    val ActivationIds     = "ActivationIds".asInstanceOf[InstanceInformationFilterKey]
+    val IamRole           = "IamRole".asInstanceOf[InstanceInformationFilterKey]
+    val ResourceType      = "ResourceType".asInstanceOf[InstanceInformationFilterKey]
+    val AssociationStatus = "AssociationStatus".asInstanceOf[InstanceInformationFilterKey]
 
     val values = js.Object.freeze(
       js.Array(
@@ -7139,12 +7100,13 @@ package ssm {
       __obj.asInstanceOf[InstancePatchStateFilter]
     }
   }
-
-  object InstancePatchStateOperatorTypeEnum {
-    val Equal       = "Equal"
-    val NotEqual    = "NotEqual"
-    val LessThan    = "LessThan"
-    val GreaterThan = "GreaterThan"
+  @js.native
+  sealed trait InstancePatchStateOperatorType extends js.Any
+  object InstancePatchStateOperatorType extends js.Object {
+    val Equal       = "Equal".asInstanceOf[InstancePatchStateOperatorType]
+    val NotEqual    = "NotEqual".asInstanceOf[InstancePatchStateOperatorType]
+    val LessThan    = "LessThan".asInstanceOf[InstancePatchStateOperatorType]
+    val GreaterThan = "GreaterThan".asInstanceOf[InstancePatchStateOperatorType]
 
     val values = js.Object.freeze(js.Array(Equal, NotEqual, LessThan, GreaterThan))
   }
@@ -7173,17 +7135,19 @@ package ssm {
       __obj.asInstanceOf[InventoryAggregator]
     }
   }
-
-  object InventoryAttributeDataTypeEnum {
-    val string = "string"
-    val number = "number"
+  @js.native
+  sealed trait InventoryAttributeDataType extends js.Any
+  object InventoryAttributeDataType extends js.Object {
+    val string = "string".asInstanceOf[InventoryAttributeDataType]
+    val number = "number".asInstanceOf[InventoryAttributeDataType]
 
     val values = js.Object.freeze(js.Array(string, number))
   }
-
-  object InventoryDeletionStatusEnum {
-    val InProgress = "InProgress"
-    val Complete   = "Complete"
+  @js.native
+  sealed trait InventoryDeletionStatus extends js.Any
+  object InventoryDeletionStatus extends js.Object {
+    val InProgress = "InProgress".asInstanceOf[InventoryDeletionStatus]
+    val Complete   = "Complete".asInstanceOf[InventoryDeletionStatus]
 
     val values = js.Object.freeze(js.Array(InProgress, Complete))
   }
@@ -7415,14 +7379,15 @@ package ssm {
       __obj.asInstanceOf[InventoryItemSchema]
     }
   }
-
-  object InventoryQueryOperatorTypeEnum {
-    val Equal       = "Equal"
-    val NotEqual    = "NotEqual"
-    val BeginWith   = "BeginWith"
-    val LessThan    = "LessThan"
-    val GreaterThan = "GreaterThan"
-    val Exists      = "Exists"
+  @js.native
+  sealed trait InventoryQueryOperatorType extends js.Any
+  object InventoryQueryOperatorType extends js.Object {
+    val Equal       = "Equal".asInstanceOf[InventoryQueryOperatorType]
+    val NotEqual    = "NotEqual".asInstanceOf[InventoryQueryOperatorType]
+    val BeginWith   = "BeginWith".asInstanceOf[InventoryQueryOperatorType]
+    val LessThan    = "LessThan".asInstanceOf[InventoryQueryOperatorType]
+    val GreaterThan = "GreaterThan".asInstanceOf[InventoryQueryOperatorType]
+    val Exists      = "Exists".asInstanceOf[InventoryQueryOperatorType]
 
     val values = js.Object.freeze(js.Array(Equal, NotEqual, BeginWith, LessThan, GreaterThan, Exists))
   }
@@ -7481,10 +7446,11 @@ package ssm {
       __obj.asInstanceOf[InventoryResultItem]
     }
   }
-
-  object InventorySchemaDeleteOptionEnum {
-    val DisableSchema = "DisableSchema"
-    val DeleteSchema  = "DeleteSchema"
+  @js.native
+  sealed trait InventorySchemaDeleteOption extends js.Any
+  object InventorySchemaDeleteOption extends js.Object {
+    val DisableSchema = "DisableSchema".asInstanceOf[InventorySchemaDeleteOption]
+    val DeleteSchema  = "DeleteSchema".asInstanceOf[InventorySchemaDeleteOption]
 
     val values = js.Object.freeze(js.Array(DisableSchema, DeleteSchema))
   }
@@ -7531,11 +7497,12 @@ package ssm {
       __obj.asInstanceOf[LabelParameterVersionResult]
     }
   }
-
-  object LastResourceDataSyncStatusEnum {
-    val Successful = "Successful"
-    val Failed     = "Failed"
-    val InProgress = "InProgress"
+  @js.native
+  sealed trait LastResourceDataSyncStatus extends js.Any
+  object LastResourceDataSyncStatus extends js.Object {
+    val Successful = "Successful".asInstanceOf[LastResourceDataSyncStatus]
+    val Failed     = "Failed".asInstanceOf[LastResourceDataSyncStatus]
+    val InProgress = "InProgress".asInstanceOf[LastResourceDataSyncStatus]
 
     val values = js.Object.freeze(js.Array(Successful, Failed, InProgress))
   }
@@ -8162,16 +8129,17 @@ package ssm {
       __obj.asInstanceOf[MaintenanceWindowExecution]
     }
   }
-
-  object MaintenanceWindowExecutionStatusEnum {
-    val PENDING             = "PENDING"
-    val IN_PROGRESS         = "IN_PROGRESS"
-    val SUCCESS             = "SUCCESS"
-    val FAILED              = "FAILED"
-    val TIMED_OUT           = "TIMED_OUT"
-    val CANCELLING          = "CANCELLING"
-    val CANCELLED           = "CANCELLED"
-    val SKIPPED_OVERLAPPING = "SKIPPED_OVERLAPPING"
+  @js.native
+  sealed trait MaintenanceWindowExecutionStatus extends js.Any
+  object MaintenanceWindowExecutionStatus extends js.Object {
+    val PENDING             = "PENDING".asInstanceOf[MaintenanceWindowExecutionStatus]
+    val IN_PROGRESS         = "IN_PROGRESS".asInstanceOf[MaintenanceWindowExecutionStatus]
+    val SUCCESS             = "SUCCESS".asInstanceOf[MaintenanceWindowExecutionStatus]
+    val FAILED              = "FAILED".asInstanceOf[MaintenanceWindowExecutionStatus]
+    val TIMED_OUT           = "TIMED_OUT".asInstanceOf[MaintenanceWindowExecutionStatus]
+    val CANCELLING          = "CANCELLING".asInstanceOf[MaintenanceWindowExecutionStatus]
+    val CANCELLED           = "CANCELLED".asInstanceOf[MaintenanceWindowExecutionStatus]
+    val SKIPPED_OVERLAPPING = "SKIPPED_OVERLAPPING".asInstanceOf[MaintenanceWindowExecutionStatus]
 
     val values = js.Object.freeze(
       js.Array(PENDING, IN_PROGRESS, SUCCESS, FAILED, TIMED_OUT, CANCELLING, CANCELLED, SKIPPED_OVERLAPPING)
@@ -8392,10 +8360,11 @@ package ssm {
       __obj.asInstanceOf[MaintenanceWindowLambdaParameters]
     }
   }
-
-  object MaintenanceWindowResourceTypeEnum {
-    val INSTANCE       = "INSTANCE"
-    val RESOURCE_GROUP = "RESOURCE_GROUP"
+  @js.native
+  sealed trait MaintenanceWindowResourceType extends js.Any
+  object MaintenanceWindowResourceType extends js.Object {
+    val INSTANCE       = "INSTANCE".asInstanceOf[MaintenanceWindowResourceType]
+    val RESOURCE_GROUP = "RESOURCE_GROUP".asInstanceOf[MaintenanceWindowResourceType]
 
     val values = js.Object.freeze(js.Array(INSTANCE, RESOURCE_GROUP))
   }
@@ -8619,12 +8588,13 @@ package ssm {
       __obj.asInstanceOf[MaintenanceWindowTaskParameterValueExpression]
     }
   }
-
-  object MaintenanceWindowTaskTypeEnum {
-    val RUN_COMMAND    = "RUN_COMMAND"
-    val AUTOMATION     = "AUTOMATION"
-    val STEP_FUNCTIONS = "STEP_FUNCTIONS"
-    val LAMBDA         = "LAMBDA"
+  @js.native
+  sealed trait MaintenanceWindowTaskType extends js.Any
+  object MaintenanceWindowTaskType extends js.Object {
+    val RUN_COMMAND    = "RUN_COMMAND".asInstanceOf[MaintenanceWindowTaskType]
+    val AUTOMATION     = "AUTOMATION".asInstanceOf[MaintenanceWindowTaskType]
+    val STEP_FUNCTIONS = "STEP_FUNCTIONS".asInstanceOf[MaintenanceWindowTaskType]
+    val LAMBDA         = "LAMBDA".asInstanceOf[MaintenanceWindowTaskType]
 
     val values = js.Object.freeze(js.Array(RUN_COMMAND, AUTOMATION, STEP_FUNCTIONS, LAMBDA))
   }
@@ -8718,33 +8688,36 @@ package ssm {
       __obj.asInstanceOf[NotificationConfig]
     }
   }
-
-  object NotificationEventEnum {
-    val All        = "All"
-    val InProgress = "InProgress"
-    val Success    = "Success"
-    val TimedOut   = "TimedOut"
-    val Cancelled  = "Cancelled"
-    val Failed     = "Failed"
+  @js.native
+  sealed trait NotificationEvent extends js.Any
+  object NotificationEvent extends js.Object {
+    val All        = "All".asInstanceOf[NotificationEvent]
+    val InProgress = "InProgress".asInstanceOf[NotificationEvent]
+    val Success    = "Success".asInstanceOf[NotificationEvent]
+    val TimedOut   = "TimedOut".asInstanceOf[NotificationEvent]
+    val Cancelled  = "Cancelled".asInstanceOf[NotificationEvent]
+    val Failed     = "Failed".asInstanceOf[NotificationEvent]
 
     val values = js.Object.freeze(js.Array(All, InProgress, Success, TimedOut, Cancelled, Failed))
   }
-
-  object NotificationTypeEnum {
-    val Command    = "Command"
-    val Invocation = "Invocation"
+  @js.native
+  sealed trait NotificationType extends js.Any
+  object NotificationType extends js.Object {
+    val Command    = "Command".asInstanceOf[NotificationType]
+    val Invocation = "Invocation".asInstanceOf[NotificationType]
 
     val values = js.Object.freeze(js.Array(Command, Invocation))
   }
-
-  object OperatingSystemEnum {
-    val WINDOWS                 = "WINDOWS"
-    val AMAZON_LINUX            = "AMAZON_LINUX"
-    val AMAZON_LINUX_2          = "AMAZON_LINUX_2"
-    val UBUNTU                  = "UBUNTU"
-    val REDHAT_ENTERPRISE_LINUX = "REDHAT_ENTERPRISE_LINUX"
-    val SUSE                    = "SUSE"
-    val CENTOS                  = "CENTOS"
+  @js.native
+  sealed trait OperatingSystem extends js.Any
+  object OperatingSystem extends js.Object {
+    val WINDOWS                 = "WINDOWS".asInstanceOf[OperatingSystem]
+    val AMAZON_LINUX            = "AMAZON_LINUX".asInstanceOf[OperatingSystem]
+    val AMAZON_LINUX_2          = "AMAZON_LINUX_2".asInstanceOf[OperatingSystem]
+    val UBUNTU                  = "UBUNTU".asInstanceOf[OperatingSystem]
+    val REDHAT_ENTERPRISE_LINUX = "REDHAT_ENTERPRISE_LINUX".asInstanceOf[OperatingSystem]
+    val SUSE                    = "SUSE".asInstanceOf[OperatingSystem]
+    val CENTOS                  = "CENTOS".asInstanceOf[OperatingSystem]
 
     val values =
       js.Object.freeze(js.Array(WINDOWS, AMAZON_LINUX, AMAZON_LINUX_2, UBUNTU, REDHAT_ENTERPRISE_LINUX, SUSE, CENTOS))
@@ -8854,14 +8827,15 @@ package ssm {
       __obj.asInstanceOf[OpsFilter]
     }
   }
-
-  object OpsFilterOperatorTypeEnum {
-    val Equal       = "Equal"
-    val NotEqual    = "NotEqual"
-    val BeginWith   = "BeginWith"
-    val LessThan    = "LessThan"
-    val GreaterThan = "GreaterThan"
-    val Exists      = "Exists"
+  @js.native
+  sealed trait OpsFilterOperatorType extends js.Any
+  object OpsFilterOperatorType extends js.Object {
+    val Equal       = "Equal".asInstanceOf[OpsFilterOperatorType]
+    val NotEqual    = "NotEqual".asInstanceOf[OpsFilterOperatorType]
+    val BeginWith   = "BeginWith".asInstanceOf[OpsFilterOperatorType]
+    val LessThan    = "LessThan".asInstanceOf[OpsFilterOperatorType]
+    val GreaterThan = "GreaterThan".asInstanceOf[OpsFilterOperatorType]
+    val Exists      = "Exists".asInstanceOf[OpsFilterOperatorType]
 
     val values = js.Object.freeze(js.Array(Equal, NotEqual, BeginWith, LessThan, GreaterThan, Exists))
   }
@@ -8929,10 +8903,11 @@ package ssm {
       __obj.asInstanceOf[OpsItem]
     }
   }
-
-  object OpsItemDataTypeEnum {
-    val SearchableString = "SearchableString"
-    val String           = "String"
+  @js.native
+  sealed trait OpsItemDataType extends js.Any
+  object OpsItemDataType extends js.Object {
+    val SearchableString = "SearchableString".asInstanceOf[OpsItemDataType]
+    val String           = "String".asInstanceOf[OpsItemDataType]
 
     val values = js.Object.freeze(js.Array(SearchableString, String))
   }
@@ -8985,23 +8960,24 @@ package ssm {
       __obj.asInstanceOf[OpsItemFilter]
     }
   }
-
-  object OpsItemFilterKeyEnum {
-    val Status               = "Status"
-    val CreatedBy            = "CreatedBy"
-    val Source               = "Source"
-    val Priority             = "Priority"
-    val Title                = "Title"
-    val OpsItemId            = "OpsItemId"
-    val CreatedTime          = "CreatedTime"
-    val LastModifiedTime     = "LastModifiedTime"
-    val OperationalData      = "OperationalData"
-    val OperationalDataKey   = "OperationalDataKey"
-    val OperationalDataValue = "OperationalDataValue"
-    val ResourceId           = "ResourceId"
-    val AutomationId         = "AutomationId"
-    val Category             = "Category"
-    val Severity             = "Severity"
+  @js.native
+  sealed trait OpsItemFilterKey extends js.Any
+  object OpsItemFilterKey extends js.Object {
+    val Status               = "Status".asInstanceOf[OpsItemFilterKey]
+    val CreatedBy            = "CreatedBy".asInstanceOf[OpsItemFilterKey]
+    val Source               = "Source".asInstanceOf[OpsItemFilterKey]
+    val Priority             = "Priority".asInstanceOf[OpsItemFilterKey]
+    val Title                = "Title".asInstanceOf[OpsItemFilterKey]
+    val OpsItemId            = "OpsItemId".asInstanceOf[OpsItemFilterKey]
+    val CreatedTime          = "CreatedTime".asInstanceOf[OpsItemFilterKey]
+    val LastModifiedTime     = "LastModifiedTime".asInstanceOf[OpsItemFilterKey]
+    val OperationalData      = "OperationalData".asInstanceOf[OpsItemFilterKey]
+    val OperationalDataKey   = "OperationalDataKey".asInstanceOf[OpsItemFilterKey]
+    val OperationalDataValue = "OperationalDataValue".asInstanceOf[OpsItemFilterKey]
+    val ResourceId           = "ResourceId".asInstanceOf[OpsItemFilterKey]
+    val AutomationId         = "AutomationId".asInstanceOf[OpsItemFilterKey]
+    val Category             = "Category".asInstanceOf[OpsItemFilterKey]
+    val Severity             = "Severity".asInstanceOf[OpsItemFilterKey]
 
     val values = js.Object.freeze(
       js.Array(
@@ -9023,12 +8999,13 @@ package ssm {
       )
     )
   }
-
-  object OpsItemFilterOperatorEnum {
-    val Equal       = "Equal"
-    val Contains    = "Contains"
-    val GreaterThan = "GreaterThan"
-    val LessThan    = "LessThan"
+  @js.native
+  sealed trait OpsItemFilterOperator extends js.Any
+  object OpsItemFilterOperator extends js.Object {
+    val Equal       = "Equal".asInstanceOf[OpsItemFilterOperator]
+    val Contains    = "Contains".asInstanceOf[OpsItemFilterOperator]
+    val GreaterThan = "GreaterThan".asInstanceOf[OpsItemFilterOperator]
+    val LessThan    = "LessThan".asInstanceOf[OpsItemFilterOperator]
 
     val values = js.Object.freeze(js.Array(Equal, Contains, GreaterThan, LessThan))
   }
@@ -9051,11 +9028,12 @@ package ssm {
       __obj.asInstanceOf[OpsItemNotification]
     }
   }
-
-  object OpsItemStatusEnum {
-    val Open       = "Open"
-    val InProgress = "InProgress"
-    val Resolved   = "Resolved"
+  @js.native
+  sealed trait OpsItemStatus extends js.Any
+  object OpsItemStatus extends js.Object {
+    val Open       = "Open".asInstanceOf[OpsItemStatus]
+    val InProgress = "InProgress".asInstanceOf[OpsItemStatus]
+    val Resolved   = "Resolved".asInstanceOf[OpsItemStatus]
 
     val values = js.Object.freeze(js.Array(Open, InProgress, Resolved))
   }
@@ -9349,19 +9327,21 @@ package ssm {
       __obj.asInstanceOf[ParameterStringFilter]
     }
   }
-
-  object ParameterTierEnum {
-    val Standard              = "Standard"
-    val Advanced              = "Advanced"
-    val `Intelligent-Tiering` = "Intelligent-Tiering"
+  @js.native
+  sealed trait ParameterTier extends js.Any
+  object ParameterTier extends js.Object {
+    val Standard              = "Standard".asInstanceOf[ParameterTier]
+    val Advanced              = "Advanced".asInstanceOf[ParameterTier]
+    val `Intelligent-Tiering` = "Intelligent-Tiering".asInstanceOf[ParameterTier]
 
     val values = js.Object.freeze(js.Array(Standard, Advanced, `Intelligent-Tiering`))
   }
-
-  object ParameterTypeEnum {
-    val String       = "String"
-    val StringList   = "StringList"
-    val SecureString = "SecureString"
+  @js.native
+  sealed trait ParameterType extends js.Any
+  object ParameterType extends js.Object {
+    val String       = "String".asInstanceOf[ParameterType]
+    val StringList   = "StringList".asInstanceOf[ParameterType]
+    val SecureString = "SecureString".asInstanceOf[ParameterType]
 
     val values = js.Object.freeze(js.Array(String, StringList, SecureString))
   }
@@ -9389,11 +9369,12 @@ package ssm {
       __obj.asInstanceOf[ParametersFilter]
     }
   }
-
-  object ParametersFilterKeyEnum {
-    val Name  = "Name"
-    val Type  = "Type"
-    val KeyId = "KeyId"
+  @js.native
+  sealed trait ParametersFilterKey extends js.Any
+  object ParametersFilterKey extends js.Object {
+    val Name  = "Name".asInstanceOf[ParametersFilterKey]
+    val Type  = "Type".asInstanceOf[ParametersFilterKey]
+    val KeyId = "KeyId".asInstanceOf[ParametersFilterKey]
 
     val values = js.Object.freeze(js.Array(Name, Type, KeyId))
   }
@@ -9452,10 +9433,11 @@ package ssm {
       __obj.asInstanceOf[Patch]
     }
   }
-
-  object PatchActionEnum {
-    val ALLOW_AS_DEPENDENCY = "ALLOW_AS_DEPENDENCY"
-    val BLOCK               = "BLOCK"
+  @js.native
+  sealed trait PatchAction extends js.Any
+  object PatchAction extends js.Object {
+    val ALLOW_AS_DEPENDENCY = "ALLOW_AS_DEPENDENCY".asInstanceOf[PatchAction]
+    val BLOCK               = "BLOCK".asInstanceOf[PatchAction]
 
     val values = js.Object.freeze(js.Array(ALLOW_AS_DEPENDENCY, BLOCK))
   }
@@ -9526,15 +9508,16 @@ package ssm {
       __obj.asInstanceOf[PatchComplianceData]
     }
   }
-
-  object PatchComplianceDataStateEnum {
-    val INSTALLED                = "INSTALLED"
-    val INSTALLED_OTHER          = "INSTALLED_OTHER"
-    val INSTALLED_PENDING_REBOOT = "INSTALLED_PENDING_REBOOT"
-    val INSTALLED_REJECTED       = "INSTALLED_REJECTED"
-    val MISSING                  = "MISSING"
-    val NOT_APPLICABLE           = "NOT_APPLICABLE"
-    val FAILED                   = "FAILED"
+  @js.native
+  sealed trait PatchComplianceDataState extends js.Any
+  object PatchComplianceDataState extends js.Object {
+    val INSTALLED                = "INSTALLED".asInstanceOf[PatchComplianceDataState]
+    val INSTALLED_OTHER          = "INSTALLED_OTHER".asInstanceOf[PatchComplianceDataState]
+    val INSTALLED_PENDING_REBOOT = "INSTALLED_PENDING_REBOOT".asInstanceOf[PatchComplianceDataState]
+    val INSTALLED_REJECTED       = "INSTALLED_REJECTED".asInstanceOf[PatchComplianceDataState]
+    val MISSING                  = "MISSING".asInstanceOf[PatchComplianceDataState]
+    val NOT_APPLICABLE           = "NOT_APPLICABLE".asInstanceOf[PatchComplianceDataState]
+    val FAILED                   = "FAILED".asInstanceOf[PatchComplianceDataState]
 
     val values = js.Object.freeze(
       js.Array(
@@ -9548,23 +9531,25 @@ package ssm {
       )
     )
   }
-
-  object PatchComplianceLevelEnum {
-    val CRITICAL      = "CRITICAL"
-    val HIGH          = "HIGH"
-    val MEDIUM        = "MEDIUM"
-    val LOW           = "LOW"
-    val INFORMATIONAL = "INFORMATIONAL"
-    val UNSPECIFIED   = "UNSPECIFIED"
+  @js.native
+  sealed trait PatchComplianceLevel extends js.Any
+  object PatchComplianceLevel extends js.Object {
+    val CRITICAL      = "CRITICAL".asInstanceOf[PatchComplianceLevel]
+    val HIGH          = "HIGH".asInstanceOf[PatchComplianceLevel]
+    val MEDIUM        = "MEDIUM".asInstanceOf[PatchComplianceLevel]
+    val LOW           = "LOW".asInstanceOf[PatchComplianceLevel]
+    val INFORMATIONAL = "INFORMATIONAL".asInstanceOf[PatchComplianceLevel]
+    val UNSPECIFIED   = "UNSPECIFIED".asInstanceOf[PatchComplianceLevel]
 
     val values = js.Object.freeze(js.Array(CRITICAL, HIGH, MEDIUM, LOW, INFORMATIONAL, UNSPECIFIED))
   }
-
-  object PatchDeploymentStatusEnum {
-    val APPROVED          = "APPROVED"
-    val PENDING_APPROVAL  = "PENDING_APPROVAL"
-    val EXPLICIT_APPROVED = "EXPLICIT_APPROVED"
-    val EXPLICIT_REJECTED = "EXPLICIT_REJECTED"
+  @js.native
+  sealed trait PatchDeploymentStatus extends js.Any
+  object PatchDeploymentStatus extends js.Object {
+    val APPROVED          = "APPROVED".asInstanceOf[PatchDeploymentStatus]
+    val PENDING_APPROVAL  = "PENDING_APPROVAL".asInstanceOf[PatchDeploymentStatus]
+    val EXPLICIT_APPROVED = "EXPLICIT_APPROVED".asInstanceOf[PatchDeploymentStatus]
+    val EXPLICIT_REJECTED = "EXPLICIT_REJECTED".asInstanceOf[PatchDeploymentStatus]
 
     val values = js.Object.freeze(js.Array(APPROVED, PENDING_APPROVAL, EXPLICIT_APPROVED, EXPLICIT_REJECTED))
   }
@@ -9615,17 +9600,18 @@ package ssm {
       __obj.asInstanceOf[PatchFilterGroup]
     }
   }
-
-  object PatchFilterKeyEnum {
-    val PATCH_SET      = "PATCH_SET"
-    val PRODUCT        = "PRODUCT"
-    val PRODUCT_FAMILY = "PRODUCT_FAMILY"
-    val CLASSIFICATION = "CLASSIFICATION"
-    val MSRC_SEVERITY  = "MSRC_SEVERITY"
-    val PATCH_ID       = "PATCH_ID"
-    val SECTION        = "SECTION"
-    val PRIORITY       = "PRIORITY"
-    val SEVERITY       = "SEVERITY"
+  @js.native
+  sealed trait PatchFilterKey extends js.Any
+  object PatchFilterKey extends js.Object {
+    val PATCH_SET      = "PATCH_SET".asInstanceOf[PatchFilterKey]
+    val PRODUCT        = "PRODUCT".asInstanceOf[PatchFilterKey]
+    val PRODUCT_FAMILY = "PRODUCT_FAMILY".asInstanceOf[PatchFilterKey]
+    val CLASSIFICATION = "CLASSIFICATION".asInstanceOf[PatchFilterKey]
+    val MSRC_SEVERITY  = "MSRC_SEVERITY".asInstanceOf[PatchFilterKey]
+    val PATCH_ID       = "PATCH_ID".asInstanceOf[PatchFilterKey]
+    val SECTION        = "SECTION".asInstanceOf[PatchFilterKey]
+    val PRIORITY       = "PRIORITY".asInstanceOf[PatchFilterKey]
+    val SEVERITY       = "SEVERITY".asInstanceOf[PatchFilterKey]
 
     val values = js.Object.freeze(
       js.Array(PATCH_SET, PRODUCT, PRODUCT_FAMILY, CLASSIFICATION, MSRC_SEVERITY, PATCH_ID, SECTION, PRIORITY, SEVERITY)
@@ -9653,10 +9639,11 @@ package ssm {
       __obj.asInstanceOf[PatchGroupPatchBaselineMapping]
     }
   }
-
-  object PatchOperationTypeEnum {
-    val Scan    = "Scan"
-    val Install = "Install"
+  @js.native
+  sealed trait PatchOperationType extends js.Any
+  object PatchOperationType extends js.Object {
+    val Scan    = "Scan".asInstanceOf[PatchOperationType]
+    val Install = "Install".asInstanceOf[PatchOperationType]
 
     val values = js.Object.freeze(js.Array(Scan, Install))
   }
@@ -9682,14 +9669,15 @@ package ssm {
       __obj.asInstanceOf[PatchOrchestratorFilter]
     }
   }
-
-  object PatchPropertyEnum {
-    val PRODUCT        = "PRODUCT"
-    val PRODUCT_FAMILY = "PRODUCT_FAMILY"
-    val CLASSIFICATION = "CLASSIFICATION"
-    val MSRC_SEVERITY  = "MSRC_SEVERITY"
-    val PRIORITY       = "PRIORITY"
-    val SEVERITY       = "SEVERITY"
+  @js.native
+  sealed trait PatchProperty extends js.Any
+  object PatchProperty extends js.Object {
+    val PRODUCT        = "PRODUCT".asInstanceOf[PatchProperty]
+    val PRODUCT_FAMILY = "PRODUCT_FAMILY".asInstanceOf[PatchProperty]
+    val CLASSIFICATION = "CLASSIFICATION".asInstanceOf[PatchProperty]
+    val MSRC_SEVERITY  = "MSRC_SEVERITY".asInstanceOf[PatchProperty]
+    val PRIORITY       = "PRIORITY".asInstanceOf[PatchProperty]
+    val SEVERITY       = "SEVERITY".asInstanceOf[PatchProperty]
 
     val values = js.Object.freeze(js.Array(PRODUCT, PRODUCT_FAMILY, CLASSIFICATION, MSRC_SEVERITY, PRIORITY, SEVERITY))
   }
@@ -9747,10 +9735,11 @@ package ssm {
       __obj.asInstanceOf[PatchRuleGroup]
     }
   }
-
-  object PatchSetEnum {
-    val OS          = "OS"
-    val APPLICATION = "APPLICATION"
+  @js.native
+  sealed trait PatchSet extends js.Any
+  object PatchSet extends js.Object {
+    val OS          = "OS".asInstanceOf[PatchSet]
+    val APPLICATION = "APPLICATION".asInstanceOf[PatchSet]
 
     val values = js.Object.freeze(js.Array(OS, APPLICATION))
   }
@@ -9806,18 +9795,20 @@ package ssm {
       __obj.asInstanceOf[PatchStatus]
     }
   }
-
-  object PingStatusEnum {
-    val Online         = "Online"
-    val ConnectionLost = "ConnectionLost"
-    val Inactive       = "Inactive"
+  @js.native
+  sealed trait PingStatus extends js.Any
+  object PingStatus extends js.Object {
+    val Online         = "Online".asInstanceOf[PingStatus]
+    val ConnectionLost = "ConnectionLost".asInstanceOf[PingStatus]
+    val Inactive       = "Inactive".asInstanceOf[PingStatus]
 
     val values = js.Object.freeze(js.Array(Online, ConnectionLost, Inactive))
   }
-
-  object PlatformTypeEnum {
-    val Windows = "Windows"
-    val Linux   = "Linux"
+  @js.native
+  sealed trait PlatformType extends js.Any
+  object PlatformType extends js.Object {
+    val Windows = "Windows".asInstanceOf[PlatformType]
+    val Linux   = "Linux".asInstanceOf[PlatformType]
 
     val values = js.Object.freeze(js.Array(Windows, Linux))
   }
@@ -9999,10 +9990,11 @@ package ssm {
       __obj.asInstanceOf[PutParameterResult]
     }
   }
-
-  object RebootOptionEnum {
-    val RebootIfNeeded = "RebootIfNeeded"
-    val NoReboot       = "NoReboot"
+  @js.native
+  sealed trait RebootOption extends js.Any
+  object RebootOption extends js.Object {
+    val RebootIfNeeded = "RebootIfNeeded".asInstanceOf[RebootOption]
+    val NoReboot       = "NoReboot".asInstanceOf[RebootOption]
 
     val values = js.Object.freeze(js.Array(RebootIfNeeded, NoReboot))
   }
@@ -10487,9 +10479,10 @@ package ssm {
       __obj.asInstanceOf[ResourceDataSyncS3Destination]
     }
   }
-
-  object ResourceDataSyncS3FormatEnum {
-    val JsonSerDe = "JsonSerDe"
+  @js.native
+  sealed trait ResourceDataSyncS3Format extends js.Any
+  object ResourceDataSyncS3Format extends js.Object {
+    val JsonSerDe = "JsonSerDe".asInstanceOf[ResourceDataSyncS3Format]
 
     val values = js.Object.freeze(js.Array(JsonSerDe))
   }
@@ -10558,22 +10551,24 @@ package ssm {
       __obj.asInstanceOf[ResourceDataSyncSourceWithState]
     }
   }
-
-  object ResourceTypeEnum {
-    val ManagedInstance = "ManagedInstance"
-    val Document        = "Document"
-    val EC2Instance     = "EC2Instance"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val ManagedInstance = "ManagedInstance".asInstanceOf[ResourceType]
+    val Document        = "Document".asInstanceOf[ResourceType]
+    val EC2Instance     = "EC2Instance".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(ManagedInstance, Document, EC2Instance))
   }
-
-  object ResourceTypeForTaggingEnum {
-    val Document          = "Document"
-    val ManagedInstance   = "ManagedInstance"
-    val MaintenanceWindow = "MaintenanceWindow"
-    val Parameter         = "Parameter"
-    val PatchBaseline     = "PatchBaseline"
-    val OpsItem           = "OpsItem"
+  @js.native
+  sealed trait ResourceTypeForTagging extends js.Any
+  object ResourceTypeForTagging extends js.Object {
+    val Document          = "Document".asInstanceOf[ResourceTypeForTagging]
+    val ManagedInstance   = "ManagedInstance".asInstanceOf[ResourceTypeForTagging]
+    val MaintenanceWindow = "MaintenanceWindow".asInstanceOf[ResourceTypeForTagging]
+    val Parameter         = "Parameter".asInstanceOf[ResourceTypeForTagging]
+    val PatchBaseline     = "PatchBaseline".asInstanceOf[ResourceTypeForTagging]
+    val OpsItem           = "OpsItem".asInstanceOf[ResourceTypeForTagging]
 
     val values =
       js.Object.freeze(js.Array(Document, ManagedInstance, MaintenanceWindow, Parameter, PatchBaseline, OpsItem))
@@ -10930,13 +10925,14 @@ package ssm {
       __obj.asInstanceOf[SessionFilter]
     }
   }
-
-  object SessionFilterKeyEnum {
-    val InvokedAfter  = "InvokedAfter"
-    val InvokedBefore = "InvokedBefore"
-    val Target        = "Target"
-    val Owner         = "Owner"
-    val Status        = "Status"
+  @js.native
+  sealed trait SessionFilterKey extends js.Any
+  object SessionFilterKey extends js.Object {
+    val InvokedAfter  = "InvokedAfter".asInstanceOf[SessionFilterKey]
+    val InvokedBefore = "InvokedBefore".asInstanceOf[SessionFilterKey]
+    val Target        = "Target".asInstanceOf[SessionFilterKey]
+    val Owner         = "Owner".asInstanceOf[SessionFilterKey]
+    val Status        = "Status".asInstanceOf[SessionFilterKey]
 
     val values = js.Object.freeze(js.Array(InvokedAfter, InvokedBefore, Target, Owner, Status))
   }
@@ -10962,21 +10958,23 @@ package ssm {
       __obj.asInstanceOf[SessionManagerOutputUrl]
     }
   }
-
-  object SessionStateEnum {
-    val Active  = "Active"
-    val History = "History"
+  @js.native
+  sealed trait SessionState extends js.Any
+  object SessionState extends js.Object {
+    val Active  = "Active".asInstanceOf[SessionState]
+    val History = "History".asInstanceOf[SessionState]
 
     val values = js.Object.freeze(js.Array(Active, History))
   }
-
-  object SessionStatusEnum {
-    val Connected    = "Connected"
-    val Connecting   = "Connecting"
-    val Disconnected = "Disconnected"
-    val Terminated   = "Terminated"
-    val Terminating  = "Terminating"
-    val Failed       = "Failed"
+  @js.native
+  sealed trait SessionStatus extends js.Any
+  object SessionStatus extends js.Object {
+    val Connected    = "Connected".asInstanceOf[SessionStatus]
+    val Connecting   = "Connecting".asInstanceOf[SessionStatus]
+    val Disconnected = "Disconnected".asInstanceOf[SessionStatus]
+    val Terminated   = "Terminated".asInstanceOf[SessionStatus]
+    val Terminating  = "Terminating".asInstanceOf[SessionStatus]
+    val Failed       = "Failed".asInstanceOf[SessionStatus]
 
     val values = js.Object.freeze(js.Array(Connected, Connecting, Disconnected, Terminated, Terminating, Failed))
   }
@@ -11014,13 +11012,14 @@ package ssm {
       __obj.asInstanceOf[SeveritySummary]
     }
   }
-
-  object SignalTypeEnum {
-    val Approve   = "Approve"
-    val Reject    = "Reject"
-    val StartStep = "StartStep"
-    val StopStep  = "StopStep"
-    val Resume    = "Resume"
+  @js.native
+  sealed trait SignalType extends js.Any
+  object SignalType extends js.Object {
+    val Approve   = "Approve".asInstanceOf[SignalType]
+    val Reject    = "Reject".asInstanceOf[SignalType]
+    val StartStep = "StartStep".asInstanceOf[SignalType]
+    val StopStep  = "StopStep".asInstanceOf[SignalType]
+    val Resume    = "Resume".asInstanceOf[SignalType]
 
     val values = js.Object.freeze(js.Array(Approve, Reject, StartStep, StopStep, Resume))
   }
@@ -11274,14 +11273,15 @@ package ssm {
       __obj.asInstanceOf[StepExecutionFilter]
     }
   }
-
-  object StepExecutionFilterKeyEnum {
-    val StartTimeBefore     = "StartTimeBefore"
-    val StartTimeAfter      = "StartTimeAfter"
-    val StepExecutionStatus = "StepExecutionStatus"
-    val StepExecutionId     = "StepExecutionId"
-    val StepName            = "StepName"
-    val Action              = "Action"
+  @js.native
+  sealed trait StepExecutionFilterKey extends js.Any
+  object StepExecutionFilterKey extends js.Object {
+    val StartTimeBefore     = "StartTimeBefore".asInstanceOf[StepExecutionFilterKey]
+    val StartTimeAfter      = "StartTimeAfter".asInstanceOf[StepExecutionFilterKey]
+    val StepExecutionStatus = "StepExecutionStatus".asInstanceOf[StepExecutionFilterKey]
+    val StepExecutionId     = "StepExecutionId".asInstanceOf[StepExecutionFilterKey]
+    val StepName            = "StepName".asInstanceOf[StepExecutionFilterKey]
+    val Action              = "Action".asInstanceOf[StepExecutionFilterKey]
 
     val values = js.Object.freeze(
       js.Array(StartTimeBefore, StartTimeAfter, StepExecutionStatus, StepExecutionId, StepName, Action)
@@ -11321,10 +11321,11 @@ package ssm {
       __obj.asInstanceOf[StopAutomationExecutionResult]
     }
   }
-
-  object StopTypeEnum {
-    val Complete = "Complete"
-    val Cancel   = "Cancel"
+  @js.native
+  sealed trait StopType extends js.Any
+  object StopType extends js.Object {
+    val Complete = "Complete".asInstanceOf[StopType]
+    val Cancel   = "Cancel".asInstanceOf[StopType]
 
     val values = js.Object.freeze(js.Array(Complete, Cancel))
   }

--- a/services/stepfunctions/src/main/scala/facade/amazonaws/services/StepFunctions.scala
+++ b/services/stepfunctions/src/main/scala/facade/amazonaws/services/StepFunctions.scala
@@ -13,14 +13,11 @@ package object stepfunctions {
   type Definition              = String
   type EventId                 = Double
   type ExecutionList           = js.Array[ExecutionListItem]
-  type ExecutionStatus         = String
   type HistoryEventList        = js.Array[HistoryEvent]
-  type HistoryEventType        = String
   type Identity                = String
   type IncludeExecutionData    = Boolean
   type ListExecutionsPageToken = String
   type LogDestinationList      = js.Array[LogDestination]
-  type LogLevel                = String
   type Name                    = String
   type PageSize                = Int
   type PageToken               = String
@@ -30,8 +27,6 @@ package object stepfunctions {
   type SensitiveDataJobInput   = String
   type SensitiveError          = String
   type StateMachineList        = js.Array[StateMachineListItem]
-  type StateMachineStatus      = String
-  type StateMachineType        = String
   type TagKey                  = String
   type TagKeyList              = js.Array[TagKey]
   type TagList                 = js.Array[Tag]
@@ -767,13 +762,14 @@ package stepfunctions {
       __obj.asInstanceOf[ExecutionStartedEventDetails]
     }
   }
-
-  object ExecutionStatusEnum {
-    val RUNNING   = "RUNNING"
-    val SUCCEEDED = "SUCCEEDED"
-    val FAILED    = "FAILED"
-    val TIMED_OUT = "TIMED_OUT"
-    val ABORTED   = "ABORTED"
+  @js.native
+  sealed trait ExecutionStatus extends js.Any
+  object ExecutionStatus extends js.Object {
+    val RUNNING   = "RUNNING".asInstanceOf[ExecutionStatus]
+    val SUCCEEDED = "SUCCEEDED".asInstanceOf[ExecutionStatus]
+    val FAILED    = "FAILED".asInstanceOf[ExecutionStatus]
+    val TIMED_OUT = "TIMED_OUT".asInstanceOf[ExecutionStatus]
+    val ABORTED   = "ABORTED".asInstanceOf[ExecutionStatus]
 
     val values = js.Object.freeze(js.Array(RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED))
   }
@@ -1086,63 +1082,64 @@ package stepfunctions {
       __obj.asInstanceOf[HistoryEvent]
     }
   }
-
-  object HistoryEventTypeEnum {
-    val ActivityFailed               = "ActivityFailed"
-    val ActivityScheduled            = "ActivityScheduled"
-    val ActivityScheduleFailed       = "ActivityScheduleFailed"
-    val ActivityStarted              = "ActivityStarted"
-    val ActivitySucceeded            = "ActivitySucceeded"
-    val ActivityTimedOut             = "ActivityTimedOut"
-    val ChoiceStateEntered           = "ChoiceStateEntered"
-    val ChoiceStateExited            = "ChoiceStateExited"
-    val ExecutionAborted             = "ExecutionAborted"
-    val ExecutionFailed              = "ExecutionFailed"
-    val ExecutionStarted             = "ExecutionStarted"
-    val ExecutionSucceeded           = "ExecutionSucceeded"
-    val ExecutionTimedOut            = "ExecutionTimedOut"
-    val FailStateEntered             = "FailStateEntered"
-    val LambdaFunctionFailed         = "LambdaFunctionFailed"
-    val LambdaFunctionScheduled      = "LambdaFunctionScheduled"
-    val LambdaFunctionScheduleFailed = "LambdaFunctionScheduleFailed"
-    val LambdaFunctionStarted        = "LambdaFunctionStarted"
-    val LambdaFunctionStartFailed    = "LambdaFunctionStartFailed"
-    val LambdaFunctionSucceeded      = "LambdaFunctionSucceeded"
-    val LambdaFunctionTimedOut       = "LambdaFunctionTimedOut"
-    val MapIterationAborted          = "MapIterationAborted"
-    val MapIterationFailed           = "MapIterationFailed"
-    val MapIterationStarted          = "MapIterationStarted"
-    val MapIterationSucceeded        = "MapIterationSucceeded"
-    val MapStateAborted              = "MapStateAborted"
-    val MapStateEntered              = "MapStateEntered"
-    val MapStateExited               = "MapStateExited"
-    val MapStateFailed               = "MapStateFailed"
-    val MapStateStarted              = "MapStateStarted"
-    val MapStateSucceeded            = "MapStateSucceeded"
-    val ParallelStateAborted         = "ParallelStateAborted"
-    val ParallelStateEntered         = "ParallelStateEntered"
-    val ParallelStateExited          = "ParallelStateExited"
-    val ParallelStateFailed          = "ParallelStateFailed"
-    val ParallelStateStarted         = "ParallelStateStarted"
-    val ParallelStateSucceeded       = "ParallelStateSucceeded"
-    val PassStateEntered             = "PassStateEntered"
-    val PassStateExited              = "PassStateExited"
-    val SucceedStateEntered          = "SucceedStateEntered"
-    val SucceedStateExited           = "SucceedStateExited"
-    val TaskFailed                   = "TaskFailed"
-    val TaskScheduled                = "TaskScheduled"
-    val TaskStarted                  = "TaskStarted"
-    val TaskStartFailed              = "TaskStartFailed"
-    val TaskStateAborted             = "TaskStateAborted"
-    val TaskStateEntered             = "TaskStateEntered"
-    val TaskStateExited              = "TaskStateExited"
-    val TaskSubmitFailed             = "TaskSubmitFailed"
-    val TaskSubmitted                = "TaskSubmitted"
-    val TaskSucceeded                = "TaskSucceeded"
-    val TaskTimedOut                 = "TaskTimedOut"
-    val WaitStateAborted             = "WaitStateAborted"
-    val WaitStateEntered             = "WaitStateEntered"
-    val WaitStateExited              = "WaitStateExited"
+  @js.native
+  sealed trait HistoryEventType extends js.Any
+  object HistoryEventType extends js.Object {
+    val ActivityFailed               = "ActivityFailed".asInstanceOf[HistoryEventType]
+    val ActivityScheduled            = "ActivityScheduled".asInstanceOf[HistoryEventType]
+    val ActivityScheduleFailed       = "ActivityScheduleFailed".asInstanceOf[HistoryEventType]
+    val ActivityStarted              = "ActivityStarted".asInstanceOf[HistoryEventType]
+    val ActivitySucceeded            = "ActivitySucceeded".asInstanceOf[HistoryEventType]
+    val ActivityTimedOut             = "ActivityTimedOut".asInstanceOf[HistoryEventType]
+    val ChoiceStateEntered           = "ChoiceStateEntered".asInstanceOf[HistoryEventType]
+    val ChoiceStateExited            = "ChoiceStateExited".asInstanceOf[HistoryEventType]
+    val ExecutionAborted             = "ExecutionAborted".asInstanceOf[HistoryEventType]
+    val ExecutionFailed              = "ExecutionFailed".asInstanceOf[HistoryEventType]
+    val ExecutionStarted             = "ExecutionStarted".asInstanceOf[HistoryEventType]
+    val ExecutionSucceeded           = "ExecutionSucceeded".asInstanceOf[HistoryEventType]
+    val ExecutionTimedOut            = "ExecutionTimedOut".asInstanceOf[HistoryEventType]
+    val FailStateEntered             = "FailStateEntered".asInstanceOf[HistoryEventType]
+    val LambdaFunctionFailed         = "LambdaFunctionFailed".asInstanceOf[HistoryEventType]
+    val LambdaFunctionScheduled      = "LambdaFunctionScheduled".asInstanceOf[HistoryEventType]
+    val LambdaFunctionScheduleFailed = "LambdaFunctionScheduleFailed".asInstanceOf[HistoryEventType]
+    val LambdaFunctionStarted        = "LambdaFunctionStarted".asInstanceOf[HistoryEventType]
+    val LambdaFunctionStartFailed    = "LambdaFunctionStartFailed".asInstanceOf[HistoryEventType]
+    val LambdaFunctionSucceeded      = "LambdaFunctionSucceeded".asInstanceOf[HistoryEventType]
+    val LambdaFunctionTimedOut       = "LambdaFunctionTimedOut".asInstanceOf[HistoryEventType]
+    val MapIterationAborted          = "MapIterationAborted".asInstanceOf[HistoryEventType]
+    val MapIterationFailed           = "MapIterationFailed".asInstanceOf[HistoryEventType]
+    val MapIterationStarted          = "MapIterationStarted".asInstanceOf[HistoryEventType]
+    val MapIterationSucceeded        = "MapIterationSucceeded".asInstanceOf[HistoryEventType]
+    val MapStateAborted              = "MapStateAborted".asInstanceOf[HistoryEventType]
+    val MapStateEntered              = "MapStateEntered".asInstanceOf[HistoryEventType]
+    val MapStateExited               = "MapStateExited".asInstanceOf[HistoryEventType]
+    val MapStateFailed               = "MapStateFailed".asInstanceOf[HistoryEventType]
+    val MapStateStarted              = "MapStateStarted".asInstanceOf[HistoryEventType]
+    val MapStateSucceeded            = "MapStateSucceeded".asInstanceOf[HistoryEventType]
+    val ParallelStateAborted         = "ParallelStateAborted".asInstanceOf[HistoryEventType]
+    val ParallelStateEntered         = "ParallelStateEntered".asInstanceOf[HistoryEventType]
+    val ParallelStateExited          = "ParallelStateExited".asInstanceOf[HistoryEventType]
+    val ParallelStateFailed          = "ParallelStateFailed".asInstanceOf[HistoryEventType]
+    val ParallelStateStarted         = "ParallelStateStarted".asInstanceOf[HistoryEventType]
+    val ParallelStateSucceeded       = "ParallelStateSucceeded".asInstanceOf[HistoryEventType]
+    val PassStateEntered             = "PassStateEntered".asInstanceOf[HistoryEventType]
+    val PassStateExited              = "PassStateExited".asInstanceOf[HistoryEventType]
+    val SucceedStateEntered          = "SucceedStateEntered".asInstanceOf[HistoryEventType]
+    val SucceedStateExited           = "SucceedStateExited".asInstanceOf[HistoryEventType]
+    val TaskFailed                   = "TaskFailed".asInstanceOf[HistoryEventType]
+    val TaskScheduled                = "TaskScheduled".asInstanceOf[HistoryEventType]
+    val TaskStarted                  = "TaskStarted".asInstanceOf[HistoryEventType]
+    val TaskStartFailed              = "TaskStartFailed".asInstanceOf[HistoryEventType]
+    val TaskStateAborted             = "TaskStateAborted".asInstanceOf[HistoryEventType]
+    val TaskStateEntered             = "TaskStateEntered".asInstanceOf[HistoryEventType]
+    val TaskStateExited              = "TaskStateExited".asInstanceOf[HistoryEventType]
+    val TaskSubmitFailed             = "TaskSubmitFailed".asInstanceOf[HistoryEventType]
+    val TaskSubmitted                = "TaskSubmitted".asInstanceOf[HistoryEventType]
+    val TaskSucceeded                = "TaskSucceeded".asInstanceOf[HistoryEventType]
+    val TaskTimedOut                 = "TaskTimedOut".asInstanceOf[HistoryEventType]
+    val WaitStateAborted             = "WaitStateAborted".asInstanceOf[HistoryEventType]
+    val WaitStateEntered             = "WaitStateEntered".asInstanceOf[HistoryEventType]
+    val WaitStateExited              = "WaitStateExited".asInstanceOf[HistoryEventType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1519,12 +1516,13 @@ package stepfunctions {
       __obj.asInstanceOf[LogDestination]
     }
   }
-
-  object LogLevelEnum {
-    val ALL   = "ALL"
-    val ERROR = "ERROR"
-    val FATAL = "FATAL"
-    val OFF   = "OFF"
+  @js.native
+  sealed trait LogLevel extends js.Any
+  object LogLevel extends js.Object {
+    val ALL   = "ALL".asInstanceOf[LogLevel]
+    val ERROR = "ERROR".asInstanceOf[LogLevel]
+    val FATAL = "FATAL".asInstanceOf[LogLevel]
+    val OFF   = "OFF".asInstanceOf[LogLevel]
 
     val values = js.Object.freeze(js.Array(ALL, ERROR, FATAL, OFF))
   }
@@ -1819,17 +1817,19 @@ package stepfunctions {
       __obj.asInstanceOf[StateMachineListItem]
     }
   }
-
-  object StateMachineStatusEnum {
-    val ACTIVE   = "ACTIVE"
-    val DELETING = "DELETING"
+  @js.native
+  sealed trait StateMachineStatus extends js.Any
+  object StateMachineStatus extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[StateMachineStatus]
+    val DELETING = "DELETING".asInstanceOf[StateMachineStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, DELETING))
   }
-
-  object StateMachineTypeEnum {
-    val STANDARD = "STANDARD"
-    val EXPRESS  = "EXPRESS"
+  @js.native
+  sealed trait StateMachineType extends js.Any
+  object StateMachineType extends js.Object {
+    val STANDARD = "STANDARD".asInstanceOf[StateMachineType]
+    val EXPRESS  = "EXPRESS".asInstanceOf[StateMachineType]
 
     val values = js.Object.freeze(js.Array(STANDARD, EXPRESS))
   }

--- a/services/storagegateway/src/main/scala/facade/amazonaws/services/StorageGateway.scala
+++ b/services/storagegateway/src/main/scala/facade/amazonaws/services/StorageGateway.scala
@@ -7,132 +7,126 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object storagegateway {
-  type ActivationKey                 = String
-  type ActiveDirectoryStatus         = String
-  type Authentication                = String
-  type AvailabilityMonitorTestStatus = String
-  type BandwidthDownloadRateLimit    = Double
-  type BandwidthType                 = String
-  type BandwidthUploadRateLimit      = Double
-  type CachediSCSIVolumes            = js.Array[CachediSCSIVolume]
-  type ChapCredentials               = js.Array[ChapInfo]
-  type ChapSecret                    = String
-  type ClientToken                   = String
-  type CloudWatchLogGroupARN         = String
-  type CreatedDate                   = js.Date
-  type DayOfMonth                    = Int
-  type DayOfWeek                     = Int
-  type Description                   = String
-  type DeviceType                    = String
-  type DiskAllocationType            = String
-  type DiskAttribute                 = String
-  type DiskAttributeList             = js.Array[DiskAttribute]
-  type DiskId                        = String
-  type DiskIds                       = js.Array[DiskId]
-  type Disks                         = js.Array[Disk]
-  type DomainName                    = String
-  type DomainUserName                = String
-  type DomainUserPassword            = String
-  type DoubleObject                  = Double
-  type Ec2InstanceId                 = String
-  type Ec2InstanceRegion             = String
-  type FileShareARN                  = String
-  type FileShareARNList              = js.Array[FileShareARN]
-  type FileShareClientList           = js.Array[IPV4AddressCIDR]
-  type FileShareId                   = String
-  type FileShareInfoList             = js.Array[FileShareInfo]
-  type FileShareStatus               = String
-  type FileShareType                 = String
-  type FileShareUser                 = String
-  type FileShareUserList             = js.Array[FileShareUser]
-  type Folder                        = String
-  type FolderList                    = js.Array[Folder]
-  type GatewayARN                    = String
-  type GatewayId                     = String
-  type GatewayName                   = String
-  type GatewayNetworkInterfaces      = js.Array[NetworkInterface]
-  type GatewayOperationalState       = String
-  type GatewayState                  = String
-  type GatewayTimezone               = String
-  type GatewayType                   = String
-  type Gateways                      = js.Array[GatewayInfo]
-  type Host                          = String
-  type HostEnvironment               = String
-  type Hosts                         = js.Array[Host]
-  type HourOfDay                     = Int
-  type IPV4AddressCIDR               = String
-  type Initiator                     = String
-  type Initiators                    = js.Array[Initiator]
-  type IqnName                       = String
-  type KMSKey                        = String
-  type LastSoftwareUpdate            = String
-  type LocalConsolePassword          = String
-  type LocationARN                   = String
-  type Marker                        = String
-  type MediumChangerType             = String
-  type MinuteOfHour                  = Int
-  type NFSFileShareInfoList          = js.Array[NFSFileShareInfo]
-  type NetworkInterfaceId            = String
-  type NextUpdateAvailabilityDate    = String
-  type NotificationId                = String
-  type NumTapesToCreate              = Int
-  type ObjectACL                     = String
-  type OrganizationalUnit            = String
-  type Path                          = String
-  type PermissionId                  = Double
-  type PermissionMode                = String
-  type PoolId                        = String
-  type PositiveIntObject             = Int
-  type RecurrenceInHours             = Int
-  type RegionId                      = String
-  type ResourceARN                   = String
-  type Role                          = String
-  type SMBFileShareInfoList          = js.Array[SMBFileShareInfo]
-  type SMBGuestPassword              = String
-  type SMBSecurityStrategy           = String
-  type SnapshotDescription           = String
-  type SnapshotId                    = String
-  type Squash                        = String
-  type StorageClass                  = String
-  type StorediSCSIVolumes            = js.Array[StorediSCSIVolume]
-  type TagKey                        = String
-  type TagKeys                       = js.Array[TagKey]
-  type TagValue                      = String
-  type Tags                          = js.Array[Tag]
-  type TapeARN                       = String
-  type TapeARNs                      = js.Array[TapeARN]
-  type TapeArchiveStatus             = String
-  type TapeArchives                  = js.Array[TapeArchive]
-  type TapeBarcode                   = String
-  type TapeBarcodePrefix             = String
-  type TapeDriveType                 = String
-  type TapeInfos                     = js.Array[TapeInfo]
-  type TapeRecoveryPointInfos        = js.Array[TapeRecoveryPointInfo]
-  type TapeRecoveryPointStatus       = String
-  type TapeSize                      = Double
-  type TapeStatus                    = String
-  type TapeUsage                     = Double
-  type Tapes                         = js.Array[Tape]
-  type TargetARN                     = String
-  type TargetName                    = String
-  type Time                          = js.Date
-  type TimeoutInSeconds              = Int
-  type VTLDeviceARN                  = String
-  type VTLDeviceARNs                 = js.Array[VTLDeviceARN]
-  type VTLDeviceProductIdentifier    = String
-  type VTLDeviceType                 = String
-  type VTLDeviceVendor               = String
-  type VTLDevices                    = js.Array[VTLDevice]
-  type VolumeARN                     = String
-  type VolumeARNs                    = js.Array[VolumeARN]
-  type VolumeAttachmentStatus        = String
-  type VolumeId                      = String
-  type VolumeInfos                   = js.Array[VolumeInfo]
-  type VolumeRecoveryPointInfos      = js.Array[VolumeRecoveryPointInfo]
-  type VolumeStatus                  = String
-  type VolumeType                    = String
-  type VolumeUsedInBytes             = Double
-  type double                        = Double
+  type ActivationKey              = String
+  type Authentication             = String
+  type BandwidthDownloadRateLimit = Double
+  type BandwidthType              = String
+  type BandwidthUploadRateLimit   = Double
+  type CachediSCSIVolumes         = js.Array[CachediSCSIVolume]
+  type ChapCredentials            = js.Array[ChapInfo]
+  type ChapSecret                 = String
+  type ClientToken                = String
+  type CloudWatchLogGroupARN      = String
+  type CreatedDate                = js.Date
+  type DayOfMonth                 = Int
+  type DayOfWeek                  = Int
+  type Description                = String
+  type DeviceType                 = String
+  type DiskAllocationType         = String
+  type DiskAttribute              = String
+  type DiskAttributeList          = js.Array[DiskAttribute]
+  type DiskId                     = String
+  type DiskIds                    = js.Array[DiskId]
+  type Disks                      = js.Array[Disk]
+  type DomainName                 = String
+  type DomainUserName             = String
+  type DomainUserPassword         = String
+  type DoubleObject               = Double
+  type Ec2InstanceId              = String
+  type Ec2InstanceRegion          = String
+  type FileShareARN               = String
+  type FileShareARNList           = js.Array[FileShareARN]
+  type FileShareClientList        = js.Array[IPV4AddressCIDR]
+  type FileShareId                = String
+  type FileShareInfoList          = js.Array[FileShareInfo]
+  type FileShareStatus            = String
+  type FileShareUser              = String
+  type FileShareUserList          = js.Array[FileShareUser]
+  type Folder                     = String
+  type FolderList                 = js.Array[Folder]
+  type GatewayARN                 = String
+  type GatewayId                  = String
+  type GatewayName                = String
+  type GatewayNetworkInterfaces   = js.Array[NetworkInterface]
+  type GatewayOperationalState    = String
+  type GatewayState               = String
+  type GatewayTimezone            = String
+  type GatewayType                = String
+  type Gateways                   = js.Array[GatewayInfo]
+  type Host                       = String
+  type Hosts                      = js.Array[Host]
+  type HourOfDay                  = Int
+  type IPV4AddressCIDR            = String
+  type Initiator                  = String
+  type Initiators                 = js.Array[Initiator]
+  type IqnName                    = String
+  type KMSKey                     = String
+  type LastSoftwareUpdate         = String
+  type LocalConsolePassword       = String
+  type LocationARN                = String
+  type Marker                     = String
+  type MediumChangerType          = String
+  type MinuteOfHour               = Int
+  type NFSFileShareInfoList       = js.Array[NFSFileShareInfo]
+  type NetworkInterfaceId         = String
+  type NextUpdateAvailabilityDate = String
+  type NotificationId             = String
+  type NumTapesToCreate           = Int
+  type OrganizationalUnit         = String
+  type Path                       = String
+  type PermissionId               = Double
+  type PermissionMode             = String
+  type PoolId                     = String
+  type PositiveIntObject          = Int
+  type RecurrenceInHours          = Int
+  type RegionId                   = String
+  type ResourceARN                = String
+  type Role                       = String
+  type SMBFileShareInfoList       = js.Array[SMBFileShareInfo]
+  type SMBGuestPassword           = String
+  type SnapshotDescription        = String
+  type SnapshotId                 = String
+  type Squash                     = String
+  type StorageClass               = String
+  type StorediSCSIVolumes         = js.Array[StorediSCSIVolume]
+  type TagKey                     = String
+  type TagKeys                    = js.Array[TagKey]
+  type TagValue                   = String
+  type Tags                       = js.Array[Tag]
+  type TapeARN                    = String
+  type TapeARNs                   = js.Array[TapeARN]
+  type TapeArchiveStatus          = String
+  type TapeArchives               = js.Array[TapeArchive]
+  type TapeBarcode                = String
+  type TapeBarcodePrefix          = String
+  type TapeDriveType              = String
+  type TapeInfos                  = js.Array[TapeInfo]
+  type TapeRecoveryPointInfos     = js.Array[TapeRecoveryPointInfo]
+  type TapeRecoveryPointStatus    = String
+  type TapeSize                   = Double
+  type TapeStatus                 = String
+  type TapeUsage                  = Double
+  type Tapes                      = js.Array[Tape]
+  type TargetARN                  = String
+  type TargetName                 = String
+  type Time                       = js.Date
+  type TimeoutInSeconds           = Int
+  type VTLDeviceARN               = String
+  type VTLDeviceARNs              = js.Array[VTLDeviceARN]
+  type VTLDeviceProductIdentifier = String
+  type VTLDeviceType              = String
+  type VTLDeviceVendor            = String
+  type VTLDevices                 = js.Array[VTLDevice]
+  type VolumeARN                  = String
+  type VolumeARNs                 = js.Array[VolumeARN]
+  type VolumeAttachmentStatus     = String
+  type VolumeId                   = String
+  type VolumeInfos                = js.Array[VolumeInfo]
+  type VolumeRecoveryPointInfos   = js.Array[VolumeRecoveryPointInfo]
+  type VolumeStatus               = String
+  type VolumeType                 = String
+  type VolumeUsedInBytes          = Double
+  type double                     = Double
 
   implicit final class StorageGatewayOps(private val service: StorageGateway) extends AnyVal {
 
@@ -494,15 +488,16 @@ package storagegateway {
       __obj.asInstanceOf[ActivateGatewayOutput]
     }
   }
-
-  object ActiveDirectoryStatusEnum {
-    val ACCESS_DENIED = "ACCESS_DENIED"
-    val DETACHED      = "DETACHED"
-    val JOINED        = "JOINED"
-    val JOINING       = "JOINING"
-    val NETWORK_ERROR = "NETWORK_ERROR"
-    val TIMEOUT       = "TIMEOUT"
-    val UNKNOWN_ERROR = "UNKNOWN_ERROR"
+  @js.native
+  sealed trait ActiveDirectoryStatus extends js.Any
+  object ActiveDirectoryStatus extends js.Object {
+    val ACCESS_DENIED = "ACCESS_DENIED".asInstanceOf[ActiveDirectoryStatus]
+    val DETACHED      = "DETACHED".asInstanceOf[ActiveDirectoryStatus]
+    val JOINED        = "JOINED".asInstanceOf[ActiveDirectoryStatus]
+    val JOINING       = "JOINING".asInstanceOf[ActiveDirectoryStatus]
+    val NETWORK_ERROR = "NETWORK_ERROR".asInstanceOf[ActiveDirectoryStatus]
+    val TIMEOUT       = "TIMEOUT".asInstanceOf[ActiveDirectoryStatus]
+    val UNKNOWN_ERROR = "UNKNOWN_ERROR".asInstanceOf[ActiveDirectoryStatus]
 
     val values =
       js.Object.freeze(js.Array(ACCESS_DENIED, DETACHED, JOINED, JOINING, NETWORK_ERROR, TIMEOUT, UNKNOWN_ERROR))
@@ -748,11 +743,12 @@ package storagegateway {
       __obj.asInstanceOf[AttachVolumeOutput]
     }
   }
-
-  object AvailabilityMonitorTestStatusEnum {
-    val COMPLETE = "COMPLETE"
-    val FAILED   = "FAILED"
-    val PENDING  = "PENDING"
+  @js.native
+  sealed trait AvailabilityMonitorTestStatus extends js.Any
+  object AvailabilityMonitorTestStatus extends js.Object {
+    val COMPLETE = "COMPLETE".asInstanceOf[AvailabilityMonitorTestStatus]
+    val FAILED   = "FAILED".asInstanceOf[AvailabilityMonitorTestStatus]
+    val PENDING  = "PENDING".asInstanceOf[AvailabilityMonitorTestStatus]
 
     val values = js.Object.freeze(js.Array(COMPLETE, FAILED, PENDING))
   }
@@ -2767,9 +2763,11 @@ package storagegateway {
   /**
     * The type of the file share.
     */
-  object FileShareTypeEnum {
-    val NFS = "NFS"
-    val SMB = "SMB"
+  @js.native
+  sealed trait FileShareType extends js.Any
+  object FileShareType extends js.Object {
+    val NFS = "NFS".asInstanceOf[FileShareType]
+    val SMB = "SMB".asInstanceOf[FileShareType]
 
     val values = js.Object.freeze(js.Array(NFS, SMB))
   }
@@ -2810,13 +2808,14 @@ package storagegateway {
       __obj.asInstanceOf[GatewayInfo]
     }
   }
-
-  object HostEnvironmentEnum {
-    val VMWARE    = "VMWARE"
-    val `HYPER-V` = "HYPER-V"
-    val EC2       = "EC2"
-    val KVM       = "KVM"
-    val OTHER     = "OTHER"
+  @js.native
+  sealed trait HostEnvironment extends js.Any
+  object HostEnvironment extends js.Object {
+    val VMWARE    = "VMWARE".asInstanceOf[HostEnvironment]
+    val `HYPER-V` = "HYPER-V".asInstanceOf[HostEnvironment]
+    val EC2       = "EC2".asInstanceOf[HostEnvironment]
+    val KVM       = "KVM".asInstanceOf[HostEnvironment]
+    val OTHER     = "OTHER".asInstanceOf[HostEnvironment]
 
     val values = js.Object.freeze(js.Array(VMWARE, `HYPER-V`, EC2, KVM, OTHER))
   }
@@ -3395,14 +3394,16 @@ package storagegateway {
   /**
     * A value that sets the access control list permission for objects in the S3 bucket that a file gateway puts objects into. The default value is "private".
     */
-  object ObjectACLEnum {
-    val `private`                   = "private"
-    val `public-read`               = "public-read"
-    val `public-read-write`         = "public-read-write"
-    val `authenticated-read`        = "authenticated-read"
-    val `bucket-owner-read`         = "bucket-owner-read"
-    val `bucket-owner-full-control` = "bucket-owner-full-control"
-    val `aws-exec-read`             = "aws-exec-read"
+  @js.native
+  sealed trait ObjectACL extends js.Any
+  object ObjectACL extends js.Object {
+    val `private`                   = "private".asInstanceOf[ObjectACL]
+    val `public-read`               = "public-read".asInstanceOf[ObjectACL]
+    val `public-read-write`         = "public-read-write".asInstanceOf[ObjectACL]
+    val `authenticated-read`        = "authenticated-read".asInstanceOf[ObjectACL]
+    val `bucket-owner-read`         = "bucket-owner-read".asInstanceOf[ObjectACL]
+    val `bucket-owner-full-control` = "bucket-owner-full-control".asInstanceOf[ObjectACL]
+    val `aws-exec-read`             = "aws-exec-read".asInstanceOf[ObjectACL]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3680,11 +3681,12 @@ package storagegateway {
       __obj.asInstanceOf[SMBFileShareInfo]
     }
   }
-
-  object SMBSecurityStrategyEnum {
-    val ClientSpecified     = "ClientSpecified"
-    val MandatorySigning    = "MandatorySigning"
-    val MandatoryEncryption = "MandatoryEncryption"
+  @js.native
+  sealed trait SMBSecurityStrategy extends js.Any
+  object SMBSecurityStrategy extends js.Object {
+    val ClientSpecified     = "ClientSpecified".asInstanceOf[SMBSecurityStrategy]
+    val MandatorySigning    = "MandatorySigning".asInstanceOf[SMBSecurityStrategy]
+    val MandatoryEncryption = "MandatoryEncryption".asInstanceOf[SMBSecurityStrategy]
 
     val values = js.Object.freeze(js.Array(ClientSpecified, MandatorySigning, MandatoryEncryption))
   }

--- a/services/swf/src/main/scala/facade/amazonaws/services/SWF.scala
+++ b/services/swf/src/main/scala/facade/amazonaws/services/SWF.scala
@@ -7,80 +7,54 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object swf {
-  type ActivityId                                        = String
-  type ActivityTaskTimeoutType                           = String
-  type ActivityTypeInfoList                              = js.Array[ActivityTypeInfo]
-  type Arn                                               = String
-  type CancelTimerFailedCause                            = String
-  type CancelWorkflowExecutionFailedCause                = String
-  type Canceled                                          = Boolean
-  type CauseMessage                                      = String
-  type ChildPolicy                                       = String
-  type CloseStatus                                       = String
-  type CompleteWorkflowExecutionFailedCause              = String
-  type ContinueAsNewWorkflowExecutionFailedCause         = String
-  type Count                                             = Int
-  type Data                                              = String
-  type DecisionList                                      = js.Array[Decision]
-  type DecisionTaskTimeoutType                           = String
-  type DecisionType                                      = String
-  type Description                                       = String
-  type DomainInfoList                                    = js.Array[DomainInfo]
-  type DomainName                                        = String
-  type DurationInDays                                    = String
-  type DurationInSeconds                                 = String
-  type DurationInSecondsOptional                         = String
-  type EventId                                           = Double
-  type EventType                                         = String
-  type ExecutionStatus                                   = String
-  type FailWorkflowExecutionFailedCause                  = String
-  type FailureReason                                     = String
-  type FunctionId                                        = String
-  type FunctionInput                                     = String
-  type FunctionName                                      = String
-  type HistoryEventList                                  = js.Array[HistoryEvent]
-  type Identity                                          = String
-  type LambdaFunctionTimeoutType                         = String
-  type LimitedData                                       = String
-  type MarkerName                                        = String
-  type Name                                              = String
-  type OpenDecisionTasksCount                            = Int
-  type PageSize                                          = Int
-  type PageToken                                         = String
-  type RecordMarkerFailedCause                           = String
-  type RegistrationStatus                                = String
-  type RequestCancelActivityTaskFailedCause              = String
-  type RequestCancelExternalWorkflowExecutionFailedCause = String
-  type ResourceTagKey                                    = String
-  type ResourceTagKeyList                                = js.Array[ResourceTagKey]
-  type ResourceTagList                                   = js.Array[ResourceTag]
-  type ResourceTagValue                                  = String
-  type ReverseOrder                                      = Boolean
-  type ScheduleActivityTaskFailedCause                   = String
-  type ScheduleLambdaFunctionFailedCause                 = String
-  type SignalExternalWorkflowExecutionFailedCause        = String
-  type SignalName                                        = String
-  type StartChildWorkflowExecutionFailedCause            = String
-  type StartLambdaFunctionFailedCause                    = String
-  type StartTimerFailedCause                             = String
-  type Tag                                               = String
-  type TagList                                           = js.Array[Tag]
-  type TaskPriority                                      = String
-  type TaskToken                                         = String
-  type TerminateReason                                   = String
-  type TimerId                                           = String
-  type Timestamp                                         = js.Date
-  type Truncated                                         = Boolean
-  type Version                                           = String
-  type VersionOptional                                   = String
-  type WorkflowExecutionCancelRequestedCause             = String
-  type WorkflowExecutionInfoList                         = js.Array[WorkflowExecutionInfo]
-  type WorkflowExecutionTerminatedCause                  = String
-  type WorkflowExecutionTimeoutType                      = String
-  type WorkflowId                                        = String
-  type WorkflowRunId                                     = String
-  type WorkflowRunIdOptional                             = String
-  type WorkflowTypeInfoList                              = js.Array[WorkflowTypeInfo]
+  type ActivityId                = String
+  type ActivityTypeInfoList      = js.Array[ActivityTypeInfo]
+  type Arn                       = String
+  type Canceled                  = Boolean
+  type CauseMessage              = String
+  type Count                     = Int
+  type Data                      = String
+  type DecisionList              = js.Array[Decision]
+  type Description               = String
+  type DomainInfoList            = js.Array[DomainInfo]
+  type DomainName                = String
+  type DurationInDays            = String
+  type DurationInSeconds         = String
+  type DurationInSecondsOptional = String
+  type EventId                   = Double
+  type FailureReason             = String
+  type FunctionId                = String
+  type FunctionInput             = String
+  type FunctionName              = String
+  type HistoryEventList          = js.Array[HistoryEvent]
+  type Identity                  = String
+  type LimitedData               = String
+  type MarkerName                = String
+  type Name                      = String
+  type OpenDecisionTasksCount    = Int
+  type PageSize                  = Int
+  type PageToken                 = String
+  type ResourceTagKey            = String
+  type ResourceTagKeyList        = js.Array[ResourceTagKey]
+  type ResourceTagList           = js.Array[ResourceTag]
+  type ResourceTagValue          = String
+  type ReverseOrder              = Boolean
+  type SignalName                = String
+  type Tag                       = String
+  type TagList                   = js.Array[Tag]
+  type TaskPriority              = String
+  type TaskToken                 = String
+  type TerminateReason           = String
+  type TimerId                   = String
+  type Timestamp                 = js.Date
+  type Truncated                 = Boolean
+  type Version                   = String
+  type VersionOptional           = String
+  type WorkflowExecutionInfoList = js.Array[WorkflowExecutionInfo]
+  type WorkflowId                = String
+  type WorkflowRunId             = String
+  type WorkflowRunIdOptional     = String
+  type WorkflowTypeInfoList      = js.Array[WorkflowTypeInfo]
 
   implicit final class SWFOps(private val service: SWF) extends AnyVal {
 
@@ -489,12 +463,13 @@ package swf {
       __obj.asInstanceOf[ActivityTaskTimedOutEventAttributes]
     }
   }
-
-  object ActivityTaskTimeoutTypeEnum {
-    val START_TO_CLOSE    = "START_TO_CLOSE"
-    val SCHEDULE_TO_START = "SCHEDULE_TO_START"
-    val SCHEDULE_TO_CLOSE = "SCHEDULE_TO_CLOSE"
-    val HEARTBEAT         = "HEARTBEAT"
+  @js.native
+  sealed trait ActivityTaskTimeoutType extends js.Any
+  object ActivityTaskTimeoutType extends js.Object {
+    val START_TO_CLOSE    = "START_TO_CLOSE".asInstanceOf[ActivityTaskTimeoutType]
+    val SCHEDULE_TO_START = "SCHEDULE_TO_START".asInstanceOf[ActivityTaskTimeoutType]
+    val SCHEDULE_TO_CLOSE = "SCHEDULE_TO_CLOSE".asInstanceOf[ActivityTaskTimeoutType]
+    val HEARTBEAT         = "HEARTBEAT".asInstanceOf[ActivityTaskTimeoutType]
 
     val values = js.Object.freeze(js.Array(START_TO_CLOSE, SCHEDULE_TO_START, SCHEDULE_TO_CLOSE, HEARTBEAT))
   }
@@ -672,10 +647,11 @@ package swf {
       __obj.asInstanceOf[CancelTimerDecisionAttributes]
     }
   }
-
-  object CancelTimerFailedCauseEnum {
-    val TIMER_ID_UNKNOWN        = "TIMER_ID_UNKNOWN"
-    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait CancelTimerFailedCause extends js.Any
+  object CancelTimerFailedCause extends js.Object {
+    val TIMER_ID_UNKNOWN        = "TIMER_ID_UNKNOWN".asInstanceOf[CancelTimerFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[CancelTimerFailedCause]
 
     val values = js.Object.freeze(js.Array(TIMER_ID_UNKNOWN, OPERATION_NOT_PERMITTED))
   }
@@ -731,10 +707,11 @@ package swf {
       __obj.asInstanceOf[CancelWorkflowExecutionDecisionAttributes]
     }
   }
-
-  object CancelWorkflowExecutionFailedCauseEnum {
-    val UNHANDLED_DECISION      = "UNHANDLED_DECISION"
-    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait CancelWorkflowExecutionFailedCause extends js.Any
+  object CancelWorkflowExecutionFailedCause extends js.Object {
+    val UNHANDLED_DECISION      = "UNHANDLED_DECISION".asInstanceOf[CancelWorkflowExecutionFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[CancelWorkflowExecutionFailedCause]
 
     val values = js.Object.freeze(js.Array(UNHANDLED_DECISION, OPERATION_NOT_PERMITTED))
   }
@@ -762,11 +739,12 @@ package swf {
       __obj.asInstanceOf[CancelWorkflowExecutionFailedEventAttributes]
     }
   }
-
-  object ChildPolicyEnum {
-    val TERMINATE      = "TERMINATE"
-    val REQUEST_CANCEL = "REQUEST_CANCEL"
-    val ABANDON        = "ABANDON"
+  @js.native
+  sealed trait ChildPolicy extends js.Any
+  object ChildPolicy extends js.Object {
+    val TERMINATE      = "TERMINATE".asInstanceOf[ChildPolicy]
+    val REQUEST_CANCEL = "REQUEST_CANCEL".asInstanceOf[ChildPolicy]
+    val ABANDON        = "ABANDON".asInstanceOf[ChildPolicy]
 
     val values = js.Object.freeze(js.Array(TERMINATE, REQUEST_CANCEL, ABANDON))
   }
@@ -962,14 +940,15 @@ package swf {
       __obj.asInstanceOf[ChildWorkflowExecutionTimedOutEventAttributes]
     }
   }
-
-  object CloseStatusEnum {
-    val COMPLETED        = "COMPLETED"
-    val FAILED           = "FAILED"
-    val CANCELED         = "CANCELED"
-    val TERMINATED       = "TERMINATED"
-    val CONTINUED_AS_NEW = "CONTINUED_AS_NEW"
-    val TIMED_OUT        = "TIMED_OUT"
+  @js.native
+  sealed trait CloseStatus extends js.Any
+  object CloseStatus extends js.Object {
+    val COMPLETED        = "COMPLETED".asInstanceOf[CloseStatus]
+    val FAILED           = "FAILED".asInstanceOf[CloseStatus]
+    val CANCELED         = "CANCELED".asInstanceOf[CloseStatus]
+    val TERMINATED       = "TERMINATED".asInstanceOf[CloseStatus]
+    val CONTINUED_AS_NEW = "CONTINUED_AS_NEW".asInstanceOf[CloseStatus]
+    val TIMED_OUT        = "TIMED_OUT".asInstanceOf[CloseStatus]
 
     val values = js.Object.freeze(js.Array(COMPLETED, FAILED, CANCELED, TERMINATED, CONTINUED_AS_NEW, TIMED_OUT))
   }
@@ -1019,10 +998,11 @@ package swf {
       __obj.asInstanceOf[CompleteWorkflowExecutionDecisionAttributes]
     }
   }
-
-  object CompleteWorkflowExecutionFailedCauseEnum {
-    val UNHANDLED_DECISION      = "UNHANDLED_DECISION"
-    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait CompleteWorkflowExecutionFailedCause extends js.Any
+  object CompleteWorkflowExecutionFailedCause extends js.Object {
+    val UNHANDLED_DECISION      = "UNHANDLED_DECISION".asInstanceOf[CompleteWorkflowExecutionFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[CompleteWorkflowExecutionFailedCause]
 
     val values = js.Object.freeze(js.Array(UNHANDLED_DECISION, OPERATION_NOT_PERMITTED))
   }
@@ -1104,17 +1084,24 @@ package swf {
       __obj.asInstanceOf[ContinueAsNewWorkflowExecutionDecisionAttributes]
     }
   }
-
-  object ContinueAsNewWorkflowExecutionFailedCauseEnum {
-    val UNHANDLED_DECISION                                 = "UNHANDLED_DECISION"
-    val WORKFLOW_TYPE_DEPRECATED                           = "WORKFLOW_TYPE_DEPRECATED"
-    val WORKFLOW_TYPE_DOES_NOT_EXIST                       = "WORKFLOW_TYPE_DOES_NOT_EXIST"
-    val DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED = "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED"
-    val DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED      = "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
-    val DEFAULT_TASK_LIST_UNDEFINED                        = "DEFAULT_TASK_LIST_UNDEFINED"
-    val DEFAULT_CHILD_POLICY_UNDEFINED                     = "DEFAULT_CHILD_POLICY_UNDEFINED"
-    val CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED   = "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED"
-    val OPERATION_NOT_PERMITTED                            = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait ContinueAsNewWorkflowExecutionFailedCause extends js.Any
+  object ContinueAsNewWorkflowExecutionFailedCause extends js.Object {
+    val UNHANDLED_DECISION       = "UNHANDLED_DECISION".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val WORKFLOW_TYPE_DEPRECATED = "WORKFLOW_TYPE_DEPRECATED".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val WORKFLOW_TYPE_DOES_NOT_EXIST =
+      "WORKFLOW_TYPE_DOES_NOT_EXIST".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED =
+      "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED =
+      "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val DEFAULT_TASK_LIST_UNDEFINED =
+      "DEFAULT_TASK_LIST_UNDEFINED".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val DEFAULT_CHILD_POLICY_UNDEFINED =
+      "DEFAULT_CHILD_POLICY_UNDEFINED".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED =
+      "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[ContinueAsNewWorkflowExecutionFailedCause]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1550,27 +1537,29 @@ package swf {
       __obj.asInstanceOf[DecisionTaskTimedOutEventAttributes]
     }
   }
-
-  object DecisionTaskTimeoutTypeEnum {
-    val START_TO_CLOSE = "START_TO_CLOSE"
+  @js.native
+  sealed trait DecisionTaskTimeoutType extends js.Any
+  object DecisionTaskTimeoutType extends js.Object {
+    val START_TO_CLOSE = "START_TO_CLOSE".asInstanceOf[DecisionTaskTimeoutType]
 
     val values = js.Object.freeze(js.Array(START_TO_CLOSE))
   }
-
-  object DecisionTypeEnum {
-    val ScheduleActivityTask                   = "ScheduleActivityTask"
-    val RequestCancelActivityTask              = "RequestCancelActivityTask"
-    val CompleteWorkflowExecution              = "CompleteWorkflowExecution"
-    val FailWorkflowExecution                  = "FailWorkflowExecution"
-    val CancelWorkflowExecution                = "CancelWorkflowExecution"
-    val ContinueAsNewWorkflowExecution         = "ContinueAsNewWorkflowExecution"
-    val RecordMarker                           = "RecordMarker"
-    val StartTimer                             = "StartTimer"
-    val CancelTimer                            = "CancelTimer"
-    val SignalExternalWorkflowExecution        = "SignalExternalWorkflowExecution"
-    val RequestCancelExternalWorkflowExecution = "RequestCancelExternalWorkflowExecution"
-    val StartChildWorkflowExecution            = "StartChildWorkflowExecution"
-    val ScheduleLambdaFunction                 = "ScheduleLambdaFunction"
+  @js.native
+  sealed trait DecisionType extends js.Any
+  object DecisionType extends js.Object {
+    val ScheduleActivityTask                   = "ScheduleActivityTask".asInstanceOf[DecisionType]
+    val RequestCancelActivityTask              = "RequestCancelActivityTask".asInstanceOf[DecisionType]
+    val CompleteWorkflowExecution              = "CompleteWorkflowExecution".asInstanceOf[DecisionType]
+    val FailWorkflowExecution                  = "FailWorkflowExecution".asInstanceOf[DecisionType]
+    val CancelWorkflowExecution                = "CancelWorkflowExecution".asInstanceOf[DecisionType]
+    val ContinueAsNewWorkflowExecution         = "ContinueAsNewWorkflowExecution".asInstanceOf[DecisionType]
+    val RecordMarker                           = "RecordMarker".asInstanceOf[DecisionType]
+    val StartTimer                             = "StartTimer".asInstanceOf[DecisionType]
+    val CancelTimer                            = "CancelTimer".asInstanceOf[DecisionType]
+    val SignalExternalWorkflowExecution        = "SignalExternalWorkflowExecution".asInstanceOf[DecisionType]
+    val RequestCancelExternalWorkflowExecution = "RequestCancelExternalWorkflowExecution".asInstanceOf[DecisionType]
+    val StartChildWorkflowExecution            = "StartChildWorkflowExecution".asInstanceOf[DecisionType]
+    val ScheduleLambdaFunction                 = "ScheduleLambdaFunction".asInstanceOf[DecisionType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1830,62 +1819,65 @@ package swf {
       __obj.asInstanceOf[DomainInfos]
     }
   }
-
-  object EventTypeEnum {
-    val WorkflowExecutionStarted                        = "WorkflowExecutionStarted"
-    val WorkflowExecutionCancelRequested                = "WorkflowExecutionCancelRequested"
-    val WorkflowExecutionCompleted                      = "WorkflowExecutionCompleted"
-    val CompleteWorkflowExecutionFailed                 = "CompleteWorkflowExecutionFailed"
-    val WorkflowExecutionFailed                         = "WorkflowExecutionFailed"
-    val FailWorkflowExecutionFailed                     = "FailWorkflowExecutionFailed"
-    val WorkflowExecutionTimedOut                       = "WorkflowExecutionTimedOut"
-    val WorkflowExecutionCanceled                       = "WorkflowExecutionCanceled"
-    val CancelWorkflowExecutionFailed                   = "CancelWorkflowExecutionFailed"
-    val WorkflowExecutionContinuedAsNew                 = "WorkflowExecutionContinuedAsNew"
-    val ContinueAsNewWorkflowExecutionFailed            = "ContinueAsNewWorkflowExecutionFailed"
-    val WorkflowExecutionTerminated                     = "WorkflowExecutionTerminated"
-    val DecisionTaskScheduled                           = "DecisionTaskScheduled"
-    val DecisionTaskStarted                             = "DecisionTaskStarted"
-    val DecisionTaskCompleted                           = "DecisionTaskCompleted"
-    val DecisionTaskTimedOut                            = "DecisionTaskTimedOut"
-    val ActivityTaskScheduled                           = "ActivityTaskScheduled"
-    val ScheduleActivityTaskFailed                      = "ScheduleActivityTaskFailed"
-    val ActivityTaskStarted                             = "ActivityTaskStarted"
-    val ActivityTaskCompleted                           = "ActivityTaskCompleted"
-    val ActivityTaskFailed                              = "ActivityTaskFailed"
-    val ActivityTaskTimedOut                            = "ActivityTaskTimedOut"
-    val ActivityTaskCanceled                            = "ActivityTaskCanceled"
-    val ActivityTaskCancelRequested                     = "ActivityTaskCancelRequested"
-    val RequestCancelActivityTaskFailed                 = "RequestCancelActivityTaskFailed"
-    val WorkflowExecutionSignaled                       = "WorkflowExecutionSignaled"
-    val MarkerRecorded                                  = "MarkerRecorded"
-    val RecordMarkerFailed                              = "RecordMarkerFailed"
-    val TimerStarted                                    = "TimerStarted"
-    val StartTimerFailed                                = "StartTimerFailed"
-    val TimerFired                                      = "TimerFired"
-    val TimerCanceled                                   = "TimerCanceled"
-    val CancelTimerFailed                               = "CancelTimerFailed"
-    val StartChildWorkflowExecutionInitiated            = "StartChildWorkflowExecutionInitiated"
-    val StartChildWorkflowExecutionFailed               = "StartChildWorkflowExecutionFailed"
-    val ChildWorkflowExecutionStarted                   = "ChildWorkflowExecutionStarted"
-    val ChildWorkflowExecutionCompleted                 = "ChildWorkflowExecutionCompleted"
-    val ChildWorkflowExecutionFailed                    = "ChildWorkflowExecutionFailed"
-    val ChildWorkflowExecutionTimedOut                  = "ChildWorkflowExecutionTimedOut"
-    val ChildWorkflowExecutionCanceled                  = "ChildWorkflowExecutionCanceled"
-    val ChildWorkflowExecutionTerminated                = "ChildWorkflowExecutionTerminated"
-    val SignalExternalWorkflowExecutionInitiated        = "SignalExternalWorkflowExecutionInitiated"
-    val SignalExternalWorkflowExecutionFailed           = "SignalExternalWorkflowExecutionFailed"
-    val ExternalWorkflowExecutionSignaled               = "ExternalWorkflowExecutionSignaled"
-    val RequestCancelExternalWorkflowExecutionInitiated = "RequestCancelExternalWorkflowExecutionInitiated"
-    val RequestCancelExternalWorkflowExecutionFailed    = "RequestCancelExternalWorkflowExecutionFailed"
-    val ExternalWorkflowExecutionCancelRequested        = "ExternalWorkflowExecutionCancelRequested"
-    val LambdaFunctionScheduled                         = "LambdaFunctionScheduled"
-    val LambdaFunctionStarted                           = "LambdaFunctionStarted"
-    val LambdaFunctionCompleted                         = "LambdaFunctionCompleted"
-    val LambdaFunctionFailed                            = "LambdaFunctionFailed"
-    val LambdaFunctionTimedOut                          = "LambdaFunctionTimedOut"
-    val ScheduleLambdaFunctionFailed                    = "ScheduleLambdaFunctionFailed"
-    val StartLambdaFunctionFailed                       = "StartLambdaFunctionFailed"
+  @js.native
+  sealed trait EventType extends js.Any
+  object EventType extends js.Object {
+    val WorkflowExecutionStarted                 = "WorkflowExecutionStarted".asInstanceOf[EventType]
+    val WorkflowExecutionCancelRequested         = "WorkflowExecutionCancelRequested".asInstanceOf[EventType]
+    val WorkflowExecutionCompleted               = "WorkflowExecutionCompleted".asInstanceOf[EventType]
+    val CompleteWorkflowExecutionFailed          = "CompleteWorkflowExecutionFailed".asInstanceOf[EventType]
+    val WorkflowExecutionFailed                  = "WorkflowExecutionFailed".asInstanceOf[EventType]
+    val FailWorkflowExecutionFailed              = "FailWorkflowExecutionFailed".asInstanceOf[EventType]
+    val WorkflowExecutionTimedOut                = "WorkflowExecutionTimedOut".asInstanceOf[EventType]
+    val WorkflowExecutionCanceled                = "WorkflowExecutionCanceled".asInstanceOf[EventType]
+    val CancelWorkflowExecutionFailed            = "CancelWorkflowExecutionFailed".asInstanceOf[EventType]
+    val WorkflowExecutionContinuedAsNew          = "WorkflowExecutionContinuedAsNew".asInstanceOf[EventType]
+    val ContinueAsNewWorkflowExecutionFailed     = "ContinueAsNewWorkflowExecutionFailed".asInstanceOf[EventType]
+    val WorkflowExecutionTerminated              = "WorkflowExecutionTerminated".asInstanceOf[EventType]
+    val DecisionTaskScheduled                    = "DecisionTaskScheduled".asInstanceOf[EventType]
+    val DecisionTaskStarted                      = "DecisionTaskStarted".asInstanceOf[EventType]
+    val DecisionTaskCompleted                    = "DecisionTaskCompleted".asInstanceOf[EventType]
+    val DecisionTaskTimedOut                     = "DecisionTaskTimedOut".asInstanceOf[EventType]
+    val ActivityTaskScheduled                    = "ActivityTaskScheduled".asInstanceOf[EventType]
+    val ScheduleActivityTaskFailed               = "ScheduleActivityTaskFailed".asInstanceOf[EventType]
+    val ActivityTaskStarted                      = "ActivityTaskStarted".asInstanceOf[EventType]
+    val ActivityTaskCompleted                    = "ActivityTaskCompleted".asInstanceOf[EventType]
+    val ActivityTaskFailed                       = "ActivityTaskFailed".asInstanceOf[EventType]
+    val ActivityTaskTimedOut                     = "ActivityTaskTimedOut".asInstanceOf[EventType]
+    val ActivityTaskCanceled                     = "ActivityTaskCanceled".asInstanceOf[EventType]
+    val ActivityTaskCancelRequested              = "ActivityTaskCancelRequested".asInstanceOf[EventType]
+    val RequestCancelActivityTaskFailed          = "RequestCancelActivityTaskFailed".asInstanceOf[EventType]
+    val WorkflowExecutionSignaled                = "WorkflowExecutionSignaled".asInstanceOf[EventType]
+    val MarkerRecorded                           = "MarkerRecorded".asInstanceOf[EventType]
+    val RecordMarkerFailed                       = "RecordMarkerFailed".asInstanceOf[EventType]
+    val TimerStarted                             = "TimerStarted".asInstanceOf[EventType]
+    val StartTimerFailed                         = "StartTimerFailed".asInstanceOf[EventType]
+    val TimerFired                               = "TimerFired".asInstanceOf[EventType]
+    val TimerCanceled                            = "TimerCanceled".asInstanceOf[EventType]
+    val CancelTimerFailed                        = "CancelTimerFailed".asInstanceOf[EventType]
+    val StartChildWorkflowExecutionInitiated     = "StartChildWorkflowExecutionInitiated".asInstanceOf[EventType]
+    val StartChildWorkflowExecutionFailed        = "StartChildWorkflowExecutionFailed".asInstanceOf[EventType]
+    val ChildWorkflowExecutionStarted            = "ChildWorkflowExecutionStarted".asInstanceOf[EventType]
+    val ChildWorkflowExecutionCompleted          = "ChildWorkflowExecutionCompleted".asInstanceOf[EventType]
+    val ChildWorkflowExecutionFailed             = "ChildWorkflowExecutionFailed".asInstanceOf[EventType]
+    val ChildWorkflowExecutionTimedOut           = "ChildWorkflowExecutionTimedOut".asInstanceOf[EventType]
+    val ChildWorkflowExecutionCanceled           = "ChildWorkflowExecutionCanceled".asInstanceOf[EventType]
+    val ChildWorkflowExecutionTerminated         = "ChildWorkflowExecutionTerminated".asInstanceOf[EventType]
+    val SignalExternalWorkflowExecutionInitiated = "SignalExternalWorkflowExecutionInitiated".asInstanceOf[EventType]
+    val SignalExternalWorkflowExecutionFailed    = "SignalExternalWorkflowExecutionFailed".asInstanceOf[EventType]
+    val ExternalWorkflowExecutionSignaled        = "ExternalWorkflowExecutionSignaled".asInstanceOf[EventType]
+    val RequestCancelExternalWorkflowExecutionInitiated =
+      "RequestCancelExternalWorkflowExecutionInitiated".asInstanceOf[EventType]
+    val RequestCancelExternalWorkflowExecutionFailed =
+      "RequestCancelExternalWorkflowExecutionFailed".asInstanceOf[EventType]
+    val ExternalWorkflowExecutionCancelRequested = "ExternalWorkflowExecutionCancelRequested".asInstanceOf[EventType]
+    val LambdaFunctionScheduled                  = "LambdaFunctionScheduled".asInstanceOf[EventType]
+    val LambdaFunctionStarted                    = "LambdaFunctionStarted".asInstanceOf[EventType]
+    val LambdaFunctionCompleted                  = "LambdaFunctionCompleted".asInstanceOf[EventType]
+    val LambdaFunctionFailed                     = "LambdaFunctionFailed".asInstanceOf[EventType]
+    val LambdaFunctionTimedOut                   = "LambdaFunctionTimedOut".asInstanceOf[EventType]
+    val ScheduleLambdaFunctionFailed             = "ScheduleLambdaFunctionFailed".asInstanceOf[EventType]
+    val StartLambdaFunctionFailed                = "StartLambdaFunctionFailed".asInstanceOf[EventType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1946,10 +1938,11 @@ package swf {
       )
     )
   }
-
-  object ExecutionStatusEnum {
-    val OPEN   = "OPEN"
-    val CLOSED = "CLOSED"
+  @js.native
+  sealed trait ExecutionStatus extends js.Any
+  object ExecutionStatus extends js.Object {
+    val OPEN   = "OPEN".asInstanceOf[ExecutionStatus]
+    val CLOSED = "CLOSED".asInstanceOf[ExecutionStatus]
 
     val values = js.Object.freeze(js.Array(OPEN, CLOSED))
   }
@@ -2053,10 +2046,11 @@ package swf {
       __obj.asInstanceOf[FailWorkflowExecutionDecisionAttributes]
     }
   }
-
-  object FailWorkflowExecutionFailedCauseEnum {
-    val UNHANDLED_DECISION      = "UNHANDLED_DECISION"
-    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait FailWorkflowExecutionFailedCause extends js.Any
+  object FailWorkflowExecutionFailedCause extends js.Object {
+    val UNHANDLED_DECISION      = "UNHANDLED_DECISION".asInstanceOf[FailWorkflowExecutionFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[FailWorkflowExecutionFailedCause]
 
     val values = js.Object.freeze(js.Array(UNHANDLED_DECISION, OPERATION_NOT_PERMITTED))
   }
@@ -2669,9 +2663,10 @@ package swf {
       __obj.asInstanceOf[LambdaFunctionTimedOutEventAttributes]
     }
   }
-
-  object LambdaFunctionTimeoutTypeEnum {
-    val START_TO_CLOSE = "START_TO_CLOSE"
+  @js.native
+  sealed trait LambdaFunctionTimeoutType extends js.Any
+  object LambdaFunctionTimeoutType extends js.Object {
+    val START_TO_CLOSE = "START_TO_CLOSE".asInstanceOf[LambdaFunctionTimeoutType]
 
     val values = js.Object.freeze(js.Array(START_TO_CLOSE))
   }
@@ -3045,9 +3040,10 @@ package swf {
       __obj.asInstanceOf[RecordMarkerDecisionAttributes]
     }
   }
-
-  object RecordMarkerFailedCauseEnum {
-    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait RecordMarkerFailedCause extends js.Any
+  object RecordMarkerFailedCause extends js.Object {
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[RecordMarkerFailedCause]
 
     val values = js.Object.freeze(js.Array(OPERATION_NOT_PERMITTED))
   }
@@ -3207,10 +3203,11 @@ package swf {
       __obj.asInstanceOf[RegisterWorkflowTypeInput]
     }
   }
-
-  object RegistrationStatusEnum {
-    val REGISTERED = "REGISTERED"
-    val DEPRECATED = "DEPRECATED"
+  @js.native
+  sealed trait RegistrationStatus extends js.Any
+  object RegistrationStatus extends js.Object {
+    val REGISTERED = "REGISTERED".asInstanceOf[RegistrationStatus]
+    val DEPRECATED = "DEPRECATED".asInstanceOf[RegistrationStatus]
 
     val values = js.Object.freeze(js.Array(REGISTERED, DEPRECATED))
   }
@@ -3241,10 +3238,11 @@ package swf {
       __obj.asInstanceOf[RequestCancelActivityTaskDecisionAttributes]
     }
   }
-
-  object RequestCancelActivityTaskFailedCauseEnum {
-    val ACTIVITY_ID_UNKNOWN     = "ACTIVITY_ID_UNKNOWN"
-    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait RequestCancelActivityTaskFailedCause extends js.Any
+  object RequestCancelActivityTaskFailedCause extends js.Object {
+    val ACTIVITY_ID_UNKNOWN     = "ACTIVITY_ID_UNKNOWN".asInstanceOf[RequestCancelActivityTaskFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[RequestCancelActivityTaskFailedCause]
 
     val values = js.Object.freeze(js.Array(ACTIVITY_ID_UNKNOWN, OPERATION_NOT_PERMITTED))
   }
@@ -3308,12 +3306,16 @@ package swf {
       __obj.asInstanceOf[RequestCancelExternalWorkflowExecutionDecisionAttributes]
     }
   }
-
-  object RequestCancelExternalWorkflowExecutionFailedCauseEnum {
-    val UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION = "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
+  @js.native
+  sealed trait RequestCancelExternalWorkflowExecutionFailedCause extends js.Any
+  object RequestCancelExternalWorkflowExecutionFailedCause extends js.Object {
+    val UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION =
+      "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION".asInstanceOf[RequestCancelExternalWorkflowExecutionFailedCause]
     val REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED =
       "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
-    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED"
+        .asInstanceOf[RequestCancelExternalWorkflowExecutionFailedCause]
+    val OPERATION_NOT_PERMITTED =
+      "OPERATION_NOT_PERMITTED".asInstanceOf[RequestCancelExternalWorkflowExecutionFailedCause]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3607,19 +3609,25 @@ package swf {
       __obj.asInstanceOf[ScheduleActivityTaskDecisionAttributes]
     }
   }
-
-  object ScheduleActivityTaskFailedCauseEnum {
-    val ACTIVITY_TYPE_DEPRECATED                    = "ACTIVITY_TYPE_DEPRECATED"
-    val ACTIVITY_TYPE_DOES_NOT_EXIST                = "ACTIVITY_TYPE_DOES_NOT_EXIST"
-    val ACTIVITY_ID_ALREADY_IN_USE                  = "ACTIVITY_ID_ALREADY_IN_USE"
-    val OPEN_ACTIVITIES_LIMIT_EXCEEDED              = "OPEN_ACTIVITIES_LIMIT_EXCEEDED"
-    val ACTIVITY_CREATION_RATE_EXCEEDED             = "ACTIVITY_CREATION_RATE_EXCEEDED"
-    val DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED = "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED"
-    val DEFAULT_TASK_LIST_UNDEFINED                 = "DEFAULT_TASK_LIST_UNDEFINED"
-    val DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED = "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED"
-    val DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED    = "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED"
-    val DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED         = "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED"
-    val OPERATION_NOT_PERMITTED                     = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait ScheduleActivityTaskFailedCause extends js.Any
+  object ScheduleActivityTaskFailedCause extends js.Object {
+    val ACTIVITY_TYPE_DEPRECATED       = "ACTIVITY_TYPE_DEPRECATED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val ACTIVITY_TYPE_DOES_NOT_EXIST   = "ACTIVITY_TYPE_DOES_NOT_EXIST".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val ACTIVITY_ID_ALREADY_IN_USE     = "ACTIVITY_ID_ALREADY_IN_USE".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val OPEN_ACTIVITIES_LIMIT_EXCEEDED = "OPEN_ACTIVITIES_LIMIT_EXCEEDED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val ACTIVITY_CREATION_RATE_EXCEEDED =
+      "ACTIVITY_CREATION_RATE_EXCEEDED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED =
+      "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val DEFAULT_TASK_LIST_UNDEFINED = "DEFAULT_TASK_LIST_UNDEFINED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED =
+      "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED =
+      "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED =
+      "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED".asInstanceOf[ScheduleActivityTaskFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[ScheduleActivityTaskFailedCause]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3700,12 +3708,16 @@ package swf {
       __obj.asInstanceOf[ScheduleLambdaFunctionDecisionAttributes]
     }
   }
-
-  object ScheduleLambdaFunctionFailedCauseEnum {
-    val ID_ALREADY_IN_USE                      = "ID_ALREADY_IN_USE"
-    val OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED   = "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED"
-    val LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED = "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED"
-    val LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION = "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
+  @js.native
+  sealed trait ScheduleLambdaFunctionFailedCause extends js.Any
+  object ScheduleLambdaFunctionFailedCause extends js.Object {
+    val ID_ALREADY_IN_USE = "ID_ALREADY_IN_USE".asInstanceOf[ScheduleLambdaFunctionFailedCause]
+    val OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED =
+      "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED".asInstanceOf[ScheduleLambdaFunctionFailedCause]
+    val LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED =
+      "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED".asInstanceOf[ScheduleLambdaFunctionFailedCause]
+    val LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION =
+      "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION".asInstanceOf[ScheduleLambdaFunctionFailedCause]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3785,11 +3797,14 @@ package swf {
       __obj.asInstanceOf[SignalExternalWorkflowExecutionDecisionAttributes]
     }
   }
-
-  object SignalExternalWorkflowExecutionFailedCauseEnum {
-    val UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION              = "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
-    val SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED = "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED"
-    val OPERATION_NOT_PERMITTED                          = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait SignalExternalWorkflowExecutionFailedCause extends js.Any
+  object SignalExternalWorkflowExecutionFailedCause extends js.Object {
+    val UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION =
+      "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION".asInstanceOf[SignalExternalWorkflowExecutionFailedCause]
+    val SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED =
+      "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED".asInstanceOf[SignalExternalWorkflowExecutionFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[SignalExternalWorkflowExecutionFailedCause]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3964,19 +3979,27 @@ package swf {
       __obj.asInstanceOf[StartChildWorkflowExecutionDecisionAttributes]
     }
   }
-
-  object StartChildWorkflowExecutionFailedCauseEnum {
-    val WORKFLOW_TYPE_DOES_NOT_EXIST                       = "WORKFLOW_TYPE_DOES_NOT_EXIST"
-    val WORKFLOW_TYPE_DEPRECATED                           = "WORKFLOW_TYPE_DEPRECATED"
-    val OPEN_CHILDREN_LIMIT_EXCEEDED                       = "OPEN_CHILDREN_LIMIT_EXCEEDED"
-    val OPEN_WORKFLOWS_LIMIT_EXCEEDED                      = "OPEN_WORKFLOWS_LIMIT_EXCEEDED"
-    val CHILD_CREATION_RATE_EXCEEDED                       = "CHILD_CREATION_RATE_EXCEEDED"
-    val WORKFLOW_ALREADY_RUNNING                           = "WORKFLOW_ALREADY_RUNNING"
-    val DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED = "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED"
-    val DEFAULT_TASK_LIST_UNDEFINED                        = "DEFAULT_TASK_LIST_UNDEFINED"
-    val DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED      = "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED"
-    val DEFAULT_CHILD_POLICY_UNDEFINED                     = "DEFAULT_CHILD_POLICY_UNDEFINED"
-    val OPERATION_NOT_PERMITTED                            = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait StartChildWorkflowExecutionFailedCause extends js.Any
+  object StartChildWorkflowExecutionFailedCause extends js.Object {
+    val WORKFLOW_TYPE_DOES_NOT_EXIST =
+      "WORKFLOW_TYPE_DOES_NOT_EXIST".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val WORKFLOW_TYPE_DEPRECATED = "WORKFLOW_TYPE_DEPRECATED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val OPEN_CHILDREN_LIMIT_EXCEEDED =
+      "OPEN_CHILDREN_LIMIT_EXCEEDED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val OPEN_WORKFLOWS_LIMIT_EXCEEDED =
+      "OPEN_WORKFLOWS_LIMIT_EXCEEDED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val CHILD_CREATION_RATE_EXCEEDED =
+      "CHILD_CREATION_RATE_EXCEEDED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val WORKFLOW_ALREADY_RUNNING = "WORKFLOW_ALREADY_RUNNING".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED =
+      "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val DEFAULT_TASK_LIST_UNDEFINED = "DEFAULT_TASK_LIST_UNDEFINED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED =
+      "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val DEFAULT_CHILD_POLICY_UNDEFINED =
+      "DEFAULT_CHILD_POLICY_UNDEFINED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
+    val OPERATION_NOT_PERMITTED = "OPERATION_NOT_PERMITTED".asInstanceOf[StartChildWorkflowExecutionFailedCause]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4086,9 +4109,10 @@ package swf {
       __obj.asInstanceOf[StartChildWorkflowExecutionInitiatedEventAttributes]
     }
   }
-
-  object StartLambdaFunctionFailedCauseEnum {
-    val ASSUME_ROLE_FAILED = "ASSUME_ROLE_FAILED"
+  @js.native
+  sealed trait StartLambdaFunctionFailedCause extends js.Any
+  object StartLambdaFunctionFailedCause extends js.Object {
+    val ASSUME_ROLE_FAILED = "ASSUME_ROLE_FAILED".asInstanceOf[StartLambdaFunctionFailedCause]
 
     val values = js.Object.freeze(js.Array(ASSUME_ROLE_FAILED))
   }
@@ -4150,12 +4174,13 @@ package swf {
       __obj.asInstanceOf[StartTimerDecisionAttributes]
     }
   }
-
-  object StartTimerFailedCauseEnum {
-    val TIMER_ID_ALREADY_IN_USE      = "TIMER_ID_ALREADY_IN_USE"
-    val OPEN_TIMERS_LIMIT_EXCEEDED   = "OPEN_TIMERS_LIMIT_EXCEEDED"
-    val TIMER_CREATION_RATE_EXCEEDED = "TIMER_CREATION_RATE_EXCEEDED"
-    val OPERATION_NOT_PERMITTED      = "OPERATION_NOT_PERMITTED"
+  @js.native
+  sealed trait StartTimerFailedCause extends js.Any
+  object StartTimerFailedCause extends js.Object {
+    val TIMER_ID_ALREADY_IN_USE      = "TIMER_ID_ALREADY_IN_USE".asInstanceOf[StartTimerFailedCause]
+    val OPEN_TIMERS_LIMIT_EXCEEDED   = "OPEN_TIMERS_LIMIT_EXCEEDED".asInstanceOf[StartTimerFailedCause]
+    val TIMER_CREATION_RATE_EXCEEDED = "TIMER_CREATION_RATE_EXCEEDED".asInstanceOf[StartTimerFailedCause]
+    val OPERATION_NOT_PERMITTED      = "OPERATION_NOT_PERMITTED".asInstanceOf[StartTimerFailedCause]
 
     val values = js.Object.freeze(
       js.Array(
@@ -4525,9 +4550,10 @@ package swf {
       __obj.asInstanceOf[WorkflowExecution]
     }
   }
-
-  object WorkflowExecutionCancelRequestedCauseEnum {
-    val CHILD_POLICY_APPLIED = "CHILD_POLICY_APPLIED"
+  @js.native
+  sealed trait WorkflowExecutionCancelRequestedCause extends js.Any
+  object WorkflowExecutionCancelRequestedCause extends js.Object {
+    val CHILD_POLICY_APPLIED = "CHILD_POLICY_APPLIED".asInstanceOf[WorkflowExecutionCancelRequestedCause]
 
     val values = js.Object.freeze(js.Array(CHILD_POLICY_APPLIED))
   }
@@ -4992,11 +5018,12 @@ package swf {
       __obj.asInstanceOf[WorkflowExecutionStartedEventAttributes]
     }
   }
-
-  object WorkflowExecutionTerminatedCauseEnum {
-    val CHILD_POLICY_APPLIED = "CHILD_POLICY_APPLIED"
-    val EVENT_LIMIT_EXCEEDED = "EVENT_LIMIT_EXCEEDED"
-    val OPERATOR_INITIATED   = "OPERATOR_INITIATED"
+  @js.native
+  sealed trait WorkflowExecutionTerminatedCause extends js.Any
+  object WorkflowExecutionTerminatedCause extends js.Object {
+    val CHILD_POLICY_APPLIED = "CHILD_POLICY_APPLIED".asInstanceOf[WorkflowExecutionTerminatedCause]
+    val EVENT_LIMIT_EXCEEDED = "EVENT_LIMIT_EXCEEDED".asInstanceOf[WorkflowExecutionTerminatedCause]
+    val OPERATOR_INITIATED   = "OPERATOR_INITIATED".asInstanceOf[WorkflowExecutionTerminatedCause]
 
     val values = js.Object.freeze(js.Array(CHILD_POLICY_APPLIED, EVENT_LIMIT_EXCEEDED, OPERATOR_INITIATED))
   }
@@ -5054,9 +5081,10 @@ package swf {
       __obj.asInstanceOf[WorkflowExecutionTimedOutEventAttributes]
     }
   }
-
-  object WorkflowExecutionTimeoutTypeEnum {
-    val START_TO_CLOSE = "START_TO_CLOSE"
+  @js.native
+  sealed trait WorkflowExecutionTimeoutType extends js.Any
+  object WorkflowExecutionTimeoutType extends js.Object {
+    val START_TO_CLOSE = "START_TO_CLOSE".asInstanceOf[WorkflowExecutionTimeoutType]
 
     val values = js.Object.freeze(js.Array(START_TO_CLOSE))
   }

--- a/services/textract/src/main/scala/facade/amazonaws/services/Textract.scala
+++ b/services/textract/src/main/scala/facade/amazonaws/services/Textract.scala
@@ -8,14 +8,10 @@ import facade.amazonaws._
 
 package object textract {
   type BlockList                                      = js.Array[Block]
-  type BlockType                                      = String
   type ClientRequestToken                             = String
-  type ContentClassifier                              = String
   type ContentClassifiers                             = js.Array[ContentClassifier]
-  type EntityType                                     = String
   type EntityTypes                                    = js.Array[EntityType]
   type ErrorCode                                      = String
-  type FeatureType                                    = String
   type FeatureTypes                                   = js.Array[FeatureType]
   type FlowDefinitionArn                              = String
   type HumanLoopActivationConditionsEvaluationResults = String
@@ -26,7 +22,6 @@ package object textract {
   type IdList                                         = js.Array[NonEmptyString]
   type ImageBlob                                      = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type JobId                                          = String
-  type JobStatus                                      = String
   type JobTag                                         = String
   type MaxResults                                     = Int
   type NonEmptyString                                 = String
@@ -35,13 +30,11 @@ package object textract {
   type Percent                                        = Float
   type Polygon                                        = js.Array[Point]
   type RelationshipList                               = js.Array[Relationship]
-  type RelationshipType                               = String
   type RoleArn                                        = String
   type S3Bucket                                       = String
   type S3ObjectName                                   = String
   type S3ObjectVersion                                = String
   type SNSTopicArn                                    = String
-  type SelectionStatus                                = String
   type StatusMessage                                  = String
   type UInteger                                       = Int
   type Warnings                                       = js.Array[Warning]
@@ -192,15 +185,16 @@ package textract {
       __obj.asInstanceOf[Block]
     }
   }
-
-  object BlockTypeEnum {
-    val KEY_VALUE_SET     = "KEY_VALUE_SET"
-    val PAGE              = "PAGE"
-    val LINE              = "LINE"
-    val WORD              = "WORD"
-    val TABLE             = "TABLE"
-    val CELL              = "CELL"
-    val SELECTION_ELEMENT = "SELECTION_ELEMENT"
+  @js.native
+  sealed trait BlockType extends js.Any
+  object BlockType extends js.Object {
+    val KEY_VALUE_SET     = "KEY_VALUE_SET".asInstanceOf[BlockType]
+    val PAGE              = "PAGE".asInstanceOf[BlockType]
+    val LINE              = "LINE".asInstanceOf[BlockType]
+    val WORD              = "WORD".asInstanceOf[BlockType]
+    val TABLE             = "TABLE".asInstanceOf[BlockType]
+    val CELL              = "CELL".asInstanceOf[BlockType]
+    val SELECTION_ELEMENT = "SELECTION_ELEMENT".asInstanceOf[BlockType]
 
     val values = js.Object.freeze(js.Array(KEY_VALUE_SET, PAGE, LINE, WORD, TABLE, CELL, SELECTION_ELEMENT))
   }
@@ -234,10 +228,12 @@ package textract {
       __obj.asInstanceOf[BoundingBox]
     }
   }
-
-  object ContentClassifierEnum {
-    val FreeOfPersonallyIdentifiableInformation = "FreeOfPersonallyIdentifiableInformation"
-    val FreeOfAdultContent                      = "FreeOfAdultContent"
+  @js.native
+  sealed trait ContentClassifier extends js.Any
+  object ContentClassifier extends js.Object {
+    val FreeOfPersonallyIdentifiableInformation =
+      "FreeOfPersonallyIdentifiableInformation".asInstanceOf[ContentClassifier]
+    val FreeOfAdultContent = "FreeOfAdultContent".asInstanceOf[ContentClassifier]
 
     val values = js.Object.freeze(js.Array(FreeOfPersonallyIdentifiableInformation, FreeOfAdultContent))
   }
@@ -349,17 +345,19 @@ package textract {
       __obj.asInstanceOf[DocumentMetadata]
     }
   }
-
-  object EntityTypeEnum {
-    val KEY   = "KEY"
-    val VALUE = "VALUE"
+  @js.native
+  sealed trait EntityType extends js.Any
+  object EntityType extends js.Object {
+    val KEY   = "KEY".asInstanceOf[EntityType]
+    val VALUE = "VALUE".asInstanceOf[EntityType]
 
     val values = js.Object.freeze(js.Array(KEY, VALUE))
   }
-
-  object FeatureTypeEnum {
-    val TABLES = "TABLES"
-    val FORMS  = "FORMS"
+  @js.native
+  sealed trait FeatureType extends js.Any
+  object FeatureType extends js.Object {
+    val TABLES = "TABLES".asInstanceOf[FeatureType]
+    val FORMS  = "FORMS".asInstanceOf[FeatureType]
 
     val values = js.Object.freeze(js.Array(TABLES, FORMS))
   }
@@ -581,12 +579,13 @@ package textract {
       __obj.asInstanceOf[HumanLoopDataAttributes]
     }
   }
-
-  object JobStatusEnum {
-    val IN_PROGRESS     = "IN_PROGRESS"
-    val SUCCEEDED       = "SUCCEEDED"
-    val FAILED          = "FAILED"
-    val PARTIAL_SUCCESS = "PARTIAL_SUCCESS"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val IN_PROGRESS     = "IN_PROGRESS".asInstanceOf[JobStatus]
+    val SUCCEEDED       = "SUCCEEDED".asInstanceOf[JobStatus]
+    val FAILED          = "FAILED".asInstanceOf[JobStatus]
+    val PARTIAL_SUCCESS = "PARTIAL_SUCCESS".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(js.Array(IN_PROGRESS, SUCCEEDED, FAILED, PARTIAL_SUCCESS))
   }
@@ -660,10 +659,11 @@ package textract {
       __obj.asInstanceOf[Relationship]
     }
   }
-
-  object RelationshipTypeEnum {
-    val VALUE = "VALUE"
-    val CHILD = "CHILD"
+  @js.native
+  sealed trait RelationshipType extends js.Any
+  object RelationshipType extends js.Object {
+    val VALUE = "VALUE".asInstanceOf[RelationshipType]
+    val CHILD = "CHILD".asInstanceOf[RelationshipType]
 
     val values = js.Object.freeze(js.Array(VALUE, CHILD))
   }
@@ -694,10 +694,11 @@ package textract {
       __obj.asInstanceOf[S3Object]
     }
   }
-
-  object SelectionStatusEnum {
-    val SELECTED     = "SELECTED"
-    val NOT_SELECTED = "NOT_SELECTED"
+  @js.native
+  sealed trait SelectionStatus extends js.Any
+  object SelectionStatus extends js.Object {
+    val SELECTED     = "SELECTED".asInstanceOf[SelectionStatus]
+    val NOT_SELECTED = "NOT_SELECTED".asInstanceOf[SelectionStatus]
 
     val values = js.Object.freeze(js.Array(SELECTED, NOT_SELECTED))
   }

--- a/services/transcribeservice/src/main/scala/facade/amazonaws/services/TranscribeService.scala
+++ b/services/transcribeservice/src/main/scala/facade/amazonaws/services/TranscribeService.scala
@@ -11,27 +11,21 @@ package object transcribeservice {
   type DateTime                  = js.Date
   type FailureReason             = String
   type KMSKeyId                  = String
-  type LanguageCode              = String
   type MaxAlternatives           = Int
   type MaxResults                = Int
   type MaxSpeakers               = Int
-  type MediaFormat               = String
   type MediaSampleRateHertz      = Int
   type NextToken                 = String
   type OutputBucketName          = String
-  type OutputLocationType        = String
   type Phrase                    = String
   type Phrases                   = js.Array[Phrase]
   type TranscriptionJobName      = String
-  type TranscriptionJobStatus    = String
   type TranscriptionJobSummaries = js.Array[TranscriptionJobSummary]
   type Uri                       = String
   type Vocabularies              = js.Array[VocabularyInfo]
-  type VocabularyFilterMethod    = String
   type VocabularyFilterName      = String
   type VocabularyFilters         = js.Array[VocabularyFilterInfo]
   type VocabularyName            = String
-  type VocabularyState           = String
   type Word                      = String
   type Words                     = js.Array[Word]
 
@@ -402,39 +396,40 @@ package transcribeservice {
       __obj.asInstanceOf[JobExecutionSettings]
     }
   }
-
-  object LanguageCodeEnum {
-    val `en-US` = "en-US"
-    val `es-US` = "es-US"
-    val `en-AU` = "en-AU"
-    val `fr-CA` = "fr-CA"
-    val `en-GB` = "en-GB"
-    val `de-DE` = "de-DE"
-    val `pt-BR` = "pt-BR"
-    val `fr-FR` = "fr-FR"
-    val `it-IT` = "it-IT"
-    val `ko-KR` = "ko-KR"
-    val `es-ES` = "es-ES"
-    val `en-IN` = "en-IN"
-    val `hi-IN` = "hi-IN"
-    val `ar-SA` = "ar-SA"
-    val `ru-RU` = "ru-RU"
-    val `zh-CN` = "zh-CN"
-    val `nl-NL` = "nl-NL"
-    val `id-ID` = "id-ID"
-    val `ta-IN` = "ta-IN"
-    val `fa-IR` = "fa-IR"
-    val `en-IE` = "en-IE"
-    val `en-AB` = "en-AB"
-    val `en-WL` = "en-WL"
-    val `pt-PT` = "pt-PT"
-    val `te-IN` = "te-IN"
-    val `tr-TR` = "tr-TR"
-    val `de-CH` = "de-CH"
-    val `he-IL` = "he-IL"
-    val `ms-MY` = "ms-MY"
-    val `ja-JP` = "ja-JP"
-    val `ar-AE` = "ar-AE"
+  @js.native
+  sealed trait LanguageCode extends js.Any
+  object LanguageCode extends js.Object {
+    val `en-US` = "en-US".asInstanceOf[LanguageCode]
+    val `es-US` = "es-US".asInstanceOf[LanguageCode]
+    val `en-AU` = "en-AU".asInstanceOf[LanguageCode]
+    val `fr-CA` = "fr-CA".asInstanceOf[LanguageCode]
+    val `en-GB` = "en-GB".asInstanceOf[LanguageCode]
+    val `de-DE` = "de-DE".asInstanceOf[LanguageCode]
+    val `pt-BR` = "pt-BR".asInstanceOf[LanguageCode]
+    val `fr-FR` = "fr-FR".asInstanceOf[LanguageCode]
+    val `it-IT` = "it-IT".asInstanceOf[LanguageCode]
+    val `ko-KR` = "ko-KR".asInstanceOf[LanguageCode]
+    val `es-ES` = "es-ES".asInstanceOf[LanguageCode]
+    val `en-IN` = "en-IN".asInstanceOf[LanguageCode]
+    val `hi-IN` = "hi-IN".asInstanceOf[LanguageCode]
+    val `ar-SA` = "ar-SA".asInstanceOf[LanguageCode]
+    val `ru-RU` = "ru-RU".asInstanceOf[LanguageCode]
+    val `zh-CN` = "zh-CN".asInstanceOf[LanguageCode]
+    val `nl-NL` = "nl-NL".asInstanceOf[LanguageCode]
+    val `id-ID` = "id-ID".asInstanceOf[LanguageCode]
+    val `ta-IN` = "ta-IN".asInstanceOf[LanguageCode]
+    val `fa-IR` = "fa-IR".asInstanceOf[LanguageCode]
+    val `en-IE` = "en-IE".asInstanceOf[LanguageCode]
+    val `en-AB` = "en-AB".asInstanceOf[LanguageCode]
+    val `en-WL` = "en-WL".asInstanceOf[LanguageCode]
+    val `pt-PT` = "pt-PT".asInstanceOf[LanguageCode]
+    val `te-IN` = "te-IN".asInstanceOf[LanguageCode]
+    val `tr-TR` = "tr-TR".asInstanceOf[LanguageCode]
+    val `de-CH` = "de-CH".asInstanceOf[LanguageCode]
+    val `he-IL` = "he-IL".asInstanceOf[LanguageCode]
+    val `ms-MY` = "ms-MY".asInstanceOf[LanguageCode]
+    val `ja-JP` = "ja-JP".asInstanceOf[LanguageCode]
+    val `ar-AE` = "ar-AE".asInstanceOf[LanguageCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -628,19 +623,21 @@ package transcribeservice {
       __obj.asInstanceOf[Media]
     }
   }
-
-  object MediaFormatEnum {
-    val mp3  = "mp3"
-    val mp4  = "mp4"
-    val wav  = "wav"
-    val flac = "flac"
+  @js.native
+  sealed trait MediaFormat extends js.Any
+  object MediaFormat extends js.Object {
+    val mp3  = "mp3".asInstanceOf[MediaFormat]
+    val mp4  = "mp4".asInstanceOf[MediaFormat]
+    val wav  = "wav".asInstanceOf[MediaFormat]
+    val flac = "flac".asInstanceOf[MediaFormat]
 
     val values = js.Object.freeze(js.Array(mp3, mp4, wav, flac))
   }
-
-  object OutputLocationTypeEnum {
-    val CUSTOMER_BUCKET = "CUSTOMER_BUCKET"
-    val SERVICE_BUCKET  = "SERVICE_BUCKET"
+  @js.native
+  sealed trait OutputLocationType extends js.Any
+  object OutputLocationType extends js.Object {
+    val CUSTOMER_BUCKET = "CUSTOMER_BUCKET".asInstanceOf[OutputLocationType]
+    val SERVICE_BUCKET  = "SERVICE_BUCKET".asInstanceOf[OutputLocationType]
 
     val values = js.Object.freeze(js.Array(CUSTOMER_BUCKET, SERVICE_BUCKET))
   }
@@ -816,12 +813,13 @@ package transcribeservice {
       __obj.asInstanceOf[TranscriptionJob]
     }
   }
-
-  object TranscriptionJobStatusEnum {
-    val QUEUED      = "QUEUED"
-    val IN_PROGRESS = "IN_PROGRESS"
-    val FAILED      = "FAILED"
-    val COMPLETED   = "COMPLETED"
+  @js.native
+  sealed trait TranscriptionJobStatus extends js.Any
+  object TranscriptionJobStatus extends js.Object {
+    val QUEUED      = "QUEUED".asInstanceOf[TranscriptionJobStatus]
+    val IN_PROGRESS = "IN_PROGRESS".asInstanceOf[TranscriptionJobStatus]
+    val FAILED      = "FAILED".asInstanceOf[TranscriptionJobStatus]
+    val COMPLETED   = "COMPLETED".asInstanceOf[TranscriptionJobStatus]
 
     val values = js.Object.freeze(js.Array(QUEUED, IN_PROGRESS, FAILED, COMPLETED))
   }
@@ -988,10 +986,11 @@ package transcribeservice {
       __obj.asInstanceOf[VocabularyFilterInfo]
     }
   }
-
-  object VocabularyFilterMethodEnum {
-    val remove = "remove"
-    val mask   = "mask"
+  @js.native
+  sealed trait VocabularyFilterMethod extends js.Any
+  object VocabularyFilterMethod extends js.Object {
+    val remove = "remove".asInstanceOf[VocabularyFilterMethod]
+    val mask   = "mask".asInstanceOf[VocabularyFilterMethod]
 
     val values = js.Object.freeze(js.Array(remove, mask))
   }
@@ -1023,11 +1022,12 @@ package transcribeservice {
       __obj.asInstanceOf[VocabularyInfo]
     }
   }
-
-  object VocabularyStateEnum {
-    val PENDING = "PENDING"
-    val READY   = "READY"
-    val FAILED  = "FAILED"
+  @js.native
+  sealed trait VocabularyState extends js.Any
+  object VocabularyState extends js.Object {
+    val PENDING = "PENDING".asInstanceOf[VocabularyState]
+    val READY   = "READY".asInstanceOf[VocabularyState]
+    val FAILED  = "FAILED".asInstanceOf[VocabularyState]
 
     val values = js.Object.freeze(js.Array(PENDING, READY, FAILED))
   }

--- a/services/transfer/src/main/scala/facade/amazonaws/services/Transfer.scala
+++ b/services/transfer/src/main/scala/facade/amazonaws/services/Transfer.scala
@@ -11,13 +11,10 @@ package object transfer {
   type AddressAllocationIds  = js.Array[AddressAllocationId]
   type Arn                   = String
   type DateImported          = js.Date
-  type EndpointType          = String
   type HomeDirectory         = String
   type HomeDirectoryMappings = js.Array[HomeDirectoryMapEntry]
-  type HomeDirectoryType     = String
   type HostKey               = String
   type HostKeyFingerprint    = String
-  type IdentityProviderType  = String
   type ListedServers         = js.Array[ListedServer]
   type ListedUsers           = js.Array[ListedUser]
   type MapEntry              = String
@@ -34,7 +31,6 @@ package object transfer {
   type SshPublicKeyCount     = Int
   type SshPublicKeyId        = String
   type SshPublicKeys         = js.Array[SshPublicKey]
-  type State                 = String
   type StatusCode            = Int
   type SubnetId              = String
   type SubnetIds             = js.Array[SubnetId]
@@ -495,11 +491,12 @@ package transfer {
       __obj.asInstanceOf[EndpointDetails]
     }
   }
-
-  object EndpointTypeEnum {
-    val PUBLIC       = "PUBLIC"
-    val VPC          = "VPC"
-    val VPC_ENDPOINT = "VPC_ENDPOINT"
+  @js.native
+  sealed trait EndpointType extends js.Any
+  object EndpointType extends js.Object {
+    val PUBLIC       = "PUBLIC".asInstanceOf[EndpointType]
+    val VPC          = "VPC".asInstanceOf[EndpointType]
+    val VPC_ENDPOINT = "VPC_ENDPOINT".asInstanceOf[EndpointType]
 
     val values = js.Object.freeze(js.Array(PUBLIC, VPC, VPC_ENDPOINT))
   }
@@ -527,10 +524,11 @@ package transfer {
       __obj.asInstanceOf[HomeDirectoryMapEntry]
     }
   }
-
-  object HomeDirectoryTypeEnum {
-    val PATH    = "PATH"
-    val LOGICAL = "LOGICAL"
+  @js.native
+  sealed trait HomeDirectoryType extends js.Any
+  object HomeDirectoryType extends js.Object {
+    val PATH    = "PATH".asInstanceOf[HomeDirectoryType]
+    val LOGICAL = "LOGICAL".asInstanceOf[HomeDirectoryType]
 
     val values = js.Object.freeze(js.Array(PATH, LOGICAL))
   }
@@ -560,9 +558,11 @@ package transfer {
   /**
     * Returns information related to the type of user authentication that is in use for a server's users. For <code>SERVICE_MANAGED</code> authentication, the Secure Shell (SSH) public keys are stored with a user on an SFTP server instance. For <code>API_GATEWAY</code> authentication, your custom authentication method is implemented by using an API call. A server can have only one method of authentication.
     */
-  object IdentityProviderTypeEnum {
-    val SERVICE_MANAGED = "SERVICE_MANAGED"
-    val API_GATEWAY     = "API_GATEWAY"
+  @js.native
+  sealed trait IdentityProviderType extends js.Any
+  object IdentityProviderType extends js.Object {
+    val SERVICE_MANAGED = "SERVICE_MANAGED".asInstanceOf[IdentityProviderType]
+    val API_GATEWAY     = "API_GATEWAY".asInstanceOf[IdentityProviderType]
 
     val values = js.Object.freeze(js.Array(SERVICE_MANAGED, API_GATEWAY))
   }
@@ -876,13 +876,15 @@ package transfer {
     * Describes the condition of the SFTP server with respect to its ability to perform file operations. There are six possible states: <code>OFFLINE</code>, <code>ONLINE</code>, <code>STARTING</code>, <code>STOPPING</code>, <code>START_FAILED</code>, and <code>STOP_FAILED</code>.
     *  <code>OFFLINE</code> indicates that the SFTP server exists, but that it is not available for file operations. <code>ONLINE</code> indicates that the SFTP server is available to perform file operations. <code>STARTING</code> indicates that the SFTP server's was instantiated, but the server is not yet available to perform file operations. Under normal conditions, it can take a couple of minutes for an SFTP server to be completely operational. Both <code>START_FAILED</code> and <code>STOP_FAILED</code> are error conditions.
     */
-  object StateEnum {
-    val OFFLINE      = "OFFLINE"
-    val ONLINE       = "ONLINE"
-    val STARTING     = "STARTING"
-    val STOPPING     = "STOPPING"
-    val START_FAILED = "START_FAILED"
-    val STOP_FAILED  = "STOP_FAILED"
+  @js.native
+  sealed trait State extends js.Any
+  object State extends js.Object {
+    val OFFLINE      = "OFFLINE".asInstanceOf[State]
+    val ONLINE       = "ONLINE".asInstanceOf[State]
+    val STARTING     = "STARTING".asInstanceOf[State]
+    val STOPPING     = "STOPPING".asInstanceOf[State]
+    val START_FAILED = "START_FAILED".asInstanceOf[State]
+    val STOP_FAILED  = "STOP_FAILED".asInstanceOf[State]
 
     val values = js.Object.freeze(js.Array(OFFLINE, ONLINE, STARTING, STOPPING, START_FAILED, STOP_FAILED))
   }

--- a/services/translate/src/main/scala/facade/amazonaws/services/Translate.scala
+++ b/services/translate/src/main/scala/facade/amazonaws/services/Translate.scala
@@ -13,15 +13,12 @@ package object translate {
   type ContentType                      = String
   type Description                      = String
   type EncryptionKeyID                  = String
-  type EncryptionKeyType                = String
   type IamRoleArn                       = String
   type JobId                            = String
   type JobName                          = String
-  type JobStatus                        = String
   type LanguageCodeString               = String
   type LanguageCodeStringList           = js.Array[LanguageCodeString]
   type MaxResultsInteger                = Int
-  type MergeStrategy                    = String
   type NextToken                        = String
   type ResourceName                     = String
   type ResourceNameList                 = js.Array[ResourceName]
@@ -29,7 +26,6 @@ package object translate {
   type TargetLanguageCodeStringList     = js.Array[LanguageCodeString]
   type TermList                         = js.Array[Term]
   type TerminologyArn                   = String
-  type TerminologyDataFormat            = String
   type TerminologyFile                  = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type TerminologyPropertiesList        = js.Array[TerminologyProperties]
   type TextTranslationJobPropertiesList = js.Array[TextTranslationJobProperties]
@@ -184,9 +180,10 @@ package translate {
       __obj.asInstanceOf[EncryptionKey]
     }
   }
-
-  object EncryptionKeyTypeEnum {
-    val KMS = "KMS"
+  @js.native
+  sealed trait EncryptionKeyType extends js.Any
+  object EncryptionKeyType extends js.Object {
+    val KMS = "KMS".asInstanceOf[EncryptionKeyType]
 
     val values = js.Object.freeze(js.Array(KMS))
   }
@@ -325,15 +322,16 @@ package translate {
       __obj.asInstanceOf[JobDetails]
     }
   }
-
-  object JobStatusEnum {
-    val SUBMITTED            = "SUBMITTED"
-    val IN_PROGRESS          = "IN_PROGRESS"
-    val COMPLETED            = "COMPLETED"
-    val COMPLETED_WITH_ERROR = "COMPLETED_WITH_ERROR"
-    val FAILED               = "FAILED"
-    val STOP_REQUESTED       = "STOP_REQUESTED"
-    val STOPPED              = "STOPPED"
+  @js.native
+  sealed trait JobStatus extends js.Any
+  object JobStatus extends js.Object {
+    val SUBMITTED            = "SUBMITTED".asInstanceOf[JobStatus]
+    val IN_PROGRESS          = "IN_PROGRESS".asInstanceOf[JobStatus]
+    val COMPLETED            = "COMPLETED".asInstanceOf[JobStatus]
+    val COMPLETED_WITH_ERROR = "COMPLETED_WITH_ERROR".asInstanceOf[JobStatus]
+    val FAILED               = "FAILED".asInstanceOf[JobStatus]
+    val STOP_REQUESTED       = "STOP_REQUESTED".asInstanceOf[JobStatus]
+    val STOPPED              = "STOPPED".asInstanceOf[JobStatus]
 
     val values = js.Object.freeze(
       js.Array(SUBMITTED, IN_PROGRESS, COMPLETED, COMPLETED_WITH_ERROR, FAILED, STOP_REQUESTED, STOPPED)
@@ -422,9 +420,10 @@ package translate {
       __obj.asInstanceOf[ListTextTranslationJobsResponse]
     }
   }
-
-  object MergeStrategyEnum {
-    val OVERWRITE = "OVERWRITE"
+  @js.native
+  sealed trait MergeStrategy extends js.Any
+  object MergeStrategy extends js.Object {
+    val OVERWRITE = "OVERWRITE".asInstanceOf[MergeStrategy]
 
     val values = js.Object.freeze(js.Array(OVERWRITE))
   }
@@ -590,10 +589,11 @@ package translate {
       __obj.asInstanceOf[TerminologyData]
     }
   }
-
-  object TerminologyDataFormatEnum {
-    val CSV = "CSV"
-    val TMX = "TMX"
+  @js.native
+  sealed trait TerminologyDataFormat extends js.Any
+  object TerminologyDataFormat extends js.Object {
+    val CSV = "CSV".asInstanceOf[TerminologyDataFormat]
+    val TMX = "TMX".asInstanceOf[TerminologyDataFormat]
 
     val values = js.Object.freeze(js.Array(CSV, TMX))
   }

--- a/services/waf/src/main/scala/facade/amazonaws/services/WAF.scala
+++ b/services/waf/src/main/scala/facade/amazonaws/services/WAF.scala
@@ -13,14 +13,9 @@ package object waf {
   type ByteMatchSetUpdates           = js.Array[ByteMatchSetUpdate]
   type ByteMatchTargetString         = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type ByteMatchTuples               = js.Array[ByteMatchTuple]
-  type ChangeAction                  = String
   type ChangeToken                   = String
-  type ChangeTokenStatus             = String
-  type ComparisonOperator            = String
   type Country                       = String
   type ExcludedRules                 = js.Array[ExcludedRule]
-  type GeoMatchConstraintType        = String
-  type GeoMatchConstraintValue       = String
   type GeoMatchConstraints           = js.Array[GeoMatchConstraint]
   type GeoMatchSetSummaries          = js.Array[GeoMatchSetSummary]
   type GeoMatchSetUpdates            = js.Array[GeoMatchSetUpdate]
@@ -30,7 +25,6 @@ package object waf {
   type HTTPVersion                   = String
   type HeaderName                    = String
   type HeaderValue                   = String
-  type IPSetDescriptorType           = String
   type IPSetDescriptorValue          = String
   type IPSetDescriptors              = js.Array[IPSetDescriptor]
   type IPSetSummaries                = js.Array[IPSetSummary]
@@ -41,17 +35,13 @@ package object waf {
   type ManagedKey                    = String
   type ManagedKeys                   = js.Array[ManagedKey]
   type MatchFieldData                = String
-  type MatchFieldType                = String
   type MetricName                    = String
   type Negated                       = Boolean
   type NextMarker                    = String
   type PaginationLimit               = Int
   type PolicyString                  = String
   type PopulationSize                = Double
-  type PositionalConstraint          = String
-  type PredicateType                 = String
   type Predicates                    = js.Array[Predicate]
-  type RateKey                       = String
   type RateLimit                     = Double
   type RedactedFields                = js.Array[FieldToMatch]
   type RegexMatchSetSummaries        = js.Array[RegexMatchSetSummary]
@@ -83,12 +73,8 @@ package object waf {
   type TagKeyList                    = js.Array[TagKey]
   type TagList                       = js.Array[Tag]
   type TagValue                      = String
-  type TextTransformation            = String
   type Timestamp                     = js.Date
   type URIString                     = String
-  type WafActionType                 = String
-  type WafOverrideActionType         = String
-  type WafRuleType                   = String
   type WebACLSummaries               = js.Array[WebACLSummary]
   type WebACLUpdates                 = js.Array[WebACLUpdate]
   type XssMatchSetSummaries          = js.Array[XssMatchSetSummary]
@@ -523,29 +509,32 @@ package waf {
       __obj.asInstanceOf[ByteMatchTuple]
     }
   }
-
-  object ChangeActionEnum {
-    val INSERT = "INSERT"
-    val DELETE = "DELETE"
+  @js.native
+  sealed trait ChangeAction extends js.Any
+  object ChangeAction extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[ChangeAction]
+    val DELETE = "DELETE".asInstanceOf[ChangeAction]
 
     val values = js.Object.freeze(js.Array(INSERT, DELETE))
   }
-
-  object ChangeTokenStatusEnum {
-    val PROVISIONED = "PROVISIONED"
-    val PENDING     = "PENDING"
-    val INSYNC      = "INSYNC"
+  @js.native
+  sealed trait ChangeTokenStatus extends js.Any
+  object ChangeTokenStatus extends js.Object {
+    val PROVISIONED = "PROVISIONED".asInstanceOf[ChangeTokenStatus]
+    val PENDING     = "PENDING".asInstanceOf[ChangeTokenStatus]
+    val INSYNC      = "INSYNC".asInstanceOf[ChangeTokenStatus]
 
     val values = js.Object.freeze(js.Array(PROVISIONED, PENDING, INSYNC))
   }
-
-  object ComparisonOperatorEnum {
-    val EQ = "EQ"
-    val NE = "NE"
-    val LE = "LE"
-    val LT = "LT"
-    val GE = "GE"
-    val GT = "GT"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val EQ = "EQ".asInstanceOf[ComparisonOperator]
+    val NE = "NE".asInstanceOf[ComparisonOperator]
+    val LE = "LE".asInstanceOf[ComparisonOperator]
+    val LT = "LT".asInstanceOf[ComparisonOperator]
+    val GE = "GE".asInstanceOf[ComparisonOperator]
+    val GT = "GT".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(js.Array(EQ, NE, LE, LT, GE, GT))
   }
@@ -1661,263 +1650,265 @@ package waf {
       __obj.asInstanceOf[GeoMatchConstraint]
     }
   }
-
-  object GeoMatchConstraintTypeEnum {
-    val Country = "Country"
+  @js.native
+  sealed trait GeoMatchConstraintType extends js.Any
+  object GeoMatchConstraintType extends js.Object {
+    val Country = "Country".asInstanceOf[GeoMatchConstraintType]
 
     val values = js.Object.freeze(js.Array(Country))
   }
-
-  object GeoMatchConstraintValueEnum {
-    val AF = "AF"
-    val AX = "AX"
-    val AL = "AL"
-    val DZ = "DZ"
-    val AS = "AS"
-    val AD = "AD"
-    val AO = "AO"
-    val AI = "AI"
-    val AQ = "AQ"
-    val AG = "AG"
-    val AR = "AR"
-    val AM = "AM"
-    val AW = "AW"
-    val AU = "AU"
-    val AT = "AT"
-    val AZ = "AZ"
-    val BS = "BS"
-    val BH = "BH"
-    val BD = "BD"
-    val BB = "BB"
-    val BY = "BY"
-    val BE = "BE"
-    val BZ = "BZ"
-    val BJ = "BJ"
-    val BM = "BM"
-    val BT = "BT"
-    val BO = "BO"
-    val BQ = "BQ"
-    val BA = "BA"
-    val BW = "BW"
-    val BV = "BV"
-    val BR = "BR"
-    val IO = "IO"
-    val BN = "BN"
-    val BG = "BG"
-    val BF = "BF"
-    val BI = "BI"
-    val KH = "KH"
-    val CM = "CM"
-    val CA = "CA"
-    val CV = "CV"
-    val KY = "KY"
-    val CF = "CF"
-    val TD = "TD"
-    val CL = "CL"
-    val CN = "CN"
-    val CX = "CX"
-    val CC = "CC"
-    val CO = "CO"
-    val KM = "KM"
-    val CG = "CG"
-    val CD = "CD"
-    val CK = "CK"
-    val CR = "CR"
-    val CI = "CI"
-    val HR = "HR"
-    val CU = "CU"
-    val CW = "CW"
-    val CY = "CY"
-    val CZ = "CZ"
-    val DK = "DK"
-    val DJ = "DJ"
-    val DM = "DM"
-    val DO = "DO"
-    val EC = "EC"
-    val EG = "EG"
-    val SV = "SV"
-    val GQ = "GQ"
-    val ER = "ER"
-    val EE = "EE"
-    val ET = "ET"
-    val FK = "FK"
-    val FO = "FO"
-    val FJ = "FJ"
-    val FI = "FI"
-    val FR = "FR"
-    val GF = "GF"
-    val PF = "PF"
-    val TF = "TF"
-    val GA = "GA"
-    val GM = "GM"
-    val GE = "GE"
-    val DE = "DE"
-    val GH = "GH"
-    val GI = "GI"
-    val GR = "GR"
-    val GL = "GL"
-    val GD = "GD"
-    val GP = "GP"
-    val GU = "GU"
-    val GT = "GT"
-    val GG = "GG"
-    val GN = "GN"
-    val GW = "GW"
-    val GY = "GY"
-    val HT = "HT"
-    val HM = "HM"
-    val VA = "VA"
-    val HN = "HN"
-    val HK = "HK"
-    val HU = "HU"
-    val IS = "IS"
-    val IN = "IN"
-    val ID = "ID"
-    val IR = "IR"
-    val IQ = "IQ"
-    val IE = "IE"
-    val IM = "IM"
-    val IL = "IL"
-    val IT = "IT"
-    val JM = "JM"
-    val JP = "JP"
-    val JE = "JE"
-    val JO = "JO"
-    val KZ = "KZ"
-    val KE = "KE"
-    val KI = "KI"
-    val KP = "KP"
-    val KR = "KR"
-    val KW = "KW"
-    val KG = "KG"
-    val LA = "LA"
-    val LV = "LV"
-    val LB = "LB"
-    val LS = "LS"
-    val LR = "LR"
-    val LY = "LY"
-    val LI = "LI"
-    val LT = "LT"
-    val LU = "LU"
-    val MO = "MO"
-    val MK = "MK"
-    val MG = "MG"
-    val MW = "MW"
-    val MY = "MY"
-    val MV = "MV"
-    val ML = "ML"
-    val MT = "MT"
-    val MH = "MH"
-    val MQ = "MQ"
-    val MR = "MR"
-    val MU = "MU"
-    val YT = "YT"
-    val MX = "MX"
-    val FM = "FM"
-    val MD = "MD"
-    val MC = "MC"
-    val MN = "MN"
-    val ME = "ME"
-    val MS = "MS"
-    val MA = "MA"
-    val MZ = "MZ"
-    val MM = "MM"
-    val NA = "NA"
-    val NR = "NR"
-    val NP = "NP"
-    val NL = "NL"
-    val NC = "NC"
-    val NZ = "NZ"
-    val NI = "NI"
-    val NE = "NE"
-    val NG = "NG"
-    val NU = "NU"
-    val NF = "NF"
-    val MP = "MP"
-    val NO = "NO"
-    val OM = "OM"
-    val PK = "PK"
-    val PW = "PW"
-    val PS = "PS"
-    val PA = "PA"
-    val PG = "PG"
-    val PY = "PY"
-    val PE = "PE"
-    val PH = "PH"
-    val PN = "PN"
-    val PL = "PL"
-    val PT = "PT"
-    val PR = "PR"
-    val QA = "QA"
-    val RE = "RE"
-    val RO = "RO"
-    val RU = "RU"
-    val RW = "RW"
-    val BL = "BL"
-    val SH = "SH"
-    val KN = "KN"
-    val LC = "LC"
-    val MF = "MF"
-    val PM = "PM"
-    val VC = "VC"
-    val WS = "WS"
-    val SM = "SM"
-    val ST = "ST"
-    val SA = "SA"
-    val SN = "SN"
-    val RS = "RS"
-    val SC = "SC"
-    val SL = "SL"
-    val SG = "SG"
-    val SX = "SX"
-    val SK = "SK"
-    val SI = "SI"
-    val SB = "SB"
-    val SO = "SO"
-    val ZA = "ZA"
-    val GS = "GS"
-    val SS = "SS"
-    val ES = "ES"
-    val LK = "LK"
-    val SD = "SD"
-    val SR = "SR"
-    val SJ = "SJ"
-    val SZ = "SZ"
-    val SE = "SE"
-    val CH = "CH"
-    val SY = "SY"
-    val TW = "TW"
-    val TJ = "TJ"
-    val TZ = "TZ"
-    val TH = "TH"
-    val TL = "TL"
-    val TG = "TG"
-    val TK = "TK"
-    val TO = "TO"
-    val TT = "TT"
-    val TN = "TN"
-    val TR = "TR"
-    val TM = "TM"
-    val TC = "TC"
-    val TV = "TV"
-    val UG = "UG"
-    val UA = "UA"
-    val AE = "AE"
-    val GB = "GB"
-    val US = "US"
-    val UM = "UM"
-    val UY = "UY"
-    val UZ = "UZ"
-    val VU = "VU"
-    val VE = "VE"
-    val VN = "VN"
-    val VG = "VG"
-    val VI = "VI"
-    val WF = "WF"
-    val EH = "EH"
-    val YE = "YE"
-    val ZM = "ZM"
-    val ZW = "ZW"
+  @js.native
+  sealed trait GeoMatchConstraintValue extends js.Any
+  object GeoMatchConstraintValue extends js.Object {
+    val AF = "AF".asInstanceOf[GeoMatchConstraintValue]
+    val AX = "AX".asInstanceOf[GeoMatchConstraintValue]
+    val AL = "AL".asInstanceOf[GeoMatchConstraintValue]
+    val DZ = "DZ".asInstanceOf[GeoMatchConstraintValue]
+    val AS = "AS".asInstanceOf[GeoMatchConstraintValue]
+    val AD = "AD".asInstanceOf[GeoMatchConstraintValue]
+    val AO = "AO".asInstanceOf[GeoMatchConstraintValue]
+    val AI = "AI".asInstanceOf[GeoMatchConstraintValue]
+    val AQ = "AQ".asInstanceOf[GeoMatchConstraintValue]
+    val AG = "AG".asInstanceOf[GeoMatchConstraintValue]
+    val AR = "AR".asInstanceOf[GeoMatchConstraintValue]
+    val AM = "AM".asInstanceOf[GeoMatchConstraintValue]
+    val AW = "AW".asInstanceOf[GeoMatchConstraintValue]
+    val AU = "AU".asInstanceOf[GeoMatchConstraintValue]
+    val AT = "AT".asInstanceOf[GeoMatchConstraintValue]
+    val AZ = "AZ".asInstanceOf[GeoMatchConstraintValue]
+    val BS = "BS".asInstanceOf[GeoMatchConstraintValue]
+    val BH = "BH".asInstanceOf[GeoMatchConstraintValue]
+    val BD = "BD".asInstanceOf[GeoMatchConstraintValue]
+    val BB = "BB".asInstanceOf[GeoMatchConstraintValue]
+    val BY = "BY".asInstanceOf[GeoMatchConstraintValue]
+    val BE = "BE".asInstanceOf[GeoMatchConstraintValue]
+    val BZ = "BZ".asInstanceOf[GeoMatchConstraintValue]
+    val BJ = "BJ".asInstanceOf[GeoMatchConstraintValue]
+    val BM = "BM".asInstanceOf[GeoMatchConstraintValue]
+    val BT = "BT".asInstanceOf[GeoMatchConstraintValue]
+    val BO = "BO".asInstanceOf[GeoMatchConstraintValue]
+    val BQ = "BQ".asInstanceOf[GeoMatchConstraintValue]
+    val BA = "BA".asInstanceOf[GeoMatchConstraintValue]
+    val BW = "BW".asInstanceOf[GeoMatchConstraintValue]
+    val BV = "BV".asInstanceOf[GeoMatchConstraintValue]
+    val BR = "BR".asInstanceOf[GeoMatchConstraintValue]
+    val IO = "IO".asInstanceOf[GeoMatchConstraintValue]
+    val BN = "BN".asInstanceOf[GeoMatchConstraintValue]
+    val BG = "BG".asInstanceOf[GeoMatchConstraintValue]
+    val BF = "BF".asInstanceOf[GeoMatchConstraintValue]
+    val BI = "BI".asInstanceOf[GeoMatchConstraintValue]
+    val KH = "KH".asInstanceOf[GeoMatchConstraintValue]
+    val CM = "CM".asInstanceOf[GeoMatchConstraintValue]
+    val CA = "CA".asInstanceOf[GeoMatchConstraintValue]
+    val CV = "CV".asInstanceOf[GeoMatchConstraintValue]
+    val KY = "KY".asInstanceOf[GeoMatchConstraintValue]
+    val CF = "CF".asInstanceOf[GeoMatchConstraintValue]
+    val TD = "TD".asInstanceOf[GeoMatchConstraintValue]
+    val CL = "CL".asInstanceOf[GeoMatchConstraintValue]
+    val CN = "CN".asInstanceOf[GeoMatchConstraintValue]
+    val CX = "CX".asInstanceOf[GeoMatchConstraintValue]
+    val CC = "CC".asInstanceOf[GeoMatchConstraintValue]
+    val CO = "CO".asInstanceOf[GeoMatchConstraintValue]
+    val KM = "KM".asInstanceOf[GeoMatchConstraintValue]
+    val CG = "CG".asInstanceOf[GeoMatchConstraintValue]
+    val CD = "CD".asInstanceOf[GeoMatchConstraintValue]
+    val CK = "CK".asInstanceOf[GeoMatchConstraintValue]
+    val CR = "CR".asInstanceOf[GeoMatchConstraintValue]
+    val CI = "CI".asInstanceOf[GeoMatchConstraintValue]
+    val HR = "HR".asInstanceOf[GeoMatchConstraintValue]
+    val CU = "CU".asInstanceOf[GeoMatchConstraintValue]
+    val CW = "CW".asInstanceOf[GeoMatchConstraintValue]
+    val CY = "CY".asInstanceOf[GeoMatchConstraintValue]
+    val CZ = "CZ".asInstanceOf[GeoMatchConstraintValue]
+    val DK = "DK".asInstanceOf[GeoMatchConstraintValue]
+    val DJ = "DJ".asInstanceOf[GeoMatchConstraintValue]
+    val DM = "DM".asInstanceOf[GeoMatchConstraintValue]
+    val DO = "DO".asInstanceOf[GeoMatchConstraintValue]
+    val EC = "EC".asInstanceOf[GeoMatchConstraintValue]
+    val EG = "EG".asInstanceOf[GeoMatchConstraintValue]
+    val SV = "SV".asInstanceOf[GeoMatchConstraintValue]
+    val GQ = "GQ".asInstanceOf[GeoMatchConstraintValue]
+    val ER = "ER".asInstanceOf[GeoMatchConstraintValue]
+    val EE = "EE".asInstanceOf[GeoMatchConstraintValue]
+    val ET = "ET".asInstanceOf[GeoMatchConstraintValue]
+    val FK = "FK".asInstanceOf[GeoMatchConstraintValue]
+    val FO = "FO".asInstanceOf[GeoMatchConstraintValue]
+    val FJ = "FJ".asInstanceOf[GeoMatchConstraintValue]
+    val FI = "FI".asInstanceOf[GeoMatchConstraintValue]
+    val FR = "FR".asInstanceOf[GeoMatchConstraintValue]
+    val GF = "GF".asInstanceOf[GeoMatchConstraintValue]
+    val PF = "PF".asInstanceOf[GeoMatchConstraintValue]
+    val TF = "TF".asInstanceOf[GeoMatchConstraintValue]
+    val GA = "GA".asInstanceOf[GeoMatchConstraintValue]
+    val GM = "GM".asInstanceOf[GeoMatchConstraintValue]
+    val GE = "GE".asInstanceOf[GeoMatchConstraintValue]
+    val DE = "DE".asInstanceOf[GeoMatchConstraintValue]
+    val GH = "GH".asInstanceOf[GeoMatchConstraintValue]
+    val GI = "GI".asInstanceOf[GeoMatchConstraintValue]
+    val GR = "GR".asInstanceOf[GeoMatchConstraintValue]
+    val GL = "GL".asInstanceOf[GeoMatchConstraintValue]
+    val GD = "GD".asInstanceOf[GeoMatchConstraintValue]
+    val GP = "GP".asInstanceOf[GeoMatchConstraintValue]
+    val GU = "GU".asInstanceOf[GeoMatchConstraintValue]
+    val GT = "GT".asInstanceOf[GeoMatchConstraintValue]
+    val GG = "GG".asInstanceOf[GeoMatchConstraintValue]
+    val GN = "GN".asInstanceOf[GeoMatchConstraintValue]
+    val GW = "GW".asInstanceOf[GeoMatchConstraintValue]
+    val GY = "GY".asInstanceOf[GeoMatchConstraintValue]
+    val HT = "HT".asInstanceOf[GeoMatchConstraintValue]
+    val HM = "HM".asInstanceOf[GeoMatchConstraintValue]
+    val VA = "VA".asInstanceOf[GeoMatchConstraintValue]
+    val HN = "HN".asInstanceOf[GeoMatchConstraintValue]
+    val HK = "HK".asInstanceOf[GeoMatchConstraintValue]
+    val HU = "HU".asInstanceOf[GeoMatchConstraintValue]
+    val IS = "IS".asInstanceOf[GeoMatchConstraintValue]
+    val IN = "IN".asInstanceOf[GeoMatchConstraintValue]
+    val ID = "ID".asInstanceOf[GeoMatchConstraintValue]
+    val IR = "IR".asInstanceOf[GeoMatchConstraintValue]
+    val IQ = "IQ".asInstanceOf[GeoMatchConstraintValue]
+    val IE = "IE".asInstanceOf[GeoMatchConstraintValue]
+    val IM = "IM".asInstanceOf[GeoMatchConstraintValue]
+    val IL = "IL".asInstanceOf[GeoMatchConstraintValue]
+    val IT = "IT".asInstanceOf[GeoMatchConstraintValue]
+    val JM = "JM".asInstanceOf[GeoMatchConstraintValue]
+    val JP = "JP".asInstanceOf[GeoMatchConstraintValue]
+    val JE = "JE".asInstanceOf[GeoMatchConstraintValue]
+    val JO = "JO".asInstanceOf[GeoMatchConstraintValue]
+    val KZ = "KZ".asInstanceOf[GeoMatchConstraintValue]
+    val KE = "KE".asInstanceOf[GeoMatchConstraintValue]
+    val KI = "KI".asInstanceOf[GeoMatchConstraintValue]
+    val KP = "KP".asInstanceOf[GeoMatchConstraintValue]
+    val KR = "KR".asInstanceOf[GeoMatchConstraintValue]
+    val KW = "KW".asInstanceOf[GeoMatchConstraintValue]
+    val KG = "KG".asInstanceOf[GeoMatchConstraintValue]
+    val LA = "LA".asInstanceOf[GeoMatchConstraintValue]
+    val LV = "LV".asInstanceOf[GeoMatchConstraintValue]
+    val LB = "LB".asInstanceOf[GeoMatchConstraintValue]
+    val LS = "LS".asInstanceOf[GeoMatchConstraintValue]
+    val LR = "LR".asInstanceOf[GeoMatchConstraintValue]
+    val LY = "LY".asInstanceOf[GeoMatchConstraintValue]
+    val LI = "LI".asInstanceOf[GeoMatchConstraintValue]
+    val LT = "LT".asInstanceOf[GeoMatchConstraintValue]
+    val LU = "LU".asInstanceOf[GeoMatchConstraintValue]
+    val MO = "MO".asInstanceOf[GeoMatchConstraintValue]
+    val MK = "MK".asInstanceOf[GeoMatchConstraintValue]
+    val MG = "MG".asInstanceOf[GeoMatchConstraintValue]
+    val MW = "MW".asInstanceOf[GeoMatchConstraintValue]
+    val MY = "MY".asInstanceOf[GeoMatchConstraintValue]
+    val MV = "MV".asInstanceOf[GeoMatchConstraintValue]
+    val ML = "ML".asInstanceOf[GeoMatchConstraintValue]
+    val MT = "MT".asInstanceOf[GeoMatchConstraintValue]
+    val MH = "MH".asInstanceOf[GeoMatchConstraintValue]
+    val MQ = "MQ".asInstanceOf[GeoMatchConstraintValue]
+    val MR = "MR".asInstanceOf[GeoMatchConstraintValue]
+    val MU = "MU".asInstanceOf[GeoMatchConstraintValue]
+    val YT = "YT".asInstanceOf[GeoMatchConstraintValue]
+    val MX = "MX".asInstanceOf[GeoMatchConstraintValue]
+    val FM = "FM".asInstanceOf[GeoMatchConstraintValue]
+    val MD = "MD".asInstanceOf[GeoMatchConstraintValue]
+    val MC = "MC".asInstanceOf[GeoMatchConstraintValue]
+    val MN = "MN".asInstanceOf[GeoMatchConstraintValue]
+    val ME = "ME".asInstanceOf[GeoMatchConstraintValue]
+    val MS = "MS".asInstanceOf[GeoMatchConstraintValue]
+    val MA = "MA".asInstanceOf[GeoMatchConstraintValue]
+    val MZ = "MZ".asInstanceOf[GeoMatchConstraintValue]
+    val MM = "MM".asInstanceOf[GeoMatchConstraintValue]
+    val NA = "NA".asInstanceOf[GeoMatchConstraintValue]
+    val NR = "NR".asInstanceOf[GeoMatchConstraintValue]
+    val NP = "NP".asInstanceOf[GeoMatchConstraintValue]
+    val NL = "NL".asInstanceOf[GeoMatchConstraintValue]
+    val NC = "NC".asInstanceOf[GeoMatchConstraintValue]
+    val NZ = "NZ".asInstanceOf[GeoMatchConstraintValue]
+    val NI = "NI".asInstanceOf[GeoMatchConstraintValue]
+    val NE = "NE".asInstanceOf[GeoMatchConstraintValue]
+    val NG = "NG".asInstanceOf[GeoMatchConstraintValue]
+    val NU = "NU".asInstanceOf[GeoMatchConstraintValue]
+    val NF = "NF".asInstanceOf[GeoMatchConstraintValue]
+    val MP = "MP".asInstanceOf[GeoMatchConstraintValue]
+    val NO = "NO".asInstanceOf[GeoMatchConstraintValue]
+    val OM = "OM".asInstanceOf[GeoMatchConstraintValue]
+    val PK = "PK".asInstanceOf[GeoMatchConstraintValue]
+    val PW = "PW".asInstanceOf[GeoMatchConstraintValue]
+    val PS = "PS".asInstanceOf[GeoMatchConstraintValue]
+    val PA = "PA".asInstanceOf[GeoMatchConstraintValue]
+    val PG = "PG".asInstanceOf[GeoMatchConstraintValue]
+    val PY = "PY".asInstanceOf[GeoMatchConstraintValue]
+    val PE = "PE".asInstanceOf[GeoMatchConstraintValue]
+    val PH = "PH".asInstanceOf[GeoMatchConstraintValue]
+    val PN = "PN".asInstanceOf[GeoMatchConstraintValue]
+    val PL = "PL".asInstanceOf[GeoMatchConstraintValue]
+    val PT = "PT".asInstanceOf[GeoMatchConstraintValue]
+    val PR = "PR".asInstanceOf[GeoMatchConstraintValue]
+    val QA = "QA".asInstanceOf[GeoMatchConstraintValue]
+    val RE = "RE".asInstanceOf[GeoMatchConstraintValue]
+    val RO = "RO".asInstanceOf[GeoMatchConstraintValue]
+    val RU = "RU".asInstanceOf[GeoMatchConstraintValue]
+    val RW = "RW".asInstanceOf[GeoMatchConstraintValue]
+    val BL = "BL".asInstanceOf[GeoMatchConstraintValue]
+    val SH = "SH".asInstanceOf[GeoMatchConstraintValue]
+    val KN = "KN".asInstanceOf[GeoMatchConstraintValue]
+    val LC = "LC".asInstanceOf[GeoMatchConstraintValue]
+    val MF = "MF".asInstanceOf[GeoMatchConstraintValue]
+    val PM = "PM".asInstanceOf[GeoMatchConstraintValue]
+    val VC = "VC".asInstanceOf[GeoMatchConstraintValue]
+    val WS = "WS".asInstanceOf[GeoMatchConstraintValue]
+    val SM = "SM".asInstanceOf[GeoMatchConstraintValue]
+    val ST = "ST".asInstanceOf[GeoMatchConstraintValue]
+    val SA = "SA".asInstanceOf[GeoMatchConstraintValue]
+    val SN = "SN".asInstanceOf[GeoMatchConstraintValue]
+    val RS = "RS".asInstanceOf[GeoMatchConstraintValue]
+    val SC = "SC".asInstanceOf[GeoMatchConstraintValue]
+    val SL = "SL".asInstanceOf[GeoMatchConstraintValue]
+    val SG = "SG".asInstanceOf[GeoMatchConstraintValue]
+    val SX = "SX".asInstanceOf[GeoMatchConstraintValue]
+    val SK = "SK".asInstanceOf[GeoMatchConstraintValue]
+    val SI = "SI".asInstanceOf[GeoMatchConstraintValue]
+    val SB = "SB".asInstanceOf[GeoMatchConstraintValue]
+    val SO = "SO".asInstanceOf[GeoMatchConstraintValue]
+    val ZA = "ZA".asInstanceOf[GeoMatchConstraintValue]
+    val GS = "GS".asInstanceOf[GeoMatchConstraintValue]
+    val SS = "SS".asInstanceOf[GeoMatchConstraintValue]
+    val ES = "ES".asInstanceOf[GeoMatchConstraintValue]
+    val LK = "LK".asInstanceOf[GeoMatchConstraintValue]
+    val SD = "SD".asInstanceOf[GeoMatchConstraintValue]
+    val SR = "SR".asInstanceOf[GeoMatchConstraintValue]
+    val SJ = "SJ".asInstanceOf[GeoMatchConstraintValue]
+    val SZ = "SZ".asInstanceOf[GeoMatchConstraintValue]
+    val SE = "SE".asInstanceOf[GeoMatchConstraintValue]
+    val CH = "CH".asInstanceOf[GeoMatchConstraintValue]
+    val SY = "SY".asInstanceOf[GeoMatchConstraintValue]
+    val TW = "TW".asInstanceOf[GeoMatchConstraintValue]
+    val TJ = "TJ".asInstanceOf[GeoMatchConstraintValue]
+    val TZ = "TZ".asInstanceOf[GeoMatchConstraintValue]
+    val TH = "TH".asInstanceOf[GeoMatchConstraintValue]
+    val TL = "TL".asInstanceOf[GeoMatchConstraintValue]
+    val TG = "TG".asInstanceOf[GeoMatchConstraintValue]
+    val TK = "TK".asInstanceOf[GeoMatchConstraintValue]
+    val TO = "TO".asInstanceOf[GeoMatchConstraintValue]
+    val TT = "TT".asInstanceOf[GeoMatchConstraintValue]
+    val TN = "TN".asInstanceOf[GeoMatchConstraintValue]
+    val TR = "TR".asInstanceOf[GeoMatchConstraintValue]
+    val TM = "TM".asInstanceOf[GeoMatchConstraintValue]
+    val TC = "TC".asInstanceOf[GeoMatchConstraintValue]
+    val TV = "TV".asInstanceOf[GeoMatchConstraintValue]
+    val UG = "UG".asInstanceOf[GeoMatchConstraintValue]
+    val UA = "UA".asInstanceOf[GeoMatchConstraintValue]
+    val AE = "AE".asInstanceOf[GeoMatchConstraintValue]
+    val GB = "GB".asInstanceOf[GeoMatchConstraintValue]
+    val US = "US".asInstanceOf[GeoMatchConstraintValue]
+    val UM = "UM".asInstanceOf[GeoMatchConstraintValue]
+    val UY = "UY".asInstanceOf[GeoMatchConstraintValue]
+    val UZ = "UZ".asInstanceOf[GeoMatchConstraintValue]
+    val VU = "VU".asInstanceOf[GeoMatchConstraintValue]
+    val VE = "VE".asInstanceOf[GeoMatchConstraintValue]
+    val VN = "VN".asInstanceOf[GeoMatchConstraintValue]
+    val VG = "VG".asInstanceOf[GeoMatchConstraintValue]
+    val VI = "VI".asInstanceOf[GeoMatchConstraintValue]
+    val WF = "WF".asInstanceOf[GeoMatchConstraintValue]
+    val EH = "EH".asInstanceOf[GeoMatchConstraintValue]
+    val YE = "YE".asInstanceOf[GeoMatchConstraintValue]
+    val ZM = "ZM".asInstanceOf[GeoMatchConstraintValue]
+    val ZW = "ZW".asInstanceOf[GeoMatchConstraintValue]
 
     val values = js.Object.freeze(
       js.Array(
@@ -2996,10 +2987,11 @@ package waf {
       __obj.asInstanceOf[IPSetDescriptor]
     }
   }
-
-  object IPSetDescriptorTypeEnum {
-    val IPV4 = "IPV4"
-    val IPV6 = "IPV6"
+  @js.native
+  sealed trait IPSetDescriptorType extends js.Any
+  object IPSetDescriptorType extends js.Object {
+    val IPV4 = "IPV4".asInstanceOf[IPSetDescriptorType]
+    val IPV6 = "IPV6".asInstanceOf[IPSetDescriptorType]
 
     val values = js.Object.freeze(js.Array(IPV4, IPV6))
   }
@@ -3706,25 +3698,27 @@ package waf {
       __obj.asInstanceOf[LoggingConfiguration]
     }
   }
-
-  object MatchFieldTypeEnum {
-    val URI              = "URI"
-    val QUERY_STRING     = "QUERY_STRING"
-    val HEADER           = "HEADER"
-    val METHOD           = "METHOD"
-    val BODY             = "BODY"
-    val SINGLE_QUERY_ARG = "SINGLE_QUERY_ARG"
-    val ALL_QUERY_ARGS   = "ALL_QUERY_ARGS"
+  @js.native
+  sealed trait MatchFieldType extends js.Any
+  object MatchFieldType extends js.Object {
+    val URI              = "URI".asInstanceOf[MatchFieldType]
+    val QUERY_STRING     = "QUERY_STRING".asInstanceOf[MatchFieldType]
+    val HEADER           = "HEADER".asInstanceOf[MatchFieldType]
+    val METHOD           = "METHOD".asInstanceOf[MatchFieldType]
+    val BODY             = "BODY".asInstanceOf[MatchFieldType]
+    val SINGLE_QUERY_ARG = "SINGLE_QUERY_ARG".asInstanceOf[MatchFieldType]
+    val ALL_QUERY_ARGS   = "ALL_QUERY_ARGS".asInstanceOf[MatchFieldType]
 
     val values = js.Object.freeze(js.Array(URI, QUERY_STRING, HEADER, METHOD, BODY, SINGLE_QUERY_ARG, ALL_QUERY_ARGS))
   }
-
-  object PositionalConstraintEnum {
-    val EXACTLY       = "EXACTLY"
-    val STARTS_WITH   = "STARTS_WITH"
-    val ENDS_WITH     = "ENDS_WITH"
-    val CONTAINS      = "CONTAINS"
-    val CONTAINS_WORD = "CONTAINS_WORD"
+  @js.native
+  sealed trait PositionalConstraint extends js.Any
+  object PositionalConstraint extends js.Object {
+    val EXACTLY       = "EXACTLY".asInstanceOf[PositionalConstraint]
+    val STARTS_WITH   = "STARTS_WITH".asInstanceOf[PositionalConstraint]
+    val ENDS_WITH     = "ENDS_WITH".asInstanceOf[PositionalConstraint]
+    val CONTAINS      = "CONTAINS".asInstanceOf[PositionalConstraint]
+    val CONTAINS_WORD = "CONTAINS_WORD".asInstanceOf[PositionalConstraint]
 
     val values = js.Object.freeze(js.Array(EXACTLY, STARTS_WITH, ENDS_WITH, CONTAINS, CONTAINS_WORD))
   }
@@ -3755,15 +3749,16 @@ package waf {
       __obj.asInstanceOf[Predicate]
     }
   }
-
-  object PredicateTypeEnum {
-    val IPMatch           = "IPMatch"
-    val ByteMatch         = "ByteMatch"
-    val SqlInjectionMatch = "SqlInjectionMatch"
-    val GeoMatch          = "GeoMatch"
-    val SizeConstraint    = "SizeConstraint"
-    val XssMatch          = "XssMatch"
-    val RegexMatch        = "RegexMatch"
+  @js.native
+  sealed trait PredicateType extends js.Any
+  object PredicateType extends js.Object {
+    val IPMatch           = "IPMatch".asInstanceOf[PredicateType]
+    val ByteMatch         = "ByteMatch".asInstanceOf[PredicateType]
+    val SqlInjectionMatch = "SqlInjectionMatch".asInstanceOf[PredicateType]
+    val GeoMatch          = "GeoMatch".asInstanceOf[PredicateType]
+    val SizeConstraint    = "SizeConstraint".asInstanceOf[PredicateType]
+    val XssMatch          = "XssMatch".asInstanceOf[PredicateType]
+    val RegexMatch        = "RegexMatch".asInstanceOf[PredicateType]
 
     val values =
       js.Object.freeze(js.Array(IPMatch, ByteMatch, SqlInjectionMatch, GeoMatch, SizeConstraint, XssMatch, RegexMatch))
@@ -3876,9 +3871,10 @@ package waf {
       __obj.asInstanceOf[RateBasedRule]
     }
   }
-
-  object RateKeyEnum {
-    val IP = "IP"
+  @js.native
+  sealed trait RateKey extends js.Any
+  object RateKey extends js.Object {
+    val IP = "IP".asInstanceOf[RateKey]
 
     val values = js.Object.freeze(js.Array(IP))
   }
@@ -4557,14 +4553,15 @@ package waf {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TextTransformationEnum {
-    val NONE                 = "NONE"
-    val COMPRESS_WHITE_SPACE = "COMPRESS_WHITE_SPACE"
-    val HTML_ENTITY_DECODE   = "HTML_ENTITY_DECODE"
-    val LOWERCASE            = "LOWERCASE"
-    val CMD_LINE             = "CMD_LINE"
-    val URL_DECODE           = "URL_DECODE"
+  @js.native
+  sealed trait TextTransformation extends js.Any
+  object TextTransformation extends js.Object {
+    val NONE                 = "NONE".asInstanceOf[TextTransformation]
+    val COMPRESS_WHITE_SPACE = "COMPRESS_WHITE_SPACE".asInstanceOf[TextTransformation]
+    val HTML_ENTITY_DECODE   = "HTML_ENTITY_DECODE".asInstanceOf[TextTransformation]
+    val LOWERCASE            = "LOWERCASE".asInstanceOf[TextTransformation]
+    val CMD_LINE             = "CMD_LINE".asInstanceOf[TextTransformation]
+    val URL_DECODE           = "URL_DECODE".asInstanceOf[TextTransformation]
 
     val values =
       js.Object.freeze(js.Array(NONE, COMPRESS_WHITE_SPACE, HTML_ENTITY_DECODE, LOWERCASE, CMD_LINE, URL_DECODE))
@@ -5147,11 +5144,12 @@ package waf {
       __obj.asInstanceOf[WafAction]
     }
   }
-
-  object WafActionTypeEnum {
-    val BLOCK = "BLOCK"
-    val ALLOW = "ALLOW"
-    val COUNT = "COUNT"
+  @js.native
+  sealed trait WafActionType extends js.Any
+  object WafActionType extends js.Object {
+    val BLOCK = "BLOCK".asInstanceOf[WafActionType]
+    val ALLOW = "ALLOW".asInstanceOf[WafActionType]
+    val COUNT = "COUNT".asInstanceOf[WafActionType]
 
     val values = js.Object.freeze(js.Array(BLOCK, ALLOW, COUNT))
   }
@@ -5176,18 +5174,20 @@ package waf {
       __obj.asInstanceOf[WafOverrideAction]
     }
   }
-
-  object WafOverrideActionTypeEnum {
-    val NONE  = "NONE"
-    val COUNT = "COUNT"
+  @js.native
+  sealed trait WafOverrideActionType extends js.Any
+  object WafOverrideActionType extends js.Object {
+    val NONE  = "NONE".asInstanceOf[WafOverrideActionType]
+    val COUNT = "COUNT".asInstanceOf[WafOverrideActionType]
 
     val values = js.Object.freeze(js.Array(NONE, COUNT))
   }
-
-  object WafRuleTypeEnum {
-    val REGULAR    = "REGULAR"
-    val RATE_BASED = "RATE_BASED"
-    val GROUP      = "GROUP"
+  @js.native
+  sealed trait WafRuleType extends js.Any
+  object WafRuleType extends js.Object {
+    val REGULAR    = "REGULAR".asInstanceOf[WafRuleType]
+    val RATE_BASED = "RATE_BASED".asInstanceOf[WafRuleType]
+    val GROUP      = "GROUP".asInstanceOf[WafRuleType]
 
     val values = js.Object.freeze(js.Array(REGULAR, RATE_BASED, GROUP))
   }

--- a/services/wafregional/src/main/scala/facade/amazonaws/services/WAFRegional.scala
+++ b/services/wafregional/src/main/scala/facade/amazonaws/services/WAFRegional.scala
@@ -13,14 +13,9 @@ package object wafregional {
   type ByteMatchSetUpdates           = js.Array[ByteMatchSetUpdate]
   type ByteMatchTargetString         = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
   type ByteMatchTuples               = js.Array[ByteMatchTuple]
-  type ChangeAction                  = String
   type ChangeToken                   = String
-  type ChangeTokenStatus             = String
-  type ComparisonOperator            = String
   type Country                       = String
   type ExcludedRules                 = js.Array[ExcludedRule]
-  type GeoMatchConstraintType        = String
-  type GeoMatchConstraintValue       = String
   type GeoMatchConstraints           = js.Array[GeoMatchConstraint]
   type GeoMatchSetSummaries          = js.Array[GeoMatchSetSummary]
   type GeoMatchSetUpdates            = js.Array[GeoMatchSetUpdate]
@@ -30,7 +25,6 @@ package object wafregional {
   type HTTPVersion                   = String
   type HeaderName                    = String
   type HeaderValue                   = String
-  type IPSetDescriptorType           = String
   type IPSetDescriptorValue          = String
   type IPSetDescriptors              = js.Array[IPSetDescriptor]
   type IPSetSummaries                = js.Array[IPSetSummary]
@@ -41,17 +35,13 @@ package object wafregional {
   type ManagedKey                    = String
   type ManagedKeys                   = js.Array[ManagedKey]
   type MatchFieldData                = String
-  type MatchFieldType                = String
   type MetricName                    = String
   type Negated                       = Boolean
   type NextMarker                    = String
   type PaginationLimit               = Int
   type PolicyString                  = String
   type PopulationSize                = Double
-  type PositionalConstraint          = String
-  type PredicateType                 = String
   type Predicates                    = js.Array[Predicate]
-  type RateKey                       = String
   type RateLimit                     = Double
   type RedactedFields                = js.Array[FieldToMatch]
   type RegexMatchSetSummaries        = js.Array[RegexMatchSetSummary]
@@ -65,7 +55,6 @@ package object wafregional {
   type ResourceArns                  = js.Array[ResourceArn]
   type ResourceId                    = String
   type ResourceName                  = String
-  type ResourceType                  = String
   type RuleGroupSummaries            = js.Array[RuleGroupSummary]
   type RuleGroupUpdates              = js.Array[RuleGroupUpdate]
   type RulePriority                  = Int
@@ -85,12 +74,8 @@ package object wafregional {
   type TagKeyList                    = js.Array[TagKey]
   type TagList                       = js.Array[Tag]
   type TagValue                      = String
-  type TextTransformation            = String
   type Timestamp                     = js.Date
   type URIString                     = String
-  type WafActionType                 = String
-  type WafOverrideActionType         = String
-  type WafRuleType                   = String
   type WebACLSummaries               = js.Array[WebACLSummary]
   type WebACLUpdates                 = js.Array[WebACLUpdate]
   type XssMatchSetSummaries          = js.Array[XssMatchSetSummary]
@@ -573,29 +558,32 @@ package wafregional {
       __obj.asInstanceOf[ByteMatchTuple]
     }
   }
-
-  object ChangeActionEnum {
-    val INSERT = "INSERT"
-    val DELETE = "DELETE"
+  @js.native
+  sealed trait ChangeAction extends js.Any
+  object ChangeAction extends js.Object {
+    val INSERT = "INSERT".asInstanceOf[ChangeAction]
+    val DELETE = "DELETE".asInstanceOf[ChangeAction]
 
     val values = js.Object.freeze(js.Array(INSERT, DELETE))
   }
-
-  object ChangeTokenStatusEnum {
-    val PROVISIONED = "PROVISIONED"
-    val PENDING     = "PENDING"
-    val INSYNC      = "INSYNC"
+  @js.native
+  sealed trait ChangeTokenStatus extends js.Any
+  object ChangeTokenStatus extends js.Object {
+    val PROVISIONED = "PROVISIONED".asInstanceOf[ChangeTokenStatus]
+    val PENDING     = "PENDING".asInstanceOf[ChangeTokenStatus]
+    val INSYNC      = "INSYNC".asInstanceOf[ChangeTokenStatus]
 
     val values = js.Object.freeze(js.Array(PROVISIONED, PENDING, INSYNC))
   }
-
-  object ComparisonOperatorEnum {
-    val EQ = "EQ"
-    val NE = "NE"
-    val LE = "LE"
-    val LT = "LT"
-    val GE = "GE"
-    val GT = "GT"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val EQ = "EQ".asInstanceOf[ComparisonOperator]
+    val NE = "NE".asInstanceOf[ComparisonOperator]
+    val LE = "LE".asInstanceOf[ComparisonOperator]
+    val LT = "LT".asInstanceOf[ComparisonOperator]
+    val GE = "GE".asInstanceOf[ComparisonOperator]
+    val GT = "GT".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(js.Array(EQ, NE, LE, LT, GE, GT))
   }
@@ -1742,263 +1730,265 @@ package wafregional {
       __obj.asInstanceOf[GeoMatchConstraint]
     }
   }
-
-  object GeoMatchConstraintTypeEnum {
-    val Country = "Country"
+  @js.native
+  sealed trait GeoMatchConstraintType extends js.Any
+  object GeoMatchConstraintType extends js.Object {
+    val Country = "Country".asInstanceOf[GeoMatchConstraintType]
 
     val values = js.Object.freeze(js.Array(Country))
   }
-
-  object GeoMatchConstraintValueEnum {
-    val AF = "AF"
-    val AX = "AX"
-    val AL = "AL"
-    val DZ = "DZ"
-    val AS = "AS"
-    val AD = "AD"
-    val AO = "AO"
-    val AI = "AI"
-    val AQ = "AQ"
-    val AG = "AG"
-    val AR = "AR"
-    val AM = "AM"
-    val AW = "AW"
-    val AU = "AU"
-    val AT = "AT"
-    val AZ = "AZ"
-    val BS = "BS"
-    val BH = "BH"
-    val BD = "BD"
-    val BB = "BB"
-    val BY = "BY"
-    val BE = "BE"
-    val BZ = "BZ"
-    val BJ = "BJ"
-    val BM = "BM"
-    val BT = "BT"
-    val BO = "BO"
-    val BQ = "BQ"
-    val BA = "BA"
-    val BW = "BW"
-    val BV = "BV"
-    val BR = "BR"
-    val IO = "IO"
-    val BN = "BN"
-    val BG = "BG"
-    val BF = "BF"
-    val BI = "BI"
-    val KH = "KH"
-    val CM = "CM"
-    val CA = "CA"
-    val CV = "CV"
-    val KY = "KY"
-    val CF = "CF"
-    val TD = "TD"
-    val CL = "CL"
-    val CN = "CN"
-    val CX = "CX"
-    val CC = "CC"
-    val CO = "CO"
-    val KM = "KM"
-    val CG = "CG"
-    val CD = "CD"
-    val CK = "CK"
-    val CR = "CR"
-    val CI = "CI"
-    val HR = "HR"
-    val CU = "CU"
-    val CW = "CW"
-    val CY = "CY"
-    val CZ = "CZ"
-    val DK = "DK"
-    val DJ = "DJ"
-    val DM = "DM"
-    val DO = "DO"
-    val EC = "EC"
-    val EG = "EG"
-    val SV = "SV"
-    val GQ = "GQ"
-    val ER = "ER"
-    val EE = "EE"
-    val ET = "ET"
-    val FK = "FK"
-    val FO = "FO"
-    val FJ = "FJ"
-    val FI = "FI"
-    val FR = "FR"
-    val GF = "GF"
-    val PF = "PF"
-    val TF = "TF"
-    val GA = "GA"
-    val GM = "GM"
-    val GE = "GE"
-    val DE = "DE"
-    val GH = "GH"
-    val GI = "GI"
-    val GR = "GR"
-    val GL = "GL"
-    val GD = "GD"
-    val GP = "GP"
-    val GU = "GU"
-    val GT = "GT"
-    val GG = "GG"
-    val GN = "GN"
-    val GW = "GW"
-    val GY = "GY"
-    val HT = "HT"
-    val HM = "HM"
-    val VA = "VA"
-    val HN = "HN"
-    val HK = "HK"
-    val HU = "HU"
-    val IS = "IS"
-    val IN = "IN"
-    val ID = "ID"
-    val IR = "IR"
-    val IQ = "IQ"
-    val IE = "IE"
-    val IM = "IM"
-    val IL = "IL"
-    val IT = "IT"
-    val JM = "JM"
-    val JP = "JP"
-    val JE = "JE"
-    val JO = "JO"
-    val KZ = "KZ"
-    val KE = "KE"
-    val KI = "KI"
-    val KP = "KP"
-    val KR = "KR"
-    val KW = "KW"
-    val KG = "KG"
-    val LA = "LA"
-    val LV = "LV"
-    val LB = "LB"
-    val LS = "LS"
-    val LR = "LR"
-    val LY = "LY"
-    val LI = "LI"
-    val LT = "LT"
-    val LU = "LU"
-    val MO = "MO"
-    val MK = "MK"
-    val MG = "MG"
-    val MW = "MW"
-    val MY = "MY"
-    val MV = "MV"
-    val ML = "ML"
-    val MT = "MT"
-    val MH = "MH"
-    val MQ = "MQ"
-    val MR = "MR"
-    val MU = "MU"
-    val YT = "YT"
-    val MX = "MX"
-    val FM = "FM"
-    val MD = "MD"
-    val MC = "MC"
-    val MN = "MN"
-    val ME = "ME"
-    val MS = "MS"
-    val MA = "MA"
-    val MZ = "MZ"
-    val MM = "MM"
-    val NA = "NA"
-    val NR = "NR"
-    val NP = "NP"
-    val NL = "NL"
-    val NC = "NC"
-    val NZ = "NZ"
-    val NI = "NI"
-    val NE = "NE"
-    val NG = "NG"
-    val NU = "NU"
-    val NF = "NF"
-    val MP = "MP"
-    val NO = "NO"
-    val OM = "OM"
-    val PK = "PK"
-    val PW = "PW"
-    val PS = "PS"
-    val PA = "PA"
-    val PG = "PG"
-    val PY = "PY"
-    val PE = "PE"
-    val PH = "PH"
-    val PN = "PN"
-    val PL = "PL"
-    val PT = "PT"
-    val PR = "PR"
-    val QA = "QA"
-    val RE = "RE"
-    val RO = "RO"
-    val RU = "RU"
-    val RW = "RW"
-    val BL = "BL"
-    val SH = "SH"
-    val KN = "KN"
-    val LC = "LC"
-    val MF = "MF"
-    val PM = "PM"
-    val VC = "VC"
-    val WS = "WS"
-    val SM = "SM"
-    val ST = "ST"
-    val SA = "SA"
-    val SN = "SN"
-    val RS = "RS"
-    val SC = "SC"
-    val SL = "SL"
-    val SG = "SG"
-    val SX = "SX"
-    val SK = "SK"
-    val SI = "SI"
-    val SB = "SB"
-    val SO = "SO"
-    val ZA = "ZA"
-    val GS = "GS"
-    val SS = "SS"
-    val ES = "ES"
-    val LK = "LK"
-    val SD = "SD"
-    val SR = "SR"
-    val SJ = "SJ"
-    val SZ = "SZ"
-    val SE = "SE"
-    val CH = "CH"
-    val SY = "SY"
-    val TW = "TW"
-    val TJ = "TJ"
-    val TZ = "TZ"
-    val TH = "TH"
-    val TL = "TL"
-    val TG = "TG"
-    val TK = "TK"
-    val TO = "TO"
-    val TT = "TT"
-    val TN = "TN"
-    val TR = "TR"
-    val TM = "TM"
-    val TC = "TC"
-    val TV = "TV"
-    val UG = "UG"
-    val UA = "UA"
-    val AE = "AE"
-    val GB = "GB"
-    val US = "US"
-    val UM = "UM"
-    val UY = "UY"
-    val UZ = "UZ"
-    val VU = "VU"
-    val VE = "VE"
-    val VN = "VN"
-    val VG = "VG"
-    val VI = "VI"
-    val WF = "WF"
-    val EH = "EH"
-    val YE = "YE"
-    val ZM = "ZM"
-    val ZW = "ZW"
+  @js.native
+  sealed trait GeoMatchConstraintValue extends js.Any
+  object GeoMatchConstraintValue extends js.Object {
+    val AF = "AF".asInstanceOf[GeoMatchConstraintValue]
+    val AX = "AX".asInstanceOf[GeoMatchConstraintValue]
+    val AL = "AL".asInstanceOf[GeoMatchConstraintValue]
+    val DZ = "DZ".asInstanceOf[GeoMatchConstraintValue]
+    val AS = "AS".asInstanceOf[GeoMatchConstraintValue]
+    val AD = "AD".asInstanceOf[GeoMatchConstraintValue]
+    val AO = "AO".asInstanceOf[GeoMatchConstraintValue]
+    val AI = "AI".asInstanceOf[GeoMatchConstraintValue]
+    val AQ = "AQ".asInstanceOf[GeoMatchConstraintValue]
+    val AG = "AG".asInstanceOf[GeoMatchConstraintValue]
+    val AR = "AR".asInstanceOf[GeoMatchConstraintValue]
+    val AM = "AM".asInstanceOf[GeoMatchConstraintValue]
+    val AW = "AW".asInstanceOf[GeoMatchConstraintValue]
+    val AU = "AU".asInstanceOf[GeoMatchConstraintValue]
+    val AT = "AT".asInstanceOf[GeoMatchConstraintValue]
+    val AZ = "AZ".asInstanceOf[GeoMatchConstraintValue]
+    val BS = "BS".asInstanceOf[GeoMatchConstraintValue]
+    val BH = "BH".asInstanceOf[GeoMatchConstraintValue]
+    val BD = "BD".asInstanceOf[GeoMatchConstraintValue]
+    val BB = "BB".asInstanceOf[GeoMatchConstraintValue]
+    val BY = "BY".asInstanceOf[GeoMatchConstraintValue]
+    val BE = "BE".asInstanceOf[GeoMatchConstraintValue]
+    val BZ = "BZ".asInstanceOf[GeoMatchConstraintValue]
+    val BJ = "BJ".asInstanceOf[GeoMatchConstraintValue]
+    val BM = "BM".asInstanceOf[GeoMatchConstraintValue]
+    val BT = "BT".asInstanceOf[GeoMatchConstraintValue]
+    val BO = "BO".asInstanceOf[GeoMatchConstraintValue]
+    val BQ = "BQ".asInstanceOf[GeoMatchConstraintValue]
+    val BA = "BA".asInstanceOf[GeoMatchConstraintValue]
+    val BW = "BW".asInstanceOf[GeoMatchConstraintValue]
+    val BV = "BV".asInstanceOf[GeoMatchConstraintValue]
+    val BR = "BR".asInstanceOf[GeoMatchConstraintValue]
+    val IO = "IO".asInstanceOf[GeoMatchConstraintValue]
+    val BN = "BN".asInstanceOf[GeoMatchConstraintValue]
+    val BG = "BG".asInstanceOf[GeoMatchConstraintValue]
+    val BF = "BF".asInstanceOf[GeoMatchConstraintValue]
+    val BI = "BI".asInstanceOf[GeoMatchConstraintValue]
+    val KH = "KH".asInstanceOf[GeoMatchConstraintValue]
+    val CM = "CM".asInstanceOf[GeoMatchConstraintValue]
+    val CA = "CA".asInstanceOf[GeoMatchConstraintValue]
+    val CV = "CV".asInstanceOf[GeoMatchConstraintValue]
+    val KY = "KY".asInstanceOf[GeoMatchConstraintValue]
+    val CF = "CF".asInstanceOf[GeoMatchConstraintValue]
+    val TD = "TD".asInstanceOf[GeoMatchConstraintValue]
+    val CL = "CL".asInstanceOf[GeoMatchConstraintValue]
+    val CN = "CN".asInstanceOf[GeoMatchConstraintValue]
+    val CX = "CX".asInstanceOf[GeoMatchConstraintValue]
+    val CC = "CC".asInstanceOf[GeoMatchConstraintValue]
+    val CO = "CO".asInstanceOf[GeoMatchConstraintValue]
+    val KM = "KM".asInstanceOf[GeoMatchConstraintValue]
+    val CG = "CG".asInstanceOf[GeoMatchConstraintValue]
+    val CD = "CD".asInstanceOf[GeoMatchConstraintValue]
+    val CK = "CK".asInstanceOf[GeoMatchConstraintValue]
+    val CR = "CR".asInstanceOf[GeoMatchConstraintValue]
+    val CI = "CI".asInstanceOf[GeoMatchConstraintValue]
+    val HR = "HR".asInstanceOf[GeoMatchConstraintValue]
+    val CU = "CU".asInstanceOf[GeoMatchConstraintValue]
+    val CW = "CW".asInstanceOf[GeoMatchConstraintValue]
+    val CY = "CY".asInstanceOf[GeoMatchConstraintValue]
+    val CZ = "CZ".asInstanceOf[GeoMatchConstraintValue]
+    val DK = "DK".asInstanceOf[GeoMatchConstraintValue]
+    val DJ = "DJ".asInstanceOf[GeoMatchConstraintValue]
+    val DM = "DM".asInstanceOf[GeoMatchConstraintValue]
+    val DO = "DO".asInstanceOf[GeoMatchConstraintValue]
+    val EC = "EC".asInstanceOf[GeoMatchConstraintValue]
+    val EG = "EG".asInstanceOf[GeoMatchConstraintValue]
+    val SV = "SV".asInstanceOf[GeoMatchConstraintValue]
+    val GQ = "GQ".asInstanceOf[GeoMatchConstraintValue]
+    val ER = "ER".asInstanceOf[GeoMatchConstraintValue]
+    val EE = "EE".asInstanceOf[GeoMatchConstraintValue]
+    val ET = "ET".asInstanceOf[GeoMatchConstraintValue]
+    val FK = "FK".asInstanceOf[GeoMatchConstraintValue]
+    val FO = "FO".asInstanceOf[GeoMatchConstraintValue]
+    val FJ = "FJ".asInstanceOf[GeoMatchConstraintValue]
+    val FI = "FI".asInstanceOf[GeoMatchConstraintValue]
+    val FR = "FR".asInstanceOf[GeoMatchConstraintValue]
+    val GF = "GF".asInstanceOf[GeoMatchConstraintValue]
+    val PF = "PF".asInstanceOf[GeoMatchConstraintValue]
+    val TF = "TF".asInstanceOf[GeoMatchConstraintValue]
+    val GA = "GA".asInstanceOf[GeoMatchConstraintValue]
+    val GM = "GM".asInstanceOf[GeoMatchConstraintValue]
+    val GE = "GE".asInstanceOf[GeoMatchConstraintValue]
+    val DE = "DE".asInstanceOf[GeoMatchConstraintValue]
+    val GH = "GH".asInstanceOf[GeoMatchConstraintValue]
+    val GI = "GI".asInstanceOf[GeoMatchConstraintValue]
+    val GR = "GR".asInstanceOf[GeoMatchConstraintValue]
+    val GL = "GL".asInstanceOf[GeoMatchConstraintValue]
+    val GD = "GD".asInstanceOf[GeoMatchConstraintValue]
+    val GP = "GP".asInstanceOf[GeoMatchConstraintValue]
+    val GU = "GU".asInstanceOf[GeoMatchConstraintValue]
+    val GT = "GT".asInstanceOf[GeoMatchConstraintValue]
+    val GG = "GG".asInstanceOf[GeoMatchConstraintValue]
+    val GN = "GN".asInstanceOf[GeoMatchConstraintValue]
+    val GW = "GW".asInstanceOf[GeoMatchConstraintValue]
+    val GY = "GY".asInstanceOf[GeoMatchConstraintValue]
+    val HT = "HT".asInstanceOf[GeoMatchConstraintValue]
+    val HM = "HM".asInstanceOf[GeoMatchConstraintValue]
+    val VA = "VA".asInstanceOf[GeoMatchConstraintValue]
+    val HN = "HN".asInstanceOf[GeoMatchConstraintValue]
+    val HK = "HK".asInstanceOf[GeoMatchConstraintValue]
+    val HU = "HU".asInstanceOf[GeoMatchConstraintValue]
+    val IS = "IS".asInstanceOf[GeoMatchConstraintValue]
+    val IN = "IN".asInstanceOf[GeoMatchConstraintValue]
+    val ID = "ID".asInstanceOf[GeoMatchConstraintValue]
+    val IR = "IR".asInstanceOf[GeoMatchConstraintValue]
+    val IQ = "IQ".asInstanceOf[GeoMatchConstraintValue]
+    val IE = "IE".asInstanceOf[GeoMatchConstraintValue]
+    val IM = "IM".asInstanceOf[GeoMatchConstraintValue]
+    val IL = "IL".asInstanceOf[GeoMatchConstraintValue]
+    val IT = "IT".asInstanceOf[GeoMatchConstraintValue]
+    val JM = "JM".asInstanceOf[GeoMatchConstraintValue]
+    val JP = "JP".asInstanceOf[GeoMatchConstraintValue]
+    val JE = "JE".asInstanceOf[GeoMatchConstraintValue]
+    val JO = "JO".asInstanceOf[GeoMatchConstraintValue]
+    val KZ = "KZ".asInstanceOf[GeoMatchConstraintValue]
+    val KE = "KE".asInstanceOf[GeoMatchConstraintValue]
+    val KI = "KI".asInstanceOf[GeoMatchConstraintValue]
+    val KP = "KP".asInstanceOf[GeoMatchConstraintValue]
+    val KR = "KR".asInstanceOf[GeoMatchConstraintValue]
+    val KW = "KW".asInstanceOf[GeoMatchConstraintValue]
+    val KG = "KG".asInstanceOf[GeoMatchConstraintValue]
+    val LA = "LA".asInstanceOf[GeoMatchConstraintValue]
+    val LV = "LV".asInstanceOf[GeoMatchConstraintValue]
+    val LB = "LB".asInstanceOf[GeoMatchConstraintValue]
+    val LS = "LS".asInstanceOf[GeoMatchConstraintValue]
+    val LR = "LR".asInstanceOf[GeoMatchConstraintValue]
+    val LY = "LY".asInstanceOf[GeoMatchConstraintValue]
+    val LI = "LI".asInstanceOf[GeoMatchConstraintValue]
+    val LT = "LT".asInstanceOf[GeoMatchConstraintValue]
+    val LU = "LU".asInstanceOf[GeoMatchConstraintValue]
+    val MO = "MO".asInstanceOf[GeoMatchConstraintValue]
+    val MK = "MK".asInstanceOf[GeoMatchConstraintValue]
+    val MG = "MG".asInstanceOf[GeoMatchConstraintValue]
+    val MW = "MW".asInstanceOf[GeoMatchConstraintValue]
+    val MY = "MY".asInstanceOf[GeoMatchConstraintValue]
+    val MV = "MV".asInstanceOf[GeoMatchConstraintValue]
+    val ML = "ML".asInstanceOf[GeoMatchConstraintValue]
+    val MT = "MT".asInstanceOf[GeoMatchConstraintValue]
+    val MH = "MH".asInstanceOf[GeoMatchConstraintValue]
+    val MQ = "MQ".asInstanceOf[GeoMatchConstraintValue]
+    val MR = "MR".asInstanceOf[GeoMatchConstraintValue]
+    val MU = "MU".asInstanceOf[GeoMatchConstraintValue]
+    val YT = "YT".asInstanceOf[GeoMatchConstraintValue]
+    val MX = "MX".asInstanceOf[GeoMatchConstraintValue]
+    val FM = "FM".asInstanceOf[GeoMatchConstraintValue]
+    val MD = "MD".asInstanceOf[GeoMatchConstraintValue]
+    val MC = "MC".asInstanceOf[GeoMatchConstraintValue]
+    val MN = "MN".asInstanceOf[GeoMatchConstraintValue]
+    val ME = "ME".asInstanceOf[GeoMatchConstraintValue]
+    val MS = "MS".asInstanceOf[GeoMatchConstraintValue]
+    val MA = "MA".asInstanceOf[GeoMatchConstraintValue]
+    val MZ = "MZ".asInstanceOf[GeoMatchConstraintValue]
+    val MM = "MM".asInstanceOf[GeoMatchConstraintValue]
+    val NA = "NA".asInstanceOf[GeoMatchConstraintValue]
+    val NR = "NR".asInstanceOf[GeoMatchConstraintValue]
+    val NP = "NP".asInstanceOf[GeoMatchConstraintValue]
+    val NL = "NL".asInstanceOf[GeoMatchConstraintValue]
+    val NC = "NC".asInstanceOf[GeoMatchConstraintValue]
+    val NZ = "NZ".asInstanceOf[GeoMatchConstraintValue]
+    val NI = "NI".asInstanceOf[GeoMatchConstraintValue]
+    val NE = "NE".asInstanceOf[GeoMatchConstraintValue]
+    val NG = "NG".asInstanceOf[GeoMatchConstraintValue]
+    val NU = "NU".asInstanceOf[GeoMatchConstraintValue]
+    val NF = "NF".asInstanceOf[GeoMatchConstraintValue]
+    val MP = "MP".asInstanceOf[GeoMatchConstraintValue]
+    val NO = "NO".asInstanceOf[GeoMatchConstraintValue]
+    val OM = "OM".asInstanceOf[GeoMatchConstraintValue]
+    val PK = "PK".asInstanceOf[GeoMatchConstraintValue]
+    val PW = "PW".asInstanceOf[GeoMatchConstraintValue]
+    val PS = "PS".asInstanceOf[GeoMatchConstraintValue]
+    val PA = "PA".asInstanceOf[GeoMatchConstraintValue]
+    val PG = "PG".asInstanceOf[GeoMatchConstraintValue]
+    val PY = "PY".asInstanceOf[GeoMatchConstraintValue]
+    val PE = "PE".asInstanceOf[GeoMatchConstraintValue]
+    val PH = "PH".asInstanceOf[GeoMatchConstraintValue]
+    val PN = "PN".asInstanceOf[GeoMatchConstraintValue]
+    val PL = "PL".asInstanceOf[GeoMatchConstraintValue]
+    val PT = "PT".asInstanceOf[GeoMatchConstraintValue]
+    val PR = "PR".asInstanceOf[GeoMatchConstraintValue]
+    val QA = "QA".asInstanceOf[GeoMatchConstraintValue]
+    val RE = "RE".asInstanceOf[GeoMatchConstraintValue]
+    val RO = "RO".asInstanceOf[GeoMatchConstraintValue]
+    val RU = "RU".asInstanceOf[GeoMatchConstraintValue]
+    val RW = "RW".asInstanceOf[GeoMatchConstraintValue]
+    val BL = "BL".asInstanceOf[GeoMatchConstraintValue]
+    val SH = "SH".asInstanceOf[GeoMatchConstraintValue]
+    val KN = "KN".asInstanceOf[GeoMatchConstraintValue]
+    val LC = "LC".asInstanceOf[GeoMatchConstraintValue]
+    val MF = "MF".asInstanceOf[GeoMatchConstraintValue]
+    val PM = "PM".asInstanceOf[GeoMatchConstraintValue]
+    val VC = "VC".asInstanceOf[GeoMatchConstraintValue]
+    val WS = "WS".asInstanceOf[GeoMatchConstraintValue]
+    val SM = "SM".asInstanceOf[GeoMatchConstraintValue]
+    val ST = "ST".asInstanceOf[GeoMatchConstraintValue]
+    val SA = "SA".asInstanceOf[GeoMatchConstraintValue]
+    val SN = "SN".asInstanceOf[GeoMatchConstraintValue]
+    val RS = "RS".asInstanceOf[GeoMatchConstraintValue]
+    val SC = "SC".asInstanceOf[GeoMatchConstraintValue]
+    val SL = "SL".asInstanceOf[GeoMatchConstraintValue]
+    val SG = "SG".asInstanceOf[GeoMatchConstraintValue]
+    val SX = "SX".asInstanceOf[GeoMatchConstraintValue]
+    val SK = "SK".asInstanceOf[GeoMatchConstraintValue]
+    val SI = "SI".asInstanceOf[GeoMatchConstraintValue]
+    val SB = "SB".asInstanceOf[GeoMatchConstraintValue]
+    val SO = "SO".asInstanceOf[GeoMatchConstraintValue]
+    val ZA = "ZA".asInstanceOf[GeoMatchConstraintValue]
+    val GS = "GS".asInstanceOf[GeoMatchConstraintValue]
+    val SS = "SS".asInstanceOf[GeoMatchConstraintValue]
+    val ES = "ES".asInstanceOf[GeoMatchConstraintValue]
+    val LK = "LK".asInstanceOf[GeoMatchConstraintValue]
+    val SD = "SD".asInstanceOf[GeoMatchConstraintValue]
+    val SR = "SR".asInstanceOf[GeoMatchConstraintValue]
+    val SJ = "SJ".asInstanceOf[GeoMatchConstraintValue]
+    val SZ = "SZ".asInstanceOf[GeoMatchConstraintValue]
+    val SE = "SE".asInstanceOf[GeoMatchConstraintValue]
+    val CH = "CH".asInstanceOf[GeoMatchConstraintValue]
+    val SY = "SY".asInstanceOf[GeoMatchConstraintValue]
+    val TW = "TW".asInstanceOf[GeoMatchConstraintValue]
+    val TJ = "TJ".asInstanceOf[GeoMatchConstraintValue]
+    val TZ = "TZ".asInstanceOf[GeoMatchConstraintValue]
+    val TH = "TH".asInstanceOf[GeoMatchConstraintValue]
+    val TL = "TL".asInstanceOf[GeoMatchConstraintValue]
+    val TG = "TG".asInstanceOf[GeoMatchConstraintValue]
+    val TK = "TK".asInstanceOf[GeoMatchConstraintValue]
+    val TO = "TO".asInstanceOf[GeoMatchConstraintValue]
+    val TT = "TT".asInstanceOf[GeoMatchConstraintValue]
+    val TN = "TN".asInstanceOf[GeoMatchConstraintValue]
+    val TR = "TR".asInstanceOf[GeoMatchConstraintValue]
+    val TM = "TM".asInstanceOf[GeoMatchConstraintValue]
+    val TC = "TC".asInstanceOf[GeoMatchConstraintValue]
+    val TV = "TV".asInstanceOf[GeoMatchConstraintValue]
+    val UG = "UG".asInstanceOf[GeoMatchConstraintValue]
+    val UA = "UA".asInstanceOf[GeoMatchConstraintValue]
+    val AE = "AE".asInstanceOf[GeoMatchConstraintValue]
+    val GB = "GB".asInstanceOf[GeoMatchConstraintValue]
+    val US = "US".asInstanceOf[GeoMatchConstraintValue]
+    val UM = "UM".asInstanceOf[GeoMatchConstraintValue]
+    val UY = "UY".asInstanceOf[GeoMatchConstraintValue]
+    val UZ = "UZ".asInstanceOf[GeoMatchConstraintValue]
+    val VU = "VU".asInstanceOf[GeoMatchConstraintValue]
+    val VE = "VE".asInstanceOf[GeoMatchConstraintValue]
+    val VN = "VN".asInstanceOf[GeoMatchConstraintValue]
+    val VG = "VG".asInstanceOf[GeoMatchConstraintValue]
+    val VI = "VI".asInstanceOf[GeoMatchConstraintValue]
+    val WF = "WF".asInstanceOf[GeoMatchConstraintValue]
+    val EH = "EH".asInstanceOf[GeoMatchConstraintValue]
+    val YE = "YE".asInstanceOf[GeoMatchConstraintValue]
+    val ZM = "ZM".asInstanceOf[GeoMatchConstraintValue]
+    val ZW = "ZW".asInstanceOf[GeoMatchConstraintValue]
 
     val values = js.Object.freeze(
       js.Array(
@@ -3111,10 +3101,11 @@ package wafregional {
       __obj.asInstanceOf[IPSetDescriptor]
     }
   }
-
-  object IPSetDescriptorTypeEnum {
-    val IPV4 = "IPV4"
-    val IPV6 = "IPV6"
+  @js.native
+  sealed trait IPSetDescriptorType extends js.Any
+  object IPSetDescriptorType extends js.Object {
+    val IPV4 = "IPV4".asInstanceOf[IPSetDescriptorType]
+    val IPV6 = "IPV6".asInstanceOf[IPSetDescriptorType]
 
     val values = js.Object.freeze(js.Array(IPV4, IPV6))
   }
@@ -3858,25 +3849,27 @@ package wafregional {
       __obj.asInstanceOf[LoggingConfiguration]
     }
   }
-
-  object MatchFieldTypeEnum {
-    val URI              = "URI"
-    val QUERY_STRING     = "QUERY_STRING"
-    val HEADER           = "HEADER"
-    val METHOD           = "METHOD"
-    val BODY             = "BODY"
-    val SINGLE_QUERY_ARG = "SINGLE_QUERY_ARG"
-    val ALL_QUERY_ARGS   = "ALL_QUERY_ARGS"
+  @js.native
+  sealed trait MatchFieldType extends js.Any
+  object MatchFieldType extends js.Object {
+    val URI              = "URI".asInstanceOf[MatchFieldType]
+    val QUERY_STRING     = "QUERY_STRING".asInstanceOf[MatchFieldType]
+    val HEADER           = "HEADER".asInstanceOf[MatchFieldType]
+    val METHOD           = "METHOD".asInstanceOf[MatchFieldType]
+    val BODY             = "BODY".asInstanceOf[MatchFieldType]
+    val SINGLE_QUERY_ARG = "SINGLE_QUERY_ARG".asInstanceOf[MatchFieldType]
+    val ALL_QUERY_ARGS   = "ALL_QUERY_ARGS".asInstanceOf[MatchFieldType]
 
     val values = js.Object.freeze(js.Array(URI, QUERY_STRING, HEADER, METHOD, BODY, SINGLE_QUERY_ARG, ALL_QUERY_ARGS))
   }
-
-  object PositionalConstraintEnum {
-    val EXACTLY       = "EXACTLY"
-    val STARTS_WITH   = "STARTS_WITH"
-    val ENDS_WITH     = "ENDS_WITH"
-    val CONTAINS      = "CONTAINS"
-    val CONTAINS_WORD = "CONTAINS_WORD"
+  @js.native
+  sealed trait PositionalConstraint extends js.Any
+  object PositionalConstraint extends js.Object {
+    val EXACTLY       = "EXACTLY".asInstanceOf[PositionalConstraint]
+    val STARTS_WITH   = "STARTS_WITH".asInstanceOf[PositionalConstraint]
+    val ENDS_WITH     = "ENDS_WITH".asInstanceOf[PositionalConstraint]
+    val CONTAINS      = "CONTAINS".asInstanceOf[PositionalConstraint]
+    val CONTAINS_WORD = "CONTAINS_WORD".asInstanceOf[PositionalConstraint]
 
     val values = js.Object.freeze(js.Array(EXACTLY, STARTS_WITH, ENDS_WITH, CONTAINS, CONTAINS_WORD))
   }
@@ -3907,15 +3900,16 @@ package wafregional {
       __obj.asInstanceOf[Predicate]
     }
   }
-
-  object PredicateTypeEnum {
-    val IPMatch           = "IPMatch"
-    val ByteMatch         = "ByteMatch"
-    val SqlInjectionMatch = "SqlInjectionMatch"
-    val GeoMatch          = "GeoMatch"
-    val SizeConstraint    = "SizeConstraint"
-    val XssMatch          = "XssMatch"
-    val RegexMatch        = "RegexMatch"
+  @js.native
+  sealed trait PredicateType extends js.Any
+  object PredicateType extends js.Object {
+    val IPMatch           = "IPMatch".asInstanceOf[PredicateType]
+    val ByteMatch         = "ByteMatch".asInstanceOf[PredicateType]
+    val SqlInjectionMatch = "SqlInjectionMatch".asInstanceOf[PredicateType]
+    val GeoMatch          = "GeoMatch".asInstanceOf[PredicateType]
+    val SizeConstraint    = "SizeConstraint".asInstanceOf[PredicateType]
+    val XssMatch          = "XssMatch".asInstanceOf[PredicateType]
+    val RegexMatch        = "RegexMatch".asInstanceOf[PredicateType]
 
     val values =
       js.Object.freeze(js.Array(IPMatch, ByteMatch, SqlInjectionMatch, GeoMatch, SizeConstraint, XssMatch, RegexMatch))
@@ -4028,9 +4022,10 @@ package wafregional {
       __obj.asInstanceOf[RateBasedRule]
     }
   }
-
-  object RateKeyEnum {
-    val IP = "IP"
+  @js.native
+  sealed trait RateKey extends js.Any
+  object RateKey extends js.Object {
+    val IP = "IP".asInstanceOf[RateKey]
 
     val values = js.Object.freeze(js.Array(IP))
   }
@@ -4213,10 +4208,11 @@ package wafregional {
       __obj.asInstanceOf[RegexPatternSetUpdate]
     }
   }
-
-  object ResourceTypeEnum {
-    val APPLICATION_LOAD_BALANCER = "APPLICATION_LOAD_BALANCER"
-    val API_GATEWAY               = "API_GATEWAY"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val APPLICATION_LOAD_BALANCER = "APPLICATION_LOAD_BALANCER".asInstanceOf[ResourceType]
+    val API_GATEWAY               = "API_GATEWAY".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(APPLICATION_LOAD_BALANCER, API_GATEWAY))
   }
@@ -4716,14 +4712,15 @@ package wafregional {
       __obj.asInstanceOf[TagResourceResponse]
     }
   }
-
-  object TextTransformationEnum {
-    val NONE                 = "NONE"
-    val COMPRESS_WHITE_SPACE = "COMPRESS_WHITE_SPACE"
-    val HTML_ENTITY_DECODE   = "HTML_ENTITY_DECODE"
-    val LOWERCASE            = "LOWERCASE"
-    val CMD_LINE             = "CMD_LINE"
-    val URL_DECODE           = "URL_DECODE"
+  @js.native
+  sealed trait TextTransformation extends js.Any
+  object TextTransformation extends js.Object {
+    val NONE                 = "NONE".asInstanceOf[TextTransformation]
+    val COMPRESS_WHITE_SPACE = "COMPRESS_WHITE_SPACE".asInstanceOf[TextTransformation]
+    val HTML_ENTITY_DECODE   = "HTML_ENTITY_DECODE".asInstanceOf[TextTransformation]
+    val LOWERCASE            = "LOWERCASE".asInstanceOf[TextTransformation]
+    val CMD_LINE             = "CMD_LINE".asInstanceOf[TextTransformation]
+    val URL_DECODE           = "URL_DECODE".asInstanceOf[TextTransformation]
 
     val values =
       js.Object.freeze(js.Array(NONE, COMPRESS_WHITE_SPACE, HTML_ENTITY_DECODE, LOWERCASE, CMD_LINE, URL_DECODE))
@@ -5306,11 +5303,12 @@ package wafregional {
       __obj.asInstanceOf[WafAction]
     }
   }
-
-  object WafActionTypeEnum {
-    val BLOCK = "BLOCK"
-    val ALLOW = "ALLOW"
-    val COUNT = "COUNT"
+  @js.native
+  sealed trait WafActionType extends js.Any
+  object WafActionType extends js.Object {
+    val BLOCK = "BLOCK".asInstanceOf[WafActionType]
+    val ALLOW = "ALLOW".asInstanceOf[WafActionType]
+    val COUNT = "COUNT".asInstanceOf[WafActionType]
 
     val values = js.Object.freeze(js.Array(BLOCK, ALLOW, COUNT))
   }
@@ -5335,18 +5333,20 @@ package wafregional {
       __obj.asInstanceOf[WafOverrideAction]
     }
   }
-
-  object WafOverrideActionTypeEnum {
-    val NONE  = "NONE"
-    val COUNT = "COUNT"
+  @js.native
+  sealed trait WafOverrideActionType extends js.Any
+  object WafOverrideActionType extends js.Object {
+    val NONE  = "NONE".asInstanceOf[WafOverrideActionType]
+    val COUNT = "COUNT".asInstanceOf[WafOverrideActionType]
 
     val values = js.Object.freeze(js.Array(NONE, COUNT))
   }
-
-  object WafRuleTypeEnum {
-    val REGULAR    = "REGULAR"
-    val RATE_BASED = "RATE_BASED"
-    val GROUP      = "GROUP"
+  @js.native
+  sealed trait WafRuleType extends js.Any
+  object WafRuleType extends js.Object {
+    val REGULAR    = "REGULAR".asInstanceOf[WafRuleType]
+    val RATE_BASED = "RATE_BASED".asInstanceOf[WafRuleType]
+    val GROUP      = "GROUP".asInstanceOf[WafRuleType]
 
     val values = js.Object.freeze(js.Array(REGULAR, RATE_BASED, GROUP))
   }

--- a/services/wafv2/src/main/scala/facade/amazonaws/services/WAFv2.scala
+++ b/services/wafv2/src/main/scala/facade/amazonaws/services/WAFv2.scala
@@ -7,68 +7,60 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object wafv2 {
-  type Action                             = String
-  type CapacityUnit                       = Double
-  type ComparisonOperator                 = String
-  type ConsumedCapacity                   = Double
-  type Country                            = String
-  type CountryCode                        = String
-  type CountryCodes                       = js.Array[CountryCode]
-  type EntityDescription                  = String
-  type EntityId                           = String
-  type EntityName                         = String
-  type ExcludedRules                      = js.Array[ExcludedRule]
-  type FieldToMatchData                   = String
-  type HTTPHeaders                        = js.Array[HTTPHeader]
-  type HTTPMethod                         = String
-  type HTTPVersion                        = String
-  type HeaderName                         = String
-  type HeaderValue                        = String
-  type IPAddress                          = String
-  type IPAddressVersion                   = String
-  type IPAddresses                        = js.Array[IPAddress]
-  type IPSetSummaries                     = js.Array[IPSetSummary]
-  type IPString                           = String
-  type ListMaxItems                       = Double
-  type LockToken                          = String
-  type LogDestinationConfigs              = js.Array[ResourceArn]
-  type LoggingConfigurations              = js.Array[LoggingConfiguration]
-  type ManagedRuleGroupSummaries          = js.Array[ManagedRuleGroupSummary]
-  type MetricName                         = String
-  type NextMarker                         = String
-  type PaginationLimit                    = Int
-  type PopulationSize                     = Double
-  type PositionalConstraint               = String
-  type RateBasedStatementAggregateKeyType = String
-  type RateLimit                          = Double
-  type RedactedFields                     = js.Array[FieldToMatch]
-  type RegexPatternSetSummaries           = js.Array[RegexPatternSetSummary]
-  type RegexPatternString                 = String
-  type RegularExpressionList              = js.Array[Regex]
-  type ResourceArn                        = String
-  type ResourceArns                       = js.Array[ResourceArn]
-  type ResourceType                       = String
-  type RuleGroupSummaries                 = js.Array[RuleGroupSummary]
-  type RulePriority                       = Int
-  type RuleSummaries                      = js.Array[RuleSummary]
-  type Rules                              = js.Array[Rule]
-  type SampleWeight                       = Double
-  type SampledHTTPRequests                = js.Array[SampledHTTPRequest]
-  type Scope                              = String
-  type SearchString                       = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
-  type Size                               = Double
-  type Statements                         = js.Array[Statement]
-  type TagKey                             = String
-  type TagKeyList                         = js.Array[TagKey]
-  type TagList                            = js.Array[Tag]
-  type TagValue                           = String
-  type TextTransformationPriority         = Int
-  type TextTransformationType             = String
-  type TextTransformations                = js.Array[TextTransformation]
-  type Timestamp                          = js.Date
-  type URIString                          = String
-  type VendorName                         = String
-  type WebACLSummaries                    = js.Array[WebACLSummary]
+  type Action                     = String
+  type CapacityUnit               = Double
+  type ConsumedCapacity           = Double
+  type Country                    = String
+  type CountryCodes               = js.Array[CountryCode]
+  type EntityDescription          = String
+  type EntityId                   = String
+  type EntityName                 = String
+  type ExcludedRules              = js.Array[ExcludedRule]
+  type FieldToMatchData           = String
+  type HTTPHeaders                = js.Array[HTTPHeader]
+  type HTTPMethod                 = String
+  type HTTPVersion                = String
+  type HeaderName                 = String
+  type HeaderValue                = String
+  type IPAddress                  = String
+  type IPAddresses                = js.Array[IPAddress]
+  type IPSetSummaries             = js.Array[IPSetSummary]
+  type IPString                   = String
+  type ListMaxItems               = Double
+  type LockToken                  = String
+  type LogDestinationConfigs      = js.Array[ResourceArn]
+  type LoggingConfigurations      = js.Array[LoggingConfiguration]
+  type ManagedRuleGroupSummaries  = js.Array[ManagedRuleGroupSummary]
+  type MetricName                 = String
+  type NextMarker                 = String
+  type PaginationLimit            = Int
+  type PopulationSize             = Double
+  type RateLimit                  = Double
+  type RedactedFields             = js.Array[FieldToMatch]
+  type RegexPatternSetSummaries   = js.Array[RegexPatternSetSummary]
+  type RegexPatternString         = String
+  type RegularExpressionList      = js.Array[Regex]
+  type ResourceArn                = String
+  type ResourceArns               = js.Array[ResourceArn]
+  type RuleGroupSummaries         = js.Array[RuleGroupSummary]
+  type RulePriority               = Int
+  type RuleSummaries              = js.Array[RuleSummary]
+  type Rules                      = js.Array[Rule]
+  type SampleWeight               = Double
+  type SampledHTTPRequests        = js.Array[SampledHTTPRequest]
+  type SearchString               = js.typedarray.TypedArray[_, _] | js.Array[Byte] | String
+  type Size                       = Double
+  type Statements                 = js.Array[Statement]
+  type TagKey                     = String
+  type TagKeyList                 = js.Array[TagKey]
+  type TagList                    = js.Array[Tag]
+  type TagValue                   = String
+  type TextTransformationPriority = Int
+  type TextTransformations        = js.Array[TextTransformation]
+  type Timestamp                  = js.Date
+  type URIString                  = String
+  type VendorName                 = String
+  type WebACLSummaries            = js.Array[WebACLSummary]
 
   implicit final class WAFv2Ops(private val service: WAFv2) extends AnyVal {
 
@@ -410,14 +402,15 @@ package wafv2 {
       __obj.asInstanceOf[CheckCapacityResponse]
     }
   }
-
-  object ComparisonOperatorEnum {
-    val EQ = "EQ"
-    val NE = "NE"
-    val LE = "LE"
-    val LT = "LT"
-    val GE = "GE"
-    val GT = "GT"
+  @js.native
+  sealed trait ComparisonOperator extends js.Any
+  object ComparisonOperator extends js.Object {
+    val EQ = "EQ".asInstanceOf[ComparisonOperator]
+    val NE = "NE".asInstanceOf[ComparisonOperator]
+    val LE = "LE".asInstanceOf[ComparisonOperator]
+    val LT = "LT".asInstanceOf[ComparisonOperator]
+    val GE = "GE".asInstanceOf[ComparisonOperator]
+    val GT = "GT".asInstanceOf[ComparisonOperator]
 
     val values = js.Object.freeze(js.Array(EQ, NE, LE, LT, GE, GT))
   }
@@ -439,257 +432,258 @@ package wafv2 {
       __obj.asInstanceOf[CountAction]
     }
   }
-
-  object CountryCodeEnum {
-    val AF = "AF"
-    val AX = "AX"
-    val AL = "AL"
-    val DZ = "DZ"
-    val AS = "AS"
-    val AD = "AD"
-    val AO = "AO"
-    val AI = "AI"
-    val AQ = "AQ"
-    val AG = "AG"
-    val AR = "AR"
-    val AM = "AM"
-    val AW = "AW"
-    val AU = "AU"
-    val AT = "AT"
-    val AZ = "AZ"
-    val BS = "BS"
-    val BH = "BH"
-    val BD = "BD"
-    val BB = "BB"
-    val BY = "BY"
-    val BE = "BE"
-    val BZ = "BZ"
-    val BJ = "BJ"
-    val BM = "BM"
-    val BT = "BT"
-    val BO = "BO"
-    val BQ = "BQ"
-    val BA = "BA"
-    val BW = "BW"
-    val BV = "BV"
-    val BR = "BR"
-    val IO = "IO"
-    val BN = "BN"
-    val BG = "BG"
-    val BF = "BF"
-    val BI = "BI"
-    val KH = "KH"
-    val CM = "CM"
-    val CA = "CA"
-    val CV = "CV"
-    val KY = "KY"
-    val CF = "CF"
-    val TD = "TD"
-    val CL = "CL"
-    val CN = "CN"
-    val CX = "CX"
-    val CC = "CC"
-    val CO = "CO"
-    val KM = "KM"
-    val CG = "CG"
-    val CD = "CD"
-    val CK = "CK"
-    val CR = "CR"
-    val CI = "CI"
-    val HR = "HR"
-    val CU = "CU"
-    val CW = "CW"
-    val CY = "CY"
-    val CZ = "CZ"
-    val DK = "DK"
-    val DJ = "DJ"
-    val DM = "DM"
-    val DO = "DO"
-    val EC = "EC"
-    val EG = "EG"
-    val SV = "SV"
-    val GQ = "GQ"
-    val ER = "ER"
-    val EE = "EE"
-    val ET = "ET"
-    val FK = "FK"
-    val FO = "FO"
-    val FJ = "FJ"
-    val FI = "FI"
-    val FR = "FR"
-    val GF = "GF"
-    val PF = "PF"
-    val TF = "TF"
-    val GA = "GA"
-    val GM = "GM"
-    val GE = "GE"
-    val DE = "DE"
-    val GH = "GH"
-    val GI = "GI"
-    val GR = "GR"
-    val GL = "GL"
-    val GD = "GD"
-    val GP = "GP"
-    val GU = "GU"
-    val GT = "GT"
-    val GG = "GG"
-    val GN = "GN"
-    val GW = "GW"
-    val GY = "GY"
-    val HT = "HT"
-    val HM = "HM"
-    val VA = "VA"
-    val HN = "HN"
-    val HK = "HK"
-    val HU = "HU"
-    val IS = "IS"
-    val IN = "IN"
-    val ID = "ID"
-    val IR = "IR"
-    val IQ = "IQ"
-    val IE = "IE"
-    val IM = "IM"
-    val IL = "IL"
-    val IT = "IT"
-    val JM = "JM"
-    val JP = "JP"
-    val JE = "JE"
-    val JO = "JO"
-    val KZ = "KZ"
-    val KE = "KE"
-    val KI = "KI"
-    val KP = "KP"
-    val KR = "KR"
-    val KW = "KW"
-    val KG = "KG"
-    val LA = "LA"
-    val LV = "LV"
-    val LB = "LB"
-    val LS = "LS"
-    val LR = "LR"
-    val LY = "LY"
-    val LI = "LI"
-    val LT = "LT"
-    val LU = "LU"
-    val MO = "MO"
-    val MK = "MK"
-    val MG = "MG"
-    val MW = "MW"
-    val MY = "MY"
-    val MV = "MV"
-    val ML = "ML"
-    val MT = "MT"
-    val MH = "MH"
-    val MQ = "MQ"
-    val MR = "MR"
-    val MU = "MU"
-    val YT = "YT"
-    val MX = "MX"
-    val FM = "FM"
-    val MD = "MD"
-    val MC = "MC"
-    val MN = "MN"
-    val ME = "ME"
-    val MS = "MS"
-    val MA = "MA"
-    val MZ = "MZ"
-    val MM = "MM"
-    val NA = "NA"
-    val NR = "NR"
-    val NP = "NP"
-    val NL = "NL"
-    val NC = "NC"
-    val NZ = "NZ"
-    val NI = "NI"
-    val NE = "NE"
-    val NG = "NG"
-    val NU = "NU"
-    val NF = "NF"
-    val MP = "MP"
-    val NO = "NO"
-    val OM = "OM"
-    val PK = "PK"
-    val PW = "PW"
-    val PS = "PS"
-    val PA = "PA"
-    val PG = "PG"
-    val PY = "PY"
-    val PE = "PE"
-    val PH = "PH"
-    val PN = "PN"
-    val PL = "PL"
-    val PT = "PT"
-    val PR = "PR"
-    val QA = "QA"
-    val RE = "RE"
-    val RO = "RO"
-    val RU = "RU"
-    val RW = "RW"
-    val BL = "BL"
-    val SH = "SH"
-    val KN = "KN"
-    val LC = "LC"
-    val MF = "MF"
-    val PM = "PM"
-    val VC = "VC"
-    val WS = "WS"
-    val SM = "SM"
-    val ST = "ST"
-    val SA = "SA"
-    val SN = "SN"
-    val RS = "RS"
-    val SC = "SC"
-    val SL = "SL"
-    val SG = "SG"
-    val SX = "SX"
-    val SK = "SK"
-    val SI = "SI"
-    val SB = "SB"
-    val SO = "SO"
-    val ZA = "ZA"
-    val GS = "GS"
-    val SS = "SS"
-    val ES = "ES"
-    val LK = "LK"
-    val SD = "SD"
-    val SR = "SR"
-    val SJ = "SJ"
-    val SZ = "SZ"
-    val SE = "SE"
-    val CH = "CH"
-    val SY = "SY"
-    val TW = "TW"
-    val TJ = "TJ"
-    val TZ = "TZ"
-    val TH = "TH"
-    val TL = "TL"
-    val TG = "TG"
-    val TK = "TK"
-    val TO = "TO"
-    val TT = "TT"
-    val TN = "TN"
-    val TR = "TR"
-    val TM = "TM"
-    val TC = "TC"
-    val TV = "TV"
-    val UG = "UG"
-    val UA = "UA"
-    val AE = "AE"
-    val GB = "GB"
-    val US = "US"
-    val UM = "UM"
-    val UY = "UY"
-    val UZ = "UZ"
-    val VU = "VU"
-    val VE = "VE"
-    val VN = "VN"
-    val VG = "VG"
-    val VI = "VI"
-    val WF = "WF"
-    val EH = "EH"
-    val YE = "YE"
-    val ZM = "ZM"
-    val ZW = "ZW"
+  @js.native
+  sealed trait CountryCode extends js.Any
+  object CountryCode extends js.Object {
+    val AF = "AF".asInstanceOf[CountryCode]
+    val AX = "AX".asInstanceOf[CountryCode]
+    val AL = "AL".asInstanceOf[CountryCode]
+    val DZ = "DZ".asInstanceOf[CountryCode]
+    val AS = "AS".asInstanceOf[CountryCode]
+    val AD = "AD".asInstanceOf[CountryCode]
+    val AO = "AO".asInstanceOf[CountryCode]
+    val AI = "AI".asInstanceOf[CountryCode]
+    val AQ = "AQ".asInstanceOf[CountryCode]
+    val AG = "AG".asInstanceOf[CountryCode]
+    val AR = "AR".asInstanceOf[CountryCode]
+    val AM = "AM".asInstanceOf[CountryCode]
+    val AW = "AW".asInstanceOf[CountryCode]
+    val AU = "AU".asInstanceOf[CountryCode]
+    val AT = "AT".asInstanceOf[CountryCode]
+    val AZ = "AZ".asInstanceOf[CountryCode]
+    val BS = "BS".asInstanceOf[CountryCode]
+    val BH = "BH".asInstanceOf[CountryCode]
+    val BD = "BD".asInstanceOf[CountryCode]
+    val BB = "BB".asInstanceOf[CountryCode]
+    val BY = "BY".asInstanceOf[CountryCode]
+    val BE = "BE".asInstanceOf[CountryCode]
+    val BZ = "BZ".asInstanceOf[CountryCode]
+    val BJ = "BJ".asInstanceOf[CountryCode]
+    val BM = "BM".asInstanceOf[CountryCode]
+    val BT = "BT".asInstanceOf[CountryCode]
+    val BO = "BO".asInstanceOf[CountryCode]
+    val BQ = "BQ".asInstanceOf[CountryCode]
+    val BA = "BA".asInstanceOf[CountryCode]
+    val BW = "BW".asInstanceOf[CountryCode]
+    val BV = "BV".asInstanceOf[CountryCode]
+    val BR = "BR".asInstanceOf[CountryCode]
+    val IO = "IO".asInstanceOf[CountryCode]
+    val BN = "BN".asInstanceOf[CountryCode]
+    val BG = "BG".asInstanceOf[CountryCode]
+    val BF = "BF".asInstanceOf[CountryCode]
+    val BI = "BI".asInstanceOf[CountryCode]
+    val KH = "KH".asInstanceOf[CountryCode]
+    val CM = "CM".asInstanceOf[CountryCode]
+    val CA = "CA".asInstanceOf[CountryCode]
+    val CV = "CV".asInstanceOf[CountryCode]
+    val KY = "KY".asInstanceOf[CountryCode]
+    val CF = "CF".asInstanceOf[CountryCode]
+    val TD = "TD".asInstanceOf[CountryCode]
+    val CL = "CL".asInstanceOf[CountryCode]
+    val CN = "CN".asInstanceOf[CountryCode]
+    val CX = "CX".asInstanceOf[CountryCode]
+    val CC = "CC".asInstanceOf[CountryCode]
+    val CO = "CO".asInstanceOf[CountryCode]
+    val KM = "KM".asInstanceOf[CountryCode]
+    val CG = "CG".asInstanceOf[CountryCode]
+    val CD = "CD".asInstanceOf[CountryCode]
+    val CK = "CK".asInstanceOf[CountryCode]
+    val CR = "CR".asInstanceOf[CountryCode]
+    val CI = "CI".asInstanceOf[CountryCode]
+    val HR = "HR".asInstanceOf[CountryCode]
+    val CU = "CU".asInstanceOf[CountryCode]
+    val CW = "CW".asInstanceOf[CountryCode]
+    val CY = "CY".asInstanceOf[CountryCode]
+    val CZ = "CZ".asInstanceOf[CountryCode]
+    val DK = "DK".asInstanceOf[CountryCode]
+    val DJ = "DJ".asInstanceOf[CountryCode]
+    val DM = "DM".asInstanceOf[CountryCode]
+    val DO = "DO".asInstanceOf[CountryCode]
+    val EC = "EC".asInstanceOf[CountryCode]
+    val EG = "EG".asInstanceOf[CountryCode]
+    val SV = "SV".asInstanceOf[CountryCode]
+    val GQ = "GQ".asInstanceOf[CountryCode]
+    val ER = "ER".asInstanceOf[CountryCode]
+    val EE = "EE".asInstanceOf[CountryCode]
+    val ET = "ET".asInstanceOf[CountryCode]
+    val FK = "FK".asInstanceOf[CountryCode]
+    val FO = "FO".asInstanceOf[CountryCode]
+    val FJ = "FJ".asInstanceOf[CountryCode]
+    val FI = "FI".asInstanceOf[CountryCode]
+    val FR = "FR".asInstanceOf[CountryCode]
+    val GF = "GF".asInstanceOf[CountryCode]
+    val PF = "PF".asInstanceOf[CountryCode]
+    val TF = "TF".asInstanceOf[CountryCode]
+    val GA = "GA".asInstanceOf[CountryCode]
+    val GM = "GM".asInstanceOf[CountryCode]
+    val GE = "GE".asInstanceOf[CountryCode]
+    val DE = "DE".asInstanceOf[CountryCode]
+    val GH = "GH".asInstanceOf[CountryCode]
+    val GI = "GI".asInstanceOf[CountryCode]
+    val GR = "GR".asInstanceOf[CountryCode]
+    val GL = "GL".asInstanceOf[CountryCode]
+    val GD = "GD".asInstanceOf[CountryCode]
+    val GP = "GP".asInstanceOf[CountryCode]
+    val GU = "GU".asInstanceOf[CountryCode]
+    val GT = "GT".asInstanceOf[CountryCode]
+    val GG = "GG".asInstanceOf[CountryCode]
+    val GN = "GN".asInstanceOf[CountryCode]
+    val GW = "GW".asInstanceOf[CountryCode]
+    val GY = "GY".asInstanceOf[CountryCode]
+    val HT = "HT".asInstanceOf[CountryCode]
+    val HM = "HM".asInstanceOf[CountryCode]
+    val VA = "VA".asInstanceOf[CountryCode]
+    val HN = "HN".asInstanceOf[CountryCode]
+    val HK = "HK".asInstanceOf[CountryCode]
+    val HU = "HU".asInstanceOf[CountryCode]
+    val IS = "IS".asInstanceOf[CountryCode]
+    val IN = "IN".asInstanceOf[CountryCode]
+    val ID = "ID".asInstanceOf[CountryCode]
+    val IR = "IR".asInstanceOf[CountryCode]
+    val IQ = "IQ".asInstanceOf[CountryCode]
+    val IE = "IE".asInstanceOf[CountryCode]
+    val IM = "IM".asInstanceOf[CountryCode]
+    val IL = "IL".asInstanceOf[CountryCode]
+    val IT = "IT".asInstanceOf[CountryCode]
+    val JM = "JM".asInstanceOf[CountryCode]
+    val JP = "JP".asInstanceOf[CountryCode]
+    val JE = "JE".asInstanceOf[CountryCode]
+    val JO = "JO".asInstanceOf[CountryCode]
+    val KZ = "KZ".asInstanceOf[CountryCode]
+    val KE = "KE".asInstanceOf[CountryCode]
+    val KI = "KI".asInstanceOf[CountryCode]
+    val KP = "KP".asInstanceOf[CountryCode]
+    val KR = "KR".asInstanceOf[CountryCode]
+    val KW = "KW".asInstanceOf[CountryCode]
+    val KG = "KG".asInstanceOf[CountryCode]
+    val LA = "LA".asInstanceOf[CountryCode]
+    val LV = "LV".asInstanceOf[CountryCode]
+    val LB = "LB".asInstanceOf[CountryCode]
+    val LS = "LS".asInstanceOf[CountryCode]
+    val LR = "LR".asInstanceOf[CountryCode]
+    val LY = "LY".asInstanceOf[CountryCode]
+    val LI = "LI".asInstanceOf[CountryCode]
+    val LT = "LT".asInstanceOf[CountryCode]
+    val LU = "LU".asInstanceOf[CountryCode]
+    val MO = "MO".asInstanceOf[CountryCode]
+    val MK = "MK".asInstanceOf[CountryCode]
+    val MG = "MG".asInstanceOf[CountryCode]
+    val MW = "MW".asInstanceOf[CountryCode]
+    val MY = "MY".asInstanceOf[CountryCode]
+    val MV = "MV".asInstanceOf[CountryCode]
+    val ML = "ML".asInstanceOf[CountryCode]
+    val MT = "MT".asInstanceOf[CountryCode]
+    val MH = "MH".asInstanceOf[CountryCode]
+    val MQ = "MQ".asInstanceOf[CountryCode]
+    val MR = "MR".asInstanceOf[CountryCode]
+    val MU = "MU".asInstanceOf[CountryCode]
+    val YT = "YT".asInstanceOf[CountryCode]
+    val MX = "MX".asInstanceOf[CountryCode]
+    val FM = "FM".asInstanceOf[CountryCode]
+    val MD = "MD".asInstanceOf[CountryCode]
+    val MC = "MC".asInstanceOf[CountryCode]
+    val MN = "MN".asInstanceOf[CountryCode]
+    val ME = "ME".asInstanceOf[CountryCode]
+    val MS = "MS".asInstanceOf[CountryCode]
+    val MA = "MA".asInstanceOf[CountryCode]
+    val MZ = "MZ".asInstanceOf[CountryCode]
+    val MM = "MM".asInstanceOf[CountryCode]
+    val NA = "NA".asInstanceOf[CountryCode]
+    val NR = "NR".asInstanceOf[CountryCode]
+    val NP = "NP".asInstanceOf[CountryCode]
+    val NL = "NL".asInstanceOf[CountryCode]
+    val NC = "NC".asInstanceOf[CountryCode]
+    val NZ = "NZ".asInstanceOf[CountryCode]
+    val NI = "NI".asInstanceOf[CountryCode]
+    val NE = "NE".asInstanceOf[CountryCode]
+    val NG = "NG".asInstanceOf[CountryCode]
+    val NU = "NU".asInstanceOf[CountryCode]
+    val NF = "NF".asInstanceOf[CountryCode]
+    val MP = "MP".asInstanceOf[CountryCode]
+    val NO = "NO".asInstanceOf[CountryCode]
+    val OM = "OM".asInstanceOf[CountryCode]
+    val PK = "PK".asInstanceOf[CountryCode]
+    val PW = "PW".asInstanceOf[CountryCode]
+    val PS = "PS".asInstanceOf[CountryCode]
+    val PA = "PA".asInstanceOf[CountryCode]
+    val PG = "PG".asInstanceOf[CountryCode]
+    val PY = "PY".asInstanceOf[CountryCode]
+    val PE = "PE".asInstanceOf[CountryCode]
+    val PH = "PH".asInstanceOf[CountryCode]
+    val PN = "PN".asInstanceOf[CountryCode]
+    val PL = "PL".asInstanceOf[CountryCode]
+    val PT = "PT".asInstanceOf[CountryCode]
+    val PR = "PR".asInstanceOf[CountryCode]
+    val QA = "QA".asInstanceOf[CountryCode]
+    val RE = "RE".asInstanceOf[CountryCode]
+    val RO = "RO".asInstanceOf[CountryCode]
+    val RU = "RU".asInstanceOf[CountryCode]
+    val RW = "RW".asInstanceOf[CountryCode]
+    val BL = "BL".asInstanceOf[CountryCode]
+    val SH = "SH".asInstanceOf[CountryCode]
+    val KN = "KN".asInstanceOf[CountryCode]
+    val LC = "LC".asInstanceOf[CountryCode]
+    val MF = "MF".asInstanceOf[CountryCode]
+    val PM = "PM".asInstanceOf[CountryCode]
+    val VC = "VC".asInstanceOf[CountryCode]
+    val WS = "WS".asInstanceOf[CountryCode]
+    val SM = "SM".asInstanceOf[CountryCode]
+    val ST = "ST".asInstanceOf[CountryCode]
+    val SA = "SA".asInstanceOf[CountryCode]
+    val SN = "SN".asInstanceOf[CountryCode]
+    val RS = "RS".asInstanceOf[CountryCode]
+    val SC = "SC".asInstanceOf[CountryCode]
+    val SL = "SL".asInstanceOf[CountryCode]
+    val SG = "SG".asInstanceOf[CountryCode]
+    val SX = "SX".asInstanceOf[CountryCode]
+    val SK = "SK".asInstanceOf[CountryCode]
+    val SI = "SI".asInstanceOf[CountryCode]
+    val SB = "SB".asInstanceOf[CountryCode]
+    val SO = "SO".asInstanceOf[CountryCode]
+    val ZA = "ZA".asInstanceOf[CountryCode]
+    val GS = "GS".asInstanceOf[CountryCode]
+    val SS = "SS".asInstanceOf[CountryCode]
+    val ES = "ES".asInstanceOf[CountryCode]
+    val LK = "LK".asInstanceOf[CountryCode]
+    val SD = "SD".asInstanceOf[CountryCode]
+    val SR = "SR".asInstanceOf[CountryCode]
+    val SJ = "SJ".asInstanceOf[CountryCode]
+    val SZ = "SZ".asInstanceOf[CountryCode]
+    val SE = "SE".asInstanceOf[CountryCode]
+    val CH = "CH".asInstanceOf[CountryCode]
+    val SY = "SY".asInstanceOf[CountryCode]
+    val TW = "TW".asInstanceOf[CountryCode]
+    val TJ = "TJ".asInstanceOf[CountryCode]
+    val TZ = "TZ".asInstanceOf[CountryCode]
+    val TH = "TH".asInstanceOf[CountryCode]
+    val TL = "TL".asInstanceOf[CountryCode]
+    val TG = "TG".asInstanceOf[CountryCode]
+    val TK = "TK".asInstanceOf[CountryCode]
+    val TO = "TO".asInstanceOf[CountryCode]
+    val TT = "TT".asInstanceOf[CountryCode]
+    val TN = "TN".asInstanceOf[CountryCode]
+    val TR = "TR".asInstanceOf[CountryCode]
+    val TM = "TM".asInstanceOf[CountryCode]
+    val TC = "TC".asInstanceOf[CountryCode]
+    val TV = "TV".asInstanceOf[CountryCode]
+    val UG = "UG".asInstanceOf[CountryCode]
+    val UA = "UA".asInstanceOf[CountryCode]
+    val AE = "AE".asInstanceOf[CountryCode]
+    val GB = "GB".asInstanceOf[CountryCode]
+    val US = "US".asInstanceOf[CountryCode]
+    val UM = "UM".asInstanceOf[CountryCode]
+    val UY = "UY".asInstanceOf[CountryCode]
+    val UZ = "UZ".asInstanceOf[CountryCode]
+    val VU = "VU".asInstanceOf[CountryCode]
+    val VE = "VE".asInstanceOf[CountryCode]
+    val VN = "VN".asInstanceOf[CountryCode]
+    val VG = "VG".asInstanceOf[CountryCode]
+    val VI = "VI".asInstanceOf[CountryCode]
+    val WF = "WF".asInstanceOf[CountryCode]
+    val EH = "EH".asInstanceOf[CountryCode]
+    val YE = "YE".asInstanceOf[CountryCode]
+    val ZM = "ZM".asInstanceOf[CountryCode]
+    val ZW = "ZW".asInstanceOf[CountryCode]
 
     val values = js.Object.freeze(
       js.Array(
@@ -1908,10 +1902,11 @@ package wafv2 {
       __obj.asInstanceOf[HTTPRequest]
     }
   }
-
-  object IPAddressVersionEnum {
-    val IPV4 = "IPV4"
-    val IPV6 = "IPV6"
+  @js.native
+  sealed trait IPAddressVersion extends js.Any
+  object IPAddressVersion extends js.Object {
+    val IPV4 = "IPV4".asInstanceOf[IPAddressVersion]
+    val IPV6 = "IPV6".asInstanceOf[IPAddressVersion]
 
     val values = js.Object.freeze(js.Array(IPV4, IPV6))
   }
@@ -2530,13 +2525,14 @@ package wafv2 {
       __obj.asInstanceOf[OverrideAction]
     }
   }
-
-  object PositionalConstraintEnum {
-    val EXACTLY       = "EXACTLY"
-    val STARTS_WITH   = "STARTS_WITH"
-    val ENDS_WITH     = "ENDS_WITH"
-    val CONTAINS      = "CONTAINS"
-    val CONTAINS_WORD = "CONTAINS_WORD"
+  @js.native
+  sealed trait PositionalConstraint extends js.Any
+  object PositionalConstraint extends js.Object {
+    val EXACTLY       = "EXACTLY".asInstanceOf[PositionalConstraint]
+    val STARTS_WITH   = "STARTS_WITH".asInstanceOf[PositionalConstraint]
+    val ENDS_WITH     = "ENDS_WITH".asInstanceOf[PositionalConstraint]
+    val CONTAINS      = "CONTAINS".asInstanceOf[PositionalConstraint]
+    val CONTAINS_WORD = "CONTAINS_WORD".asInstanceOf[PositionalConstraint]
 
     val values = js.Object.freeze(js.Array(EXACTLY, STARTS_WITH, ENDS_WITH, CONTAINS, CONTAINS_WORD))
   }
@@ -2626,9 +2622,10 @@ package wafv2 {
       __obj.asInstanceOf[RateBasedStatement]
     }
   }
-
-  object RateBasedStatementAggregateKeyTypeEnum {
-    val IP = "IP"
+  @js.native
+  sealed trait RateBasedStatementAggregateKeyType extends js.Any
+  object RateBasedStatementAggregateKeyType extends js.Object {
+    val IP = "IP".asInstanceOf[RateBasedStatementAggregateKeyType]
 
     val values = js.Object.freeze(js.Array(IP))
   }
@@ -2769,10 +2766,11 @@ package wafv2 {
       __obj.asInstanceOf[RegexPatternSetSummary]
     }
   }
-
-  object ResourceTypeEnum {
-    val APPLICATION_LOAD_BALANCER = "APPLICATION_LOAD_BALANCER"
-    val API_GATEWAY               = "API_GATEWAY"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val APPLICATION_LOAD_BALANCER = "APPLICATION_LOAD_BALANCER".asInstanceOf[ResourceType]
+    val API_GATEWAY               = "API_GATEWAY".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(APPLICATION_LOAD_BALANCER, API_GATEWAY))
   }
@@ -2994,10 +2992,11 @@ package wafv2 {
       __obj.asInstanceOf[SampledHTTPRequest]
     }
   }
-
-  object ScopeEnum {
-    val CLOUDFRONT = "CLOUDFRONT"
-    val REGIONAL   = "REGIONAL"
+  @js.native
+  sealed trait Scope extends js.Any
+  object Scope extends js.Object {
+    val CLOUDFRONT = "CLOUDFRONT".asInstanceOf[Scope]
+    val REGIONAL   = "REGIONAL".asInstanceOf[Scope]
 
     val values = js.Object.freeze(js.Array(CLOUDFRONT, REGIONAL))
   }
@@ -3273,14 +3272,15 @@ package wafv2 {
       __obj.asInstanceOf[TextTransformation]
     }
   }
-
-  object TextTransformationTypeEnum {
-    val NONE                 = "NONE"
-    val COMPRESS_WHITE_SPACE = "COMPRESS_WHITE_SPACE"
-    val HTML_ENTITY_DECODE   = "HTML_ENTITY_DECODE"
-    val LOWERCASE            = "LOWERCASE"
-    val CMD_LINE             = "CMD_LINE"
-    val URL_DECODE           = "URL_DECODE"
+  @js.native
+  sealed trait TextTransformationType extends js.Any
+  object TextTransformationType extends js.Object {
+    val NONE                 = "NONE".asInstanceOf[TextTransformationType]
+    val COMPRESS_WHITE_SPACE = "COMPRESS_WHITE_SPACE".asInstanceOf[TextTransformationType]
+    val HTML_ENTITY_DECODE   = "HTML_ENTITY_DECODE".asInstanceOf[TextTransformationType]
+    val LOWERCASE            = "LOWERCASE".asInstanceOf[TextTransformationType]
+    val CMD_LINE             = "CMD_LINE".asInstanceOf[TextTransformationType]
+    val URL_DECODE           = "URL_DECODE".asInstanceOf[TextTransformationType]
 
     val values =
       js.Object.freeze(js.Array(NONE, COMPRESS_WHITE_SPACE, HTML_ENTITY_DECODE, LOWERCASE, CMD_LINE, URL_DECODE))

--- a/services/workdocs/src/main/scala/facade/amazonaws/services/WorkDocs.scala
+++ b/services/workdocs/src/main/scala/facade/amazonaws/services/WorkDocs.scala
@@ -8,32 +8,23 @@ import facade.amazonaws._
 
 package object workdocs {
   type ActivityNamesFilterType     = String
-  type ActivityType                = String
   type AuthenticationHeaderType    = String
-  type BooleanEnumType             = String
   type BooleanType                 = Boolean
   type CommentIdType               = String
   type CommentList                 = js.Array[Comment]
-  type CommentStatusType           = String
   type CommentTextType             = String
-  type CommentVisibilityType       = String
   type CustomMetadataKeyList       = js.Array[CustomMetadataKeyType]
   type CustomMetadataKeyType       = String
   type CustomMetadataMap           = js.Dictionary[CustomMetadataValueType]
   type CustomMetadataValueType     = String
   type DocumentContentType         = String
   type DocumentMetadataList        = js.Array[DocumentMetadata]
-  type DocumentSourceType          = String
   type DocumentSourceUrlMap        = js.Dictionary[UrlType]
-  type DocumentStatusType          = String
-  type DocumentThumbnailType       = String
   type DocumentThumbnailUrlMap     = js.Dictionary[UrlType]
   type DocumentVersionIdType       = String
   type DocumentVersionMetadataList = js.Array[DocumentVersionMetadata]
-  type DocumentVersionStatus       = String
   type EmailAddressType            = String
   type FieldNamesType              = String
-  type FolderContentType           = String
   type FolderMetadataList          = js.Array[FolderMetadata]
   type GroupMetadataList           = js.Array[GroupMetadata]
   type GroupNameType               = String
@@ -42,10 +33,8 @@ package object workdocs {
   type HeaderValueType             = String
   type IdType                      = String
   type LimitType                   = Int
-  type LocaleType                  = String
   type MarkerType                  = String
   type MessageType                 = String
-  type OrderType                   = String
   type OrganizationUserList        = js.Array[User]
   type PageMarkerType              = String
   type PasswordType                = String
@@ -53,40 +42,25 @@ package object workdocs {
   type PositiveIntegerType         = Int
   type PositiveSizeType            = Double
   type PrincipalList               = js.Array[Principal]
-  type PrincipalType               = String
-  type ResourceCollectionType      = String
   type ResourceIdType              = String
   type ResourceNameType            = String
   type ResourcePathComponentList   = js.Array[ResourcePathComponent]
-  type ResourceSortType            = String
-  type ResourceStateType           = String
-  type ResourceType                = String
-  type RolePermissionType          = String
-  type RoleType                    = String
   type SearchQueryType             = String
   type SharePrincipalList          = js.Array[SharePrincipal]
   type ShareResultsList            = js.Array[ShareResult]
-  type ShareStatusType             = String
   type SharedLabel                 = String
   type SharedLabels                = js.Array[SharedLabel]
   type SignedHeaderMap             = js.Dictionary[HeaderValueType]
   type SizeType                    = Double
-  type StorageType                 = String
   type SubscriptionEndPointType    = String
   type SubscriptionList            = js.Array[Subscription]
-  type SubscriptionProtocolType    = String
-  type SubscriptionType            = String
   type TimeZoneIdType              = String
   type TimestampType               = js.Date
   type UrlType                     = String
   type UserActivities              = js.Array[Activity]
   type UserAttributeValueType      = String
-  type UserFilterType              = String
   type UserIdsType                 = String
   type UserMetadataList            = js.Array[UserMetadata]
-  type UserSortType                = String
-  type UserStatusType              = String
-  type UserType                    = String
   type UsernameType                = String
 
   implicit final class WorkDocsOps(private val service: WorkDocs) extends AnyVal {
@@ -347,41 +321,43 @@ package workdocs {
       __obj.asInstanceOf[Activity]
     }
   }
-
-  object ActivityTypeEnum {
-    val DOCUMENT_CHECKED_IN                        = "DOCUMENT_CHECKED_IN"
-    val DOCUMENT_CHECKED_OUT                       = "DOCUMENT_CHECKED_OUT"
-    val DOCUMENT_RENAMED                           = "DOCUMENT_RENAMED"
-    val DOCUMENT_VERSION_UPLOADED                  = "DOCUMENT_VERSION_UPLOADED"
-    val DOCUMENT_VERSION_DELETED                   = "DOCUMENT_VERSION_DELETED"
-    val DOCUMENT_VERSION_VIEWED                    = "DOCUMENT_VERSION_VIEWED"
-    val DOCUMENT_VERSION_DOWNLOADED                = "DOCUMENT_VERSION_DOWNLOADED"
-    val DOCUMENT_RECYCLED                          = "DOCUMENT_RECYCLED"
-    val DOCUMENT_RESTORED                          = "DOCUMENT_RESTORED"
-    val DOCUMENT_REVERTED                          = "DOCUMENT_REVERTED"
-    val DOCUMENT_SHARED                            = "DOCUMENT_SHARED"
-    val DOCUMENT_UNSHARED                          = "DOCUMENT_UNSHARED"
-    val DOCUMENT_SHARE_PERMISSION_CHANGED          = "DOCUMENT_SHARE_PERMISSION_CHANGED"
-    val DOCUMENT_SHAREABLE_LINK_CREATED            = "DOCUMENT_SHAREABLE_LINK_CREATED"
-    val DOCUMENT_SHAREABLE_LINK_REMOVED            = "DOCUMENT_SHAREABLE_LINK_REMOVED"
-    val DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED = "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED"
-    val DOCUMENT_MOVED                             = "DOCUMENT_MOVED"
-    val DOCUMENT_COMMENT_ADDED                     = "DOCUMENT_COMMENT_ADDED"
-    val DOCUMENT_COMMENT_DELETED                   = "DOCUMENT_COMMENT_DELETED"
-    val DOCUMENT_ANNOTATION_ADDED                  = "DOCUMENT_ANNOTATION_ADDED"
-    val DOCUMENT_ANNOTATION_DELETED                = "DOCUMENT_ANNOTATION_DELETED"
-    val FOLDER_CREATED                             = "FOLDER_CREATED"
-    val FOLDER_DELETED                             = "FOLDER_DELETED"
-    val FOLDER_RENAMED                             = "FOLDER_RENAMED"
-    val FOLDER_RECYCLED                            = "FOLDER_RECYCLED"
-    val FOLDER_RESTORED                            = "FOLDER_RESTORED"
-    val FOLDER_SHARED                              = "FOLDER_SHARED"
-    val FOLDER_UNSHARED                            = "FOLDER_UNSHARED"
-    val FOLDER_SHARE_PERMISSION_CHANGED            = "FOLDER_SHARE_PERMISSION_CHANGED"
-    val FOLDER_SHAREABLE_LINK_CREATED              = "FOLDER_SHAREABLE_LINK_CREATED"
-    val FOLDER_SHAREABLE_LINK_REMOVED              = "FOLDER_SHAREABLE_LINK_REMOVED"
-    val FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED   = "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED"
-    val FOLDER_MOVED                               = "FOLDER_MOVED"
+  @js.native
+  sealed trait ActivityType extends js.Any
+  object ActivityType extends js.Object {
+    val DOCUMENT_CHECKED_IN               = "DOCUMENT_CHECKED_IN".asInstanceOf[ActivityType]
+    val DOCUMENT_CHECKED_OUT              = "DOCUMENT_CHECKED_OUT".asInstanceOf[ActivityType]
+    val DOCUMENT_RENAMED                  = "DOCUMENT_RENAMED".asInstanceOf[ActivityType]
+    val DOCUMENT_VERSION_UPLOADED         = "DOCUMENT_VERSION_UPLOADED".asInstanceOf[ActivityType]
+    val DOCUMENT_VERSION_DELETED          = "DOCUMENT_VERSION_DELETED".asInstanceOf[ActivityType]
+    val DOCUMENT_VERSION_VIEWED           = "DOCUMENT_VERSION_VIEWED".asInstanceOf[ActivityType]
+    val DOCUMENT_VERSION_DOWNLOADED       = "DOCUMENT_VERSION_DOWNLOADED".asInstanceOf[ActivityType]
+    val DOCUMENT_RECYCLED                 = "DOCUMENT_RECYCLED".asInstanceOf[ActivityType]
+    val DOCUMENT_RESTORED                 = "DOCUMENT_RESTORED".asInstanceOf[ActivityType]
+    val DOCUMENT_REVERTED                 = "DOCUMENT_REVERTED".asInstanceOf[ActivityType]
+    val DOCUMENT_SHARED                   = "DOCUMENT_SHARED".asInstanceOf[ActivityType]
+    val DOCUMENT_UNSHARED                 = "DOCUMENT_UNSHARED".asInstanceOf[ActivityType]
+    val DOCUMENT_SHARE_PERMISSION_CHANGED = "DOCUMENT_SHARE_PERMISSION_CHANGED".asInstanceOf[ActivityType]
+    val DOCUMENT_SHAREABLE_LINK_CREATED   = "DOCUMENT_SHAREABLE_LINK_CREATED".asInstanceOf[ActivityType]
+    val DOCUMENT_SHAREABLE_LINK_REMOVED   = "DOCUMENT_SHAREABLE_LINK_REMOVED".asInstanceOf[ActivityType]
+    val DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED =
+      "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED".asInstanceOf[ActivityType]
+    val DOCUMENT_MOVED                           = "DOCUMENT_MOVED".asInstanceOf[ActivityType]
+    val DOCUMENT_COMMENT_ADDED                   = "DOCUMENT_COMMENT_ADDED".asInstanceOf[ActivityType]
+    val DOCUMENT_COMMENT_DELETED                 = "DOCUMENT_COMMENT_DELETED".asInstanceOf[ActivityType]
+    val DOCUMENT_ANNOTATION_ADDED                = "DOCUMENT_ANNOTATION_ADDED".asInstanceOf[ActivityType]
+    val DOCUMENT_ANNOTATION_DELETED              = "DOCUMENT_ANNOTATION_DELETED".asInstanceOf[ActivityType]
+    val FOLDER_CREATED                           = "FOLDER_CREATED".asInstanceOf[ActivityType]
+    val FOLDER_DELETED                           = "FOLDER_DELETED".asInstanceOf[ActivityType]
+    val FOLDER_RENAMED                           = "FOLDER_RENAMED".asInstanceOf[ActivityType]
+    val FOLDER_RECYCLED                          = "FOLDER_RECYCLED".asInstanceOf[ActivityType]
+    val FOLDER_RESTORED                          = "FOLDER_RESTORED".asInstanceOf[ActivityType]
+    val FOLDER_SHARED                            = "FOLDER_SHARED".asInstanceOf[ActivityType]
+    val FOLDER_UNSHARED                          = "FOLDER_UNSHARED".asInstanceOf[ActivityType]
+    val FOLDER_SHARE_PERMISSION_CHANGED          = "FOLDER_SHARE_PERMISSION_CHANGED".asInstanceOf[ActivityType]
+    val FOLDER_SHAREABLE_LINK_CREATED            = "FOLDER_SHAREABLE_LINK_CREATED".asInstanceOf[ActivityType]
+    val FOLDER_SHAREABLE_LINK_REMOVED            = "FOLDER_SHAREABLE_LINK_REMOVED".asInstanceOf[ActivityType]
+    val FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED = "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED".asInstanceOf[ActivityType]
+    val FOLDER_MOVED                             = "FOLDER_MOVED".asInstanceOf[ActivityType]
 
     val values = js.Object.freeze(
       js.Array(
@@ -464,10 +440,11 @@ package workdocs {
       __obj.asInstanceOf[AddResourcePermissionsResponse]
     }
   }
-
-  object BooleanEnumTypeEnum {
-    val TRUE  = "TRUE"
-    val FALSE = "FALSE"
+  @js.native
+  sealed trait BooleanEnumType extends js.Any
+  object BooleanEnumType extends js.Object {
+    val TRUE  = "TRUE".asInstanceOf[BooleanEnumType]
+    val FALSE = "FALSE".asInstanceOf[BooleanEnumType]
 
     val values = js.Object.freeze(js.Array(TRUE, FALSE))
   }
@@ -547,18 +524,20 @@ package workdocs {
       __obj.asInstanceOf[CommentMetadata]
     }
   }
-
-  object CommentStatusTypeEnum {
-    val DRAFT     = "DRAFT"
-    val PUBLISHED = "PUBLISHED"
-    val DELETED   = "DELETED"
+  @js.native
+  sealed trait CommentStatusType extends js.Any
+  object CommentStatusType extends js.Object {
+    val DRAFT     = "DRAFT".asInstanceOf[CommentStatusType]
+    val PUBLISHED = "PUBLISHED".asInstanceOf[CommentStatusType]
+    val DELETED   = "DELETED".asInstanceOf[CommentStatusType]
 
     val values = js.Object.freeze(js.Array(DRAFT, PUBLISHED, DELETED))
   }
-
-  object CommentVisibilityTypeEnum {
-    val PUBLIC  = "PUBLIC"
-    val PRIVATE = "PRIVATE"
+  @js.native
+  sealed trait CommentVisibilityType extends js.Any
+  object CommentVisibilityType extends js.Object {
+    val PUBLIC  = "PUBLIC".asInstanceOf[CommentVisibilityType]
+    val PRIVATE = "PRIVATE".asInstanceOf[CommentVisibilityType]
 
     val values = js.Object.freeze(js.Array(PUBLIC, PRIVATE))
   }
@@ -1586,25 +1565,28 @@ package workdocs {
       __obj.asInstanceOf[DocumentMetadata]
     }
   }
-
-  object DocumentSourceTypeEnum {
-    val ORIGINAL      = "ORIGINAL"
-    val WITH_COMMENTS = "WITH_COMMENTS"
+  @js.native
+  sealed trait DocumentSourceType extends js.Any
+  object DocumentSourceType extends js.Object {
+    val ORIGINAL      = "ORIGINAL".asInstanceOf[DocumentSourceType]
+    val WITH_COMMENTS = "WITH_COMMENTS".asInstanceOf[DocumentSourceType]
 
     val values = js.Object.freeze(js.Array(ORIGINAL, WITH_COMMENTS))
   }
-
-  object DocumentStatusTypeEnum {
-    val INITIALIZED = "INITIALIZED"
-    val ACTIVE      = "ACTIVE"
+  @js.native
+  sealed trait DocumentStatusType extends js.Any
+  object DocumentStatusType extends js.Object {
+    val INITIALIZED = "INITIALIZED".asInstanceOf[DocumentStatusType]
+    val ACTIVE      = "ACTIVE".asInstanceOf[DocumentStatusType]
 
     val values = js.Object.freeze(js.Array(INITIALIZED, ACTIVE))
   }
-
-  object DocumentThumbnailTypeEnum {
-    val SMALL    = "SMALL"
-    val SMALL_HQ = "SMALL_HQ"
-    val LARGE    = "LARGE"
+  @js.native
+  sealed trait DocumentThumbnailType extends js.Any
+  object DocumentThumbnailType extends js.Object {
+    val SMALL    = "SMALL".asInstanceOf[DocumentThumbnailType]
+    val SMALL_HQ = "SMALL_HQ".asInstanceOf[DocumentThumbnailType]
+    val LARGE    = "LARGE".asInstanceOf[DocumentThumbnailType]
 
     val values = js.Object.freeze(js.Array(SMALL, SMALL_HQ, LARGE))
   }
@@ -1663,17 +1645,19 @@ package workdocs {
       __obj.asInstanceOf[DocumentVersionMetadata]
     }
   }
-
-  object DocumentVersionStatusEnum {
-    val ACTIVE = "ACTIVE"
+  @js.native
+  sealed trait DocumentVersionStatus extends js.Any
+  object DocumentVersionStatus extends js.Object {
+    val ACTIVE = "ACTIVE".asInstanceOf[DocumentVersionStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE))
   }
-
-  object FolderContentTypeEnum {
-    val ALL      = "ALL"
-    val DOCUMENT = "DOCUMENT"
-    val FOLDER   = "FOLDER"
+  @js.native
+  sealed trait FolderContentType extends js.Any
+  object FolderContentType extends js.Object {
+    val ALL      = "ALL".asInstanceOf[FolderContentType]
+    val DOCUMENT = "DOCUMENT".asInstanceOf[FolderContentType]
+    val FOLDER   = "FOLDER".asInstanceOf[FolderContentType]
 
     val values = js.Object.freeze(js.Array(ALL, DOCUMENT, FOLDER))
   }
@@ -2117,19 +2101,20 @@ package workdocs {
       __obj.asInstanceOf[InitiateDocumentVersionUploadResponse]
     }
   }
-
-  object LocaleTypeEnum {
-    val en      = "en"
-    val fr      = "fr"
-    val ko      = "ko"
-    val de      = "de"
-    val es      = "es"
-    val ja      = "ja"
-    val ru      = "ru"
-    val zh_CN   = "zh_CN"
-    val zh_TW   = "zh_TW"
-    val pt_BR   = "pt_BR"
-    val default = "default"
+  @js.native
+  sealed trait LocaleType extends js.Any
+  object LocaleType extends js.Object {
+    val en      = "en".asInstanceOf[LocaleType]
+    val fr      = "fr".asInstanceOf[LocaleType]
+    val ko      = "ko".asInstanceOf[LocaleType]
+    val de      = "de".asInstanceOf[LocaleType]
+    val es      = "es".asInstanceOf[LocaleType]
+    val ja      = "ja".asInstanceOf[LocaleType]
+    val ru      = "ru".asInstanceOf[LocaleType]
+    val zh_CN   = "zh_CN".asInstanceOf[LocaleType]
+    val zh_TW   = "zh_TW".asInstanceOf[LocaleType]
+    val pt_BR   = "pt_BR".asInstanceOf[LocaleType]
+    val default = "default".asInstanceOf[LocaleType]
 
     val values = js.Object.freeze(js.Array(en, fr, ko, de, es, ja, ru, zh_CN, zh_TW, pt_BR, default))
   }
@@ -2155,10 +2140,11 @@ package workdocs {
       __obj.asInstanceOf[NotificationOptions]
     }
   }
-
-  object OrderTypeEnum {
-    val ASCENDING  = "ASCENDING"
-    val DESCENDING = "DESCENDING"
+  @js.native
+  sealed trait OrderType extends js.Any
+  object OrderType extends js.Object {
+    val ASCENDING  = "ASCENDING".asInstanceOf[OrderType]
+    val DESCENDING = "DESCENDING".asInstanceOf[OrderType]
 
     val values = js.Object.freeze(js.Array(ASCENDING, DESCENDING))
   }
@@ -2231,13 +2217,14 @@ package workdocs {
       __obj.asInstanceOf[Principal]
     }
   }
-
-  object PrincipalTypeEnum {
-    val USER         = "USER"
-    val GROUP        = "GROUP"
-    val INVITE       = "INVITE"
-    val ANONYMOUS    = "ANONYMOUS"
-    val ORGANIZATION = "ORGANIZATION"
+  @js.native
+  sealed trait PrincipalType extends js.Any
+  object PrincipalType extends js.Object {
+    val USER         = "USER".asInstanceOf[PrincipalType]
+    val GROUP        = "GROUP".asInstanceOf[PrincipalType]
+    val INVITE       = "INVITE".asInstanceOf[PrincipalType]
+    val ANONYMOUS    = "ANONYMOUS".asInstanceOf[PrincipalType]
+    val ORGANIZATION = "ORGANIZATION".asInstanceOf[PrincipalType]
 
     val values = js.Object.freeze(js.Array(USER, GROUP, INVITE, ANONYMOUS, ORGANIZATION))
   }
@@ -2289,9 +2276,10 @@ package workdocs {
       __obj.asInstanceOf[RemoveResourcePermissionRequest]
     }
   }
-
-  object ResourceCollectionTypeEnum {
-    val SHARED_WITH_ME = "SHARED_WITH_ME"
+  @js.native
+  sealed trait ResourceCollectionType extends js.Any
+  object ResourceCollectionType extends js.Object {
+    val SHARED_WITH_ME = "SHARED_WITH_ME".asInstanceOf[ResourceCollectionType]
 
     val values = js.Object.freeze(js.Array(SHARED_WITH_ME))
   }
@@ -2373,42 +2361,47 @@ package workdocs {
       __obj.asInstanceOf[ResourcePathComponent]
     }
   }
-
-  object ResourceSortTypeEnum {
-    val DATE = "DATE"
-    val NAME = "NAME"
+  @js.native
+  sealed trait ResourceSortType extends js.Any
+  object ResourceSortType extends js.Object {
+    val DATE = "DATE".asInstanceOf[ResourceSortType]
+    val NAME = "NAME".asInstanceOf[ResourceSortType]
 
     val values = js.Object.freeze(js.Array(DATE, NAME))
   }
-
-  object ResourceStateTypeEnum {
-    val ACTIVE    = "ACTIVE"
-    val RESTORING = "RESTORING"
-    val RECYCLING = "RECYCLING"
-    val RECYCLED  = "RECYCLED"
+  @js.native
+  sealed trait ResourceStateType extends js.Any
+  object ResourceStateType extends js.Object {
+    val ACTIVE    = "ACTIVE".asInstanceOf[ResourceStateType]
+    val RESTORING = "RESTORING".asInstanceOf[ResourceStateType]
+    val RECYCLING = "RECYCLING".asInstanceOf[ResourceStateType]
+    val RECYCLED  = "RECYCLED".asInstanceOf[ResourceStateType]
 
     val values = js.Object.freeze(js.Array(ACTIVE, RESTORING, RECYCLING, RECYCLED))
   }
-
-  object ResourceTypeEnum {
-    val FOLDER   = "FOLDER"
-    val DOCUMENT = "DOCUMENT"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val FOLDER   = "FOLDER".asInstanceOf[ResourceType]
+    val DOCUMENT = "DOCUMENT".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(FOLDER, DOCUMENT))
   }
-
-  object RolePermissionTypeEnum {
-    val DIRECT    = "DIRECT"
-    val INHERITED = "INHERITED"
+  @js.native
+  sealed trait RolePermissionType extends js.Any
+  object RolePermissionType extends js.Object {
+    val DIRECT    = "DIRECT".asInstanceOf[RolePermissionType]
+    val INHERITED = "INHERITED".asInstanceOf[RolePermissionType]
 
     val values = js.Object.freeze(js.Array(DIRECT, INHERITED))
   }
-
-  object RoleTypeEnum {
-    val VIEWER      = "VIEWER"
-    val CONTRIBUTOR = "CONTRIBUTOR"
-    val OWNER       = "OWNER"
-    val COOWNER     = "COOWNER"
+  @js.native
+  sealed trait RoleType extends js.Any
+  object RoleType extends js.Object {
+    val VIEWER      = "VIEWER".asInstanceOf[RoleType]
+    val CONTRIBUTOR = "CONTRIBUTOR".asInstanceOf[RoleType]
+    val OWNER       = "OWNER".asInstanceOf[RoleType]
+    val COOWNER     = "COOWNER".asInstanceOf[RoleType]
 
     val values = js.Object.freeze(js.Array(VIEWER, CONTRIBUTOR, OWNER, COOWNER))
   }
@@ -2473,10 +2466,11 @@ package workdocs {
       __obj.asInstanceOf[ShareResult]
     }
   }
-
-  object ShareStatusTypeEnum {
-    val SUCCESS = "SUCCESS"
-    val FAILURE = "FAILURE"
+  @js.native
+  sealed trait ShareStatusType extends js.Any
+  object ShareStatusType extends js.Object {
+    val SUCCESS = "SUCCESS".asInstanceOf[ShareStatusType]
+    val FAILURE = "FAILURE".asInstanceOf[ShareStatusType]
 
     val values = js.Object.freeze(js.Array(SUCCESS, FAILURE))
   }
@@ -2502,10 +2496,11 @@ package workdocs {
       __obj.asInstanceOf[StorageRuleType]
     }
   }
-
-  object StorageTypeEnum {
-    val UNLIMITED = "UNLIMITED"
-    val QUOTA     = "QUOTA"
+  @js.native
+  sealed trait StorageType extends js.Any
+  object StorageType extends js.Object {
+    val UNLIMITED = "UNLIMITED".asInstanceOf[StorageType]
+    val QUOTA     = "QUOTA".asInstanceOf[StorageType]
 
     val values = js.Object.freeze(js.Array(UNLIMITED, QUOTA))
   }
@@ -2534,15 +2529,17 @@ package workdocs {
       __obj.asInstanceOf[Subscription]
     }
   }
-
-  object SubscriptionProtocolTypeEnum {
-    val HTTPS = "HTTPS"
+  @js.native
+  sealed trait SubscriptionProtocolType extends js.Any
+  object SubscriptionProtocolType extends js.Object {
+    val HTTPS = "HTTPS".asInstanceOf[SubscriptionProtocolType]
 
     val values = js.Object.freeze(js.Array(HTTPS))
   }
-
-  object SubscriptionTypeEnum {
-    val ALL = "ALL"
+  @js.native
+  sealed trait SubscriptionType extends js.Any
+  object SubscriptionType extends js.Object {
+    val ALL = "ALL".asInstanceOf[SubscriptionType]
 
     val values = js.Object.freeze(js.Array(ALL))
   }
@@ -2774,10 +2771,11 @@ package workdocs {
       __obj.asInstanceOf[User]
     }
   }
-
-  object UserFilterTypeEnum {
-    val ALL            = "ALL"
-    val ACTIVE_PENDING = "ACTIVE_PENDING"
+  @js.native
+  sealed trait UserFilterType extends js.Any
+  object UserFilterType extends js.Object {
+    val ALL            = "ALL".asInstanceOf[UserFilterType]
+    val ACTIVE_PENDING = "ACTIVE_PENDING".asInstanceOf[UserFilterType]
 
     val values = js.Object.freeze(js.Array(ALL, ACTIVE_PENDING))
   }
@@ -2812,21 +2810,23 @@ package workdocs {
       __obj.asInstanceOf[UserMetadata]
     }
   }
-
-  object UserSortTypeEnum {
-    val USER_NAME     = "USER_NAME"
-    val FULL_NAME     = "FULL_NAME"
-    val STORAGE_LIMIT = "STORAGE_LIMIT"
-    val USER_STATUS   = "USER_STATUS"
-    val STORAGE_USED  = "STORAGE_USED"
+  @js.native
+  sealed trait UserSortType extends js.Any
+  object UserSortType extends js.Object {
+    val USER_NAME     = "USER_NAME".asInstanceOf[UserSortType]
+    val FULL_NAME     = "FULL_NAME".asInstanceOf[UserSortType]
+    val STORAGE_LIMIT = "STORAGE_LIMIT".asInstanceOf[UserSortType]
+    val USER_STATUS   = "USER_STATUS".asInstanceOf[UserSortType]
+    val STORAGE_USED  = "STORAGE_USED".asInstanceOf[UserSortType]
 
     val values = js.Object.freeze(js.Array(USER_NAME, FULL_NAME, STORAGE_LIMIT, USER_STATUS, STORAGE_USED))
   }
-
-  object UserStatusTypeEnum {
-    val ACTIVE   = "ACTIVE"
-    val INACTIVE = "INACTIVE"
-    val PENDING  = "PENDING"
+  @js.native
+  sealed trait UserStatusType extends js.Any
+  object UserStatusType extends js.Object {
+    val ACTIVE   = "ACTIVE".asInstanceOf[UserStatusType]
+    val INACTIVE = "INACTIVE".asInstanceOf[UserStatusType]
+    val PENDING  = "PENDING".asInstanceOf[UserStatusType]
 
     val values = js.Object.freeze(js.Array(ACTIVE, INACTIVE, PENDING))
   }
@@ -2852,13 +2852,14 @@ package workdocs {
       __obj.asInstanceOf[UserStorageMetadata]
     }
   }
-
-  object UserTypeEnum {
-    val USER           = "USER"
-    val ADMIN          = "ADMIN"
-    val POWERUSER      = "POWERUSER"
-    val MINIMALUSER    = "MINIMALUSER"
-    val WORKSPACESUSER = "WORKSPACESUSER"
+  @js.native
+  sealed trait UserType extends js.Any
+  object UserType extends js.Object {
+    val USER           = "USER".asInstanceOf[UserType]
+    val ADMIN          = "ADMIN".asInstanceOf[UserType]
+    val POWERUSER      = "POWERUSER".asInstanceOf[UserType]
+    val MINIMALUSER    = "MINIMALUSER".asInstanceOf[UserType]
+    val WORKSPACESUSER = "WORKSPACESUSER".asInstanceOf[UserType]
 
     val values = js.Object.freeze(js.Array(USER, ADMIN, POWERUSER, MINIMALUSER, WORKSPACESUSER))
   }

--- a/services/worklink/src/main/scala/facade/amazonaws/services/WorkLink.scala
+++ b/services/worklink/src/main/scala/facade/amazonaws/services/WorkLink.scala
@@ -9,7 +9,6 @@ import facade.amazonaws._
 package object worklink {
   type AcmCertificateArn                        = String
   type AuditStreamArn                           = String
-  type AuthorizationProviderType                = String
   type Certificate                              = String
   type CertificateChain                         = String
   type CompanyCode                              = String
@@ -19,18 +18,14 @@ package object worklink {
   type DeviceOperatingSystemName                = String
   type DeviceOperatingSystemVersion             = String
   type DevicePatchLevel                         = String
-  type DeviceStatus                             = String
   type DeviceSummaryList                        = js.Array[DeviceSummary]
   type DisplayName                              = String
   type DomainName                               = String
-  type DomainStatus                             = String
   type DomainSummaryList                        = js.Array[DomainSummary]
   type FleetArn                                 = String
   type FleetName                                = String
-  type FleetStatus                              = String
   type FleetSummaryList                         = js.Array[FleetSummary]
   type Id                                       = String
-  type IdentityProviderType                     = String
   type MaxResults                               = Int
   type NextToken                                = String
   type SamlMetadata                             = String
@@ -325,9 +320,10 @@ package worklink {
       __obj.asInstanceOf[AssociateWebsiteCertificateAuthorityResponse]
     }
   }
-
-  object AuthorizationProviderTypeEnum {
-    val SAML = "SAML"
+  @js.native
+  sealed trait AuthorizationProviderType extends js.Any
+  object AuthorizationProviderType extends js.Object {
+    val SAML = "SAML".asInstanceOf[AuthorizationProviderType]
 
     val values = js.Object.freeze(js.Array(SAML))
   }
@@ -763,10 +759,11 @@ package worklink {
       __obj.asInstanceOf[DescribeWebsiteCertificateAuthorityResponse]
     }
   }
-
-  object DeviceStatusEnum {
-    val ACTIVE     = "ACTIVE"
-    val SIGNED_OUT = "SIGNED_OUT"
+  @js.native
+  sealed trait DeviceStatus extends js.Any
+  object DeviceStatus extends js.Object {
+    val ACTIVE     = "ACTIVE".asInstanceOf[DeviceStatus]
+    val SIGNED_OUT = "SIGNED_OUT".asInstanceOf[DeviceStatus]
 
     val values = js.Object.freeze(js.Array(ACTIVE, SIGNED_OUT))
   }
@@ -894,16 +891,17 @@ package worklink {
       __obj.asInstanceOf[DisassociateWebsiteCertificateAuthorityResponse]
     }
   }
-
-  object DomainStatusEnum {
-    val PENDING_VALIDATION     = "PENDING_VALIDATION"
-    val ASSOCIATING            = "ASSOCIATING"
-    val ACTIVE                 = "ACTIVE"
-    val INACTIVE               = "INACTIVE"
-    val DISASSOCIATING         = "DISASSOCIATING"
-    val DISASSOCIATED          = "DISASSOCIATED"
-    val FAILED_TO_ASSOCIATE    = "FAILED_TO_ASSOCIATE"
-    val FAILED_TO_DISASSOCIATE = "FAILED_TO_DISASSOCIATE"
+  @js.native
+  sealed trait DomainStatus extends js.Any
+  object DomainStatus extends js.Object {
+    val PENDING_VALIDATION     = "PENDING_VALIDATION".asInstanceOf[DomainStatus]
+    val ASSOCIATING            = "ASSOCIATING".asInstanceOf[DomainStatus]
+    val ACTIVE                 = "ACTIVE".asInstanceOf[DomainStatus]
+    val INACTIVE               = "INACTIVE".asInstanceOf[DomainStatus]
+    val DISASSOCIATING         = "DISASSOCIATING".asInstanceOf[DomainStatus]
+    val DISASSOCIATED          = "DISASSOCIATED".asInstanceOf[DomainStatus]
+    val FAILED_TO_ASSOCIATE    = "FAILED_TO_ASSOCIATE".asInstanceOf[DomainStatus]
+    val FAILED_TO_DISASSOCIATE = "FAILED_TO_DISASSOCIATE".asInstanceOf[DomainStatus]
 
     val values = js.Object.freeze(
       js.Array(
@@ -948,14 +946,15 @@ package worklink {
       __obj.asInstanceOf[DomainSummary]
     }
   }
-
-  object FleetStatusEnum {
-    val CREATING         = "CREATING"
-    val ACTIVE           = "ACTIVE"
-    val DELETING         = "DELETING"
-    val DELETED          = "DELETED"
-    val FAILED_TO_CREATE = "FAILED_TO_CREATE"
-    val FAILED_TO_DELETE = "FAILED_TO_DELETE"
+  @js.native
+  sealed trait FleetStatus extends js.Any
+  object FleetStatus extends js.Object {
+    val CREATING         = "CREATING".asInstanceOf[FleetStatus]
+    val ACTIVE           = "ACTIVE".asInstanceOf[FleetStatus]
+    val DELETING         = "DELETING".asInstanceOf[FleetStatus]
+    val DELETED          = "DELETED".asInstanceOf[FleetStatus]
+    val FAILED_TO_CREATE = "FAILED_TO_CREATE".asInstanceOf[FleetStatus]
+    val FAILED_TO_DELETE = "FAILED_TO_DELETE".asInstanceOf[FleetStatus]
 
     val values = js.Object.freeze(js.Array(CREATING, ACTIVE, DELETING, DELETED, FAILED_TO_CREATE, FAILED_TO_DELETE))
   }
@@ -996,9 +995,10 @@ package worklink {
       __obj.asInstanceOf[FleetSummary]
     }
   }
-
-  object IdentityProviderTypeEnum {
-    val SAML = "SAML"
+  @js.native
+  sealed trait IdentityProviderType extends js.Any
+  object IdentityProviderType extends js.Object {
+    val SAML = "SAML".asInstanceOf[IdentityProviderType]
 
     val values = js.Object.freeze(js.Array(SAML))
   }

--- a/services/workmail/src/main/scala/facade/amazonaws/services/WorkMail.scala
+++ b/services/workmail/src/main/scala/facade/amazonaws/services/WorkMail.scala
@@ -9,7 +9,6 @@ import facade.amazonaws._
 package object workmail {
   type AccessControlRuleAction      = String
   type AccessControlRuleDescription = String
-  type AccessControlRuleEffect      = String
   type AccessControlRuleName        = String
   type AccessControlRuleNameList    = js.Array[AccessControlRuleName]
   type AccessControlRulesList       = js.Array[AccessControlRule]
@@ -17,7 +16,6 @@ package object workmail {
   type Aliases                      = js.Array[EmailAddress]
   type AmazonResourceName           = String
   type EmailAddress                 = String
-  type EntityState                  = String
   type GroupName                    = String
   type Groups                       = js.Array[Group]
   type IpAddress                    = String
@@ -26,20 +24,17 @@ package object workmail {
   type MailboxQuota                 = Int
   type MailboxSize                  = Double
   type MaxResults                   = Int
-  type MemberType                   = String
   type Members                      = js.Array[Member]
   type NextToken                    = String
   type OrganizationId               = String
   type OrganizationName             = String
   type OrganizationSummaries        = js.Array[OrganizationSummary]
   type Password                     = String
-  type PermissionType               = String
   type PermissionValues             = js.Array[PermissionType]
   type Permissions                  = js.Array[Permission]
   type ResourceDelegates            = js.Array[Delegate]
   type ResourceId                   = String
   type ResourceName                 = String
-  type ResourceType                 = String
   type Resources                    = js.Array[Resource]
   type TagKey                       = String
   type TagKeyList                   = js.Array[TagKey]
@@ -48,7 +43,6 @@ package object workmail {
   type Timestamp                    = js.Date
   type UserIdList                   = js.Array[WorkMailIdentifier]
   type UserName                     = String
-  type UserRole                     = String
   type Users                        = js.Array[User]
   type WorkMailIdentifier           = String
 
@@ -262,10 +256,11 @@ package workmail {
       __obj.asInstanceOf[AccessControlRule]
     }
   }
-
-  object AccessControlRuleEffectEnum {
-    val ALLOW = "ALLOW"
-    val DENY  = "DENY"
+  @js.native
+  sealed trait AccessControlRuleEffect extends js.Any
+  object AccessControlRuleEffect extends js.Object {
+    val ALLOW = "ALLOW".asInstanceOf[AccessControlRuleEffect]
+    val DENY  = "DENY".asInstanceOf[AccessControlRuleEffect]
 
     val values = js.Object.freeze(js.Array(ALLOW, DENY))
   }
@@ -1097,11 +1092,12 @@ package workmail {
       __obj.asInstanceOf[DisassociateMemberFromGroupResponse]
     }
   }
-
-  object EntityStateEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
-    val DELETED  = "DELETED"
+  @js.native
+  sealed trait EntityState extends js.Any
+  object EntityState extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[EntityState]
+    val DISABLED = "DISABLED".asInstanceOf[EntityState]
+    val DELETED  = "DELETED".asInstanceOf[EntityState]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED, DELETED))
   }
@@ -1678,10 +1674,11 @@ package workmail {
       __obj.asInstanceOf[Member]
     }
   }
-
-  object MemberTypeEnum {
-    val GROUP = "GROUP"
-    val USER  = "USER"
+  @js.native
+  sealed trait MemberType extends js.Any
+  object MemberType extends js.Object {
+    val GROUP = "GROUP".asInstanceOf[MemberType]
+    val USER  = "USER".asInstanceOf[MemberType]
 
     val values = js.Object.freeze(js.Array(GROUP, USER))
   }
@@ -1740,11 +1737,12 @@ package workmail {
       __obj.asInstanceOf[Permission]
     }
   }
-
-  object PermissionTypeEnum {
-    val FULL_ACCESS    = "FULL_ACCESS"
-    val SEND_AS        = "SEND_AS"
-    val SEND_ON_BEHALF = "SEND_ON_BEHALF"
+  @js.native
+  sealed trait PermissionType extends js.Any
+  object PermissionType extends js.Object {
+    val FULL_ACCESS    = "FULL_ACCESS".asInstanceOf[PermissionType]
+    val SEND_AS        = "SEND_AS".asInstanceOf[PermissionType]
+    val SEND_ON_BEHALF = "SEND_ON_BEHALF".asInstanceOf[PermissionType]
 
     val values = js.Object.freeze(js.Array(FULL_ACCESS, SEND_AS, SEND_ON_BEHALF))
   }
@@ -1957,10 +1955,11 @@ package workmail {
       __obj.asInstanceOf[Resource]
     }
   }
-
-  object ResourceTypeEnum {
-    val ROOM      = "ROOM"
-    val EQUIPMENT = "EQUIPMENT"
+  @js.native
+  sealed trait ResourceType extends js.Any
+  object ResourceType extends js.Object {
+    val ROOM      = "ROOM".asInstanceOf[ResourceType]
+    val EQUIPMENT = "EQUIPMENT".asInstanceOf[ResourceType]
 
     val values = js.Object.freeze(js.Array(ROOM, EQUIPMENT))
   }
@@ -2210,11 +2209,12 @@ package workmail {
       __obj.asInstanceOf[User]
     }
   }
-
-  object UserRoleEnum {
-    val USER        = "USER"
-    val RESOURCE    = "RESOURCE"
-    val SYSTEM_USER = "SYSTEM_USER"
+  @js.native
+  sealed trait UserRole extends js.Any
+  object UserRole extends js.Object {
+    val USER        = "USER".asInstanceOf[UserRole]
+    val RESOURCE    = "RESOURCE".asInstanceOf[UserRole]
+    val SYSTEM_USER = "SYSTEM_USER".asInstanceOf[UserRole]
 
     val values = js.Object.freeze(js.Array(USER, RESOURCE, SYSTEM_USER))
   }

--- a/services/workspaces/src/main/scala/facade/amazonaws/services/WorkSpaces.scala
+++ b/services/workspaces/src/main/scala/facade/amazonaws/services/WorkSpaces.scala
@@ -7,102 +7,83 @@ import scala.concurrent.Future
 import facade.amazonaws._
 
 package object workspaces {
-  type ARN                                   = String
-  type AccessPropertyValue                   = String
-  type AccountModificationList               = js.Array[AccountModification]
-  type Alias                                 = String
-  type BooleanObject                         = Boolean
-  type BundleId                              = String
-  type BundleIdList                          = js.Array[BundleId]
-  type BundleList                            = js.Array[WorkspaceBundle]
-  type BundleOwner                           = String
-  type ClientPropertiesList                  = js.Array[ClientPropertiesResult]
-  type Compute                               = String
-  type ComputerName                          = String
-  type ConnectionState                       = String
-  type DedicatedTenancyCidrRangeList         = js.Array[DedicatedTenancyManagementCidrRange]
-  type DedicatedTenancyManagementCidrRange   = String
-  type DedicatedTenancyModificationStateEnum = String
-  type DedicatedTenancySupportEnum           = String
-  type DedicatedTenancySupportResultEnum     = String
-  type DefaultOu                             = String
-  type Description                           = String
-  type DirectoryId                           = String
-  type DirectoryIdList                       = js.Array[DirectoryId]
-  type DirectoryList                         = js.Array[WorkspaceDirectory]
-  type DirectoryName                         = String
-  type DnsIpAddresses                        = js.Array[IpAddress]
-  type Ec2ImageId                            = String
-  type ErrorType                             = String
-  type FailedCreateWorkspaceRequests         = js.Array[FailedCreateWorkspaceRequest]
-  type FailedRebootWorkspaceRequests         = js.Array[FailedWorkspaceChangeRequest]
-  type FailedRebuildWorkspaceRequests        = js.Array[FailedWorkspaceChangeRequest]
-  type FailedStartWorkspaceRequests          = js.Array[FailedWorkspaceChangeRequest]
-  type FailedStopWorkspaceRequests           = js.Array[FailedWorkspaceChangeRequest]
-  type FailedTerminateWorkspaceRequests      = js.Array[FailedWorkspaceChangeRequest]
-  type IpAddress                             = String
-  type IpGroupDesc                           = String
-  type IpGroupId                             = String
-  type IpGroupIdList                         = js.Array[IpGroupId]
-  type IpGroupName                           = String
-  type IpRevokedRuleList                     = js.Array[IpRule]
-  type IpRule                                = String
-  type IpRuleDesc                            = String
-  type IpRuleList                            = js.Array[IpRuleItem]
-  type Limit                                 = Int
-  type ManagementCidrRangeConstraint         = String
-  type ManagementCidrRangeMaxResults         = Int
-  type ModificationResourceEnum              = String
-  type ModificationStateEnum                 = String
-  type ModificationStateList                 = js.Array[ModificationState]
-  type NonEmptyString                        = String
-  type OperatingSystemType                   = String
-  type PaginationToken                       = String
-  type RebootWorkspaceRequests               = js.Array[RebootRequest]
-  type RebuildWorkspaceRequests              = js.Array[RebuildRequest]
-  type ReconnectEnum                         = String
-  type Region                                = String
-  type RegistrationCode                      = String
-  type ResourceIdList                        = js.Array[NonEmptyString]
-  type RootVolumeSizeGib                     = Int
-  type RunningMode                           = String
-  type RunningModeAutoStopTimeoutInMinutes   = Int
-  type SecurityGroupId                       = String
-  type SnapshotList                          = js.Array[Snapshot]
-  type StartWorkspaceRequests                = js.Array[StartRequest]
-  type StopWorkspaceRequests                 = js.Array[StopRequest]
-  type SubnetId                              = String
-  type SubnetIds                             = js.Array[SubnetId]
-  type TagKey                                = String
-  type TagKeyList                            = js.Array[NonEmptyString]
-  type TagList                               = js.Array[Tag]
-  type TagValue                              = String
-  type TargetWorkspaceState                  = String
-  type Tenancy                               = String
-  type TerminateWorkspaceRequests            = js.Array[TerminateRequest]
-  type Timestamp                             = js.Date
-  type UserName                              = String
-  type UserVolumeSizeGib                     = Int
-  type VolumeEncryptionKey                   = String
-  type WorkspaceConnectionStatusList         = js.Array[WorkspaceConnectionStatus]
-  type WorkspaceDirectoryState               = String
-  type WorkspaceDirectoryType                = String
-  type WorkspaceErrorCode                    = String
-  type WorkspaceId                           = String
-  type WorkspaceIdList                       = js.Array[WorkspaceId]
-  type WorkspaceImageDescription             = String
-  type WorkspaceImageErrorCode               = String
-  type WorkspaceImageId                      = String
-  type WorkspaceImageIdList                  = js.Array[WorkspaceImageId]
-  type WorkspaceImageIngestionProcess        = String
-  type WorkspaceImageList                    = js.Array[WorkspaceImage]
-  type WorkspaceImageName                    = String
-  type WorkspaceImageRequiredTenancy         = String
-  type WorkspaceImageState                   = String
-  type WorkspaceList                         = js.Array[Workspace]
-  type WorkspaceRequestList                  = js.Array[WorkspaceRequest]
-  type WorkspaceState                        = String
-  type WorkspacesIpGroupsList                = js.Array[WorkspacesIpGroup]
+  type ARN                                 = String
+  type AccountModificationList             = js.Array[AccountModification]
+  type Alias                               = String
+  type BooleanObject                       = Boolean
+  type BundleId                            = String
+  type BundleIdList                        = js.Array[BundleId]
+  type BundleList                          = js.Array[WorkspaceBundle]
+  type BundleOwner                         = String
+  type ClientPropertiesList                = js.Array[ClientPropertiesResult]
+  type ComputerName                        = String
+  type DedicatedTenancyCidrRangeList       = js.Array[DedicatedTenancyManagementCidrRange]
+  type DedicatedTenancyManagementCidrRange = String
+  type DefaultOu                           = String
+  type Description                         = String
+  type DirectoryId                         = String
+  type DirectoryIdList                     = js.Array[DirectoryId]
+  type DirectoryList                       = js.Array[WorkspaceDirectory]
+  type DirectoryName                       = String
+  type DnsIpAddresses                      = js.Array[IpAddress]
+  type Ec2ImageId                          = String
+  type ErrorType                           = String
+  type FailedCreateWorkspaceRequests       = js.Array[FailedCreateWorkspaceRequest]
+  type FailedRebootWorkspaceRequests       = js.Array[FailedWorkspaceChangeRequest]
+  type FailedRebuildWorkspaceRequests      = js.Array[FailedWorkspaceChangeRequest]
+  type FailedStartWorkspaceRequests        = js.Array[FailedWorkspaceChangeRequest]
+  type FailedStopWorkspaceRequests         = js.Array[FailedWorkspaceChangeRequest]
+  type FailedTerminateWorkspaceRequests    = js.Array[FailedWorkspaceChangeRequest]
+  type IpAddress                           = String
+  type IpGroupDesc                         = String
+  type IpGroupId                           = String
+  type IpGroupIdList                       = js.Array[IpGroupId]
+  type IpGroupName                         = String
+  type IpRevokedRuleList                   = js.Array[IpRule]
+  type IpRule                              = String
+  type IpRuleDesc                          = String
+  type IpRuleList                          = js.Array[IpRuleItem]
+  type Limit                               = Int
+  type ManagementCidrRangeConstraint       = String
+  type ManagementCidrRangeMaxResults       = Int
+  type ModificationStateList               = js.Array[ModificationState]
+  type NonEmptyString                      = String
+  type PaginationToken                     = String
+  type RebootWorkspaceRequests             = js.Array[RebootRequest]
+  type RebuildWorkspaceRequests            = js.Array[RebuildRequest]
+  type Region                              = String
+  type RegistrationCode                    = String
+  type ResourceIdList                      = js.Array[NonEmptyString]
+  type RootVolumeSizeGib                   = Int
+  type RunningModeAutoStopTimeoutInMinutes = Int
+  type SecurityGroupId                     = String
+  type SnapshotList                        = js.Array[Snapshot]
+  type StartWorkspaceRequests              = js.Array[StartRequest]
+  type StopWorkspaceRequests               = js.Array[StopRequest]
+  type SubnetId                            = String
+  type SubnetIds                           = js.Array[SubnetId]
+  type TagKey                              = String
+  type TagKeyList                          = js.Array[NonEmptyString]
+  type TagList                             = js.Array[Tag]
+  type TagValue                            = String
+  type TerminateWorkspaceRequests          = js.Array[TerminateRequest]
+  type Timestamp                           = js.Date
+  type UserName                            = String
+  type UserVolumeSizeGib                   = Int
+  type VolumeEncryptionKey                 = String
+  type WorkspaceConnectionStatusList       = js.Array[WorkspaceConnectionStatus]
+  type WorkspaceErrorCode                  = String
+  type WorkspaceId                         = String
+  type WorkspaceIdList                     = js.Array[WorkspaceId]
+  type WorkspaceImageDescription           = String
+  type WorkspaceImageErrorCode             = String
+  type WorkspaceImageId                    = String
+  type WorkspaceImageIdList                = js.Array[WorkspaceImageId]
+  type WorkspaceImageList                  = js.Array[WorkspaceImage]
+  type WorkspaceImageName                  = String
+  type WorkspaceList                       = js.Array[Workspace]
+  type WorkspaceRequestList                = js.Array[WorkspaceRequest]
+  type WorkspacesIpGroupsList              = js.Array[WorkspacesIpGroup]
 
   implicit final class WorkSpacesOps(private val service: WorkSpaces) extends AnyVal {
 
@@ -281,10 +262,11 @@ package workspaces {
     def terminateWorkspaces(params: TerminateWorkspacesRequest): Request[TerminateWorkspacesResult]    = js.native
     def updateRulesOfIpGroup(params: UpdateRulesOfIpGroupRequest): Request[UpdateRulesOfIpGroupResult] = js.native
   }
-
-  object AccessPropertyValueEnum {
-    val ALLOW = "ALLOW"
-    val DENY  = "DENY"
+  @js.native
+  sealed trait AccessPropertyValue extends js.Any
+  object AccessPropertyValue extends js.Object {
+    val ALLOW = "ALLOW".asInstanceOf[AccessPropertyValue]
+    val DENY  = "DENY".asInstanceOf[AccessPropertyValue]
 
     val values = js.Object.freeze(js.Array(ALLOW, DENY))
   }
@@ -433,15 +415,16 @@ package workspaces {
       __obj.asInstanceOf[ClientPropertiesResult]
     }
   }
-
-  object ComputeEnum {
-    val VALUE       = "VALUE"
-    val STANDARD    = "STANDARD"
-    val PERFORMANCE = "PERFORMANCE"
-    val POWER       = "POWER"
-    val GRAPHICS    = "GRAPHICS"
-    val POWERPRO    = "POWERPRO"
-    val GRAPHICSPRO = "GRAPHICSPRO"
+  @js.native
+  sealed trait Compute extends js.Any
+  object Compute extends js.Object {
+    val VALUE       = "VALUE".asInstanceOf[Compute]
+    val STANDARD    = "STANDARD".asInstanceOf[Compute]
+    val PERFORMANCE = "PERFORMANCE".asInstanceOf[Compute]
+    val POWER       = "POWER".asInstanceOf[Compute]
+    val GRAPHICS    = "GRAPHICS".asInstanceOf[Compute]
+    val POWERPRO    = "POWERPRO".asInstanceOf[Compute]
+    val GRAPHICSPRO = "GRAPHICSPRO".asInstanceOf[Compute]
 
     val values = js.Object.freeze(js.Array(VALUE, STANDARD, PERFORMANCE, POWER, GRAPHICS, POWERPRO, GRAPHICSPRO))
   }
@@ -464,11 +447,12 @@ package workspaces {
       __obj.asInstanceOf[ComputeType]
     }
   }
-
-  object ConnectionStateEnum {
-    val CONNECTED    = "CONNECTED"
-    val DISCONNECTED = "DISCONNECTED"
-    val UNKNOWN      = "UNKNOWN"
+  @js.native
+  sealed trait ConnectionState extends js.Any
+  object ConnectionState extends js.Object {
+    val CONNECTED    = "CONNECTED".asInstanceOf[ConnectionState]
+    val DISCONNECTED = "DISCONNECTED".asInstanceOf[ConnectionState]
+    val UNKNOWN      = "UNKNOWN".asInstanceOf[ConnectionState]
 
     val values = js.Object.freeze(js.Array(CONNECTED, DISCONNECTED, UNKNOWN))
   }
@@ -632,24 +616,27 @@ package workspaces {
       __obj.asInstanceOf[CreateWorkspacesResult]
     }
   }
-
-  object DedicatedTenancyModificationStateEnumEnum {
-    val PENDING   = "PENDING"
-    val COMPLETED = "COMPLETED"
-    val FAILED    = "FAILED"
+  @js.native
+  sealed trait DedicatedTenancyModificationStateEnum extends js.Any
+  object DedicatedTenancyModificationStateEnum extends js.Object {
+    val PENDING   = "PENDING".asInstanceOf[DedicatedTenancyModificationStateEnum]
+    val COMPLETED = "COMPLETED".asInstanceOf[DedicatedTenancyModificationStateEnum]
+    val FAILED    = "FAILED".asInstanceOf[DedicatedTenancyModificationStateEnum]
 
     val values = js.Object.freeze(js.Array(PENDING, COMPLETED, FAILED))
   }
-
-  object DedicatedTenancySupportEnumEnum {
-    val ENABLED = "ENABLED"
+  @js.native
+  sealed trait DedicatedTenancySupportEnum extends js.Any
+  object DedicatedTenancySupportEnum extends js.Object {
+    val ENABLED = "ENABLED".asInstanceOf[DedicatedTenancySupportEnum]
 
     val values = js.Object.freeze(js.Array(ENABLED))
   }
-
-  object DedicatedTenancySupportResultEnumEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait DedicatedTenancySupportResultEnum extends js.Any
+  object DedicatedTenancySupportResultEnum extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[DedicatedTenancySupportResultEnum]
+    val DISABLED = "DISABLED".asInstanceOf[DedicatedTenancySupportResultEnum]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -1479,11 +1466,12 @@ package workspaces {
       __obj.asInstanceOf[MigrateWorkspaceResult]
     }
   }
-
-  object ModificationResourceEnumEnum {
-    val ROOT_VOLUME  = "ROOT_VOLUME"
-    val USER_VOLUME  = "USER_VOLUME"
-    val COMPUTE_TYPE = "COMPUTE_TYPE"
+  @js.native
+  sealed trait ModificationResourceEnum extends js.Any
+  object ModificationResourceEnum extends js.Object {
+    val ROOT_VOLUME  = "ROOT_VOLUME".asInstanceOf[ModificationResourceEnum]
+    val USER_VOLUME  = "USER_VOLUME".asInstanceOf[ModificationResourceEnum]
+    val COMPUTE_TYPE = "COMPUTE_TYPE".asInstanceOf[ModificationResourceEnum]
 
     val values = js.Object.freeze(js.Array(ROOT_VOLUME, USER_VOLUME, COMPUTE_TYPE))
   }
@@ -1509,10 +1497,11 @@ package workspaces {
       __obj.asInstanceOf[ModificationState]
     }
   }
-
-  object ModificationStateEnumEnum {
-    val UPDATE_INITIATED   = "UPDATE_INITIATED"
-    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS"
+  @js.native
+  sealed trait ModificationStateEnum extends js.Any
+  object ModificationStateEnum extends js.Object {
+    val UPDATE_INITIATED   = "UPDATE_INITIATED".asInstanceOf[ModificationStateEnum]
+    val UPDATE_IN_PROGRESS = "UPDATE_IN_PROGRESS".asInstanceOf[ModificationStateEnum]
 
     val values = js.Object.freeze(js.Array(UPDATE_INITIATED, UPDATE_IN_PROGRESS))
   }
@@ -1773,10 +1762,11 @@ package workspaces {
       __obj.asInstanceOf[OperatingSystem]
     }
   }
-
-  object OperatingSystemTypeEnum {
-    val WINDOWS = "WINDOWS"
-    val LINUX   = "LINUX"
+  @js.native
+  sealed trait OperatingSystemType extends js.Any
+  object OperatingSystemType extends js.Object {
+    val WINDOWS = "WINDOWS".asInstanceOf[OperatingSystemType]
+    val LINUX   = "LINUX".asInstanceOf[OperatingSystemType]
 
     val values = js.Object.freeze(js.Array(WINDOWS, LINUX))
   }
@@ -1890,10 +1880,11 @@ package workspaces {
       __obj.asInstanceOf[RebuildWorkspacesResult]
     }
   }
-
-  object ReconnectEnumEnum {
-    val ENABLED  = "ENABLED"
-    val DISABLED = "DISABLED"
+  @js.native
+  sealed trait ReconnectEnum extends js.Any
+  object ReconnectEnum extends js.Object {
+    val ENABLED  = "ENABLED".asInstanceOf[ReconnectEnum]
+    val DISABLED = "DISABLED".asInstanceOf[ReconnectEnum]
 
     val values = js.Object.freeze(js.Array(ENABLED, DISABLED))
   }
@@ -2027,10 +2018,11 @@ package workspaces {
       __obj.asInstanceOf[RootStorage]
     }
   }
-
-  object RunningModeEnum {
-    val AUTO_STOP = "AUTO_STOP"
-    val ALWAYS_ON = "ALWAYS_ON"
+  @js.native
+  sealed trait RunningMode extends js.Any
+  object RunningMode extends js.Object {
+    val AUTO_STOP = "AUTO_STOP".asInstanceOf[RunningMode]
+    val ALWAYS_ON = "ALWAYS_ON".asInstanceOf[RunningMode]
 
     val values = js.Object.freeze(js.Array(AUTO_STOP, ALWAYS_ON))
   }
@@ -2214,17 +2206,19 @@ package workspaces {
       __obj.asInstanceOf[Tag]
     }
   }
-
-  object TargetWorkspaceStateEnum {
-    val AVAILABLE         = "AVAILABLE"
-    val ADMIN_MAINTENANCE = "ADMIN_MAINTENANCE"
+  @js.native
+  sealed trait TargetWorkspaceState extends js.Any
+  object TargetWorkspaceState extends js.Object {
+    val AVAILABLE         = "AVAILABLE".asInstanceOf[TargetWorkspaceState]
+    val ADMIN_MAINTENANCE = "ADMIN_MAINTENANCE".asInstanceOf[TargetWorkspaceState]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, ADMIN_MAINTENANCE))
   }
-
-  object TenancyEnum {
-    val DEDICATED = "DEDICATED"
-    val SHARED    = "SHARED"
+  @js.native
+  sealed trait Tenancy extends js.Any
+  object Tenancy extends js.Object {
+    val DEDICATED = "DEDICATED".asInstanceOf[Tenancy]
+    val SHARED    = "SHARED".asInstanceOf[Tenancy]
 
     val values = js.Object.freeze(js.Array(DEDICATED, SHARED))
   }
@@ -2614,20 +2608,22 @@ package workspaces {
       __obj.asInstanceOf[WorkspaceDirectory]
     }
   }
-
-  object WorkspaceDirectoryStateEnum {
-    val REGISTERING   = "REGISTERING"
-    val REGISTERED    = "REGISTERED"
-    val DEREGISTERING = "DEREGISTERING"
-    val DEREGISTERED  = "DEREGISTERED"
-    val ERROR         = "ERROR"
+  @js.native
+  sealed trait WorkspaceDirectoryState extends js.Any
+  object WorkspaceDirectoryState extends js.Object {
+    val REGISTERING   = "REGISTERING".asInstanceOf[WorkspaceDirectoryState]
+    val REGISTERED    = "REGISTERED".asInstanceOf[WorkspaceDirectoryState]
+    val DEREGISTERING = "DEREGISTERING".asInstanceOf[WorkspaceDirectoryState]
+    val DEREGISTERED  = "DEREGISTERED".asInstanceOf[WorkspaceDirectoryState]
+    val ERROR         = "ERROR".asInstanceOf[WorkspaceDirectoryState]
 
     val values = js.Object.freeze(js.Array(REGISTERING, REGISTERED, DEREGISTERING, DEREGISTERED, ERROR))
   }
-
-  object WorkspaceDirectoryTypeEnum {
-    val SIMPLE_AD    = "SIMPLE_AD"
-    val AD_CONNECTOR = "AD_CONNECTOR"
+  @js.native
+  sealed trait WorkspaceDirectoryType extends js.Any
+  object WorkspaceDirectoryType extends js.Object {
+    val SIMPLE_AD    = "SIMPLE_AD".asInstanceOf[WorkspaceDirectoryType]
+    val AD_CONNECTOR = "AD_CONNECTOR".asInstanceOf[WorkspaceDirectoryType]
 
     val values = js.Object.freeze(js.Array(SIMPLE_AD, AD_CONNECTOR))
   }
@@ -2671,26 +2667,29 @@ package workspaces {
       __obj.asInstanceOf[WorkspaceImage]
     }
   }
-
-  object WorkspaceImageIngestionProcessEnum {
-    val BYOL_REGULAR     = "BYOL_REGULAR"
-    val BYOL_GRAPHICS    = "BYOL_GRAPHICS"
-    val BYOL_GRAPHICSPRO = "BYOL_GRAPHICSPRO"
+  @js.native
+  sealed trait WorkspaceImageIngestionProcess extends js.Any
+  object WorkspaceImageIngestionProcess extends js.Object {
+    val BYOL_REGULAR     = "BYOL_REGULAR".asInstanceOf[WorkspaceImageIngestionProcess]
+    val BYOL_GRAPHICS    = "BYOL_GRAPHICS".asInstanceOf[WorkspaceImageIngestionProcess]
+    val BYOL_GRAPHICSPRO = "BYOL_GRAPHICSPRO".asInstanceOf[WorkspaceImageIngestionProcess]
 
     val values = js.Object.freeze(js.Array(BYOL_REGULAR, BYOL_GRAPHICS, BYOL_GRAPHICSPRO))
   }
-
-  object WorkspaceImageRequiredTenancyEnum {
-    val DEFAULT   = "DEFAULT"
-    val DEDICATED = "DEDICATED"
+  @js.native
+  sealed trait WorkspaceImageRequiredTenancy extends js.Any
+  object WorkspaceImageRequiredTenancy extends js.Object {
+    val DEFAULT   = "DEFAULT".asInstanceOf[WorkspaceImageRequiredTenancy]
+    val DEDICATED = "DEDICATED".asInstanceOf[WorkspaceImageRequiredTenancy]
 
     val values = js.Object.freeze(js.Array(DEFAULT, DEDICATED))
   }
-
-  object WorkspaceImageStateEnum {
-    val AVAILABLE = "AVAILABLE"
-    val PENDING   = "PENDING"
-    val ERROR     = "ERROR"
+  @js.native
+  sealed trait WorkspaceImageState extends js.Any
+  object WorkspaceImageState extends js.Object {
+    val AVAILABLE = "AVAILABLE".asInstanceOf[WorkspaceImageState]
+    val PENDING   = "PENDING".asInstanceOf[WorkspaceImageState]
+    val ERROR     = "ERROR".asInstanceOf[WorkspaceImageState]
 
     val values = js.Object.freeze(js.Array(AVAILABLE, PENDING, ERROR))
   }
@@ -2773,25 +2772,26 @@ package workspaces {
       __obj.asInstanceOf[WorkspaceRequest]
     }
   }
-
-  object WorkspaceStateEnum {
-    val PENDING           = "PENDING"
-    val AVAILABLE         = "AVAILABLE"
-    val IMPAIRED          = "IMPAIRED"
-    val UNHEALTHY         = "UNHEALTHY"
-    val REBOOTING         = "REBOOTING"
-    val STARTING          = "STARTING"
-    val REBUILDING        = "REBUILDING"
-    val RESTORING         = "RESTORING"
-    val MAINTENANCE       = "MAINTENANCE"
-    val ADMIN_MAINTENANCE = "ADMIN_MAINTENANCE"
-    val TERMINATING       = "TERMINATING"
-    val TERMINATED        = "TERMINATED"
-    val SUSPENDED         = "SUSPENDED"
-    val UPDATING          = "UPDATING"
-    val STOPPING          = "STOPPING"
-    val STOPPED           = "STOPPED"
-    val ERROR             = "ERROR"
+  @js.native
+  sealed trait WorkspaceState extends js.Any
+  object WorkspaceState extends js.Object {
+    val PENDING           = "PENDING".asInstanceOf[WorkspaceState]
+    val AVAILABLE         = "AVAILABLE".asInstanceOf[WorkspaceState]
+    val IMPAIRED          = "IMPAIRED".asInstanceOf[WorkspaceState]
+    val UNHEALTHY         = "UNHEALTHY".asInstanceOf[WorkspaceState]
+    val REBOOTING         = "REBOOTING".asInstanceOf[WorkspaceState]
+    val STARTING          = "STARTING".asInstanceOf[WorkspaceState]
+    val REBUILDING        = "REBUILDING".asInstanceOf[WorkspaceState]
+    val RESTORING         = "RESTORING".asInstanceOf[WorkspaceState]
+    val MAINTENANCE       = "MAINTENANCE".asInstanceOf[WorkspaceState]
+    val ADMIN_MAINTENANCE = "ADMIN_MAINTENANCE".asInstanceOf[WorkspaceState]
+    val TERMINATING       = "TERMINATING".asInstanceOf[WorkspaceState]
+    val TERMINATED        = "TERMINATED".asInstanceOf[WorkspaceState]
+    val SUSPENDED         = "SUSPENDED".asInstanceOf[WorkspaceState]
+    val UPDATING          = "UPDATING".asInstanceOf[WorkspaceState]
+    val STOPPING          = "STOPPING".asInstanceOf[WorkspaceState]
+    val STOPPED           = "STOPPED".asInstanceOf[WorkspaceState]
+    val ERROR             = "ERROR".asInstanceOf[WorkspaceState]
 
     val values = js.Object.freeze(
       js.Array(

--- a/services/xray/src/main/scala/facade/amazonaws/services/XRay.scala
+++ b/services/xray/src/main/scala/facade/amazonaws/services/XRay.scala
@@ -19,8 +19,6 @@ package object xray {
   type EC2InstanceId                   = String
   type EdgeList                        = js.Array[Edge]
   type EncryptionKeyId                 = String
-  type EncryptionStatus                = String
-  type EncryptionType                  = String
   type EntitySelectorExpression        = String
   type ErrorRootCauseEntityPath        = js.Array[ErrorRootCauseEntity]
   type ErrorRootCauseServices          = js.Array[ErrorRootCauseService]
@@ -55,7 +53,6 @@ package object xray {
   type SamplingRuleRecordList          = js.Array[SamplingRuleRecord]
   type SamplingStatisticSummaryList    = js.Array[SamplingStatisticSummary]
   type SamplingStatisticsDocumentList  = js.Array[SamplingStatisticsDocument]
-  type SamplingStrategyName            = String
   type SamplingTargetDocumentList      = js.Array[SamplingTargetDocument]
   type SegmentDocument                 = String
   type SegmentId                       = String
@@ -66,7 +63,6 @@ package object xray {
   type ServiceNames                    = js.Array[String]
   type ServiceType                     = String
   type TelemetryRecordList             = js.Array[TelemetryRecord]
-  type TimeRangeType                   = String
   type TimeSeriesServiceStatisticsList = js.Array[TimeSeriesServiceStatistics]
   type Timestamp                       = js.Date
   type TraceAvailabilityZones          = js.Array[AvailabilityZoneDetail]
@@ -538,17 +534,19 @@ package xray {
       __obj.asInstanceOf[EncryptionConfig]
     }
   }
-
-  object EncryptionStatusEnum {
-    val UPDATING = "UPDATING"
-    val ACTIVE   = "ACTIVE"
+  @js.native
+  sealed trait EncryptionStatus extends js.Any
+  object EncryptionStatus extends js.Object {
+    val UPDATING = "UPDATING".asInstanceOf[EncryptionStatus]
+    val ACTIVE   = "ACTIVE".asInstanceOf[EncryptionStatus]
 
     val values = js.Object.freeze(js.Array(UPDATING, ACTIVE))
   }
-
-  object EncryptionTypeEnum {
-    val NONE = "NONE"
-    val KMS  = "KMS"
+  @js.native
+  sealed trait EncryptionType extends js.Any
+  object EncryptionType extends js.Object {
+    val NONE = "NONE".asInstanceOf[EncryptionType]
+    val KMS  = "KMS".asInstanceOf[EncryptionType]
 
     val values = js.Object.freeze(js.Array(NONE, KMS))
   }
@@ -1760,10 +1758,11 @@ package xray {
       __obj.asInstanceOf[SamplingStrategy]
     }
   }
-
-  object SamplingStrategyNameEnum {
-    val PartialScan = "PartialScan"
-    val FixedRate   = "FixedRate"
+  @js.native
+  sealed trait SamplingStrategyName extends js.Any
+  object SamplingStrategyName extends js.Object {
+    val PartialScan = "PartialScan".asInstanceOf[SamplingStrategyName]
+    val FixedRate   = "FixedRate".asInstanceOf[SamplingStrategyName]
 
     val values = js.Object.freeze(js.Array(PartialScan, FixedRate))
   }
@@ -1971,10 +1970,11 @@ package xray {
       __obj.asInstanceOf[TelemetryRecord]
     }
   }
-
-  object TimeRangeTypeEnum {
-    val TraceId = "TraceId"
-    val Event   = "Event"
+  @js.native
+  sealed trait TimeRangeType extends js.Any
+  object TimeRangeType extends js.Object {
+    val TraceId = "TraceId".asInstanceOf[TimeRangeType]
+    val Event   = "Event".asInstanceOf[TimeRangeType]
 
     val values = js.Object.freeze(js.Array(TraceId, Event))
   }


### PR DESCRIPTION
Closes #178 
Generated by https://github.com/exoego/aws-sdk-scalajs-facade-generator/pull/79

Until we can combinate literal type and union type in Scala 3.x (e.g. `type Permission = "FULL_CONTROL" | "READ" | "WRITE"`), this trick helps a lot.

```scala
// Before
s3.TargetGrant(Permission = "FULL_CONTROL") // valid value
s3.TargetGrant(Permission = "typo") // Invalid value, but passes type-check 😞 

// After this PR
s3.TargetGrant(Permission = "FULL_CONTROL") // type error !
s3.TargetGrant(Permission = "typo") // type error !
s3.TargetGrant(Permission = BucketLogsPermission.FULL_CONTROL) // ✔️ 
```
