### PR TITLE
[pre-release][credentials] Remove LoginId due to typing issue

### DIFF
--- a/credentials/src/main/scala/facade/amazonaws/credentials/CognitoIdentityCredentials.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/CognitoIdentityCredentials.scala
@@ -8,11 +8,21 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.|
 
+// TODO: support { LoginId: js.UndefOr[String] } in options
 @js.native
 @JSImport("aws-sdk/lib/node_loader", "CognitoIdentityCredentials", "AWS.CognitoIdentityCredentials")
 class CognitoIdentityCredentials() extends AWSCredentials {
-  def this(options: CognitoIdentityOptions) = this()
-  def this(options: CognitoIdentityOptions, clientConfig: AWSConfig) = this()
+  def this(options: cognitoidentity.GetIdInput) = this()
+  def this(options: cognitoidentity.GetIdInput, clientConfig: AWSConfig) = this()
+
+  def this(options: cognitoidentity.GetCredentialsForIdentityInput) = this()
+  def this(options: cognitoidentity.GetCredentialsForIdentityInput, clientConfig: AWSConfig) = this()
+
+  def this(options: cognitoidentity.GetOpenIdTokenInput) = this()
+  def this(options: cognitoidentity.GetOpenIdTokenInput, clientConfig: AWSConfig) = this()
+
+  def this(options: sts.AssumeRoleWithWebIdentityRequest) = this()
+  def this(options: sts.AssumeRoleWithWebIdentityRequest, clientConfig: AWSConfig) = this()
 
   def clearCacheId(): Unit = js.native
 

--- a/credentials/src/main/scala/facade/amazonaws/credentials/package.scala
+++ b/credentials/src/main/scala/facade/amazonaws/credentials/package.scala
@@ -1,16 +1,7 @@
 package facade.amazonaws
 
-import facade.amazonaws.services.{cognitoidentity, sts}
-
 import scala.scalajs.js
-import scala.scalajs.js.|
 
 package object credentials {
   type Provider = js.Function0[AWSCredentials]
-
-  trait HasLoginId extends js.Object {
-    var LoginId: js.UndefOr[String]
-  }
-  type CognitoIdentityCredentialsInputs = cognitoidentity.GetIdInput | cognitoidentity.GetCredentialsForIdentityInput | cognitoidentity.GetOpenIdTokenInput | sts.AssumeRoleWithWebIdentityRequest
-  type CognitoIdentityOptions = CognitoIdentityCredentialsInputs with HasLoginId
 }


### PR DESCRIPTION
Fix the issue where options can not be passed:
```scala
new CognitoIdentityCredentials(
  cognitoidentity.GetIdInput(
    IdentityPoolId = ""
  )
)
```