### PR TITLE
[tree-shaking support] Update import path so that Endpoint are properly loaded

### DIFF
--- a/core/src/main/scala/facade/amazonaws/AWS.scala
+++ b/core/src/main/scala/facade/amazonaws/AWS.scala
@@ -4,7 +4,7 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 @js.native
-@JSImport("aws-sdk/lib/core", JSImport.Namespace, "AWS")
+@JSImport("aws-sdk/lib/node_loader", JSImport.Namespace, "AWS")
 object AWS extends js.Object {
   var config: AWSConfigWithServicesDefault = js.native
 }

--- a/core/src/main/scala/facade/amazonaws/AWSCredentials.scala
+++ b/core/src/main/scala/facade/amazonaws/AWSCredentials.scala
@@ -4,7 +4,7 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 @js.native
-@JSImport("aws-sdk/lib/core", "Credentials", "AWS.Credentials")
+@JSImport("aws-sdk/lib/node_loader", "Credentials", "AWS.Credentials")
 class AWSCredentials extends js.Object {
   def this(accessKeyId: String, secretAccessKey: String, sessionToken: js.UndefOr[String] = js.undefined) = this()
 

--- a/core/src/main/scala/facade/amazonaws/Endpoint.scala
+++ b/core/src/main/scala/facade/amazonaws/Endpoint.scala
@@ -4,7 +4,7 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 @js.native
-@JSImport("aws-sdk/lib/core", "Endpoint", "AWS.Endpoint")
+@JSImport("aws-sdk/lib/node_loader", "Endpoint", "AWS.Endpoint")
 class Endpoint(url: String) extends js.Object {
 
   /** The host portion of the endpoint including the port, e.g., example.com:80.

--- a/core/src/main/scala/facade/amazonaws/HttpRequest.scala
+++ b/core/src/main/scala/facade/amazonaws/HttpRequest.scala
@@ -4,8 +4,7 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 @js.native
-@JSImport("aws-sdk", "HttpRequest")
-// TODO: @JSImport("aws-sdk/lib/core", "HttpRequest", "AWS.HttpRequest")
+@JSImport("aws-sdk/lib/node_loader", "HttpRequest", "AWS.HttpRequest")
 class HttpRequest(
     val endpoint: Endpoint,
     region: String

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   object shared {
     val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.3" % Test)
     val scalatestHelper = Def.setting("net.exoego" %%% "scalajs-test-helper-scalatest" % "0.2.0" % Test)
-    val compat = Def.setting("org.scala-lang.modules" %%% "scala-collection-compat" % "2.2.0")
+    val compat = Def.setting("org.scala-lang.modules" %%% "scala-collection-compat" % "2.3.0")
   }
   object scalajs {}
 }


### PR DESCRIPTION
Follow-up of #291 and #258

It turned out that `Endpoint` depends on `AWS.util.url`, which is initialized in `aws-sdk/lib/node_loader`.
Here: https://github.com/aws/aws-sdk-js/blob/44ded8259c3d1b687d9b82cd4a225ffbad52ec52/lib/node_loader.js#L11
So importing `aws-sdk/lib/core` is not enough.
