### PR TITLE
setup-scala is no longer maintained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
         scala: [3.1.0, 2.13.7, 2.12.15]
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v2
         with:
-          java-version: adopt@1.11
+          distribution: 'temurin'
+          java-version: '11'
       - name: Cache Coursier
         uses: actions/cache@v2.1.7
         with:
@@ -43,7 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Cache Coursier
         uses: actions/cache@v2.1.7
         with:


### PR DESCRIPTION
GH Actions has Java 11 and sbt built-in, but uses `setup-java` to explicitly specify java version