### PR TITLE
Exclude build.sbt from cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,16 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.11
-      - uses: coursier/cache-action@v5
+      - name: Cache Coursier
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/coursier
+          key: sbt-coursier-${{ hashFiles('project/*.sbt', 'project/*.scala') }}
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: ~/.sbt
+          key: sbt-${{ hashFiles('project/build.properties', 'project/plugins.sbt') }}
       - uses: actions/setup-node@v1
         with:
           node-version: '14'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,5 +8,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
+      - name: Cache Coursier
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/coursier
+          key: sbt-coursier-${{ hashFiles('project/*.sbt', 'project/*.scala') }}
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: ~/.sbt
+          key: sbt-${{ hashFiles('project/build.properties', 'project/plugins.sbt') }}
       - name: Check Scalafmt
-        run: sbt -jvm-opts .github/.jvmopts ++2.13.4 scalafmtSbtCheck scalafmtCheck test:scalafmtCheck
+        run: sbt -jvm-opts .github/.jvmopts ++2.13.5 scalafmtSbtCheck scalafmtCheck test:scalafmtCheck

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,8 +3,6 @@ on: [pull_request]
 jobs:
   format:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,7 @@
 import scala.util._
 
-lazy val scala213Version = "2.13.5"
-lazy val scala212Version = "2.12.13"
-crossScalaVersions in ThisBuild := Seq(scala213Version, scala212Version)
-scalaVersion in ThisBuild := scala213Version
+crossScalaVersions in ThisBuild := Seq(SharedConfig.scala213Version, SharedConfig.scala212Version)
+scalaVersion in ThisBuild := SharedConfig.scala213Version
 organization in ThisBuild := "net.exoego"
 concurrentRestrictions in ThisBuild += Tags.limit(
   ScalaJSTags.Link,

--- a/project/SharedConfig.scala
+++ b/project/SharedConfig.scala
@@ -9,6 +9,9 @@ import xerial.sbt.Sonatype.SonatypeKeys._
 object SharedConfig {
   val libraryName = "aws-sdk-scalajs-facade"
 
+  val scala213Version = "2.13.5"
+  val scala212Version = "2.12.13"
+
   val settings = Seq(
     scalacOptions ++= Seq("-deprecation"),
     scalaJSLinkerConfig ~= {


### PR DESCRIPTION
Because build.sbt is updated frequently in this repository