### PR TITLE
[dynamodb] Add dynamodb Set wrapper for BS/NS/SS

### DIFF
--- a/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDB.scala
+++ b/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDB.scala
@@ -195,6 +195,16 @@ package object dynamodb {
     def unmarshall(data: AttributeMap, options: DynamoDBConverterOptions = js.native): js.Object = js.native
   }
 
+  trait DynamoDBSetWrapper[V] extends js.Object {
+    def `type`: String
+    def wrapperName: String
+    def values: js.Array[V]
+  }
+
+  trait DynamoDBNumberSet extends DynamoDBSetWrapper[Double]
+  trait DynamoDBStringSet extends DynamoDBSetWrapper[String]
+  trait DynamoDBBinarySet extends DynamoDBSetWrapper[js.Any]
+
   trait DynamoDBConverterOptions extends js.Object {
     var convertEmptyValues: js.UndefOr[Boolean] = js.undefined
     var wrapNumbers: js.UndefOr[Boolean] = js.undefined

--- a/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDB.scala
+++ b/services/dynamodb/src/main/scala/facade/amazonaws/services/DynamoDB.scala
@@ -196,7 +196,8 @@ package object dynamodb {
   }
 
   trait DynamoDBSetWrapper[V] extends js.Object {
-    def `type`: String
+    @js.annotation.JSName("type")
+    def typeName: String
     def wrapperName: String
     def values: js.Array[V]
   }


### PR DESCRIPTION
This is useful when casting the return value of `DynamoDBConverter.output`:
```scala
val attrValue = AttributeValue.SS(js.Array("a", "b")) 
val ss = DynamoDBConverter.output(attrValue).asInstanceOf[DynamoDBStringSet]
val values = ss.values
```


Generated by https://github.com/exoego/aws-sdk-scalajs-facade-generator/pull/129