### PR TITLE
[credentials] Add facades for various Credentials

### DIFF
--- a/ARTIFACTS.md
+++ b/ARTIFACTS.md
@@ -74,6 +74,7 @@ libraryDependencies ++= Seq(
     "net.exoego" %%% "aws-sdk-scalajs-facade-connectcontactlens" % awsSdkScalajsFacadeVersion,
     "net.exoego" %%% "aws-sdk-scalajs-facade-connectparticipant" % awsSdkScalajsFacadeVersion,
     "net.exoego" %%% "aws-sdk-scalajs-facade-costexplorer" % awsSdkScalajsFacadeVersion,
+    "net.exoego" %%% "aws-sdk-scalajs-facade-credentials" % awsSdkScalajsFacadeVersion,
     "net.exoego" %%% "aws-sdk-scalajs-facade-cur" % awsSdkScalajsFacadeVersion,
     "net.exoego" %%% "aws-sdk-scalajs-facade-customerprofiles" % awsSdkScalajsFacadeVersion,
     "net.exoego" %%% "aws-sdk-scalajs-facade-databrew" % awsSdkScalajsFacadeVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,15 @@ lazy val core = (project in file("core"))
   )
   .enablePlugins(ScalaJSPlugin)
 
+lazy val credentials = (project in file("credentials"))
+  .settings(SharedConfig.settings)
+  .settings(SharedConfig.publishSetting)
+  .settings(
+    name := s"${SharedConfig.libraryName}-credentials"
+  )
+  .enablePlugins(ScalaJSPlugin)
+  .dependsOn(awsSTS, awsCognitoIdentity)
+
 def defineAwsProject(service: String): Project = {
   val lowerServiceName = service.toLowerCase
   Project(id = s"aws$service", base = file("services") / lowerServiceName)
@@ -313,6 +322,7 @@ lazy val all = (project in file("all"))
 
 lazy val subProjects: Seq[Project] = Seq(
   core,
+  credentials,
   awsAccessAnalyzer,
   awsACM,
   awsACMPCA,

--- a/core/src/main/scala/facade/amazonaws/AWSCredentials.scala
+++ b/core/src/main/scala/facade/amazonaws/AWSCredentials.scala
@@ -5,8 +5,9 @@ import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("aws-sdk/lib/node_loader", "Credentials", "AWS.Credentials")
-class AWSCredentials(options: CredentialsOptions) extends js.Object {
+class AWSCredentials() extends js.Object {
   def this(accessKeyId: String, secretAccessKey: String, sessionToken: js.UndefOr[String] = js.undefined) = this()
+  def this(options: CredentialsOptions) = this()
 
   def getPromise(): js.Promise[Unit] = js.native
 

--- a/core/src/main/scala/facade/amazonaws/AWSCredentials.scala
+++ b/core/src/main/scala/facade/amazonaws/AWSCredentials.scala
@@ -5,7 +5,7 @@ import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("aws-sdk/lib/node_loader", "Credentials", "AWS.Credentials")
-class AWSCredentials extends js.Object {
+class AWSCredentials(options: CredentialsOptions) extends js.Object {
   def this(accessKeyId: String, secretAccessKey: String, sessionToken: js.UndefOr[String] = js.undefined) = this()
 
   def getPromise(): js.Promise[Unit] = js.native
@@ -21,4 +21,25 @@ class AWSCredentials extends js.Object {
   val expireTime: js.Date = js.native
 
   var expiryWindow: Int = js.native
+}
+
+trait CredentialsOptions extends js.Object {
+  var accessKeyId: String
+  var secretAccessKey: String
+  var sessionToken: js.UndefOr[String]
+}
+
+object CredentialsOptions {
+  def apply(
+      accessKeyId: String,
+      secretAccessKey: String,
+      sessionToken: js.UndefOr[String] = js.undefined
+  ): CredentialsOptions = {
+    val _obj$ = js.Dynamic.literal(
+      "accessKeyId" -> accessKeyId.asInstanceOf[js.Any],
+      "secretAccessKey" -> secretAccessKey.asInstanceOf[js.Any]
+    )
+    sessionToken.foreach(_v => _obj$.updateDynamic("sessionToken")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[CredentialsOptions]
+  }
 }

--- a/credentials/src/main/scala/facade/amazonaws/credentials/ChainableTemporaryCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/ChainableTemporaryCredentials.scala
@@ -1,0 +1,40 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.{AWSConfig, AWSCredentials}
+import facade.amazonaws.services.sts
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.|
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "ChainableTemporaryCredentials", "AWS.ChainableTemporaryCredentials")
+class ChainableTemporaryCredentials() extends AWSCredentials {
+  def this(options: ChainableTemporaryCredentialsOptions) = this()
+
+  def service: sts.STS = js.native
+}
+
+trait ChainableTemporaryCredentialsOptions extends js.Object {
+  var params: js.UndefOr[sts.AssumeRoleRequest | sts.GetSessionTokenRequest]
+  var masterCredentials: js.UndefOr[AWSCredentials]
+  var stsConfig: js.UndefOr[AWSConfig] // js.UndefOr[ServiceConfigurationOptions with sts.ClientApiVersions]
+  var tokenCodeFn: js.UndefOr[js.Function2[String, js.Function2[js.Error, String, Unit], Unit]]
+}
+
+object ChainableTemporaryCredentialsOptions {
+  def apply(
+      params: js.UndefOr[sts.AssumeRoleRequest | sts.GetSessionTokenRequest] = js.undefined,
+      masterCredentials: js.UndefOr[AWSCredentials] = js.undefined,
+      stsConfig: js.UndefOr[AWSConfig] = js.undefined, // js.UndefOr[ServiceConfigurationOptions with sts.ClientApiVersions]
+      tokenCodeFn: js.UndefOr[js.Function2[String, js.Function2[js.Error, String, Unit], Unit]] = js.undefined
+  ): ChainableTemporaryCredentialsOptions = {
+    val _obj$ = js.Dynamic.literal(
+    )
+    params.foreach(_v => _obj$.updateDynamic("params")(_v.asInstanceOf[js.Any]))
+    masterCredentials.foreach(_v => _obj$.updateDynamic("masterCredentials")(_v.asInstanceOf[js.Any]))
+    stsConfig.foreach(_v => _obj$.updateDynamic("stsConfig")(_v.asInstanceOf[js.Any]))
+    tokenCodeFn.foreach(_v => _obj$.updateDynamic("tokenCodeFn")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[ChainableTemporaryCredentialsOptions]
+  }
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/CognitoIdentityCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/CognitoIdentityCredentials.scala
@@ -1,0 +1,24 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.{AWSConfig, AWSCredentials}
+import facade.amazonaws.services.sts
+import facade.amazonaws.services.cognitoidentity
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.|
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "CognitoIdentityCredentials", "AWS.CognitoIdentityCredentials")
+class CognitoIdentityCredentials() extends AWSCredentials {
+  def this(options: CognitoIdentityOptions) = this()
+  def this(options: CognitoIdentityOptions, clientConfig: AWSConfig) = this()
+
+  def clearCacheId(): Unit = js.native
+
+  def data: cognitoidentity.GetCredentialsForIdentityResponse | sts.AssumeRoleWithWebIdentityResponse = js.native
+
+  def identityId: String = js.native
+
+  def params: cognitoidentity.GetIdInput | cognitoidentity.GetOpenIdTokenInput | sts.AssumeRoleWithWebIdentityRequest = js.native
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/CredentialProviderChain.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/CredentialProviderChain.scala
@@ -1,0 +1,26 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+import facade.amazonaws.{Error => AWSError}
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.|
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "CredentialProviderChain", "AWS.CredentialProviderChain")
+class CredentialProviderChain() extends AWSCredentials {
+  def this(providers: js.Array[Provider]) = this()
+
+  def resolve(callback: js.Function2[AWSError | Null, js.UndefOr[AWSCredentials], Unit]): CredentialProviderChain = js.native
+
+  def resolvePromise(): js.Promise[AWSCredentials] = js.native
+
+  def providers: js.Array[AWSCredentials | Provider] = js.native
+}
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "CredentialProviderChain", "AWS.CredentialProviderChain")
+object CredentialProviderChain extends AWSCredentials {
+  var defaultProviders: js.Array[Provider] = js.native
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/EC2MetadataCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/EC2MetadataCredentials.scala
@@ -1,0 +1,47 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "EC2MetadataCredentials", "AWS.EC2MetadataCredentials")
+class EC2MetadataCredentials() extends AWSCredentials {
+  def this(options: EC2MetadataCredentialsOptions) = this()
+}
+
+trait EC2MetadataCredentialsOptions extends js.Object {
+  var httpOptions: js.UndefOr[EC2MetadataCredentialsOptions.HttpOptions]
+  var maxRetries: js.UndefOr[Double]
+}
+object EC2MetadataCredentialsOptions {
+  def apply(
+      httpOptions: js.UndefOr[EC2MetadataCredentialsOptions.HttpOptions] = js.undefined,
+      maxRetries: js.UndefOr[Double] = js.undefined
+  ): EC2MetadataCredentialsOptions = {
+    val _obj$ = js.Dynamic.literal(
+    )
+    httpOptions.foreach(_v => _obj$.updateDynamic("httpOptions")(_v.asInstanceOf[js.Any]))
+    maxRetries.foreach(_v => _obj$.updateDynamic("maxRetries")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[EC2MetadataCredentialsOptions]
+  }
+
+  trait HttpOptions extends js.Object {
+    var timeout: js.UndefOr[Double]
+    var connectTimeout: js.UndefOr[Double]
+  }
+
+  object HttpOptions {
+    def apply(
+        timeout: js.UndefOr[Double] = js.undefined,
+        connectTimeout: js.UndefOr[Double] = js.undefined
+    ): HttpOptions = {
+      val _obj$ = js.Dynamic.literal(
+      )
+      timeout.foreach(_v => _obj$.updateDynamic("timeout")(_v.asInstanceOf[js.Any]))
+      connectTimeout.foreach(_v => _obj$.updateDynamic("connectTimeout")(_v.asInstanceOf[js.Any]))
+      _obj$.asInstanceOf[HttpOptions]
+    }
+  }
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/ECSCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/ECSCredentials.scala
@@ -1,0 +1,43 @@
+package facade.amazonaws.credentials
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "ECSCredentials", "AWS.ECSCredentials")
+class ECSCredentials() extends RemoteCredentials {
+  def this(options: ECSCredentialsOptions) = this()
+}
+
+trait ECSCredentialsOptions extends js.Object {
+  var httpOptions: js.UndefOr[ECSCredentialsOptions.HttpOptions]
+  var maxRetries: js.UndefOr[Double]
+}
+
+object ECSCredentialsOptions {
+  def apply(
+      httpOptions: js.UndefOr[ECSCredentialsOptions.HttpOptions] = js.undefined,
+      maxRetries: js.UndefOr[Double] = js.undefined
+  ): ECSCredentialsOptions = {
+    val _obj$ = js.Dynamic.literal(
+    )
+    httpOptions.foreach(_v => _obj$.updateDynamic("httpOptions")(_v.asInstanceOf[js.Any]))
+    maxRetries.foreach(_v => _obj$.updateDynamic("maxRetries")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[ECSCredentialsOptions]
+  }
+
+  trait HttpOptions extends js.Object {
+    var timeout: js.UndefOr[Double]
+  }
+
+  object HttpOptions {
+    def apply(
+        timeout: js.UndefOr[Double] = js.undefined
+    ): HttpOptions = {
+      val _obj$ = js.Dynamic.literal(
+      )
+      timeout.foreach(_v => _obj$.updateDynamic("timeout")(_v.asInstanceOf[js.Any]))
+      _obj$.asInstanceOf[HttpOptions]
+    }
+  }
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/EnvironmentCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/EnvironmentCredentials.scala
@@ -1,0 +1,10 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "EnvironmentCredentials", "AWS.EnvironmentCredentials")
+class EnvironmentCredentials(envPrefix: String) extends AWSCredentials {}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/FileSystemCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/FileSystemCredentials.scala
@@ -1,0 +1,10 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "FileSystemCredentials", "AWS.FileSystemCredentials")
+class FileSystemCredentials(val filename: String) extends AWSCredentials {}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/ProcessCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/ProcessCredentials.scala
@@ -1,0 +1,34 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+import facade.amazonaws.HttpOptions
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "ProcessCredentials", "AWS.ProcessCredentials")
+class ProcessCredentials() extends AWSCredentials {
+  def this(options: ProcessCredentialsOptions) = this()
+}
+
+trait ProcessCredentialsOptions extends js.Object {
+  var profile: js.UndefOr[String]
+  var filename: js.UndefOr[String]
+  var httpOptions: js.UndefOr[HttpOptions]
+}
+
+object ProcessCredentialsOptions {
+  def apply(
+      profile: js.UndefOr[String] = js.undefined,
+      filename: js.UndefOr[String] = js.undefined,
+      httpOptions: js.UndefOr[HttpOptions] = js.undefined
+  ): ProcessCredentialsOptions = {
+    val _obj$ = js.Dynamic.literal(
+    )
+    profile.foreach(_v => _obj$.updateDynamic("profile")(_v.asInstanceOf[js.Any]))
+    filename.foreach(_v => _obj$.updateDynamic("filename")(_v.asInstanceOf[js.Any]))
+    httpOptions.foreach(_v => _obj$.updateDynamic("httpOptions")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[ProcessCredentialsOptions]
+  }
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/RemoteCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/RemoteCredentials.scala
@@ -1,0 +1,45 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "RemoteCredentials", "AWS.RemoteCredentials")
+class RemoteCredentials() extends AWSCredentials {
+  def this(options: RemoteCredentialsOptions) = this()
+}
+
+trait RemoteCredentialsOptions extends js.Object {
+  var httpOptions: js.UndefOr[RemoteCredentialsOptions.HttpOptions]
+  var maxRetries: js.UndefOr[Double]
+}
+
+object RemoteCredentialsOptions {
+  def apply(
+      httpOptions: js.UndefOr[RemoteCredentialsOptions.HttpOptions] = js.undefined,
+      maxRetries: js.UndefOr[Double] = js.undefined
+  ): RemoteCredentialsOptions = {
+    val _obj$ = js.Dynamic.literal(
+    )
+    httpOptions.foreach(_v => _obj$.updateDynamic("httpOptions")(_v.asInstanceOf[js.Any]))
+    maxRetries.foreach(_v => _obj$.updateDynamic("maxRetries")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[RemoteCredentialsOptions]
+  }
+
+  trait HttpOptions extends js.Object {
+    var timeout: js.UndefOr[Double]
+  }
+
+  object HttpOptions {
+    def apply(
+        timeout: js.UndefOr[Double] = js.undefined
+    ): HttpOptions = {
+      val _obj$ = js.Dynamic.literal(
+      )
+      timeout.foreach(_v => _obj$.updateDynamic("timeout")(_v.asInstanceOf[js.Any]))
+      _obj$.asInstanceOf[HttpOptions]
+    }
+  }
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/SAMLCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/SAMLCredentials.scala
@@ -1,0 +1,39 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "SAMLCredentials", "AWS.SAMLCredentials")
+class SAMLCredentials(options: SAMLCredentialsParams) extends AWSCredentials {
+  def params: SAMLCredentialsParams = js.native
+}
+
+trait SAMLCredentialsParams extends js.Object {
+  var RoleArn: String
+  var PrincipalArn: String
+  var SAMLAssertion: String
+  var Policy: js.UndefOr[String]
+  var DurationSeconds: js.UndefOr[Double]
+}
+
+object SAMLCredentialsParams {
+  def apply(
+      RoleArn: String,
+      PrincipalArn: String,
+      SAMLAssertion: String,
+      Policy: js.UndefOr[String] = js.undefined,
+      DurationSeconds: js.UndefOr[Double] = js.undefined
+  ): SAMLCredentialsParams = {
+    val _obj$ = js.Dynamic.literal(
+      "RoleArn" -> RoleArn.asInstanceOf[js.Any],
+      "PrincipalArn" -> PrincipalArn.asInstanceOf[js.Any],
+      "SAMLAssertion" -> SAMLAssertion.asInstanceOf[js.Any]
+    )
+    Policy.foreach(_v => _obj$.updateDynamic("Policy")(_v.asInstanceOf[js.Any]))
+    DurationSeconds.foreach(_v => _obj$.updateDynamic("DurationSeconds")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[SAMLCredentialsParams]
+  }
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/SharedIniFileCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/SharedIniFileCredentials.scala
@@ -1,0 +1,43 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+import facade.amazonaws.HttpOptions
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "SharedIniFileCredentials", "AWS.SharedIniFileCredentials")
+class SharedIniFileCredentials() extends AWSCredentials {
+  def this(options: SharedIniFileCredentialsOptions) = this()
+}
+
+trait SharedIniFileCredentialsOptions extends js.Object {
+  var profile: js.UndefOr[String]
+  var filename: js.UndefOr[String]
+  var disableAssumeRole: js.UndefOr[Boolean]
+  var tokenCodeFn: js.UndefOr[js.Function2[String, js.Function2[js.Error, String, Unit], Unit]]
+  var httpOptions: js.UndefOr[HttpOptions]
+  var callback: js.UndefOr[js.Function1[js.Error, Unit]]
+}
+
+object SharedIniFileCredentialsOptions {
+  def apply(
+      profile: js.UndefOr[String] = js.undefined,
+      filename: js.UndefOr[String] = js.undefined,
+      disableAssumeRole: js.UndefOr[Boolean] = js.undefined,
+      tokenCodeFn: js.UndefOr[js.Function2[String, js.Function2[js.Error, String, Unit], Unit]] = js.undefined,
+      httpOptions: js.UndefOr[HttpOptions] = js.undefined,
+      callback: js.UndefOr[js.Function1[js.Error, Unit]] = js.undefined
+  ): SharedIniFileCredentialsOptions = {
+    val _obj$ = js.Dynamic.literal(
+    )
+    profile.foreach(_v => _obj$.updateDynamic("profile")(_v.asInstanceOf[js.Any]))
+    filename.foreach(_v => _obj$.updateDynamic("filename")(_v.asInstanceOf[js.Any]))
+    disableAssumeRole.foreach(_v => _obj$.updateDynamic("disableAssumeRole")(_v.asInstanceOf[js.Any]))
+    tokenCodeFn.foreach(_v => _obj$.updateDynamic("tokenCodeFn")(_v.asInstanceOf[js.Any]))
+    httpOptions.foreach(_v => _obj$.updateDynamic("httpOptions")(_v.asInstanceOf[js.Any]))
+    callback.foreach(_v => _obj$.updateDynamic("callback")(_v.asInstanceOf[js.Any]))
+    _obj$.asInstanceOf[SharedIniFileCredentialsOptions]
+  }
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/TemporaryCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/TemporaryCredentials.scala
@@ -1,0 +1,19 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+import facade.amazonaws.services.sts._
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "TemporaryCredentials", "AWS.TemporaryCredentials")
+class TemporaryCredentials() extends AWSCredentials {
+  def this(options: AssumeRoleRequest, masterCredentials: AWSCredentials) = this()
+  def this(options: AssumeRoleRequest) = this()
+
+  def this(options: GetSessionTokenRequest, masterCredentials: AWSCredentials) = this()
+  def this(options: GetSessionTokenRequest) = this()
+
+  var masterCredentials: AWSCredentials = js.native
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/TokenFileWebIdentityCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/TokenFileWebIdentityCredentials.scala
@@ -1,0 +1,13 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.{AWSConfig, AWSCredentials}
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "TokenFileWebIdentityCredentials", "AWS.TokenFileWebIdentityCredentials")
+class TokenFileWebIdentityCredentials() extends AWSCredentials {
+  def this(clientConfig: AWSConfig) = this()
+
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/WebIdentityCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/WebIdentityCredentials.scala
@@ -8,9 +8,8 @@ import scala.scalajs.js.annotation.JSImport
 
 @js.native
 @JSImport("aws-sdk/lib/node_loader", "WebIdentityCredentials", "AWS.WebIdentityCredentials")
-class WebIdentityCredentials() extends AWSCredentials {
-  def this(options: sts.AssumeRoleWithWebIdentityRequest, clientConfig: AWSConfig) = this()
-  def this(options: sts.AssumeRoleWithWebIdentityRequest) = this()
+class WebIdentityCredentials(options: sts.AssumeRoleWithWebIdentityRequest, clientConfig: AWSConfig) extends AWSCredentials {
+  def this(options: sts.AssumeRoleWithWebIdentityRequest) = this(options, null)
 
   def data: sts.AssumeRoleWithWebIdentityResponse = js.native
   def params: sts.AssumeRoleWithWebIdentityRequest = js.native

--- a/credentials/src/main/scala/facade/amazonaws/credentials/WebIdentityCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/WebIdentityCredentials.scala
@@ -1,0 +1,17 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.services.sts
+import facade.amazonaws.{AWSConfig, AWSCredentials}
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("aws-sdk/lib/node_loader", "WebIdentityCredentials", "AWS.WebIdentityCredentials")
+class WebIdentityCredentials() extends AWSCredentials {
+  def this(options: sts.AssumeRoleWithWebIdentityRequest, clientConfig: AWSConfig) = this()
+  def this(options: sts.AssumeRoleWithWebIdentityRequest) = this()
+
+  def data: sts.AssumeRoleWithWebIdentityResponse = js.native
+  def params: sts.AssumeRoleWithWebIdentityRequest = js.native
+}

--- a/credentials/src/main/scala/facade/amazonaws/credentials/package.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/package.scala
@@ -1,0 +1,16 @@
+package facade.amazonaws
+
+import facade.amazonaws.services.{cognitoidentity, sts}
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+
+package object credentials {
+  type Provider = js.Function0[AWSCredentials]
+
+  trait HasLoginId extends js.Object {
+    var LoginId: js.UndefOr[String]
+  }
+  type CognitoIdentityCredentialsInputs = cognitoidentity.GetIdInput | cognitoidentity.GetCredentialsForIdentityInput | cognitoidentity.GetOpenIdTokenInput | sts.AssumeRoleWithWebIdentityRequest
+  type CognitoIdentityOptions = CognitoIdentityCredentialsInputs with HasLoginId
+}

--- a/credentials/src/test/scala/facade/amazonaws/credentials/CredentialsTest.scala
+++ b/credentials/src/test/scala/facade/amazonaws/credentials/CredentialsTest.scala
@@ -1,0 +1,71 @@
+package facade.amazonaws.credentials
+
+import facade.amazonaws.AWSCredentials
+import facade.amazonaws.services.sts
+import org.scalatest.funsuite.AnyFunSuite
+
+class CredentialsTest extends AnyFunSuite {
+  test("ChainableTemporaryCredentials") {
+    val credentials: AWSCredentials = new ChainableTemporaryCredentials()
+  }
+
+  test("CognitoIdentityCredentials") {
+    val credentials: AWSCredentials = new CognitoIdentityCredentials()
+  }
+
+  test("CredentialProviderChain") {
+    val credentials: AWSCredentials = new CredentialProviderChain()
+  }
+
+  test("EC2MetadataCredentials") {
+    val credentials: AWSCredentials = new EC2MetadataCredentials()
+  }
+
+  test("ECSCredentials") {
+    val credentials: AWSCredentials = new ECSCredentials()
+  }
+
+  test("EnvironmentCredentials") {
+    val credentials: AWSCredentials = new EnvironmentCredentials("local")
+  }
+
+  test("FileSystemCredentials") {
+    val credentials: AWSCredentials = new FileSystemCredentials("foo.txt")
+  }
+
+  test("ProcessCredentials") {
+    val credentials: AWSCredentials = new ProcessCredentials()
+  }
+
+  test("RemoteCredentials") {
+    val credentials: AWSCredentials = new RemoteCredentials()
+  }
+
+  test("SAMLCredentials") {
+    val credentials: AWSCredentials = new SAMLCredentials(SAMLCredentialsParams(
+      RoleArn = "x",
+      PrincipalArn = "y",
+      SAMLAssertion = "z"
+    ))
+  }
+
+  test("SharedIniFileCredentials") {
+    val credentials: AWSCredentials = new SharedIniFileCredentials()
+  }
+
+  test("TemporaryCredentials") {
+    val credentials: AWSCredentials = new TemporaryCredentials()
+  }
+
+  test("TokenFileWebIdentityCredentials") {
+    val credentials: AWSCredentials = new TokenFileWebIdentityCredentials()
+  }
+
+  test("WebIdentityCredentials") {
+    val credentials: AWSCredentials = new WebIdentityCredentials(sts.AssumeRoleWithWebIdentityRequest(
+      RoleArn = "x",
+      RoleSessionName = "y",
+      WebIdentityToken = "z"
+    ))
+  }
+}


### PR DESCRIPTION
Closes #345

`aws-sdk-scalajs-facade-credentials` artifact is newly added.
It includes type facades for various AWS Credential implementations.
The reason of new artifact instead of updating `core` is because to keep `core` small, since some Credentials depends on `sts` and `cognitoidentity`.