### PR TITLE
Adjust .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -2,6 +2,8 @@
 -Xms2G
 -Xmx8G
 -XX:ReservedCodeCacheSize=512M
--XX:MaxMetaspaceSize=8G
+-XX:MaxMetaspaceSize=256M
 -XX:+CMSClassUnloadingEnabled
 -XX:+UseG1GC
+-XX:+ParallelRefProcEnabled
+-XX:MaxGCPauseMillis=500


### PR DESCRIPTION
This halves scalafmt time