### PR TITLE
Run jobs on push so saved caches are usable on other PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: [pull_request]
+on:
+  pull_request:
+  push:
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: CI
 on:
-  pull_request:
   push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I do not figure out why, but it seems that caches created on `pull_request` event are always ignored...